### PR TITLE
Change the order of gzoom()'s parameters

### DIFF
--- a/draw.cpp
+++ b/draw.cpp
@@ -62,8 +62,6 @@ void prepare_item_image(int id, int color, int character_image)
             255 - c_col(2, character_color),
             5);
         gzoom(
-            22,
-            20,
             5,
             chipc(0, character_id) + 8,
             chipc(1, character_id) + 4
@@ -71,7 +69,8 @@ void prepare_item_image(int id, int color, int character_image)
             chipc(2, character_id) - 16,
             chipc(3, character_id) - 8
                 - (chipc(3, character_id) > inf_tiles) * 10,
-            1);
+            22,
+            20);
         set_color_mod(255, 255, 255, 5);
         pos(6, 974);
         gcopy(1, 0, 1008, 22, 20);

--- a/elona.hpp
+++ b/elona.hpp
@@ -436,14 +436,13 @@ void grotate(
 void gsel(int window_id);
 
 void gzoom(
-    int dst_width,
-    int dst_height,
     int window_id,
     int src_x,
     int src_y,
     int src_width,
     int src_height,
-    int mode = 0);
+    int dst_width,
+    int dst_height);
 
 
 int instr(const std::string& str, size_t pos, const std::string pattern);

--- a/elonacore.cpp
+++ b/elonacore.cpp
@@ -8857,12 +8857,12 @@ void window2(
     if (prm_661 == 0)
     {
         pos(prm_656 + 4, prm_657 + 4);
-        gzoom(x2_at_m93 - 6, y2_at_m93 - 8, 3, 24, 72, 228, 144);
+        gzoom(3, 24, 72, 228, 144, x2_at_m93 - 6, y2_at_m93 - 8);
     }
     if (prm_661 == 1)
     {
         pos(prm_656 + 4, prm_657 + 4);
-        gzoom(x2_at_m93 - 6, y2_at_m93 - 8, 3, 24, 72, 228, 144);
+        gzoom(3, 24, 72, 228, 144, x2_at_m93 - 6, y2_at_m93 - 8);
         pos(prm_656 + 4, prm_657 + 4);
         gfini(x2_at_m93 - 4, y2_at_m93 - 4);
         gfdec2(195, 205, 195);
@@ -8870,7 +8870,7 @@ void window2(
     if (prm_661 == 2)
     {
         pos(prm_656 + 4, prm_657 + 4);
-        gzoom(x2_at_m93 - 6, y2_at_m93 - 8, 3, 24, 72, 228, 144);
+        gzoom(3, 24, 72, 228, 144, x2_at_m93 - 6, y2_at_m93 - 8);
         pos(prm_656 + 4, prm_657 + 4);
         gfini(x2_at_m93 - 4, y2_at_m93 - 4);
         gfdec2(210, 215, 205);
@@ -8878,7 +8878,7 @@ void window2(
     if (prm_661 == 3)
     {
         pos(prm_656 + 4, prm_657 + 4);
-        gzoom(x2_at_m93 - 6, y2_at_m93 - 8, 3, 24, 72, 228, 144);
+        gzoom(3, 24, 72, 228, 144, x2_at_m93 - 6, y2_at_m93 - 8);
         pos(prm_656 + 4, prm_657 + 4);
         gfini(x2_at_m93 - 4, y2_at_m93 - 4);
         gfdec2(10, 13, 16);
@@ -8886,7 +8886,7 @@ void window2(
     if (prm_661 == 4)
     {
         pos(prm_656 + 4, prm_657 + 4);
-        gzoom(x2_at_m93 - 6, y2_at_m93 - 8, 3, 24, 72, 228, 144);
+        gzoom(3, 24, 72, 228, 144, x2_at_m93 - 6, y2_at_m93 - 8);
         pos(prm_656 + 4, prm_657 + 4);
         gfini(x2_at_m93 - 4, y2_at_m93 - 4);
         gfdec2(195, 205, 195);
@@ -8936,7 +8936,7 @@ void window2(
     if (prm_661 == 5)
     {
         pos(prm_656 + 2, prm_657 + 2);
-        gzoom(x2_at_m93 - 4, y2_at_m93 - 5, 3, 24, 72, 228, 144);
+        gzoom(3, 24, 72, 228, 144, x2_at_m93 - 4, y2_at_m93 - 5);
         pos(prm_656 + 2, prm_657 + 2);
         gfini(x2_at_m93 - 4, y2_at_m93 - 4);
         gfdec2(195, 205, 195);
@@ -22189,7 +22189,7 @@ void clear_background_in_character_making()
     gsel(4);
     pos(0, 0);
     picload(fs::u8path(u8"./graphic/void.bmp"), 1);
-    gzoom(windoww, windowh, 4, 0, 0, 800, 600);
+    gzoom(4, 0, 0, 800, 600, windoww, windowh);
     gsel(0);
     gmode(0);
     pos(0, 0);
@@ -34842,7 +34842,7 @@ void atxinit()
         pos(0, 0);
         picload(fs::u8path(u8"./graphic/"s + atxbg + u8".bmp"), 1);
         pos(0, inf_msgh);
-        gzoom(windoww, windowh - inf_verh - inf_msgh, 4, 0, 0, 240, 160);
+        gzoom(4, 0, 0, 240, 160, windoww, windowh - inf_verh - inf_msgh);
         gmode(2);
         p = windoww / 192;
         for (int cnt = 0, cnt_end = (p + 1); cnt < cnt_end; ++cnt)
@@ -34860,7 +34860,7 @@ void atxinit()
         }
         window2(windoww - 208, 0, 208, 98, 0, 0);
         pos(windoww - 204, 4);
-        gzoom(200, 90, 0, 120, 88, windoww - 120, windowh - inf_verh - 112, 1);
+        gzoom(0, 120, 88, windoww - 120, windowh - inf_verh - 112, 200, 90);
         gsel(0);
     }
     return;
@@ -36650,7 +36650,7 @@ void label_1886()
     pos(0, 0);
     picload(fs::u8path(u8"./graphic/bg_altar.bmp"), 1);
     pos(0, 0);
-    gzoom(windoww, windowh - inf_verh, 4, 0, 0, 600, 400, 1);
+    gzoom(4, 0, 0, 600, 400, windoww, windowh - inf_verh);
     gsel(0);
     keyrange = 0;
     for (int cnt = 0, cnt_end = (pagesize); cnt < cnt_end; ++cnt)
@@ -41248,13 +41248,13 @@ label_1956_internal:
             {
                 pos(wx + cnt * 24, wy + cnt2 * 24);
                 gzoom(
-                    24,
-                    24,
                     2,
                     list(0, p) % ww * 48,
                     list(0, p) / ww * 48,
                     48,
-                    48);
+                    48,
+                    24,
+                    24);
                 if (chipm(7, list(0, p)) & 4)
                 {
                     color(240, 230, 220);
@@ -46340,7 +46340,7 @@ label_2035_internal:
         {
             p = cdata[cc].sex * 64 + cdata[cc].portrait;
             pos(wx + 560, wy + 27);
-            gzoom(80, 112, 4, p % 16 * 48, p / 16 * 72, 48, 72);
+            gzoom(4, p % 16 * 48, p / 16 * 72, 48, 72, 80, 112);
         }
         else
         {
@@ -46351,7 +46351,7 @@ label_2035_internal:
                 if (fs::exists(s))
                 {
                     pos(wx + 560, wy + 27);
-                    gzoom(80, 112, 4, 0, 0, 80, 112);
+                    gzoom(4, 0, 0, 80, 112, 80, 112);
                 }
             }
         }
@@ -47296,17 +47296,17 @@ label_2041_internal:
         {
             p = cdata[cc].sex * 64 + cdata[cc].portrait;
             pos(wx + 238, wy + 75);
-            gzoom(80, 112, 4, p % 16 * 48, p / 16 * 72, 48, 72);
+            gzoom(4, p % 16 * 48, p / 16 * 72, 48, 72, 80, 112);
         }
         else if (cdata[cc].portrait != -1)
         {
             pos(wx + 238, wy + 75);
             gzoom(
-                80,
-                112,
                 7,
                 std::abs((cdata[cc].portrait + 2)) * 80,
                 0,
+                80,
+                112,
                 80,
                 112);
         }
@@ -51103,7 +51103,7 @@ void main_menu_continue()
     gsel(4);
     pos(0, 0);
     picload(fs::u8path(u8"./graphic/void.bmp"), 1);
-    gzoom(windoww, windowh, 4, 0, 0, 800, 600);
+    gzoom(4, 0, 0, 800, 600, windoww, windowh);
     gsel(0);
     gmode(0);
     pos(0, 0);
@@ -51274,7 +51274,7 @@ void main_menu_incarnate()
     gsel(4);
     pos(0, 0);
     picload(fs::u8path(u8"./graphic/void.bmp"), 1);
-    gzoom(windoww, windowh, 4, 0, 0, 800, 600);
+    gzoom(4, 0, 0, 800, 600, windoww, windowh);
     gsel(0);
     gmode(0);
     pos(0, 0);
@@ -53688,7 +53688,7 @@ void label_2150()
     pos(0, 0);
     picload(fs::u8path(u8"./graphic/bg_night.bmp"), 1);
     pos(0, 0);
-    gzoom(windoww, windowh - inf_verh, 4, 0, 0, 640, 480, 1);
+    gzoom(4, 0, 0, 640, 480, windoww, windowh - inf_verh);
     gsel(0);
     return;
 }
@@ -64530,7 +64530,7 @@ void show_talk_window()
             p = elona::stoi(actor(1, rc));
         }
         pos(wx + 42, wy + 42);
-        gzoom(80, 112, 4, p % 16 * 48, p / 16 * 72, 48, 72);
+        gzoom(4, p % 16 * 48, p / 16 * 72, 48, 72, 80, 112);
     }
     else
     {
@@ -64556,7 +64556,7 @@ void show_talk_window()
                 chatpicloaded = 1;
             }
             pos(wx + 42, wy + 42);
-            gzoom(80, 112, 4, 0, 0, 80, 112);
+            gzoom(4, 0, 0, 80, 112, 80, 112);
         }
     }
     font(lang(cfg_font1, cfg_font2), 10 - en * 2, 0);
@@ -68081,7 +68081,7 @@ label_2684_internal:
     pos(0, 0);
     picload(fs::u8path(u8"./graphic/"s + file + u8".bmp"), 1);
     pos(0, y1);
-    gzoom(windoww, y2 - y1, 4, 0, 0, 640, 480);
+    gzoom(4, 0, 0, 640, 480, windoww, y2 - y1);
     gmode(2);
     boxf(0, 0, windoww, y1, {5, 5, 5});
     boxf(0, y2, windoww, windowh, {5, 5, 5});
@@ -73852,7 +73852,7 @@ void conquer_lesimas()
     pos(0, 0);
     picload(fs::u8path(u8"./graphic/void.bmp"), 1);
     pos(0, 0);
-    gzoom(windoww, windowh, 4, 0, 0, 640, 480);
+    gzoom(4, 0, 0, 640, 480, windoww, windowh);
     gsel(0);
     label_1443();
     pos(0, 0);
@@ -74115,7 +74115,7 @@ void show_game_score_ranking()
     redraw(0);
     gmode(0);
     pos(0, 0);
-    gzoom(windoww, windowh, 4, 0, 0, 800, 600);
+    gzoom(4, 0, 0, 800, 600, windoww, windowh);
     gmode(2);
     x = 135;
     y = 134;

--- a/init.cpp
+++ b/init.cpp
@@ -167,7 +167,7 @@ void initialize_elona()
     if (inf_tiles != 48)
     {
         pos(0, 0);
-        gzoom(33 * inf_tiles, 25 * inf_tiles, 1, 0, 0, 1584, 1200);
+        gzoom(1, 0, 0, 1584, 1200, 33 * inf_tiles, 25 * inf_tiles);
     }
     buffer(2, 33 * inf_tiles, 25 * inf_tiles);
     buffer(6, 33 * inf_tiles, 25 * inf_tiles);
@@ -785,7 +785,7 @@ void main_title_menu()
     gmode(0);
     pos(0, 0);
     picload(fs::u8path(u8"./graphic/title.bmp"), 1);
-    gzoom(windoww, windowh, 4, 0, 0, 800, 600);
+    gzoom(4, 0, 0, 800, 600, windoww, windowh);
     gmode(2);
     font(lang(cfg_font1, cfg_font2), 13 - en * 2, 0);
     color(255, 255, 255);
@@ -965,7 +965,7 @@ void main_menu_new_game()
     gsel(4);
     pos(0, 0);
     picload(fs::u8path(u8"./graphic/void.bmp"), 1);
-    gzoom(windoww, windowh, 4, 0, 0, 800, 600);
+    gzoom(4, 0, 0, 800, 600, windoww, windowh);
     gsel(2);
     for (int cnt = 0; cnt < 8; ++cnt)
     {

--- a/message.cpp
+++ b/message.cpp
@@ -581,7 +581,7 @@ void anime_halt()
         redraw(0);
         await(10);
         pos(x_at_txtfunc, y_at_txtfunc + 12 - cnt);
-        gzoom(120, cnt * 2 + 1, 3, 552, 504, 120, 22);
+        gzoom(3, 552, 504, 120, 22, 120, cnt * 2 + 1);
         redraw(1);
     }
     press(true);
@@ -595,7 +595,7 @@ void anime_halt()
         if (cnt != 6)
         {
             pos(x_at_txtfunc, y_at_txtfunc + cnt * 2);
-            gzoom(120, 22 - cnt * 4, 3, 552, 504, 120, 22);
+            gzoom(3, 552, 504, 120, 22, 120, 22 - cnt * 4);
         }
         redraw(1);
     }
@@ -933,8 +933,7 @@ std::string name(int cc)
         return lang(u8"何か"s, u8"something"s);
     }
     if (cdata[0].blind != 0
-        || (cbit(6, cc) == 1 && cbit(7, 0) == 0
-            && cdata[cc].wet == 0))
+        || (cbit(6, cc) == 1 && cbit(7, 0) == 0 && cdata[cc].wet == 0))
     {
         return lang(u8"何か"s, u8"something"s);
     }

--- a/set_option.cpp
+++ b/set_option.cpp
@@ -62,7 +62,7 @@ void set_option()
         gmode(0);
         pos(0, 0);
         picload(fs::u8path(u8"./graphic/title.bmp"), 1);
-        gzoom(windoww, windowh, 4, 0, 0, 800, 600);
+        gzoom(4, 0, 0, 800, 600, windoww, windowh);
         gsel(0);
         gmode(0);
         pos(0, 0);

--- a/std.cpp
+++ b/std.cpp
@@ -890,16 +890,14 @@ void gsel(int window_id)
 
 
 void gzoom(
-    int dst_width,
-    int dst_height,
     int window_id,
     int src_x,
     int src_y,
     int src_width,
     int src_height,
-    int mode)
+    int dst_width,
+    int dst_height)
 {
-    (void)mode;
     snail::application::instance().get_renderer().set_blend_mode(
         snail::blend_mode_t::none);
     snail::detail::enforce_sdl(


### PR DESCRIPTION
# Summary

It is very confusing that the order of parameters of `gzoom` is different that of `gcopy`.

## Before
    destination width
    destination height
    window id
    source x
    source y
    source width
    source height
    mode (unused)

## After
    window id
    source x
    source y
    source width
    source height
    destination width
    destination height
