### PR TITLE
Add empty check of the_ability_db

### DIFF
--- a/elonacore.cpp
+++ b/elonacore.cpp
@@ -14841,7 +14841,7 @@ int advfavoriteskill(int prm_868)
     while (1)
     {
         rtval(i_at_m145) = rnd(300) + 100;
-        if (the_ability_db[rtval(i_at_m145)]->related_basic_attribute == 0)
+        if (!the_ability_db[rtval(i_at_m145)])
         {
             continue;
         }
@@ -24153,7 +24153,8 @@ void apply_general_eating_effect()
             }
             for (int cnt = 100; cnt < 400; ++cnt)
             {
-                if (the_ability_db[cnt]->related_basic_attribute == 0
+                if (!the_ability_db[cnt]
+                    || the_ability_db[cnt]->related_basic_attribute == 0
                     || sdata.get(cnt, cc).original_level == 0)
                 {
                     continue;
@@ -43796,7 +43797,7 @@ label_20331:
         }
         else if (sdata(cnt, cc) == 0)
         {
-            if (the_ability_db[cnt]->related_basic_attribute != 0)
+            if (the_ability_db[cnt])
             {
                 f = 1;
             }

--- a/magic.cpp
+++ b/magic.cpp
@@ -2367,7 +2367,7 @@ label_2181_internal:
                 }
                 if (!is_cursed(efstatus))
                 {
-                    if (the_ability_db[p]->related_basic_attribute != 0)
+                    if (the_ability_db[p])
                     {
                         if (cnt2 == 0)
                         {
@@ -2482,7 +2482,7 @@ label_2181_internal:
         {
             await();
             p = rnd(300) + 100;
-            if (the_ability_db[p]->related_basic_attribute != 0)
+            if (the_ability_db[p])
             {
                 if (!is_cursed(efstatus))
                 {
@@ -2596,7 +2596,7 @@ label_2181_internal:
             {
                 await();
                 p = rnd(300) + 100;
-                if (the_ability_db[p]->related_basic_attribute != 0)
+                if (the_ability_db[p])
                 {
                     if (sdata.get(p, tc).original_level == 0)
                     {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #247.

- Crash when wizard's dream happens during sleeping.
- Crash when reading uncursed/blessed scrolls of wonder.
- Crash when hearing favorite skills of adventurers.
- Crash when trying to train skills from adventurers.
- Crash when eating the corpse of <Little sister>.
- Crash when speaking to trainer.
- Crash when reading scrolls of growth.
- Crash when reading scrolls of gain attribute.


# Cause

The cause of the above issues is the same as each other. It is missing empty check of `boost::optional<ability_data>`, which is result of `ability_db::operator[]`.