### PR TITLE
Fix/read binary as binary mode

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -509,7 +509,7 @@ void load_config()
     picojson::value value;
 
     {
-        std::ifstream file(fs::path(u8"./config.json").native());
+        std::ifstream file{fs::path(u8"./config.json").native(), std::ios::binary};
         if (!file)
         {
             throw config_loading_error(
@@ -650,7 +650,7 @@ void set_config(const std::string& key, int value)
     picojson::value options;
 
     {
-        std::ifstream file(fs::path(u8"./config.json").native());
+        std::ifstream file{fs::path(u8"./config.json").native(), std::ios::binary};
         if (!file)
         {
             throw config_loading_error(
@@ -662,7 +662,7 @@ void set_config(const std::string& key, int value)
     options.get(key) = picojson::value{int64_t{value}};
 
     {
-        std::ofstream file(fs::path(u8"./config.json").native());
+        std::ofstream file{fs::path(u8"./config.json").native(), std::ios::binary};
         if (!file)
         {
             throw config_loading_error(
@@ -679,7 +679,7 @@ void set_config(const std::string& key, const std::string& value)
     picojson::value options;
 
     {
-        std::ifstream file{fs::path(u8"./config.json").native()};
+        std::ifstream file{fs::path(u8"./config.json").native(), std::ios::binary};
         if (!file)
         {
             throw config_loading_error{u8"Failed to open: "s
@@ -691,7 +691,7 @@ void set_config(const std::string& key, const std::string& value)
     options.get(key) = picojson::value{value};
 
     {
-        std::ofstream file{fs::path(u8"./config.json").native()};
+        std::ofstream file{fs::path(u8"./config.json").native(), std::ios::binary};
         if (!file)
         {
             throw config_loading_error{u8"Failed to open: "s
@@ -708,7 +708,7 @@ void set_config(const std::string& key, const std::string& value1, int value2)
     picojson::value options;
 
     {
-        std::ifstream file{fs::path(u8"./config.json").native()};
+        std::ifstream file{fs::path(u8"./config.json").native(), std::ios::binary};
         if (!file)
         {
             throw config_loading_error{u8"Failed to open: "s
@@ -721,7 +721,7 @@ void set_config(const std::string& key, const std::string& value1, int value2)
     (void)value2; // TODO
 
     {
-        std::ofstream file{fs::path(u8"./config.json").native()};
+        std::ofstream file{fs::path(u8"./config.json").native(), std::ios::binary};
         if (!file)
         {
             throw config_loading_error{u8"Failed to open: "s
@@ -800,7 +800,7 @@ void load_config2()
             u8"charamake_wiz", [&](auto value) { cfg_wizard = value; }),
     };
 
-    std::ifstream file(fs::path(u8"./config.json").native());
+    std::ifstream file{fs::path(u8"./config.json").native(), std::ios::binary};
     if (!file)
     {
         throw config_loading_error(

--- a/config.cpp
+++ b/config.cpp
@@ -509,7 +509,8 @@ void load_config()
     picojson::value value;
 
     {
-        std::ifstream file{fs::path(u8"./config.json").native(), std::ios::binary};
+        std::ifstream file{fs::path(u8"./config.json").native(),
+                           std::ios::binary};
         if (!file)
         {
             throw config_loading_error(
@@ -650,7 +651,8 @@ void set_config(const std::string& key, int value)
     picojson::value options;
 
     {
-        std::ifstream file{fs::path(u8"./config.json").native(), std::ios::binary};
+        std::ifstream file{fs::path(u8"./config.json").native(),
+                           std::ios::binary};
         if (!file)
         {
             throw config_loading_error(
@@ -662,7 +664,8 @@ void set_config(const std::string& key, int value)
     options.get(key) = picojson::value{int64_t{value}};
 
     {
-        std::ofstream file{fs::path(u8"./config.json").native(), std::ios::binary};
+        std::ofstream file{fs::path(u8"./config.json").native(),
+                           std::ios::binary};
         if (!file)
         {
             throw config_loading_error(
@@ -679,7 +682,8 @@ void set_config(const std::string& key, const std::string& value)
     picojson::value options;
 
     {
-        std::ifstream file{fs::path(u8"./config.json").native(), std::ios::binary};
+        std::ifstream file{fs::path(u8"./config.json").native(),
+                           std::ios::binary};
         if (!file)
         {
             throw config_loading_error{u8"Failed to open: "s
@@ -691,7 +695,8 @@ void set_config(const std::string& key, const std::string& value)
     options.get(key) = picojson::value{value};
 
     {
-        std::ofstream file{fs::path(u8"./config.json").native(), std::ios::binary};
+        std::ofstream file{fs::path(u8"./config.json").native(),
+                           std::ios::binary};
         if (!file)
         {
             throw config_loading_error{u8"Failed to open: "s
@@ -708,7 +713,8 @@ void set_config(const std::string& key, const std::string& value1, int value2)
     picojson::value options;
 
     {
-        std::ifstream file{fs::path(u8"./config.json").native(), std::ios::binary};
+        std::ifstream file{fs::path(u8"./config.json").native(),
+                           std::ios::binary};
         if (!file)
         {
             throw config_loading_error{u8"Failed to open: "s
@@ -721,7 +727,8 @@ void set_config(const std::string& key, const std::string& value1, int value2)
     (void)value2; // TODO
 
     {
-        std::ofstream file{fs::path(u8"./config.json").native(), std::ios::binary};
+        std::ofstream file{fs::path(u8"./config.json").native(),
+                           std::ios::binary};
         if (!file)
         {
             throw config_loading_error{u8"Failed to open: "s

--- a/ctrl_file.cpp
+++ b/ctrl_file.cpp
@@ -22,7 +22,7 @@ void load_v1(
     size_t begin,
     size_t end)
 {
-    std::ifstream in(filepath.native());
+    std::ifstream in{filepath.native(), std::ios::binary};
     putit::binary_iarchive ar(in);
     for (size_t i = begin; i < end; ++i)
     {
@@ -38,7 +38,7 @@ void save_v1(
     size_t begin,
     size_t end)
 {
-    std::ofstream out(filepath.native());
+    std::ofstream out{filepath.native(), std::ios::binary};
     putit::binary_oarchive ar(out);
     for (size_t i = begin; i < end; ++i)
     {
@@ -56,7 +56,7 @@ void load_v2(
     size_t j_begin,
     size_t j_end)
 {
-    std::ifstream in(filepath.native());
+    std::ifstream in{filepath.native(), std::ios::binary};
     putit::binary_iarchive ar{in};
     for (size_t j = j_begin; j < j_end; ++j)
     {
@@ -77,7 +77,7 @@ void save_v2(
     size_t j_begin,
     size_t j_end)
 {
-    std::ofstream out(filepath.native());
+    std::ofstream out{filepath.native(), std::ios::binary};
     putit::binary_oarchive ar{out};
     for (size_t j = j_begin; j < j_end; ++j)
     {
@@ -100,7 +100,7 @@ void load_v3(
     size_t k_begin,
     size_t k_end)
 {
-    std::ifstream in(filepath.native());
+    std::ifstream in{filepath.native(), std::ios::binary};
     putit::binary_iarchive ar{in};
     for (size_t k = k_begin; k < k_end; ++k)
     {
@@ -126,7 +126,7 @@ void save_v3(
     size_t k_begin,
     size_t k_end)
 {
-    std::ofstream out(filepath.native());
+    std::ofstream out{filepath.native(), std::ios::binary};
     putit::binary_oarchive ar{out};
     for (size_t k = k_begin; k < k_end; ++k)
     {
@@ -144,7 +144,7 @@ void save_v3(
 template <typename T>
 void load(const fs::path& filepath, T& data, size_t begin, size_t end)
 {
-    std::ifstream in(filepath.native());
+    std::ifstream in{filepath.native(), std::ios::binary};
     putit::binary_iarchive ar{in};
     for (size_t i = begin; i < end; ++i)
     {
@@ -156,7 +156,7 @@ void load(const fs::path& filepath, T& data, size_t begin, size_t end)
 template <typename T>
 void save(const fs::path& filepath, T& data, size_t begin, size_t end)
 {
-    std::ofstream out(filepath.native());
+    std::ofstream out{filepath.native(), std::ios::binary};
     putit::binary_oarchive ar{out};
     for (size_t i = begin; i < end; ++i)
     {
@@ -212,7 +212,7 @@ void fmode_8_7(bool read)
         {
             if (fs::exists(filepath))
             {
-                std::ifstream in{filepath};
+                std::ifstream in{filepath, std::ios::binary};
                 putit::binary_iarchive ar{in};
                 for (int cc = 0; cc < 57; ++cc)
                 {
@@ -225,7 +225,7 @@ void fmode_8_7(bool read)
         }
         else
         {
-            std::ofstream out{filepath};
+            std::ofstream out{filepath, std::ios::binary};
             putit::binary_oarchive ar{out};
             for (int cc = 0; cc < 57; ++cc)
             {
@@ -424,7 +424,7 @@ void fmode_8_7(bool read)
         const auto filepath = folder + u8"art.log"s;
         if (!read)
         {
-            std::ofstream out{filepath};
+            std::ofstream out{filepath, std::ios::binary};
             range::for_each(artifactlocation, [&](const auto& line) {
                 out << line << std::endl;
             });
@@ -443,13 +443,13 @@ void fmode_8_7(bool read)
         notesel(newsbuff);
         if (!read)
         {
-            std::ofstream out{filepath};
+            std::ofstream out{filepath, std::ios::binary};
             out << newsbuff(0) << std::endl;
         }
         if (read)
         {
             newsbuff(0).clear();
-            std::ifstream in{filepath};
+            std::ifstream in{filepath, std::ios::binary};
             std::string tmp;
             while (std::getline(in, tmp))
             {
@@ -532,7 +532,7 @@ void fmode_14_15(bool read)
         {
             if (fs::exists(filepath))
             {
-                std::ifstream in{filepath};
+                std::ifstream in{filepath, std::ios::binary};
                 putit::binary_iarchive ar{in};
                 for (int cc = 0; cc < 57; ++cc)
                 {
@@ -546,7 +546,7 @@ void fmode_14_15(bool read)
         else
         {
             fileadd(""s + filepath);
-            std::ofstream out{filepath};
+            std::ofstream out{filepath, std::ios::binary};
             putit::binary_oarchive ar{out};
             for (int cc = 0; cc < 57; ++cc)
             {
@@ -707,7 +707,7 @@ void fmode_2_1(bool read)
         const auto filepath = folder + u8"sdata_"s + mid + u8".s2"s;
         if (read)
         {
-            std::ifstream in{filepath};
+            std::ifstream in{filepath, std::ios::binary};
             putit::binary_iarchive ar{in};
             for (int cc = 57; cc < 245; ++cc)
             {
@@ -720,7 +720,7 @@ void fmode_2_1(bool read)
         else
         {
             fileadd(""s + filepath);
-            std::ofstream out{filepath};
+            std::ofstream out{filepath, std::ios::binary};
             putit::binary_oarchive ar{out};
             for (int cc = 57; cc < 245; ++cc)
             {
@@ -881,7 +881,7 @@ void fmode_22_21(bool read)
             const auto filepath = folder + u8"c2_"s + id + u8".t"s;
             if (read)
             {
-                std::ifstream in{filepath};
+                std::ifstream in{filepath, std::ios::binary};
                 putit::binary_iarchive ar{in};
                 for (int i = 0; i < 600; ++i)
                 {
@@ -890,7 +890,7 @@ void fmode_22_21(bool read)
             }
             else
             {
-                std::ofstream out{filepath};
+                std::ofstream out{filepath, std::ios::binary};
                 putit::binary_oarchive ar{out};
                 for (int i = 0; i < 600; ++i)
                 {
@@ -1132,7 +1132,7 @@ void fmode_18_17(bool read, const fs::path& file)
         const auto filepath = folder + u8"sdata_"s + mid + u8".s2"s;
         if (read)
         {
-            std::ifstream in{filepath};
+            std::ifstream in{filepath, std::ios::binary};
             putit::binary_iarchive ar{in};
             for (int cc = 57; cc < 245; ++cc)
             {
@@ -1145,7 +1145,7 @@ void fmode_18_17(bool read, const fs::path& file)
         else
         {
             fileadd(""s + filepath);
-            std::ofstream out{filepath};
+            std::ofstream out{filepath, std::ios::binary};
             putit::binary_oarchive ar{out};
             for (int cc = 57; cc < 245; ++cc)
             {

--- a/elonacore.cpp
+++ b/elonacore.cpp
@@ -8419,7 +8419,7 @@ void arrayfile_read(std::string_view fmode_str, const fs::path& filepath)
 
 void arrayfile_write(std::string_view fmode_str, const fs::path& filepath)
 {
-    std::ofstream out{filepath.native()};
+    std::ofstream out{filepath.native(), std::ios::binary};
     if (!out)
     {
         throw "TODO";
@@ -15868,7 +15868,7 @@ int net_dllist(const std::string& prm_886, int prm_887)
     notesel(netbuf);
     {
         netbuf(0).clear();
-        std::ifstream in{file_at_m147};
+        std::ifstream in{file_at_m147, std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {
@@ -15972,7 +15972,7 @@ void initialize_server_info()
     {
         {
             serverlist(0).clear();
-            std::ifstream in{fs::path(u8"./server.txt").native()};
+            std::ifstream in{fs::path(u8"./server.txt").native(), std::ios::binary};
             std::string tmp;
             while (std::getline(in, tmp))
             {
@@ -15986,7 +15986,7 @@ void initialize_server_info()
     cgiurl2 = strmid(netbuf, 0, p);
     cgiurl3 = strmid(netbuf, p + 1, instr(netbuf, p + 1, u8"%"s));
     {
-        std::ofstream out{fs::path(u8"./server.txt").native()};
+        std::ofstream out{fs::path(u8"./server.txt").native(), std::ios::binary};
         out << serverlist(0) << std::endl;
     }
     if (jp)
@@ -21658,7 +21658,7 @@ void initialize_set_of_random_generation()
     notesel(buff);
     {
         buff(0).clear();
-        std::ifstream in{fs::path(u8"./data/book.txt").native()};
+        std::ifstream in{fs::path(u8"./data/book.txt").native(), std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {
@@ -44281,7 +44281,7 @@ void label_2022()
     notesel(buff);
     {
         buff(0).clear();
-        std::ifstream in{fs::path(u8"./data/book.txt").native()};
+        std::ifstream in{fs::path(u8"./data/book.txt").native(), std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {
@@ -48724,7 +48724,7 @@ void label_2085()
     }
     s = fs::path(u8"./save/"s + playerid + u8".txt").generic_string();
     {
-        std::ofstream out{s};
+        std::ofstream out{s, std::ios::binary};
         out << s(0) << std::endl;
     }
     exec(s, 16);
@@ -49749,7 +49749,7 @@ void load_save_data()
     else
     {
         buff(0).clear();
-        std::ifstream in{folder + u8"filelist.txt"s};
+        std::ifstream in{folder + u8"filelist.txt"s, std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {
@@ -49857,7 +49857,7 @@ void save_game()
     notesel(buff);
     {
         std::ofstream out{
-            fs::path(u8"./save/"s + playerid + u8"/filelist.txt").native()};
+            fs::path(u8"./save/"s + playerid + u8"/filelist.txt").native(), std::ios::binary};
         out << buff(0) << std::endl;
     }
     return;
@@ -66416,7 +66416,7 @@ void do_play_scene()
     notesel(buff);
     {
         buff(0).clear();
-        std::ifstream in{lang(u8"scene1.hsp"s, u8"scene2.hsp"s)};
+        std::ifstream in{lang(u8"scene1.hsp"s, u8"scene2.hsp"s), std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {
@@ -66447,7 +66447,7 @@ label_2681:
     notesel(buff);
     {
         buff(0).clear();
-        std::ifstream in{lang(u8"scene1.hsp"s, u8"scene2.hsp"s)};
+        std::ifstream in{lang(u8"scene1.hsp"s, u8"scene2.hsp"s), std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {
@@ -68793,7 +68793,7 @@ void show_ex_help()
     notesel(buff);
     {
         buff(0).clear();
-        std::ifstream in{fs::path(u8"./data/exhelp.txt").native()};
+        std::ifstream in{fs::path(u8"./data/exhelp.txt").native(), std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {
@@ -68927,7 +68927,7 @@ void show_game_help()
         std::ifstream in{
             fs::path(
                 u8"./data/"s + lang(u8"manual_JP.txt"s, u8"manual_ENG.txt"s))
-                .native()};
+                .native(), std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {
@@ -69499,7 +69499,7 @@ void label_2719()
     notesel(note_buff);
     {
         note_buff.clear();
-        std::ifstream in{fs::path(u8"./user/export.txt").native()};
+        std::ifstream in{fs::path(u8"./user/export.txt").native(), std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {
@@ -69663,7 +69663,7 @@ void play_scene()
     notesel(buff);
     {
         buff(0).clear();
-        std::ifstream in{lang(u8"scene1.hsp"s, u8"scene2.hsp"s)};
+        std::ifstream in{lang(u8"scene1.hsp"s, u8"scene2.hsp"s), std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {
@@ -72462,7 +72462,7 @@ void pc_died()
     const auto bone_filepath = fs::path(u8"./save/bone.txt");
     if (fs::exists(bone_filepath))
     {
-        std::ifstream in{bone_filepath.native()};
+        std::ifstream in{bone_filepath.native(), std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {
@@ -72532,7 +72532,7 @@ void pc_died()
         noteadd(""s + cnvrank((cnt + 1)) + lang(u8"位"s, ""s), cnt * 4, 1);
     }
     {
-        std::ofstream out{bone_filepath.native()};
+        std::ofstream out{bone_filepath.native(), std::ios::binary};
         out << buff(0) << std::endl;
     }
     gsel(4);

--- a/elonacore.cpp
+++ b/elonacore.cpp
@@ -15972,7 +15972,8 @@ void initialize_server_info()
     {
         {
             serverlist(0).clear();
-            std::ifstream in{fs::path(u8"./server.txt").native(), std::ios::binary};
+            std::ifstream in{fs::path(u8"./server.txt").native(),
+                             std::ios::binary};
             std::string tmp;
             while (std::getline(in, tmp))
             {
@@ -15986,7 +15987,8 @@ void initialize_server_info()
     cgiurl2 = strmid(netbuf, 0, p);
     cgiurl3 = strmid(netbuf, p + 1, instr(netbuf, p + 1, u8"%"s));
     {
-        std::ofstream out{fs::path(u8"./server.txt").native(), std::ios::binary};
+        std::ofstream out{fs::path(u8"./server.txt").native(),
+                          std::ios::binary};
         out << serverlist(0) << std::endl;
     }
     if (jp)
@@ -21658,7 +21660,8 @@ void initialize_set_of_random_generation()
     notesel(buff);
     {
         buff(0).clear();
-        std::ifstream in{fs::path(u8"./data/book.txt").native(), std::ios::binary};
+        std::ifstream in{fs::path(u8"./data/book.txt").native(),
+                         std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {
@@ -44281,7 +44284,8 @@ void label_2022()
     notesel(buff);
     {
         buff(0).clear();
-        std::ifstream in{fs::path(u8"./data/book.txt").native(), std::ios::binary};
+        std::ifstream in{fs::path(u8"./data/book.txt").native(),
+                         std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {
@@ -49857,7 +49861,8 @@ void save_game()
     notesel(buff);
     {
         std::ofstream out{
-            fs::path(u8"./save/"s + playerid + u8"/filelist.txt").native(), std::ios::binary};
+            fs::path(u8"./save/"s + playerid + u8"/filelist.txt").native(),
+            std::ios::binary};
         out << buff(0) << std::endl;
     }
     return;
@@ -66416,7 +66421,8 @@ void do_play_scene()
     notesel(buff);
     {
         buff(0).clear();
-        std::ifstream in{lang(u8"scene1.hsp"s, u8"scene2.hsp"s), std::ios::binary};
+        std::ifstream in{lang(u8"scene1.hsp"s, u8"scene2.hsp"s),
+                         std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {
@@ -66447,7 +66453,8 @@ label_2681:
     notesel(buff);
     {
         buff(0).clear();
-        std::ifstream in{lang(u8"scene1.hsp"s, u8"scene2.hsp"s), std::ios::binary};
+        std::ifstream in{lang(u8"scene1.hsp"s, u8"scene2.hsp"s),
+                         std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {
@@ -68793,7 +68800,8 @@ void show_ex_help()
     notesel(buff);
     {
         buff(0).clear();
-        std::ifstream in{fs::path(u8"./data/exhelp.txt").native(), std::ios::binary};
+        std::ifstream in{fs::path(u8"./data/exhelp.txt").native(),
+                         std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {
@@ -68927,7 +68935,8 @@ void show_game_help()
         std::ifstream in{
             fs::path(
                 u8"./data/"s + lang(u8"manual_JP.txt"s, u8"manual_ENG.txt"s))
-                .native(), std::ios::binary};
+                .native(),
+            std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {
@@ -69499,7 +69508,8 @@ void label_2719()
     notesel(note_buff);
     {
         note_buff.clear();
-        std::ifstream in{fs::path(u8"./user/export.txt").native(), std::ios::binary};
+        std::ifstream in{fs::path(u8"./user/export.txt").native(),
+                         std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {
@@ -69663,7 +69673,8 @@ void play_scene()
     notesel(buff);
     {
         buff(0).clear();
-        std::ifstream in{lang(u8"scene1.hsp"s, u8"scene2.hsp"s), std::ios::binary};
+        std::ifstream in{lang(u8"scene1.hsp"s, u8"scene2.hsp"s),
+                         std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {

--- a/init.cpp
+++ b/init.cpp
@@ -360,7 +360,7 @@ void initialize_elona()
     notesel(buffboard);
     {
         buffboard(0).clear();
-        std::ifstream in{fs::path(u8"./data/board.txt").native()};
+        std::ifstream in{fs::path(u8"./data/board.txt").native(), std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {

--- a/init.cpp
+++ b/init.cpp
@@ -360,7 +360,8 @@ void initialize_elona()
     notesel(buffboard);
     {
         buffboard(0).clear();
-        std::ifstream in{fs::path(u8"./data/board.txt").native(), std::ios::binary};
+        std::ifstream in{fs::path(u8"./data/board.txt").native(),
+                         std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {

--- a/text.cpp
+++ b/text.cpp
@@ -1450,7 +1450,8 @@ void parse_talk_file()
     if (noteinfo() <= 1)
     {
         buff(0).clear();
-        std::ifstream in{fs::path(u8"./data/talk.txt").native(), std::ios::binary};
+        std::ifstream in{fs::path(u8"./data/talk.txt").native(),
+                         std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {
@@ -1475,7 +1476,8 @@ void read_talk_file(const std::string& valn)
     notesel(buff);
     {
         buff(0).clear();
-        std::ifstream in{fs::path(u8"./data/talk.txt").native(), std::ios::binary};
+        std::ifstream in{fs::path(u8"./data/talk.txt").native(),
+                         std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {
@@ -1495,7 +1497,8 @@ void get_npc_talk()
     notesel(buff);
     {
         buff(0).clear();
-        std::ifstream in{fs::path(u8"./data/talk.txt").native(), std::ios::binary};
+        std::ifstream in{fs::path(u8"./data/talk.txt").native(),
+                         std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {

--- a/text.cpp
+++ b/text.cpp
@@ -1450,7 +1450,7 @@ void parse_talk_file()
     if (noteinfo() <= 1)
     {
         buff(0).clear();
-        std::ifstream in{fs::path(u8"./data/talk.txt").native()};
+        std::ifstream in{fs::path(u8"./data/talk.txt").native(), std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {
@@ -1475,7 +1475,7 @@ void read_talk_file(const std::string& valn)
     notesel(buff);
     {
         buff(0).clear();
-        std::ifstream in{fs::path(u8"./data/talk.txt").native()};
+        std::ifstream in{fs::path(u8"./data/talk.txt").native(), std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {
@@ -1495,7 +1495,7 @@ void get_npc_talk()
     notesel(buff);
     {
         buff(0).clear();
-        std::ifstream in{fs::path(u8"./data/talk.txt").native()};
+        std::ifstream in{fs::path(u8"./data/talk.txt").native(), std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {


### PR DESCRIPTION
# Related Issues

Close #105.


# Summary

Added `std::ios::binary` flags. To make save data compatible on each platform, this flags are added to not only binary files but text files. Thus, if you create an adventurer on WIndows and then move the data to macOS, it can be load well.