### PR TITLE
Fix English language option

### DIFF
--- a/cat.cpp
+++ b/cat.cpp
@@ -26,8 +26,9 @@ void engine::load(const fs::path& filepath)
     std::string filepath_str = filesystem::to_narrow_path(filepath);
     if (luaL_dofile(ptr(), filepath_str.c_str()) != 0)
     {
+        const char* error_msg = lua_tostring(ptr(), -1);
         throw std::runtime_error(
-            u8"Could not load lua script at "s + filepath_str + u8"."s);
+            u8"Error when loading Lua script:\n"s + std::string(error_msg));
     }
 }
 

--- a/lang/en/buff.lua
+++ b/lang/en/buff.lua
@@ -3,7 +3,7 @@ buff['1'] = {
   message_0 = "begin",
   message_1 = " to shine.",
   description = function(self, power)
-    return "Increases PV by " .. self._effect(power)) .. "/RES+ fear"
+    return "Increases PV by " .. self._effect(power) .. "/RES+ fear"
   end,
 }
 buff['2'] = {

--- a/runtime/config.json
+++ b/runtime/config.json
@@ -1,4 +1,4 @@
 {
     "font1": "Kochi Gothic.ttf",
-    "font2": "Bitstream Sans Vera.ttf"
+    "font2": "Bitstream Sans Vera Mono.ttf"
 }


### PR DESCRIPTION
# Summary
English option fails at startup because of a typo in `buff.lua`. Also, the name of the English font is wrong. This patch fixes both. It also adds a descriptive error message if loading a Lua script fails.