### PR TITLE
Fix Foobar quiting when rolling attributes

### DIFF
--- a/init.cpp
+++ b/init.cpp
@@ -1492,7 +1492,7 @@ void character_making_role_attributes(bool label_1554_flg)
             {
                 snd(103);
                 init = true;
-                break;
+                continue;
             }
             if (p == 1)
             {
@@ -1516,7 +1516,7 @@ void character_making_role_attributes(bool label_1554_flg)
             minimum = true;
             snd(103);
             init = true;
-            break;
+            continue;
         }
         if (key == key_cancel)
         {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #116.


# Summary

`break` is used where to need `continue`.