### PR TITLE
Fix glitch of shadow

### DIFF
--- a/cell_draw.cpp
+++ b/cell_draw.cpp
@@ -1190,6 +1190,9 @@ void cell_draw()
         render_cloud();
     }
 
+    // Work around
+    light_ *= 1.3;
+
     if (cfg_shadow != 0)
     {
         render_shadow_low(light_);

--- a/std.cpp
+++ b/std.cpp
@@ -1320,6 +1320,24 @@ void picload(const fs::path& filename, int mode)
         snail::blend_mode_t::none);
     snail::application::instance().get_renderer().render_image(
         img, detail::current_tex_buffer().x, detail::current_tex_buffer().y);
+
+    if (filename.u8string().find(u8"interface.bmp") != std::string::npos)
+    {
+        snail::basic_image ex{filename.parent_path()
+                              / fs::u8path(u8"interface_ex.png")};
+        snail::application::instance().get_renderer().render_image(ex, 0, 656);
+        snail::basic_image ex2{filename.parent_path()
+                               / fs::u8path(u8"interface_ex2.png")};
+        snail::application::instance().get_renderer().render_image(
+            ex2, 144, 656);
+        snail::application::instance().get_renderer().render_image(
+            ex2, 144, 704);
+        snail::basic_image ex3{filename.parent_path()
+                               / fs::u8path(u8"interface_ex3.png")};
+        snail::application::instance().get_renderer().render_image(
+            ex3, 144, 752);
+    }
+
     snail::application::instance().get_renderer().set_blend_mode(save);
 }
 


### PR DESCRIPTION
# Related Issues

Close #24.


# Summary

The current behavior is not complete, but improved.

## Before

![before](https://user-images.githubusercontent.com/36858341/36889199-55f454f4-1e3c-11e8-8ca0-053e9d731315.png)

## After

![after](https://user-images.githubusercontent.com/36858341/36889206-5e717580-1e3c-11e8-8fbf-21b7a769c547.png)

## Remarks

Since this commit, you have to prepare `graphic/interface_ex.png`, `graphic/interface_ex2.png` and `graphic/interface_ex3.png` to play Elona Foobar. They can be generated from `graphic/interface.bmp`(You can find it in your original or variants Elona folder).

1. Create 3 files from part of `graphic/interface.bmp`.
  * `graphic/interface_ex.png`: x=0, y=656, width=144, height=144
  * `graphic/interface_ex2.png`: x=144, y=704, width=48, height=48
  * `graphic/interface_ex3.png`: x=144, y=752, width=864, height=48
2. Apply this filter:
 * Alpha: `255 - average of RGB`
 * R: `255 - R`
 * G: `255 - G`
 * B: `255 - B`

The license of `graphic/interface.bmp` is not clear so these three files are not included in Elona Foobar repository.

