### PR TITLE
Fix calcobjlv()

### DIFF
--- a/calc.cpp
+++ b/calc.cpp
@@ -236,7 +236,7 @@ std::optional<skill_damage> calc_skill_damage(int skill, int cc, int power)
 
 int calcobjlv(int base)
 {
-    int ret = base < 0 ? gdata_current_dungeon_level : base;
+    int ret = base <= 0 ? gdata_current_dungeon_level : base;
     if (gdata_current_map == 30)
     {
         ret = 1;

--- a/calc.hpp
+++ b/calc.hpp
@@ -21,7 +21,7 @@ struct skill_damage
     int element_power;
 };
 std::optional<skill_damage> calc_skill_damage(int, int, int);
-int calcobjlv(int = -1);
+int calcobjlv(int = 0);
 int calcfixlv(int = 0);
 int calcfame(int = 0, int = 0);
 int decfame(int = 0, int = 0);

--- a/proc_event.cpp
+++ b/proc_event.cpp
@@ -268,7 +268,7 @@ void proc_event()
         music = 64;
         play_music();
         snd(51);
-        flt(calcobjlv(), calcfixlv());
+        flt(0, calcfixlv());
         flttypemajor = 54000;
         itemcreate(-1, 0, cdata[0].position.x, cdata[0].position.y, 0);
         flt();


### PR DESCRIPTION
# Related Issues

Close #84.

# Summary

This commit corrects PR #61.
Restore the definition of `calcobjlv()` and fix the first argument of `flt()` when generating quest rewards.