### PR TITLE
Disable autosave

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -654,6 +654,10 @@ void load_config()
             u8"use_autopick",
             1,
             [&](auto value) { config::instance().use_autopick = value; }),
+        std::make_unique<config_integer>(
+            u8"autosave",
+            0,
+            [&](auto value) { config::instance().autosave = value; }),
     };
 
     picojson::value value;

--- a/config.hpp
+++ b/config.hpp
@@ -20,6 +20,7 @@ public:
     int attackanime;
     int attackwait;
     int autonumlock;
+    int autosave;
     int autoturn;
     int env;
     int extraclass;

--- a/elonacore.cpp
+++ b/elonacore.cpp
@@ -68812,7 +68812,8 @@ void pc_turn(bool label_2747_flg)
         if (autosave)
         {
             autosave = 0;
-            if (gdata_wizard == 0 && gdata_current_map != 40)
+            if (gdata_wizard == 0 && gdata_current_map != 40
+                && config::instance().autosave)
             {
                 snd(44);
                 save_game();

--- a/set_option.cpp
+++ b/set_option.cpp
@@ -345,6 +345,11 @@ std::vector<config_menu> create_config_menu()
         config::instance().use_autopick,
         lang(u8"使う", u8"On"),
         lang(u8"使わない", u8"Off"));
+    ELONA_CONFIG_ITEM_YESNO(
+        lang(u8"オートセーブ", u8"Autosave"),
+        config::instance().autosave,
+        lang(u8"有効", u8"On"),
+        lang(u8"無効", u8"Off"));
 
 #undef ELONA_CONFIG_ITEM
 #undef ELONA_CONFIG_ITEM_YESNO
@@ -1409,6 +1414,22 @@ void set_option()
                     snd(20);
                     set_config(
                         u8"use_autopick", config::instance().use_autopick);
+                    reset_page = true;
+                    continue;
+                }
+                if (cs == 3)
+                {
+                    config::instance().autosave += p;
+                    if (config::instance().autosave > 1)
+                    {
+                        config::instance().autosave = 1;
+                    }
+                    else if (config::instance().autosave < 0)
+                    {
+                        config::instance().autosave = 0;
+                    }
+                    snd(20);
+                    set_config(u8"autosave", config::instance().autosave);
                     reset_page = true;
                     continue;
                 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #246.


# Summary

- New option: "autosave"
  - 0: disable autosave(default), 1: enable autosave
- You can save game via [F2] as before regardless of whether autosave is disabled or not.
