### PR TITLE
Rename elona::main() to elona::run()

### DIFF
--- a/elona.hpp
+++ b/elona.hpp
@@ -25,7 +25,7 @@ namespace fs = std::experimental::filesystem;
 
 namespace elona
 {
-int main();
+int run();
 
 
 template <typename...>

--- a/init.cpp
+++ b/init.cpp
@@ -721,7 +721,7 @@ int cat_cbitmod(lua_State* L)
 }
 
 
-int main()
+int run()
 {
     cat::global.initialize();
 

--- a/main.cpp
+++ b/main.cpp
@@ -1,11 +1,11 @@
 namespace elona
 {
-int main();
+int run();
 }
 
 
 
 int main()
 {
-    return elona::main();
+    return elona::run();
 }


### PR DESCRIPTION
# Related Issues

Close #46.


# Summary

To avoid SDL's hack.