### PR TITLE
Show pets' HP bar like omake

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ See CONTRIBUTING.md for details.
   "heartbeat": 1,
   "hide_autoIdentify": 0,
   "hide_shopResult": 0,
+  "hpBar": 0,
   "ignoreDislike": 1,
   "infVerType": 1,
   "joypad": 0,

--- a/config.cpp
+++ b/config.cpp
@@ -202,6 +202,9 @@ void load_config()
             u8"extraHelp",
             [&](auto value) { cfg_extrahelp = value; }),
         std::make_unique<config_integer>(
+            u8"hpBar",
+            [&](auto value) { cfg_hp_bar = value; }),
+        std::make_unique<config_integer>(
             u8"alwaysCenter",
             [&](auto value) { cfg_alwayscenter = value; }),
         std::make_unique<config_integer>(

--- a/draw.cpp
+++ b/draw.cpp
@@ -1,4 +1,5 @@
 #include "draw.hpp"
+#include "character.hpp"
 #include "elona.hpp"
 #include "variables.hpp"
 
@@ -108,6 +109,43 @@ void prepare_item_image(int id, int color, int character_image)
         set_color_mod(255, 255, 255);
         gmode(2);
         gsel(0);
+    }
+}
+
+
+
+void show_hp_bar(show_hp_bar_side side, int inf_clocky)
+{
+    const bool right = side == show_hp_bar_side::right_side;
+
+    int cnt{};
+    for (int i = 1; i < 16; ++i)
+    {
+        auto& cc = cdata[i];
+        if ((cc.state == 1 || cc.state == 6) && cbit(966, i))
+        {
+            const auto name = cdatan(0, i);
+            const int x = 16 + (windoww - strlen_u(name) * 7 - 16) * right;
+            const int y = inf_clocky + 200 - 180 * right + cnt * 32;
+            // std::cout << "HP bar(" << i << "):name: " << position_t{x, y} <<
+            // std::endl;
+            pos(x, y);
+            color(0, 0, 0);
+            const auto color = cc.state == 1 ? snail::color{255, 255, 255}
+                                             : snail::color{255, 35, 35};
+            bmes(name, color.r, color.g, color.b);
+            if (cc.state == 1)
+            {
+                const int width = clamp(cc.hp * 30 / cc.max_hp, 1, 30);
+                const int x_ = 16 + (windoww - 108) * right;
+                const int y_ = y + 17;
+                // std::cout << "HP bar(" << i << "):bar:  " << position_t{x_,
+                // y_} << std::endl;
+                pos(x_, y_);
+                gzoom(3, 480 - width, 517, width, 3, width * 3, 9);
+            }
+            ++cnt;
+        }
     }
 }
 

--- a/draw.hpp
+++ b/draw.hpp
@@ -9,4 +9,12 @@ void prepare_item_image(int id, int color);
 void prepare_item_image(int id, int color, int character_image);
 
 void set_color_mod(int r, int g, int b, int window_id = -1);
+
+enum class show_hp_bar_side
+{
+    left_side,
+    right_side,
+};
+
+void show_hp_bar(show_hp_bar_side side, int inf_clocky);
 } // namespace elona

--- a/elonacore.cpp
+++ b/elonacore.cpp
@@ -16718,7 +16718,13 @@ void render_hud()
             255);
         ++ap3;
     }
-    return;
+    if (cfg_hp_bar)
+    {
+        show_hp_bar(
+            cfg_hp_bar == 1 ? show_hp_bar_side::left_side
+                            : show_hp_bar_side::right_side,
+            inf_clocky);
+    }
 }
 
 

--- a/position.hpp
+++ b/position.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <iostream>
+
 
 
 namespace elona
@@ -30,6 +32,13 @@ inline bool operator==(const position_t& lhs, const position_t& rhs)
 inline bool operator!=(const position_t& lhs, const position_t& rhs)
 {
     return !(lhs == rhs);
+}
+
+
+inline std::ostream& operator<<(std::ostream& out, const position_t& pos)
+{
+    out << '(' << pos.x << ", " << pos.y << ')';
+    return out;
 }
 
 

