### PR TITLE
Fix performance hit by many damage popup

### DIFF
--- a/draw.cpp
+++ b/draw.cpp
@@ -11,6 +11,9 @@ namespace
 {
 
 
+// TODO: it should be configurable.
+constexpr size_t max_damage_popups = 20; // compatible with oomEx
+
 struct damage_popup_t
 {
     int frame;
@@ -270,12 +273,25 @@ void show_hp_bar(show_hp_bar_side side, int inf_clocky)
 }
 
 
+
 void add_damage_popup(
     const std::string& text,
     int character,
     const snail::color& color)
 {
-    damage_popups.emplace_back(text, character, color);
+    if (damage_popups.size() == max_damage_popups)
+    {
+        // Substitute a new damage popup for popup whose frame is the maximum.
+        auto oldest = std::max_element(
+            std::begin(damage_popups),
+            std::end(damage_popups),
+            [](const auto& a, const auto& b) { return a.frame < b.frame; });
+        *oldest = damage_popup_t{text, character, color};
+    }
+    else
+    {
+        damage_popups.emplace_back(text, character, color);
+    }
 }
 
 

--- a/draw.cpp
+++ b/draw.cpp
@@ -279,6 +279,12 @@ void add_damage_popup(
 }
 
 
+void clear_damage_popups()
+{
+    damage_popups.clear();
+}
+
+
 void show_damage_popups(int inf_ver)
 {
     for (auto&& damage_popup : damage_popups)

--- a/draw.cpp
+++ b/draw.cpp
@@ -309,14 +309,20 @@ void show_damage_popups(int inf_ver)
         if (gdata(20) != 40)
         {
             if (!is_in_fov(cc.position))
+            {
+                ++damage_popup.frame;
                 continue;
+            }
             if (dist(
                     cdata[0].position.x,
                     cdata[0].position.y,
                     cc.position.x,
                     cc.position.y)
                 > cdata[0].vision_distance / 2)
+            {
+                ++damage_popup.frame;
                 continue;
+            }
         }
         int mondmgpos{};
         for (auto&& damage_popup2 : damage_popups)

--- a/draw.cpp
+++ b/draw.cpp
@@ -330,7 +330,7 @@ void show_damage_popups(int inf_ver)
         std::remove_if(
             std::begin(damage_popups),
             std::end(damage_popups),
-            [](const auto& d) { return d.frame > 50; }),
+            [](const auto& d) { return d.frame > 20; }),
         std::end(damage_popups));
 }
 

--- a/draw.hpp
+++ b/draw.hpp
@@ -25,6 +25,7 @@ void add_damage_popup(
     const std::string& text,
     int character,
     const snail::color& color);
+void clear_damage_popups();
 void show_damage_popups(int inf_ver);
 
 

--- a/initialize_map.cpp
+++ b/initialize_map.cpp
@@ -3,6 +3,7 @@
 #include "character.hpp"
 #include "config.hpp"
 #include "ctrl_file.hpp"
+#include "draw.hpp"
 #include "elona.hpp"
 #include "item.hpp"
 #include "variables.hpp"
@@ -22,6 +23,9 @@ void initialize_map()
     int maxmedal = 0;
     elona_vector2<int> medalbk;
     int noaggrorefresh = 0;
+
+    clear_damage_popups();
+
 label_17401:
     mapupdate = 0;
     if (gdata_current_dungeon_level > adata(10, gdata_current_map))


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #268.

# Summary

- Shorten duration until damage popup disappears (50 -> 20 frames).
- Clear damage popups when entering another map.
  - Damage popups were remained even if you exit current map and enter another map before.
- Limit the max number of damage popups (20: oomEx compatible).
  - The digit(20) should be configurable.
  - About 200 damage popups were shown at once before.
- Increment damage popups' frame even if out of view.
  - Old damage popups were left if they were out of view before.