### PR TITLE
Fix glitch in screen edge

### DIFF
--- a/std.cpp
+++ b/std.cpp
@@ -590,14 +590,49 @@ void gcopy(int window_id, int src_x, int src_y, int src_width, int src_height)
         return;
     }
 
+    int dst_x = detail::current_tex_buffer().x;
+    int dst_y = detail::current_tex_buffer().y;
+    src_width = src_width == 0 ? detail::current_tex_buffer().width : src_width;
+    src_height =
+        src_height == 0 ? detail::current_tex_buffer().height : src_height;
+    int dst_width = src_width;
+    int dst_height = src_height;
+
+    if (src_x < 0)
+    {
+        int excess = -src_x;
+        dst_x += excess;
+        dst_width -= excess;
+    }
+    if (src_y < 0)
+    {
+        int excess = -src_y;
+        dst_y += excess;
+        dst_height -= excess;
+    }
+    if (src_x + src_width >= detail::tex_buffers[window_id].tex_width)
+    {
+        int excess =
+            src_x + src_width - detail::tex_buffers[window_id].tex_width;
+        dst_width -= excess;
+    }
+    if (src_y + src_height >= detail::tex_buffers[window_id].tex_height)
+    {
+        int excess =
+            src_y + src_height - detail::tex_buffers[window_id].tex_height;
+        dst_height -= excess;
+    }
+
     snail::application::instance().get_renderer().render_image(
         detail::tex_buffers[window_id].texture,
         src_x,
         src_y,
-        src_width == 0 ? detail::current_tex_buffer().width : src_width,
-        src_height == 0 ? detail::current_tex_buffer().height : src_height,
-        detail::current_tex_buffer().x,
-        detail::current_tex_buffer().y);
+        src_width,
+        src_height,
+        dst_x,
+        dst_y,
+        dst_width,
+        dst_height);
 }
 
 


### PR DESCRIPTION
# Related Issues

Close #22.

# Summary

## Before

![before](https://user-images.githubusercontent.com/36858341/36883397-4bfcf9a2-1e1d-11e8-847d-9b6d1e5ca5cd.png)

## After

![after](https://user-images.githubusercontent.com/36858341/36883398-4ffdffa6-1e1d-11e8-8467-4f2512d8fb5f.png)


# Cause

SDL library clips the source rectangle before copying the source texture.

Black: out of range
White: texture copied from or to
Red: copied or drawn region

![description](https://user-images.githubusercontent.com/36858341/36883906-be055f0a-1e20-11e8-8d75-f9f5e0574a9e.png)
