### PR TITLE
Fix selected text at the prompt filled black

### DIFF
--- a/std.cpp
+++ b/std.cpp
@@ -312,6 +312,11 @@ void boxf(int x1, int y1, int x2, int y2, const snail::color& color)
         snail::application::instance().get_renderer().set_blend_mode(
             snail::blend_mode_t::none);
     }
+    else
+    {
+        snail::application::instance().get_renderer().set_blend_mode(
+            snail::blend_mode_t::blend);
+    }
     snail::application::instance().get_renderer().fill_rect(
         x1, y1, x2 - x1, y2 - y1);
     detail::current_tex_buffer().color.a = save_alpha;


### PR DESCRIPTION
# Related Issues

Closes #225

# Summary

Fixed a problem that the background of the prompt text becomes black.
Probably the cause is that blend_mode is always none.
So I fixed that blend_mode will be blend when color isn't {0,0,0,0}

|▼Before|▼After|
|:--:|:--:|
|![2018-05-02 03 05 17](https://user-images.githubusercontent.com/16176282/39486015-b13f861e-4db5-11e8-9ee2-e713d3ce3458.png)|![2018-05-02 03 02 21](https://user-images.githubusercontent.com/16176282/39485901-45b6097c-4db5-11e8-8eb0-c368ff7d9e51.png)|


