### PR TITLE
Skip BOM at the beginning of text files

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -676,6 +676,7 @@ void load_config()
                 + filesystem::make_preferred_path_in_utf8(
                       filesystem::dir::exe() / u8"config.json")};
         }
+        fileutil::skip_bom(file);
 
         file >> value;
     }
@@ -819,6 +820,7 @@ void set_config(const std::string& key, int value)
                 + filesystem::make_preferred_path_in_utf8(
                       filesystem::dir::exe() / u8"config.json")};
         }
+        fileutil::skip_bom(file);
         file >> options;
     }
 
@@ -854,6 +856,7 @@ void set_config(const std::string& key, const std::string& value)
                 + filesystem::make_preferred_path_in_utf8(
                       filesystem::dir::exe() / u8"config.json")};
         }
+        fileutil::skip_bom(file);
         file >> options;
     }
 
@@ -889,6 +892,7 @@ void set_config(const std::string& key, const std::string& value1, int value2)
                 + filesystem::make_preferred_path_in_utf8(
                       filesystem::dir::exe() / u8"config.json")};
         }
+        fileutil::skip_bom(file);
         file >> options;
     }
 
@@ -982,6 +986,7 @@ void load_config2()
                   filesystem::dir::exe() / u8"config.json")};
     }
 
+    fileutil::skip_bom(file);
     picojson::value value;
     file >> value;
 

--- a/util.hpp
+++ b/util.hpp
@@ -155,6 +155,19 @@ namespace fileutil
 {
 
 
+inline void skip_bom(std::istream& in)
+{
+    assert(in.tellg() == std::istream::pos_type(0));
+
+    const auto first = in.get();
+    const auto second = in.get();
+    const auto third = in.get();
+    if (first != 0xef || second != 0xbb || third != 0xbf)
+        in.seekg(0); // Not BOM
+}
+
+
+
 // Note: the line number is 1-based.
 // Note: the line does not contains a line break.
 struct read_by_line
@@ -228,14 +241,15 @@ struct read_by_line
 
 
     read_by_line(const fs::path& filepath)
-        : in(filepath.native())
     {
-        if (!fs::exists(filepath))
+        in.open(filepath.native());
+        if (!in)
         {
-            using namespace std::literals::string_literals;
             throw std::runtime_error(
-                u8"Could not open file "s + filepath.string());
+                u8"Could not open file "
+                + filesystem::make_preferred_path_in_utf8(filepath));
         }
+        skip_bom(in);
     }
 
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #261.


# Summary

Skip BOM in these files:

- config.json
- autopick
- art.log
- ndata.csv
- ndata-e.csv
- name.csv
- lastwords.txt
- lastwords-e.txt
- qname.s1
- gdatan.s1
- mdatan.s1
- cdatan.s1
- cdatan2.s1
- cdatan3.s1
- custom talk files