### PR TITLE
Add std namespace to nullptr_t

### DIFF
--- a/calc.cpp
+++ b/calc.cpp
@@ -76,7 +76,8 @@ void apply_buff(int cc, int id, int power)
 {
     const auto self = the_buff_db[id]->self;
     const auto func = the_buff_db[id]->on_refresh;
-    cat::global.call_with_self<nullptr_t>(self, func, cc, power, 1 /* TODO */);
+    cat::global.call_with_self<std::nullptr_t>(
+        self, func, cc, power, 1 /* TODO */);
 }
 
 

--- a/cat.hpp
+++ b/cat.hpp
@@ -102,7 +102,7 @@ private:
     }
 
 
-    void push(nullptr_t)
+    void push(std::nullptr_t)
     {
         lua_pushnil(ptr());
     }
@@ -111,8 +111,9 @@ private:
 
     template <
         typename T,
-        std::enable_if_t<std::is_same<T, nullptr_t>::value, nullptr_t> =
-            nullptr>
+        std::enable_if_t<
+            std::is_same<T, std::nullptr_t>::value,
+            std::nullptr_t> = nullptr>
     T to_cpp_type(int index)
     {
         (void)index;
@@ -122,7 +123,8 @@ private:
 #define ELONA_DEFINE_TO_CPP_TYPE(type, function) \
     template < \
         typename T, \
-        std::enable_if_t<std::is_same<T, type>::value, nullptr_t> = nullptr> \
+        std::enable_if_t<std::is_same<T, type>::value, std::nullptr_t> = \
+            nullptr> \
     T to_cpp_type(int index) \
     { \
         return function(ptr(), index); \

--- a/elona.hpp
+++ b/elona.hpp
@@ -86,7 +86,7 @@ struct elona_vector1
         typename U,
         std::enable_if_t<
             std::is_same<T, std::string>::value && std::is_same<U, int>::value,
-            nullptr_t> = nullptr>
+            std::nullptr_t> = nullptr>
     T& operator+=(const U& x)
     {
         return storage.at(0) += std::to_string(x);
@@ -98,7 +98,7 @@ struct elona_vector1
         std::enable_if_t<
             !std::is_same<T, std::string>::value
                 || !std::is_same<U, int>::value,
-            nullptr_t> = nullptr>
+            std::nullptr_t> = nullptr>
     T& operator+=(const U& x)
     {
         return storage.at(0) += x;

--- a/putit.hpp
+++ b/putit.hpp
@@ -47,7 +47,8 @@ public:
 
     template <
         typename T,
-        std::enable_if_t<sizeof(T) <= sizeof(long long), nullptr_t> = nullptr>
+        std::enable_if_t<sizeof(T) <= sizeof(long long), std::nullptr_t> =
+            nullptr>
     void primitive(T& data)
     {
         char* buf;
@@ -60,7 +61,8 @@ public:
 
     template <
         typename T,
-        std::enable_if_t<(sizeof(T) > sizeof(long long)), nullptr_t> = nullptr>
+        std::enable_if_t<(sizeof(T) > sizeof(long long)), std::nullptr_t> =
+            nullptr>
     void primitive(T& data)
     {
         char* buf;
@@ -142,7 +144,7 @@ private:
 template <
     typename Archive,
     typename T,
-    std::enable_if_t<!std::is_enum<T>::value, nullptr_t> = nullptr>
+    std::enable_if_t<!std::is_enum<T>::value, std::nullptr_t> = nullptr>
 void serialize(Archive& ar, T& data)
 {
     data.serialize(ar);
@@ -177,10 +179,10 @@ PRIMITIVE_TYPES(long double)
 template <
     typename Archive,
     typename E,
-    std::enable_if_t<std::is_enum<E>::value, nullptr_t> = nullptr,
+    std::enable_if_t<std::is_enum<E>::value, std::nullptr_t> = nullptr,
     std::enable_if_t<
         std::is_base_of<iarchive_base, Archive>::value,
-        nullptr_t> = nullptr>
+        std::nullptr_t> = nullptr>
 void serialize(Archive& ar, E& data)
 {
     using primitive_type = std::underlying_type_t<E>;
@@ -195,10 +197,10 @@ void serialize(Archive& ar, E& data)
 template <
     typename Archive,
     typename E,
-    std::enable_if_t<std::is_enum<E>::value, nullptr_t> = nullptr,
+    std::enable_if_t<std::is_enum<E>::value, std::nullptr_t> = nullptr,
     std::enable_if_t<
         std::is_base_of<oarchive_base, Archive>::value,
-        nullptr_t> = nullptr>
+        std::nullptr_t> = nullptr>
 void serialize(Archive& ar, E& data)
 {
     using primitive_type = std::underlying_type_t<E>;
@@ -213,7 +215,7 @@ template <
     typename Archive,
     std::enable_if_t<
         std::is_base_of<iarchive_base, Archive>::value,
-        nullptr_t> = nullptr>
+        std::nullptr_t> = nullptr>
 void serialize(Archive& ar, std::string& data)
 {
     std::string::size_type length;
@@ -229,7 +231,7 @@ template <
     typename Archive,
     std::enable_if_t<
         std::is_base_of<oarchive_base, Archive>::value,
-        nullptr_t> = nullptr>
+        std::nullptr_t> = nullptr>
 void serialize(Archive& ar, std::string& data)
 {
     const auto length = data.size();
@@ -244,7 +246,7 @@ template <
     typename T,
     std::enable_if_t<
         std::is_base_of<iarchive_base, Archive>::value,
-        nullptr_t> = nullptr>
+        std::nullptr_t> = nullptr>
 void serialize(Archive& ar, std::vector<T>& data)
 {
     typename std::vector<T>::size_type length;
@@ -261,7 +263,7 @@ template <
     typename T,
     std::enable_if_t<
         std::is_base_of<oarchive_base, Archive>::value,
-        nullptr_t> = nullptr>
+        std::nullptr_t> = nullptr>
 void serialize(Archive& ar, std::vector<T>& data)
 {
     const auto length = data.size();


### PR DESCRIPTION
# Related Issues

Close #163.


# Summary

Some compilers do not define `nullptr_t` in global namespace, so replace them with `std::nullptr_t`.