### PR TITLE
Feature/glitch of log window in japanese

### DIFF
--- a/message.cpp
+++ b/message.cpp
@@ -7,12 +7,57 @@
 
 namespace elona
 {
-
-
 int msglen = 0;
 int tcontinue_at_txtfunc = 0;
 int tcolfix_at_txtfunc = 0;
 int p_at_txtfunc = 0;
+} // namespace elona
+
+
+namespace
+{
+
+
+void msg_write(std::string& message)
+{
+    constexpr const auto musical_note = u8"♪";
+
+    const auto msglen_ = jp ? msglen / 1.5 : msglen;
+    for (auto pos = message.find(musical_note); pos != std::string::npos;
+         pos = message.find(musical_note))
+    {
+        const auto symbol_type =
+            elona::stoi(message.substr(pos + std::strlen(musical_note), 1));
+        if (jp && symbol_type == 0)
+        {
+            break;
+        }
+        message = message.substr(0, pos) + u8"  "
+            + message.substr(
+                  pos + std::strlen(musical_note) + (symbol_type != 0));
+        elona::pos(
+            (msglen_ + pos) * inf_mesfont / 2 + inf_msgx + 7 + en * 3,
+            (inf_msgline - 1) * inf_msgspace + inf_msgy + 5);
+        gmode(2);
+        gcopy(3, 600 + symbol_type * 24, 360, 16, 16);
+    }
+
+    elona::color(tcol_at_txtfunc(0), tcol_at_txtfunc(1), tcol_at_txtfunc(2));
+    elona::pos(
+        msglen_ * inf_mesfont / 2 + inf_msgx + 6,
+        (inf_msgline - 1) * inf_msgspace + inf_msgy + 6);
+    font(lang(cfg_font1, cfg_font2), inf_mesfont - en * 2, 0);
+    mes(message);
+    elona::color(0, 0, 0);
+}
+
+
+} // namespace
+
+
+
+namespace elona
+{
 
 
 void key_check(int prm_299)
@@ -560,49 +605,6 @@ void bmes(const std::string& str, int r, int g, int b)
     pos(x, y);
     mes(str);
     color(0, 0, 0);
-}
-
-
-
-void msg_write(std::string& prm_307)
-{
-    int msglen_ = jp ? msglen / 1.5 : msglen;
-    int mp_at_txtfunc = 0;
-    int mark_at_txtfunc = 0;
-    for (int cnt = 0; cnt < 1; ++cnt)
-    {
-        mp_at_txtfunc = instr(prm_307, 0, u8"♪"s);
-        if (mp_at_txtfunc != -1)
-        {
-            mark_at_txtfunc =
-                elona::stoi(strmid(prm_307, mp_at_txtfunc + 2, 1));
-            if (jp)
-            {
-                if (mark_at_txtfunc == 0)
-                {
-                    break;
-                }
-            }
-            prm_307 = strmid(prm_307, 0, mp_at_txtfunc) + u8"  "s
-                + strmid(prm_307,
-                         (mp_at_txtfunc + 2 + (mark_at_txtfunc != 0)),
-                         9999);
-            pos((msglen_ + mp_at_txtfunc) * inf_mesfont / 2 + inf_msgx + 7
-                    + en * 3,
-                (inf_msgline - 1) * inf_msgspace + inf_msgy + 5);
-            gmode(2);
-            gcopy(3, 600 + mark_at_txtfunc * 24, 360, 16, 16);
-            --cnt;
-            continue;
-        }
-    }
-    color(tcol_at_txtfunc(0), tcol_at_txtfunc(1), tcol_at_txtfunc(2));
-    pos(msglen_ * inf_mesfont / 2 + inf_msgx + 6,
-        (inf_msgline - 1) * inf_msgspace + inf_msgy + 6);
-    font(lang(cfg_font1, cfg_font2), inf_mesfont - en * 2, 0);
-    mes(prm_307);
-    color(0, 0, 0);
-    return;
 }
 
 

--- a/message.cpp
+++ b/message.cpp
@@ -52,6 +52,22 @@ void msg_write(std::string& message)
 }
 
 
+
+void clear_log_panel()
+{
+    gsel(8);
+    gmode(0);
+    pos(0, msgline % inf_maxlog * inf_msgspace);
+    gcopy(
+        0,
+        inf_msgx,
+        inf_msgy + 5 + inf_msgspace * 3 + en * 3,
+        windoww - inf_msgx,
+        inf_msgspace);
+    gsel(0);
+}
+
+
 } // namespace
 
 
