### PR TITLE
Refactor/delete meaningless function

### DIFF
--- a/elonacore.cpp
+++ b/elonacore.cpp
@@ -57294,7 +57294,6 @@ void label_2201()
             }
         }
     }
-    txt_check();
     txt(lang(
         name(cc) + u8"は空気に体当たりした。"s,
         name(cc) + u8" bash"s + _s(cc) + u8" up the air."s));

--- a/magic.cpp
+++ b/magic.cpp
@@ -1942,7 +1942,6 @@ label_2181_internal:
         }
         if (efid == 632)
         {
-            txt_check();
             txt(lang(
                 name(cc) + u8"は"s + name(tc)
                     + u8"を気の狂いそうな眼差しで見た。"s,

--- a/message.cpp
+++ b/message.cpp
@@ -1267,13 +1267,6 @@ std::string yourself(int x)
 
 
 
-void txt_check()
-{
-    txtvalid = (cc > 0 && is_in_fov(cc)) || cc == 0 ? 0 : -1;
-}
-
-
-
 void stxt(int cc, const std::string& str)
 {
     if (cc == 0 || (is_in_fov(cc) && cdata[0].blind == 0))

--- a/variables.hpp
+++ b/variables.hpp
@@ -527,7 +527,6 @@ inline int tlocy;
 inline int tnew;
 inline int tx;
 inline int txt3rd;
-inline int txtvalid;
 inline int ty;
 inline int usernpcmax;
 inline int userrelation;
@@ -1518,7 +1517,6 @@ void tcginit();
 void tcgmain();
 void text_set();
 void turn_aggro(int = 0, int = 0, int = 0);
-void txt_check();
 void txt_conv();
 void txtcontinue();
 void txtef(int = 0);
@@ -1569,7 +1567,6 @@ template <typename... Args>
 void txt(Args&&... args)
 {
     std::vector<std::string> text{txt_tostr(args)...};
-    txtvalid = 0;
     if (hear != 0)
     {
         snd(hear);


### PR DESCRIPTION
# Summary

Delete a no-effect function, `txt_check`. `txt_check` mutates `txtvalid` but this variable is never used.