### PR TITLE
Fix invalid signature

### DIFF
--- a/message.cpp
+++ b/message.cpp
@@ -985,7 +985,7 @@ std::string npcn(int cc)
 
 
 
-std::string _s(int cc, int need_e)
+std::string _s(int cc, bool need_e)
 {
     if (cc < 0 || cc >= 245)
     {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #10.


# Summary

The definition of `_s` differs from the declaration of that.