@@ -694,26 +710,10 @@ void txtef(int prm_308)
 
 
 
-void msg_newlog()
-{
-    gsel(8);
-    gmode(0);
-    pos(0, msgline % inf_maxlog * inf_msgspace);
-    gcopy(
-        0,
-        inf_msgx,
-        inf_msgy + 5 + inf_msgspace * 3 + en * 3,
-        windoww - inf_msgx,
-        inf_msgspace);
-    gsel(0);
-    return;
-}
-
-
-
 void msg_newline()
 {
-    msg_newlog();
+    clear_log_panel();
+
     msglen = 0;
     ++msgline;
     if (msgline >= inf_maxlog)

--- a/message.cpp
+++ b/message.cpp
@@ -7,7 +7,7 @@
 
 namespace elona
 {
-int msglen = 0;
+size_t message_width{};
 int tcontinue_at_txtfunc = 0;
 int tcolfix_at_txtfunc = 0;
 int p_at_txtfunc = 0;
@@ -22,7 +22,6 @@ void msg_write(std::string& message)
 {
     constexpr const auto musical_note = u8"♪";
 
-    const auto msglen_ = jp ? msglen / 1.5 : msglen;
     for (auto pos = message.find(musical_note); pos != std::string::npos;
          pos = message.find(musical_note))
     {
@@ -36,7 +35,7 @@ void msg_write(std::string& message)
             + message.substr(
                   pos + std::strlen(musical_note) + (symbol_type != 0));
         elona::pos(
-            (msglen_ + pos) * inf_mesfont / 2 + inf_msgx + 7 + en * 3,
+            (message_width + pos) * inf_mesfont / 2 + inf_msgx + 7 + en * 3,
             (inf_msgline - 1) * inf_msgspace + inf_msgy + 5);
         gmode(2);
         gcopy(3, 600 + symbol_type * 24, 360, 16, 16);
@@ -44,7 +43,7 @@ void msg_write(std::string& message)
 
     elona::color(tcol_at_txtfunc(0), tcol_at_txtfunc(1), tcol_at_txtfunc(2));
     elona::pos(
-        msglen_ * inf_mesfont / 2 + inf_msgx + 6,
+        message_width * inf_mesfont / 2 + inf_msgx + 6,
         (inf_msgline - 1) * inf_msgspace + inf_msgy + 6);
     font(lang(cfg_font1, cfg_font2), inf_mesfont - en * 2, 0);
     mes(message);
@@ -714,7 +713,7 @@ void msg_newline()
 {
     clear_log_panel();
 
-    msglen = 0;
+    message_width = 0;
     ++msgline;
     if (msgline >= inf_maxlog)
     {
@@ -762,7 +761,7 @@ void txtnew()
         if (strlen_u(msg(msgline % inf_maxlog)) > 4)
         {
             msg_newline();
-            msglen = 2;
+            message_width = 2;
         }
     }
     return;
@@ -784,7 +783,6 @@ void msg_clear()
 
 void txt_conv()
 {
-
     if (msgtemp(0).empty())
         return;
 
@@ -824,7 +822,7 @@ void txt_conv()
             }
             else
             {
-                msglen = 2;
+                message_width = 2;
             }
         }
     }
@@ -836,8 +834,6 @@ void txt_conv()
         msgtempprev = msgtemp(0);
         msgdup = 0;
     }
-
-    int inf_maxmsglen_ = inf_maxmsglen * 1.5;
 
     if (jp)
     {
@@ -855,53 +851,47 @@ void txt_conv()
             }
         }
 
-        int len = 0;
+        size_t width{};
         while (1)
         {
-            len = msgtemp(0).size();
-            if (msglen + 4 > inf_maxmsglen_ && !msgtemp(0).empty())
+            width = strlen_u(msgtemp(0));
+            if (message_width + 4 > inf_maxmsglen && !msgtemp(0).empty())
             {
                 msg_newline();
             }
-            if (msglen + len > inf_maxmsglen_)
+            if (message_width + width > inf_maxmsglen)
             {
-                int p2 = 0;
+                size_t len{};
+                size_t wdt{};
                 while (1)
                 {
-                    const uint8_t c = msgtemp(0)[p2];
-                    if (c <= 0x7F)
-                        p2 += 1;
-                    else if (c >= 0xc2 && c <= 0xdf)
-                        p2 += 2;
-                    else if (c >= 0xe0 && c <= 0xef)
-                        p2 += 3;
-                    else if (c >= 0xf0 && c <= 0xf7)
-                        p2 += 4;
-                    else if (c >= 0xf8 && c <= 0xfb)
-                        p2 += 5;
-                    else if (c >= 0xfc && c <= 0xfd)
-                        p2 += 6;
-                    else
-                        p2 += 1;
-                    if (p2 + msglen > inf_maxmsglen_)
+                    const auto byte = strutil::byte_count(msgtemp(0)[len]);
+                    wdt += byte == 1 ? 1 : 2;
+                    len += byte;
+                    if (wdt + message_width > inf_maxmsglen)
                     {
-                        if (p2 + msglen > inf_maxmsglen_ + 2)
+                        if (wdt + message_width > inf_maxmsglen + 2)
                         {
                             break;
                         }
-                        const auto m = strmid(msgtemp(0), p2, 3);
-                        if (m != u8"。" && m != u8"、" && m != u8"」"
-                            && m != u8"』" && m != u8"！" && m != u8"？"
-                            && m != u8"…")
+                        if (!strutil::starts_with(msgtemp(0), u8"。", len)
+                            && !strutil::starts_with(msgtemp(0), u8"、", len)
+                            && !strutil::starts_with(msgtemp(0), u8"」", len)
+                            && !strutil::starts_with(msgtemp(0), u8"』", len)
+                            && !strutil::starts_with(msgtemp(0), u8"！", len)
+                            && !strutil::starts_with(msgtemp(0), u8"？", len)
+                            && !strutil::starts_with(msgtemp(0), u8"…", len))
                         {
                             break;
                         }
                     }
                 }
-                auto m = strmid(msgtemp(0), 0, p2);
+                if (len >= msgtemp(0).size())
+                    len = msgtemp(0).size();
+                auto m = msgtemp(0).substr(0, len);
                 msg(msgline % inf_maxlog) += m;
                 msg_write(m);
-                msgtemp(0) = strmid(msgtemp(0), p2, len - p2);
+                msgtemp(0) = msgtemp(0).substr(len);
                 if (msgtemp(0).empty() || msgtemp(0) == u8" ")
                 {
                     break;
@@ -913,7 +903,7 @@ void txt_conv()
         }
         msg(msgline % inf_maxlog) += msgtemp(0);
         msg_write(msgtemp(0));
-        msglen += len;
+        message_width += width;
     }
     else
     {
@@ -947,7 +937,7 @@ void txt_conv()
             {
                 break;
             }
-            if (msglen + p_at_txtfunc > inf_maxmsglen)
+            if (message_width + p_at_txtfunc > inf_maxmsglen)
             {
                 msg_newline();
                 continue;
@@ -955,13 +945,13 @@ void txt_conv()
             auto mst = strmid(msgtemp(0), 0, p_at_txtfunc);
             msg(msgline % inf_maxlog) += mst;
             msg_write(mst);
-            msglen += p_at_txtfunc;
+            message_width += p_at_txtfunc;
             msgtemp(0) = strmid(
                 msgtemp(0), p_at_txtfunc, msgtemp(0).size() - p_at_txtfunc);
         }
         msg(msgline % inf_maxlog) += msgtemp(0);
         msg_write(msgtemp(0));
-        msglen += msgtemp(0).size();
+        message_width += msgtemp(0).size();
     }
 }
 

--- a/variables.hpp
+++ b/variables.hpp
@@ -1455,7 +1455,6 @@ void modweight(int, int, bool = false);
 void msg_clear();
 void msg_halt();
 void msg_newline();
-void msg_newlog();
 void netload(const std::string&);
 void opencard(int = 0);
 void page_load();

--- a/variables.hpp
+++ b/variables.hpp
@@ -1456,7 +1456,6 @@ void msg_clear();
 void msg_halt();
 void msg_newline();
 void msg_newlog();
-void msg_write(std::string&);
 void netload(const std::string&);
 void opencard(int = 0);
 void page_load();


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #181.


# Summary

Vanilla Elona assumes that Japanese text encoding is Shift-JIS. However, Foobar always uses UTF-8. In the result, algorithm to calculate text width in Japanese did not work well.