### PR TITLE
Feature/fix flavor text width

### DIFF
--- a/elonacore.cpp
+++ b/elonacore.cpp
@@ -46951,70 +46951,6 @@ void savecycle()
 
 
 
-std::string trimdesc(const std::string& prm_1060, int prm_1061)
-{
-    std::string q_at_m187;
-    int p_at_m187 = 0;
-    q_at_m187 = prm_1060;
-    while (1)
-    {
-        await();
-        p_at_m187 = instr(q_at_m187, 0, u8"\t"s);
-        if (p_at_m187 != -1)
-        {
-            q_at_m187 = strmid(q_at_m187, 0, p_at_m187)
-                + strmid(q_at_m187, (p_at_m187 + 1), 999);
-            continue;
-        }
-        if (prm_1061 == 1)
-        {
-            p_at_m187 = instr(q_at_m187, 0, u8"\n"s);
-            if (p_at_m187 != -1)
-            {
-                q_at_m187 = strmid(q_at_m187, 0, p_at_m187)
-                    + strmid(q_at_m187, (p_at_m187 + 1), 999);
-                continue;
-            }
-            p_at_m187 = instr(q_at_m187, 0, u8"#"s);
-            if (p_at_m187 != -1)
-            {
-                q_at_m187 = strmid(q_at_m187, 0, p_at_m187);
-            }
-            if (jp)
-            {
-                if (strmid(q_at_m187, q_at_m187.size() - 3, 2) == u8"。"s)
-                {
-                    q_at_m187 = strmid(q_at_m187, 0, q_at_m187.size() - 3);
-                }
-            }
-            else
-            {
-                p_at_m187 = instr(q_at_m187, 0, u8","s);
-                if (p_at_m187 != -1)
-                {
-                    q_at_m187 = strmid(q_at_m187, 0, p_at_m187) + u8"."s
-                        + strmid(q_at_m187, (p_at_m187 + 1), 999);
-                    continue;
-                }
-            }
-        }
-        if (prm_1061 == 2)
-        {
-            p_at_m187 = instr(q_at_m187, 0, u8"#"s);
-            if (p_at_m187 != -1)
-            {
-                q_at_m187 = strmid(q_at_m187, 0, p_at_m187)
-                    + strmid(q_at_m187, (p_at_m187 + 1), 999);
-                continue;
-            }
-        }
-        break;
-    }
-    return q_at_m187;
-}
-
-
-
 void show_item_description()
 {
     int inhmax = 0;
@@ -47039,7 +46975,7 @@ void show_item_description()
     if (inv[ci].identification_state
         == identification_state_t::completely_identified)
     {
-        std::string buf = trimdesc(description(3), 1);
+        std::string buf = trimdesc(description(3), true);
         if (buf != ""s)
         {
             list(0, p) = 7;
@@ -47245,7 +47181,7 @@ void show_item_description()
                 list(0, p) = 0;
                 listn(0, p) = "";
                 ++p;
-                std::string buf = trimdesc(description(cnt), 2);
+                std::string buf = trimdesc(description(cnt), false);
                 notesel(buf);
                 for (int cnt = 0, cnt_end = (noteinfo()); cnt < cnt_end; ++cnt)
                 {

--- a/elonacore.cpp
+++ b/elonacore.cpp
@@ -47187,26 +47187,31 @@ void show_item_description()
                 for (int cnt = 0, cnt_end = (noteinfo()); cnt < cnt_end; ++cnt)
                 {
                     noteget(q, cnt);
-                    p(1) = 66;
-                    p(2) = 0;
-                    if (strlen_u(q) > size_t(p(1)))
+                    constexpr size_t max_width = 66;
+                    if (strlen_u(q) > max_width)
                     {
-                        for (int cnt = 0,
-                                 cnt_end = cnt + (q(0).size() / p(1) + 1);
-                             cnt < cnt_end;
-                             ++cnt)
+                        p(2) = 0;
+                        for (size_t i = 0; i < strlen_u(q) / max_width + 1; ++i)
                         {
-                            if (strmid(q, p(2) + p(1), 2) == u8"。"s
-                                || strmid(q, p(2) + p(1), 2) == u8"、"s)
+                            auto one_line = strutil::take_by_width(
+                                q(0).substr(p(2)), max_width);
+                            p(1) = one_line.size();
+                            if (strutil::starts_with(q, u8"。", p(1) + p(2)))
                             {
-                                p(1) += 2;
+                                one_line += u8"。";
+                                p(1) += std::strlen(u8"。");
+                            }
+                            if (strutil::starts_with(q, u8"、", p(1) + p(2)))
+                            {
+                                one_line += u8"、";
+                                p(1) += std::strlen(u8"、");
                             }
                             if (strmid(q, p(2), p(1)) == ""s)
                             {
                                 break;
                             }
                             list(0, p) = -1;
-                            listn(0, p) = strmid(q, p(2), p(1));
+                            listn(0, p) = one_line;
                             ++p;
                             p(2) += p(1);
                         }

--- a/elonacore.cpp
+++ b/elonacore.cpp
@@ -46975,7 +46975,7 @@ void show_item_description()
     if (inv[ci].identification_state
         == identification_state_t::completely_identified)
     {
-        std::string buf = trimdesc(description(3), true);
+        std::string buf = trim_item_description(description(3), true);
         if (buf != ""s)
         {
             list(0, p) = 7;
@@ -47181,7 +47181,8 @@ void show_item_description()
                 list(0, p) = 0;
                 listn(0, p) = "";
                 ++p;
-                std::string buf = trimdesc(description(cnt), false);
+                std::string buf =
+                    trim_item_description(description(cnt), false);
                 notesel(buf);
                 for (int cnt = 0, cnt_end = (noteinfo()); cnt < cnt_end; ++cnt)
                 {

--- a/std.cpp
+++ b/std.cpp
@@ -10,32 +10,12 @@
 #include "snail/application.hpp"
 
 #include "elona.hpp"
+#include "util.hpp"
 #include "variables.hpp"
 
 
 namespace
 {
-
-
-
-// UTF-8
-size_t byte_count(uint8_t c)
-{
-    if (c <= 0x7F)
-        return 1;
-    else if (c >= 0xc2 && c <= 0xdf)
-        return 2;
-    else if (c >= 0xe0 && c <= 0xef)
-        return 3;
-    else if (c >= 0xf0 && c <= 0xf7)
-        return 4;
-    else if (c >= 0xf8 && c <= 0xfb)
-        return 5;
-    else if (c >= 0xfc && c <= 0xfd)
-        return 6;
-    else
-        return 1;
-}
 
 
 
@@ -1384,7 +1364,7 @@ size_t strlen_u(const std::string& str)
     int ret = 0;
     for (size_t i = 0; i < str.size();)
     {
-        const auto byte = byte_count(static_cast<uint8_t>(str[i]));
+        const auto byte = strutil::byte_count(str[i]);
         ret += byte == 1 ? 1 : 2;
         i += byte;
     }
@@ -2058,7 +2038,7 @@ int talk_conv_jp(std::string& text, int max_line_length)
         size_t line_length = 0;
         while (line_length <= len)
         {
-            line_length += byte_count(static_cast<uint8_t>(rest[line_length]));
+            line_length += strutil::byte_count(rest[line_length]);
             if (int(line_length) > max_line_length)
             {
                 // m = strmid(rest, line_length, 2);

--- a/text.cpp
+++ b/text.cpp
@@ -3524,7 +3524,7 @@ void get_enchantment_description(int val0, int power, int category, bool trait)
 
 
 
-std::string trimdesc(const std::string& source, bool summary)
+std::string trim_item_description(const std::string& source, bool summary)
 {
     std::string ret{source};
 

--- a/text.cpp
+++ b/text.cpp
@@ -3524,4 +3524,73 @@ void get_enchantment_description(int val0, int power, int category, bool trait)
 
 
 
+std::string trimdesc(const std::string& source, bool summary)
+{
+    std::string ret{source};
+
+    while (1)
+    {
+        // Delete tab character.
+        const auto tab_pos = ret.find('\t');
+        if (tab_pos != std::string::npos)
+        {
+            ret.erase(tab_pos, 1);
+            continue;
+        }
+
+        if (summary)
+        {
+            // Delete line break.
+            const auto line_break_pos = ret.find('\n');
+            if (line_break_pos != std::string::npos)
+            {
+                ret.erase(line_break_pos, 1);
+                continue;
+            }
+            // Delete number sign and rest.
+            const auto number_sign_pos = ret.find('#');
+            if (number_sign_pos != std::string::npos)
+            {
+                ret.erase(number_sign_pos);
+            }
+            if (jp)
+            {
+                // If "ret" ends with period, delete it.
+                constexpr const char* japanese_period = u8"。";
+                const auto period_pos = ret.find(japanese_period);
+                if (period_pos != std::string::npos
+                    && period_pos + std::strlen(japanese_period) == ret.size())
+                {
+                    ret.erase(period_pos);
+                }
+            }
+            else
+            {
+                // Replace comma with period.
+                const auto comma_pos = ret.find(',');
+                if (comma_pos != std::string::npos)
+                {
+                    ret[comma_pos] = '.';
+                    continue;
+                }
+            }
+        }
+        else
+        {
+            // Delete number sign.
+            const auto number_sign_pos = ret.find('#');
+            if (number_sign_pos != std::string::npos)
+            {
+                ret.erase(number_sign_pos, 1);
+                continue;
+            }
+        }
+        break;
+    }
+
+    return ret;
+}
+
+
+
 } // namespace elona

--- a/util.hpp
+++ b/util.hpp
@@ -83,6 +83,52 @@ inline std::string remove_str(
 
 
 
+inline size_t byte_count(uint8_t c)
+{
+    if (c <= 0x7F)
+        return 1;
+    else if (c >= 0xc2 && c <= 0xdf)
+        return 2;
+    else if (c >= 0xe0 && c <= 0xef)
+        return 3;
+    else if (c >= 0xf0 && c <= 0xf7)
+        return 4;
+    else if (c >= 0xf8 && c <= 0xfb)
+        return 5;
+    else if (c >= 0xfc && c <= 0xfd)
+        return 6;
+    else
+        return 1;
+}
+
+
+
+inline size_t byte_count(char c)
+{
+    return byte_count(static_cast<uint8_t>(c));
+}
+
+
+
+inline std::string take_by_width(const std::string& str, size_t width)
+{
+    size_t w{};
+    for (size_t i = 0; i < str.size();)
+    {
+        const auto byte = byte_count(str[i]);
+        const auto char_width = byte == 1 ? 1 : 2;
+        if (w + char_width > width)
+        {
+            return str.substr(0, i);
+        }
+        i += byte;
+        w += char_width;
+    }
+    return str;
+}
+
+
+
 } // namespace strutil
 
 

--- a/variables.hpp
+++ b/variables.hpp
@@ -851,7 +851,7 @@ std::string rpmatname(int = 0);
 std::string rpname(int = 0);
 std::string rpsuccessrate(int = 0);
 std::string sncnv(const std::string&);
-std::string trimdesc(const std::string&, bool);
+std::string trim_item_description(const std::string&, bool);
 std::string txtbuilding(int = 0, int = 0);
 std::string txtitemoncell(int = 0, int = 0);
 std::string txtskillchange(int, int, bool);

--- a/variables.hpp
+++ b/variables.hpp
@@ -851,7 +851,7 @@ std::string rpmatname(int = 0);
 std::string rpname(int = 0);
 std::string rpsuccessrate(int = 0);
 std::string sncnv(const std::string&);
-std::string trimdesc(const std::string&, int = 0);
+std::string trimdesc(const std::string&, bool);
 std::string txtbuilding(int = 0, int = 0);
 std::string txtitemoncell(int = 0, int = 0);
 std::string txtskillchange(int, int, bool);


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #139.

# Cause

Vanilla Elona assumes that all strings are encoded by cp932(legacy Japanese encoding on Windows). However, Foobar uses UTF8-encoded strings. Some parts of source code have not been fixed yet.


# Screenshots

## Before

![before](https://user-images.githubusercontent.com/36858341/38966043-20efbea2-43bb-11e8-876c-2a0fc8bc2665.png)

## After

![after](https://user-images.githubusercontent.com/36858341/38966048-2b1b706a-43bb-11e8-840c-94058c5a2735.png)