--- a/set_option.cpp
+++ b/set_option.cpp
@@ -162,7 +162,7 @@ std::vector<config_menu> create_config_menu()
     ret.back().items.emplace_back(std::make_unique<config_menu_item_choice>( \
         name, var, std::vector<std::string>{__VA_ARGS__}))
 
-    ret.emplace_back(lang(u8"オプション", u8"Option"), 370, 270);
+    ret.emplace_back(lang(u8"オプション", u8"Option"), 370, 285);
     ELONA_CONFIG_ITEM(lang(u8"ゲームの設定", u8"Game Setting"));
     ELONA_CONFIG_ITEM(lang(u8"画面と音の設定", u8"Screen & Sound"));
     ELONA_CONFIG_ITEM(lang(u8"ネット機能の設定", u8"Network Setting"));
@@ -170,6 +170,7 @@ std::vector<config_menu> create_config_menu()
     ELONA_CONFIG_ITEM(lang(u8"ゲームパッド", u8"Game Pad"));
     ELONA_CONFIG_ITEM(lang(u8"メッセージとログ", u8"Message & Log"));
     ELONA_CONFIG_ITEM(lang(u8"言語(Language)", u8"Language"));
+    ELONA_CONFIG_ITEM(lang(u8"拡張設定(Foobar)", u8"Ex setting(Foobar)"));
 
     ret.emplace_back(lang(u8"ゲームの設定", u8"Game Setting"), 440, 340);
     ELONA_CONFIG_ITEM_YESNO(
@@ -318,10 +319,20 @@ std::vector<config_menu> create_config_menu()
         u8"Japanese",
         u8"English");
 
+    ret.emplace_back(
+        lang(u8"拡張設定(Foobar)", u8"Ex setting(Foobar)"), 440, 300);
+    ELONA_CONFIG_ITEM_CHOICE(
+        lang(u8"ペットのHPバー", u8"Pets' HP bar"),
+        cfg_hp_bar,
+        lang(u8"表示しない", u8"Don't show"),
+        lang(u8"左側に表示", u8"Show left side"),
+        lang(u8"右側に表示", u8"Show right side"));
+
 #undef ELONA_CONFIG_ITEM
 #undef ELONA_CONFIG_ITEM_YESNO
 #undef ELONA_CONFIG_ITEM_INFO
 #undef ELONA_CONFIG_ITEM_INTEGER
+#undef ELONA_CONFIG_ITEM_CHOICE
 
     return ret;
 }
@@ -1321,6 +1332,25 @@ void set_option()
                     }
                     snd(20);
                     set_config(u8"language", cfg_language);
+                    reset_page = true;
+                    continue;
+                }
+            }
+            if (submenu == 8)
+            {
+                if (cs == 0)
+                {
+                    cfg_hp_bar += p;
+                    if (cfg_hp_bar > 2)
+                    {
+                        cfg_hp_bar = 2;
+                    }
+                    else if (cfg_hp_bar < 0)
+                    {
+                        cfg_hp_bar = 0;
+                    }
+                    snd(20);
+                    set_config(u8"hpBar", cfg_hp_bar);
                     reset_page = true;
                     continue;
                 }

--- a/variables.hpp
+++ b/variables.hpp
@@ -277,6 +277,7 @@ ELONA_EXTERN(int cfg_fullscreen);
 ELONA_EXTERN(int cfg_heart);
 ELONA_EXTERN(int cfg_hideautoidentify);
 ELONA_EXTERN(int cfg_hideshopresult);
+ELONA_EXTERN(int cfg_hp_bar);
 ELONA_EXTERN(int cfg_ignoredislike);
 ELONA_EXTERN(int cfg_joypad);
 ELONA_EXTERN(int cfg_language);


### PR DESCRIPTION
# Related Issues

Close #89.


# Summary

Add one new option "hpBar" in `config.json`. The meaning of value is compatible with omake, i.e.,
0: Don't show
1: Show left side
2: Show right side
