### PR TITLE
Fix default value of key_close

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -495,7 +495,7 @@ void load_config()
             [&](auto value) { key_skill = std::string{value}; }),
         std::make_unique<config_string>(
             u8"key_close",
-            u8"c",
+            u8"C",
             [&](auto value) { key_close = std::string{value}; }),
         std::make_unique<config_string>(
             u8"key_rest",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #254.


# Summary


New default value is large C, compatible with vanilla.