### PR TITLE
Disable voldemort mode by default

### DIFF
--- a/debug.cpp
+++ b/debug.cpp
@@ -5,6 +5,6 @@ namespace elona
 {
 namespace debug
 {
-bool voldemort = true;
+bool voldemort = false;
 } // namespace debug
 } // namespace elona

--- a/elonacore.cpp
+++ b/elonacore.cpp
@@ -70944,6 +70944,7 @@ label_2747:
     }
     if (getkey(snail::key::f12))
     {
+        debug::voldemort = true;
         if (debug::voldemort)
         {
             gdata_wizard = 1;


### PR DESCRIPTION
# Related Issues

Close #161.


# Summary

You can manually enter voldemort mode by hitting F12.