### PR TITLE
Refactor: Move methods to mef.cpp/map_cell.cpp/event.cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ set(CORE_SOURCES
     debug.cpp
     draw.cpp
     elonacore.cpp
+    event.cpp
     filesystem.cpp
     fish.cpp
     foobar_save.cpp
@@ -76,6 +77,8 @@ set(CORE_SOURCES
     magic.cpp
     main.cpp
     map.cpp
+    map_cell.cpp
+    mef.cpp
     message.cpp
     proc_event.cpp
     race.cpp

--- a/cell_draw.cpp
+++ b/cell_draw.cpp
@@ -5,6 +5,7 @@
 #include "elona.hpp"
 #include "item.hpp"
 #include "map.hpp"
+#include "map_cell.hpp"
 #include "variables.hpp"
 
 using namespace elona;

--- a/ctrl_file.cpp
+++ b/ctrl_file.cpp
@@ -5,6 +5,7 @@
 #include "filesystem.hpp"
 #include "foobar_save.hpp"
 #include "item.hpp"
+#include "mef.hpp"
 #include "putit.hpp"
 #include "variables.hpp"
 
@@ -736,7 +737,7 @@ void fmode_1_2(bool read)
         {
             DIM4(map, mdata(0), mdata(1), 10);
             DIM3(mapsync, mdata(0), mdata(1));
-            DIM3(mef, 9, 200);
+            DIM3(mef, 9, MEF_MAX);
             load_v3(filepath, map, 0, mdata(0), 0, mdata(1), 0, 10);
         }
         else
@@ -815,13 +816,13 @@ void fmode_1_2(bool read)
             }
             else
             {
-                load_v2(filepath, mef, 0, 9, 0, 200);
+                load_v2(filepath, mef, 0, 9, 0, MEF_MAX);
             }
         }
         else
         {
             fileadd(filepath);
-            save_v2(filepath, mef, 0, 9, 0, 200);
+            save_v2(filepath, mef, 0, 9, 0, MEF_MAX);
         }
     }
 
@@ -851,7 +852,7 @@ void fmode_5_6(bool read)
     if (read)
     {
         DIM3(cmapdata, 5, 400);
-        DIM3(mef, 9, 200);
+        DIM3(mef, 9, MEF_MAX);
     }
 
     {

--- a/elonacore.cpp
+++ b/elonacore.cpp
@@ -12,6 +12,7 @@
 #include "debug.hpp"
 #include "draw.hpp"
 #include "elona.hpp"
+#include "event.hpp"
 #include "filesystem.hpp"
 #include "fish.hpp"
 #include "foobar_save.hpp"
@@ -24,6 +25,8 @@
 #include "macro.hpp"
 #include "main.hpp"
 #include "map.hpp"
+#include "map_cell.hpp"
+#include "mef.hpp"
 #include "race.hpp"
 #include "random.hpp"
 #include "snail/application.hpp"
@@ -302,7 +305,6 @@ elona_vector3<int> pochart;
 elona_vector2<int> podata;
 elona_vector2<int> bdref;
 int f_at_m14 = 0;
-int evproc = 0;
 int enc = 0;
 int enc2 = 0;
 int autoturn = 0;
@@ -346,10 +348,6 @@ int lv_at_m77 = 0;
 int exp_at_m77 = 0;
 int growth_at_m77 = 0;
 int lvchange_at_m77 = 0;
-int i_at_m79 = 0;
-int cellchara = 0;
-int cellfeat = 0;
-int tc_at_m81 = 0;
 elona_vector2<int> route;
 int maxroute = 0;
 int dy_at_modfov = 0;
@@ -1104,56 +1102,6 @@ int findunid(const std::string& prm_285)
         }
     }
     return f_at_m14;
-}
-
-
-
-int evid()
-{
-    if (evnum <= 0)
-    {
-        return -1;
-    }
-    return evlist(evnum - 1);
-}
-
-
-
-int evfind(int prm_288)
-{
-    int f_at_m17 = 0;
-    f_at_m17 = 0;
-    for (int cnt = 0, cnt_end = (evnum); cnt < cnt_end; ++cnt)
-    {
-        if (evlist(cnt) == prm_288)
-        {
-            f_at_m17 = 1;
-        }
-    }
-    return f_at_m17;
-}
-
-
-
-void evadd(int prm_289, int prm_290, int prm_291)
-{
-    if (evproc)
-    {
-        evlist(evnum) = evlist(evnum - 1);
-        evdata1(evnum) = evdata1(evnum - 1);
-        evdata2(evnum) = evdata2(evnum - 1);
-        evlist(evnum - 1) = prm_289;
-        evdata1(evnum - 1) = prm_290;
-        evdata2(evnum - 1) = prm_291;
-    }
-    else
-    {
-        evlist(evnum) = prm_289;
-        evdata1(evnum) = prm_290;
-        evdata2(evnum) = prm_291;
-    }
-    ++evnum;
-    return;
 }
 
 
@@ -2424,19 +2372,7 @@ void initialize_map_chip()
 
 void initialize_item_chip()
 {
-    DIM3(mefsubref, 6, 6);
-    mefsubref(0, 1) = 144;
-    mefsubref(1, 1) = 624;
-    mefsubref(0, 2) = 272;
-    mefsubref(1, 2) = 624;
-    mefsubref(2, 2) = 1;
-    mefsubref(0, 3) = 304;
-    mefsubref(1, 3) = 624;
-    mefsubref(2, 3) = 1;
-    mefsubref(0, 4) = 368;
-    mefsubref(1, 4) = 624;
-    mefsubref(0, 5) = 464;
-    mefsubref(1, 5) = 624;
+    initialize_mef();
     SDIM3(tname, 16, 11);
     tname(1) = lang(u8"日干し岩"s, u8"a dryrock"s);
     tname(2) = lang(u8"畑"s, u8"a field"s);
@@ -5804,275 +5740,6 @@ int getworker(int map_id, int prm_579)
 }
 
 
-
-void removeworker(int map_id)
-{
-    for (int i = 1; i < 16; ++i)
-    {
-        if (cdata[i].current_map == map_id)
-        {
-            cdata[i].current_map = 0;
-        }
-    }
-}
-
-
-
-void delmef(int prm_581)
-{
-    if (mef(0, prm_581) == 7)
-    {
-        evadd(21, mef(2, prm_581), mef(3, prm_581));
-    }
-    map(mef(2, prm_581), mef(3, prm_581), 8) = 0;
-    mef(0, prm_581) = 0;
-    i_at_m79 = 199;
-    for (int cnt = 0, cnt_end = (200 - prm_581); cnt < cnt_end; ++cnt)
-    {
-        if (mef(0, i_at_m79) != 0)
-        {
-            for (int cnt = 0; cnt < 9; ++cnt)
-            {
-                mef(cnt, prm_581) = mef(cnt, i_at_m79);
-            }
-            map(mef(2, i_at_m79), mef(3, i_at_m79), 8) = prm_581 + 1;
-            mef(0, i_at_m79) = 0;
-            break;
-        }
-        --i_at_m79;
-    }
-    return;
-}
-
-
-
-void addmef(
-    int prm_582,
-    int prm_583,
-    int prm_584,
-    int prm_585,
-    int prm_586,
-    int prm_587,
-    int prm_588,
-    int prm_589,
-    int prm_590,
-    int prm_591)
-{
-    int p_at_m79 = 0;
-    p_at_m79 = map(prm_582, prm_583, 0);
-    if (prm_584 == 5)
-    {
-        if (chipm(0, p_at_m79) == 3)
-        {
-            return;
-        }
-    }
-    if (map(prm_582, prm_583, 8) != 0)
-    {
-        i_at_m79 = map(prm_582, prm_583, 8) - 1;
-    }
-    else
-    {
-        i_at_m79 = -1;
-        for (int cnt = 0; cnt < 200; ++cnt)
-        {
-            if (mef(0, cnt) == 0)
-            {
-                i_at_m79 = cnt;
-                break;
-            }
-        }
-        if (i_at_m79 == -1)
-        {
-            i_at_m79 = rnd(200);
-            map(mef(2, i_at_m79), mef(3, i_at_m79), 8) = 0;
-        }
-    }
-    mef(0, i_at_m79) = prm_584;
-    mef(1, i_at_m79) = prm_585 + prm_591 * 10000;
-    mef(2, i_at_m79) = prm_582;
-    mef(3, i_at_m79) = prm_583;
-    mef(4, i_at_m79) = prm_586;
-    mef(5, i_at_m79) = prm_587;
-    mef(6, i_at_m79) = prm_588;
-    mef(7, i_at_m79) = prm_589;
-    mef(8, i_at_m79) = prm_590;
-    map(prm_582, prm_583, 8) = i_at_m79 + 1;
-    return;
-}
-
-
-
-void cell_featset(
-    int prm_592,
-    int prm_593,
-    int prm_594,
-    int prm_595,
-    int prm_596,
-    int prm_597)
-{
-    elona_vector1<int> feat_at_m80;
-    if (prm_594 != -1)
-    {
-        feat_at_m80 = prm_594;
-    }
-    else
-    {
-        feat_at_m80 = map(prm_592, prm_593, 6) % 1000;
-    }
-    if (prm_595 != -1)
-    {
-        feat_at_m80(1) = prm_595;
-    }
-    else
-    {
-        feat_at_m80(1) = map(prm_592, prm_593, 6) / 1000 % 100;
-    }
-    if (prm_596 != -1)
-    {
-        feat_at_m80(2) = prm_596;
-    }
-    else
-    {
-        feat_at_m80(2) = map(prm_592, prm_593, 6) / 100000 % 100;
-    }
-    if (prm_597 != -1)
-    {
-        feat_at_m80(3) = prm_597;
-    }
-    else
-    {
-        feat_at_m80(3) = map(prm_592, prm_593, 6) / 10000000;
-    }
-    map(prm_592, prm_593, 6) = feat_at_m80 + feat_at_m80(1) * 1000
-        + feat_at_m80(2) * 100000 + feat_at_m80(3) * 10000000;
-    return;
-}
-
-
-
-int cell_featread(int prm_598, int prm_599, int)
-{
-    feat(0) = map(prm_598, prm_599, 6) % 1000;
-    feat(1) = map(prm_598, prm_599, 6) / 1000 % 100;
-    feat(2) = map(prm_598, prm_599, 6) / 100000 % 100;
-    feat(3) = map(prm_598, prm_599, 6) / 10000000;
-    return 0;
-}
-
-
-
-void cell_featclear(int prm_601, int prm_602)
-{
-    map(prm_601, prm_602, 6) = 0;
-    return;
-}
-
-
-
-void cell_check(int prm_603, int prm_604)
-{
-    cellaccess = 1;
-    cellchara = -1;
-    cellfeat = -1;
-    if (prm_603 < 0 || prm_603 >= mdata(0) || prm_604 < 0
-        || prm_604 >= mdata(1))
-    {
-        cellaccess = 0;
-        return;
-    }
-    if (map(prm_603, prm_604, 1) != 0)
-    {
-        cellchara = map(prm_603, prm_604, 1) - 1;
-        cellaccess = 0;
-    }
-    if (map(prm_603, prm_604, 6) != 0)
-    {
-        cellfeat = map(prm_603, prm_604, 6) / 1000 % 100;
-        if (chipm(7, map(prm_603, prm_604, 6) % 1000) & 4)
-        {
-            cellaccess = 0;
-        }
-    }
-    if (chipm(7, map(prm_603, prm_604, 0)) & 4)
-    {
-        cellaccess = 0;
-    }
-    return;
-}
-
-
-
-void cell_swap(int prm_605, int prm_606, int prm_607, int prm_608)
-{
-    int x2_at_m81 = 0;
-    int y2_at_m81 = 0;
-    if (gdata_mount != 0)
-    {
-        if (gdata_mount == prm_605 || gdata_mount == prm_606)
-        {
-            return;
-        }
-    }
-    tc_at_m81 = prm_606;
-    if (tc_at_m81 == -1)
-    {
-        if (map(prm_607, prm_608, 1) != 0)
-        {
-            tc_at_m81 = map(prm_607, prm_608, 1) - 1;
-        }
-    }
-    if (tc_at_m81 != -1)
-    {
-        map(cdata[prm_605].position.x, cdata[prm_605].position.y, 1) =
-            tc_at_m81 + 1;
-        x2_at_m81 = cdata[tc_at_m81].position.x;
-        y2_at_m81 = cdata[tc_at_m81].position.y;
-        cdata[tc_at_m81].position.x = cdata[prm_605].position.x;
-        cdata[tc_at_m81].position.y = cdata[prm_605].position.y;
-    }
-    else
-    {
-        map(cdata[prm_605].position.x, cdata[prm_605].position.y, 1) = 0;
-        x2_at_m81 = prm_607;
-        y2_at_m81 = prm_608;
-    }
-    map(x2_at_m81, y2_at_m81, 1) = prm_605 + 1;
-    cdata[prm_605].position.x = x2_at_m81;
-    cdata[prm_605].position.y = y2_at_m81;
-    if (prm_605 == 0 || tc_at_m81 == 0)
-    {
-        if (gdata_mount)
-        {
-            cdata[gdata_mount].position.x = cdata[0].position.x;
-            cdata[gdata_mount].position.y = cdata[0].position.y;
-        }
-    }
-    return;
-}
-
-
-
-void cell_movechara(int cc, int x, int y)
-{
-    if (map(x, y, 1) != 0)
-    {
-        if (map(x, y, 1) - 1 == cc)
-        {
-            return;
-        }
-        cell_swap(cc, tc_at_m81);
-    }
-    else
-    {
-        map(cdata[cc].position.x, cdata[cc].position.y, 1) = 0;
-        cdata[cc].position = {x, y};
-        map(x, y, 1) = cc + 1;
-    }
-}
-
-
-
 int route_info(int& prm_612, int& prm_613, int prm_614)
 {
     if (route(0, prm_614 % maxroute) == 1)
@@ -6250,45 +5917,6 @@ void chara_preparepic(int prm_618, int prm_619)
     return;
 }
 
-
-
-int cell_itemlist(int prm_625, int prm_626)
-{
-    listmax = 0;
-    for (const auto& cnt : items(-1))
-    {
-        if (inv[cnt].number > 0)
-        {
-            if (inv[cnt].position.x == prm_625
-                && inv[cnt].position.y == prm_626)
-            {
-                list(0, listmax) = cnt;
-                ++listmax;
-            }
-        }
-    }
-    return rtval;
-}
-
-
-
-// Returns pair of number of items and the last item on the cell.
-std::pair<int, int> cell_itemoncell(const position_t& pos)
-{
-    int number{};
-    int item{};
-
-    for (const auto& ci : items(-1))
-    {
-        if (inv[ci].number > 0 && inv[ci].position == pos)
-        {
-            ++number;
-            item = ci;
-        }
-    }
-
-    return std::make_pair(number, item);
-}
 
 
 
@@ -9683,7 +9311,7 @@ void check_quest()
             }
             if (p_at_m119 == 0)
             {
-                evadd(8);
+                event_add(8);
             }
             else
             {
@@ -9697,7 +9325,7 @@ void check_quest()
         {
             if (findchara(qdata(12, gdata_executing_immediate_quest)) == 0)
             {
-                evadd(8);
+                event_add(8);
             }
         }
     }
@@ -10336,68 +9964,6 @@ void incognitoend()
     }
     return;
 }
-
-
-
-void cell_setchara(int cc, int x, int y)
-{
-    map(x, y, 1) = cc + 1;
-    cdata[cc].position = position_t{x, y};
-}
-
-
-
-void cell_removechara(int x, int y)
-{
-    map(x, y, 1) = 0;
-}
-
-
-
-int cell_findspace(int prm_796, int prm_797, int prm_798)
-{
-    int f_at_m130 = 0;
-    int dy_at_m130 = 0;
-    int dx_at_m130 = 0;
-    f_at_m130 = 0;
-    for (int cnt = 0, cnt_end = (prm_798 * 2 + 1); cnt < cnt_end; ++cnt)
-    {
-        dy_at_m130 = prm_797 + cnt - 1;
-        if (dy_at_m130 < 0 || dy_at_m130 >= mdata(1))
-        {
-            continue;
-        }
-        for (int cnt = 0, cnt_end = (prm_798 * 2 + 1); cnt < cnt_end; ++cnt)
-        {
-            dx_at_m130 = prm_796 + cnt - 1;
-            if (dx_at_m130 < 0 || dx_at_m130 >= mdata(0))
-            {
-                continue;
-            }
-            if (map(dx_at_m130, dy_at_m130, 1) != 0)
-            {
-                continue;
-            }
-            if (chipm(7, map(dx_at_m130, dy_at_m130, 0)) & 4)
-            {
-                continue;
-            }
-            if (chipm(7, map(dx_at_m130, dy_at_m130, 6) % 1000) & 4)
-            {
-                continue;
-            }
-            rtval(0) = dx_at_m130;
-            rtval(1) = dy_at_m130;
-            f_at_m130 = 1;
-        }
-        if (f_at_m130)
-        {
-            break;
-        }
-    }
-    return f_at_m130;
-}
-
 
 
 int findbuff(int prm_799, int prm_800)
@@ -12374,7 +11940,7 @@ void mapitem_fire(int prm_842, int prm_843)
         {
             if (map(prm_842, prm_843, 8) == 0)
             {
-                addmef(prm_842, prm_843, 5, 24, rnd(10) + 5, 100, cc);
+                mef_add(prm_842, prm_843, 5, 24, rnd(10) + 5, 100, cc);
             }
         }
         cell_refresh(prm_842, prm_843);
@@ -13098,9 +12664,9 @@ int dmghp(int prm_853, int prm_854, int prm_855, int prm_856, int prm_857)
         gdata(30) = 0;
         if (cdata[prm_853].hp < 0)
         {
-            if (evid() != -1)
+            if (event_id() != -1)
             {
-                if (evid() != 21)
+                if (event_id() != 21)
                 {
                     cdata[prm_853].hp = 1;
                 }
@@ -13946,7 +13512,7 @@ int dmghp(int prm_853, int prm_854, int prm_855, int prm_856, int prm_857)
         }
         if (prm_855 == -9 || ele_at_m141 == 50)
         {
-            addmef(
+            mef_add(
                 cdata[prm_853].position.x,
                 cdata[prm_853].position.y,
                 5,
@@ -14013,7 +13579,7 @@ int dmghp(int prm_853, int prm_854, int prm_855, int prm_856, int prm_857)
                 cdata[prm_853].current_map = 0;
                 if (cdata[prm_853].is_escorted() == 1)
                 {
-                    evadd(15, cdata[prm_853].id);
+                    event_add(15, cdata[prm_853].id);
                     cdata[prm_853].state = 0;
                 }
                 if (cdata[prm_853].is_escorted_in_sub_quest() == 1)
@@ -14069,7 +13635,7 @@ int dmghp(int prm_853, int prm_854, int prm_855, int prm_856, int prm_857)
                 {
                     if (cdata[prm_853].id == 2)
                     {
-                        evadd(1);
+                        event_add(1);
                     }
                     if (cdata[prm_853].id == 141)
                     {
@@ -14140,7 +13706,7 @@ int dmghp(int prm_853, int prm_854, int prm_855, int prm_856, int prm_857)
                     }
                     if (cdata[prm_853].id == 318)
                     {
-                        evadd(
+                        event_add(
                             27,
                             cdata[prm_853].position.x,
                             cdata[prm_853].position.y);
@@ -14167,14 +13733,14 @@ int dmghp(int prm_853, int prm_854, int prm_855, int prm_856, int prm_857)
                         if (adata(20, gdata_current_map) == prm_853
                             && cdata[prm_853].is_lord_of_dungeon() == 1)
                         {
-                            evadd(5);
+                            event_add(5);
                         }
                     }
                     if (cdata[prm_853].id == 331)
                     {
                         if (rnd(4) == 0)
                         {
-                            evadd(
+                            event_add(
                                 28,
                                 cdata[prm_853].position.x,
                                 cdata[prm_853].position.y);
@@ -14187,7 +13753,7 @@ int dmghp(int prm_853, int prm_854, int prm_855, int prm_856, int prm_857)
                     if (adata(20, gdata_current_map) == prm_853
                         && cdata[prm_853].is_lord_of_dungeon() == 1)
                     {
-                        evadd(5);
+                        event_add(5);
                     }
                 }
             }
@@ -20486,7 +20052,7 @@ void label_1540()
         traveldone = 0;
         if (gdata_executing_immediate_quest_type == 0)
         {
-            evadd(6);
+            event_add(6);
         }
     }
     if (cdata[rc].character_role == 1)
@@ -23857,7 +23423,7 @@ void apply_general_eating_effect()
         }
         if (enc == 37)
         {
-            evadd(18, cc);
+            event_add(18, cc);
             continue;
         }
         if (enc == 40)
@@ -24852,10 +24418,7 @@ void map_reload(const std::string& prm_935)
             map(cnt, y_at_m166, 9) = 0;
         }
     }
-    for (int cnt = 0; cnt < 200; ++cnt)
-    {
-        mef(0, cnt) = 0;
-    }
+    mef_clear_all();
     for (const auto& cnt : items(-1))
     {
         if (inv[cnt].number > 0)
@@ -24910,7 +24473,7 @@ void map_initialize()
     }
     DIM4(map, mdata(0), mdata(1), 10);
     DIM3(mapsync, mdata(0), mdata(1));
-    DIM3(mef, 9, 200);
+    DIM3(mef, 9, MEF_MAX);
     map_tileset(mdata(12));
     return;
 }
@@ -26195,7 +25758,7 @@ int map_web(int prm_977, int prm_978, int prm_979)
         {
             if (map(dx_at_m170, dy_at_m170, 6) == 0)
             {
-                addmef(dx_at_m170, dy_at_m170, 1, 11, -1, prm_979);
+                mef_add(dx_at_m170, dy_at_m170, 1, 11, -1, prm_979);
                 return 1;
             }
         }
@@ -28430,7 +27993,16 @@ void initialize_home_adata()
     return;
 }
 
-
+void removeworker(int map_id)
+{
+    for (int i = 1; i < 16; ++i)
+    {
+        if (cdata[i].current_map == map_id)
+        {
+            cdata[i].current_map = 0;
+        }
+    }
+}
 
 turn_result_t show_house_board()
 {
@@ -30360,7 +29932,7 @@ turn_result_t exit_map()
         {
             gdata_entrance_type = adata(3, gdata_current_map);
         }
-        if (evfind(6))
+        if (event_find(6))
         {
             msgtemp += lang(
                 u8"あなたは家まで運ばれた。"s,
@@ -35983,9 +35555,9 @@ label_1894_internal:
                 efp = 200;
                 magic();
             }
-            else if (evid() == -1)
+            else if (event_id() == -1)
             {
-                evadd(26);
+                event_add(26);
             }
         }
         s = lang(u8"呪いのつぶやき"s, u8"Cursed Whispering"s);
@@ -47010,7 +46582,7 @@ void label_2088()
         adata(10, gdata_current_map) = 10;
         adata(12, gdata_current_map) = 1;
         mdata(8) = 1;
-        evadd(17);
+        event_add(17);
         calccosthire();
     }
     return;
@@ -52394,16 +51966,16 @@ turn_result_t do_throw_command()
             efp = 50 + sdata(111, cc) * 10;
             if (inv[ci].id == 392)
             {
-                addmef(tlocx, tlocy, 3, 19, rnd(15) + 5, efp, cc);
+                mef_add(tlocx, tlocy, 3, 19, rnd(15) + 5, efp, cc);
                 return turn_result_t::turn_end;
             }
             if (inv[ci].id == 577)
             {
-                addmef(tlocx, tlocy, 5, 24, rnd(15) + 25, efp, cc);
+                mef_add(tlocx, tlocy, 5, 24, rnd(15) + 25, efp, cc);
                 mapitem_fire(tlocx, tlocy);
                 return turn_result_t::turn_end;
             }
-            addmef(
+            mef_add(
                 tlocx,
                 tlocy,
                 6,
@@ -53564,36 +53136,10 @@ turn_result_t proc_movement_event()
     }
     if (map(cdata[cc].position.x, cdata[cc].position.y, 8) != 0)
     {
-        i = map(cdata[cc].position.x, cdata[cc].position.y, 8) - 1;
-        if (mef(0, i) == 1)
+        bool turn_ended = mef_proc_from_movement(cc);
+        if (turn_ended)
         {
-            if (cdatan(2, cc) != u8"spider"s)
-            {
-                if (rnd(mef(5, i) + 25) < rnd(sdata(10, cc) + sdata(12, cc) + 1)
-                    || cdata[cc].weight > 100)
-                {
-                    if (is_in_fov(cc))
-                    {
-                        txt(lang(
-                            name(cc) + u8"は蜘蛛の巣を振り払った。"s,
-                            name(cc) + u8" destroy"s + _s(cc)
-                                + u8" the cobweb."s));
-                    }
-                    delmef(i);
-                }
-                else
-                {
-                    mef(5, i) = mef(5, i) * 3 / 4;
-                    if (is_in_fov(cc))
-                    {
-                        txt(lang(
-                            name(cc) + u8"は蜘蛛の巣にひっかかった。"s,
-                            name(cc) + u8" "s + is(cc)
-                                + u8" caught in a cobweb."s));
-                    }
-                    return turn_result_t::turn_end;
-                }
-            }
+            return turn_result_t::turn_end;
         }
     }
     if (mdata(6) == 1)
@@ -54883,7 +54429,7 @@ void open_new_year_gift()
                 {
                     continue;
                 }
-                addmef(tlocx, tlocy, 5, 24, rnd(15) + 20, 50, 0);
+                mef_add(tlocx, tlocy, 5, 24, rnd(15) + 20, 50, 0);
                 mapitem_fire(tlocx, tlocy);
             }
             return;
@@ -55359,20 +54905,10 @@ label_22191_internal:
     }
     if (map(cdata[tc].position.x, cdata[tc].position.y, 8) != 0)
     {
-        i = map(cdata[tc].position.x, cdata[tc].position.y, 8) - 1;
-        if (mef(0, i) == 2)
+        bool return_now = mef_proc_from_physical_attack(tc);
+        if(return_now)
         {
-            if (rnd(2) == 0)
-            {
-                if (is_in_fov(cc))
-                {
-                    txt(lang(
-                        name(cc) + u8"は霧の中の幻影を攻撃した。"s,
-                        name(cc) + u8" attack"s + _s(cc)
-                            + u8" an illusion in the mist."s));
-                }
-                return;
-            }
+            return;
         }
     }
     if (attackrange == 1)
@@ -55432,9 +54968,9 @@ label_22191_internal:
                     {
                         txtef(9);
                         txt(lang(
-                            name(cc) + u8"は"s + s(1)
+                                name(cc) + u8"は"s + s(1)
                                 + u8"を誇らしげに構えた。"s,
-                            name(cc) + u8" wield"s + _s(cc) + u8" "s + s(1)
+                                name(cc) + u8" wield"s + _s(cc) + u8" "s + s(1)
                                 + u8" proudly."s));
                     }
                 }
@@ -55462,18 +54998,18 @@ label_22191_internal:
                 {
                     gdata(809) = 2;
                     txt(lang(
-                        aln(cc) + name(tc) + u8"を"s
+                            aln(cc) + name(tc) + u8"を"s
                             + _melee(0, cdata[cc].melee_attack_type),
-                        name(cc) + u8" "s
+                            name(cc) + u8" "s
                             + _melee(0, cdata[cc].melee_attack_type) + _s(cc)
                             + u8" "s + name(tc) + u8" and"s));
                 }
                 else
                 {
                     txt(lang(
-                        aln(tc) + name(cc) + u8"に"s
+                            aln(tc) + name(cc) + u8"に"s
                             + _melee(1, cdata[cc].melee_attack_type),
-                        name(cc) + u8" "s
+                            name(cc) + u8" "s
                             + _melee(1, cdata[cc].melee_attack_type) + _s(cc)
                             + u8" "s + name(tc) + u8"."s));
                 }
@@ -55485,15 +55021,15 @@ label_22191_internal:
                 {
                     gdata(809) = 2;
                     txt(lang(
-                        aln(cc) + name(tc) + u8"を射撃し"s,
-                        name(cc) + u8" shoot"s + _s(cc) + u8" "s + name(tc)
+                            aln(cc) + name(tc) + u8"を射撃し"s,
+                            name(cc) + u8" shoot"s + _s(cc) + u8" "s + name(tc)
                             + u8" and"s));
                 }
                 else
                 {
                     txt(lang(
-                        aln(tc) + name(cc) + u8"に"s + s(i) + u8"で撃たれた。"s,
-                        name(cc) + u8" shoot"s + _s(cc) + u8" "s + name(tc)
+                            aln(tc) + name(cc) + u8"に"s + s(i) + u8"で撃たれた。"s,
+                            name(cc) + u8" shoot"s + _s(cc) + u8" "s + name(tc)
                             + u8" with "s + his(cc) + u8" "s + s(i) + u8"."s));
                 }
             }
@@ -55504,15 +55040,15 @@ label_22191_internal:
                 {
                     gdata(809) = 2;
                     txt(lang(
-                        aln(cc) + name(tc) + u8"を射撃し"s,
-                        name(cc) + u8" shoot"s + _s(cc) + u8" "s + name(tc)
+                            aln(cc) + name(tc) + u8"を射撃し"s,
+                            name(cc) + u8" shoot"s + _s(cc) + u8" "s + name(tc)
                             + u8" and"s));
                 }
                 else
                 {
                     txt(lang(
-                        aln(tc) + name(cc) + u8"に"s + s(i) + u8"で撃たれた。"s,
-                        name(cc) + u8" shoot"s + _s(cc) + u8" "s + name(tc)
+                            aln(tc) + name(cc) + u8"に"s + s(i) + u8"で撃たれた。"s,
+                            name(cc) + u8" shoot"s + _s(cc) + u8" "s + name(tc)
                             + u8" with "s + his(cc) + u8" "s + s(i) + u8"."s));
                 }
             }
@@ -55523,15 +55059,15 @@ label_22191_internal:
                 {
                     gdata(809) = 2;
                     txt(lang(
-                        aln(cc) + name(tc) + u8"を射撃し"s,
-                        name(cc) + u8" shoot"s + _s(cc) + u8" "s + name(tc)
+                            aln(cc) + name(tc) + u8"を射撃し"s,
+                            name(cc) + u8" shoot"s + _s(cc) + u8" "s + name(tc)
                             + u8" and"s));
                 }
                 else
                 {
                     txt(lang(
-                        aln(tc) + name(cc) + u8"に"s + s(i) + u8"で撃たれた。"s,
-                        name(cc) + u8" shoot"s + _s(cc) + u8" "s + name(tc)
+                            aln(tc) + name(cc) + u8"に"s + s(i) + u8"で撃たれた。"s,
+                            name(cc) + u8" shoot"s + _s(cc) + u8" "s + name(tc)
                             + u8" with "s + his(cc) + u8" "s + s(i) + u8"."s));
                 }
             }
@@ -55542,15 +55078,15 @@ label_22191_internal:
                 {
                     gdata(809) = 2;
                     txt(lang(
-                        aln(cc) + name(tc) + u8"を切り払い"s,
-                        name(cc) + u8" slash"s + _s(cc) + u8" "s + name(tc)
+                            aln(cc) + name(tc) + u8"を切り払い"s,
+                            name(cc) + u8" slash"s + _s(cc) + u8" "s + name(tc)
                             + u8" and"s));
                 }
                 else
                 {
                     txt(lang(
-                        aln(tc) + name(cc) + u8"に"s + s(i) + u8"で切られた。"s,
-                        name(cc) + u8" slash"s + _s(cc) + u8" "s + name(tc)
+                            aln(tc) + name(cc) + u8"に"s + s(i) + u8"で切られた。"s,
+                            name(cc) + u8" slash"s + _s(cc) + u8" "s + name(tc)
                             + u8" with "s + his(cc) + u8" "s + s(i) + u8"."s));
                 }
             }
@@ -55561,15 +55097,15 @@ label_22191_internal:
                 {
                     gdata(809) = 2;
                     txt(lang(
-                        aln(cc) + name(tc) + u8"を突き刺して"s,
-                        name(cc) + u8" stab"s + _s(cc) + u8" "s + name(tc)
+                            aln(cc) + name(tc) + u8"を突き刺して"s,
+                            name(cc) + u8" stab"s + _s(cc) + u8" "s + name(tc)
                             + u8" and"s));
                 }
                 else
                 {
                     txt(lang(
-                        aln(tc) + name(cc) + u8"に"s + s(i) + u8"で刺された。"s,
-                        name(cc) + u8" stab"s + _s(cc) + u8" "s + name(tc)
+                            aln(tc) + name(cc) + u8"に"s + s(i) + u8"で刺された。"s,
+                            name(cc) + u8" stab"s + _s(cc) + u8" "s + name(tc)
                             + u8" with "s + his(cc) + u8" "s + s(i) + u8"."s));
                 }
             }
@@ -55580,15 +55116,15 @@ label_22191_internal:
                 {
                     gdata(809) = 2;
                     txt(lang(
-                        aln(cc) + name(tc) + u8"を打って"s,
-                        name(cc) + u8" smash"s + _s(cc) + u8" "s + name(tc)
+                            aln(cc) + name(tc) + u8"を打って"s,
+                            name(cc) + u8" smash"s + _s(cc) + u8" "s + name(tc)
                             + u8" and"s));
                 }
                 else
                 {
                     txt(lang(
-                        aln(tc) + name(cc) + u8"に"s + s(i) + u8"で打たれた。"s,
-                        name(cc) + u8" smash"s + _s(cc) + u8" "s + name(tc)
+                            aln(tc) + name(cc) + u8"に"s + s(i) + u8"で打たれた。"s,
+                            name(cc) + u8" smash"s + _s(cc) + u8" "s + name(tc)
                             + u8" with "s + his(cc) + u8" "s + s(i) + u8"."s));
                 }
             }
@@ -55599,15 +55135,15 @@ label_22191_internal:
                 {
                     gdata(809) = 2;
                     txt(lang(
-                        aln(cc) + name(tc) + u8"を突き刺して"s,
-                        name(cc) + u8" stab"s + _s(cc) + u8" "s + name(tc)
+                            aln(cc) + name(tc) + u8"を突き刺して"s,
+                            name(cc) + u8" stab"s + _s(cc) + u8" "s + name(tc)
                             + u8" and"s));
                 }
                 else
                 {
                     txt(lang(
-                        aln(tc) + name(cc) + u8"に"s + s(i) + u8"で刺された。"s,
-                        name(cc) + u8" stab"s + _s(cc) + u8" "s + name(tc)
+                            aln(tc) + name(cc) + u8"に"s + s(i) + u8"で刺された。"s,
+                            name(cc) + u8" stab"s + _s(cc) + u8" "s + name(tc)
                             + u8" with "s + his(cc) + u8" "s + s(i) + u8"."s));
                 }
             }
@@ -55618,15 +55154,15 @@ label_22191_internal:
                 {
                     gdata(809) = 2;
                     txt(lang(
-                        aln(cc) + name(tc) + u8"を打って"s,
-                        name(cc) + u8" smash"s + _s(cc) + u8" "s + name(tc)
+                            aln(cc) + name(tc) + u8"を打って"s,
+                            name(cc) + u8" smash"s + _s(cc) + u8" "s + name(tc)
                             + u8" and"s));
                 }
                 else
                 {
                     txt(lang(
-                        aln(tc) + name(cc) + u8"に"s + s(i) + u8"で打たれた。"s,
-                        name(cc) + u8" smash"s + _s(cc) + u8" "s + name(tc)
+                            aln(tc) + name(cc) + u8"に"s + s(i) + u8"で打たれた。"s,
+                            name(cc) + u8" smash"s + _s(cc) + u8" "s + name(tc)
                             + u8" with "s + his(cc) + u8" "s + s(i) + u8"."s));
                 }
             }
@@ -55637,15 +55173,15 @@ label_22191_internal:
                 {
                     gdata(809) = 2;
                     txt(lang(
-                        aln(cc) + name(tc) + u8"を切り払い"s,
-                        name(cc) + u8" slash"s + _s(cc) + u8" "s + name(tc)
+                            aln(cc) + name(tc) + u8"を切り払い"s,
+                            name(cc) + u8" slash"s + _s(cc) + u8" "s + name(tc)
                             + u8" and"s));
                 }
                 else
                 {
                     txt(lang(
-                        aln(tc) + name(cc) + u8"に"s + s(i) + u8"で切られた。"s,
-                        name(cc) + u8" slash"s + _s(cc) + u8" "s + name(tc)
+                            aln(tc) + name(cc) + u8"に"s + s(i) + u8"で切られた。"s,
+                            name(cc) + u8" slash"s + _s(cc) + u8" "s + name(tc)
                             + u8" with "s + his(cc) + u8" "s + s(i) + u8"."s));
                 }
             }
@@ -55656,15 +55192,15 @@ label_22191_internal:
                 {
                     gdata(809) = 2;
                     txt(lang(
-                        aln(cc) + name(tc) + u8"を切り払い"s,
-                        name(cc) + u8" slash"s + _s(cc) + u8" "s + name(tc)
+                            aln(cc) + name(tc) + u8"を切り払い"s,
+                            name(cc) + u8" slash"s + _s(cc) + u8" "s + name(tc)
                             + u8" and"s));
                 }
                 else
                 {
                     txt(lang(
-                        aln(tc) + name(cc) + u8"に"s + s(i) + u8"で切られた。"s,
-                        name(cc) + u8" slash"s + _s(cc) + u8" "s + name(tc)
+                            aln(tc) + name(cc) + u8"に"s + s(i) + u8"で切られた。"s,
+                            name(cc) + u8" slash"s + _s(cc) + u8" "s + name(tc)
                             + u8" with "s + his(cc) + u8" "s + s(i) + u8"."s));
                 }
             }
@@ -55675,16 +55211,16 @@ label_22191_internal:
                 {
                     gdata(809) = 2;
                     txt(lang(
-                        aln(cc) + name(tc) + u8"に"s + s(i) + u8"を投げ"s,
-                        name(cc) + u8" shoot"s + _s(cc) + u8" "s + name(tc)
+                            aln(cc) + name(tc) + u8"に"s + s(i) + u8"を投げ"s,
+                            name(cc) + u8" shoot"s + _s(cc) + u8" "s + name(tc)
                             + u8" and"s));
                 }
                 else
                 {
                     txt(lang(
-                        aln(tc) + name(cc) + u8"に"s + s(i)
+                            aln(tc) + name(cc) + u8"に"s + s(i)
                             + u8"で攻撃された。"s,
-                        name(cc) + u8" shoot"s + _s(cc) + u8" "s + name(tc)
+                            name(cc) + u8" shoot"s + _s(cc) + u8" "s + name(tc)
                             + u8" with "s + his(cc) + u8" "s + s(i) + u8"."s));
                 }
             }
@@ -55702,7 +55238,7 @@ label_22191_internal:
                 attackskill,
                 cc,
                 clamp((sdata(173, tc) * 2 - sdata(attackskill, cc) + 1), 5, 50)
-                    / expmodifer,
+                / expmodifer,
                 0,
                 4);
             if (attackrange == 0)
@@ -55991,7 +55527,7 @@ void label_2220()
         {
             if (rnd(66) == 0)
             {
-                evadd(18, cc);
+                event_add(18, cc);
             }
             continue;
         }
@@ -57489,7 +57025,7 @@ turn_result_t do_use_command()
             u8"原子爆弾を設置した。逃げろォー！"s,
             u8"You set up the nuke...now run!!"s));
         snd(58);
-        addmef(cdata[cc].position.x, cdata[cc].position.y, 7, 632, 10, 100, cc);
+        mef_add(cdata[cc].position.x, cdata[cc].position.y, 7, 632, 10, 100, cc);
         goto label_2229_internal;
     case 48:
         if (gdata_current_map != 35 || usermapid == 0)
@@ -58327,7 +57863,7 @@ void speak_to_npc()
     chatesc = 1;
     if (cdata[tc].relationship <= -1)
     {
-        if (evnum == 0)
+        if (!event_was_set())
         {
             txt(lang(
                 name(tc) + u8"は耳を貸さない。"s,
@@ -58362,12 +57898,12 @@ void speak_to_npc()
         chatval(1) = cdata[tc].id;
         chatval(2) = 0;
     }
-    if (evid() == 2)
+    if (event_id() == 2)
     {
         talk_wrapper(talk_result_t::talk_game_begin);
         return;
     }
-    if (evid() == 16)
+    if (event_id() == 16)
     {
         talk_wrapper(talk_result_t::talk_finish_escort);
         return;
@@ -58586,7 +58122,7 @@ talk_result_t talk_house_visitor()
                     aniy = tlocy;
                     play_animation(15);
                     cc = ccbk;
-                    addmef(tlocx, tlocy, 5, 24, rnd(15) + 20, 50, tc);
+                    mef_add(tlocx, tlocy, 5, 24, rnd(15) + 20, 50, tc);
                     mapitem_fire(tlocx, tlocy);
                 }
             }
@@ -63226,7 +62762,7 @@ void failed_quest(int val0)
                                             u8" "s + name(tc) +
                                             u8" pours a bottole of molotov cocktail over "s +
                                             him(tc) + u8"self."s);
-                                    addmef(
+                                    mef_add(
                                         cdata[0].position.x,
                                         cdata[0].position.y,
                                         5,
@@ -66849,100 +66385,17 @@ turn_result_t turn_begin()
 {
     int turncost = 0;
     int spd = 0;
-    sound = 0;
     ct = 0;
-    for (int cnt = 0; cnt < 200; ++cnt)
-    {
-        if (mef(0, cnt) == 0)
-        {
-            break;
-        }
-        if (mef(0, cnt) == 5)
-        {
-            if (mdata(14) == 2)
-            {
-                if (mdata(6) != 1)
-                {
-                    if (gdata_weather == 3 || gdata_weather == 4)
-                    {
-                        delmef(cnt);
-                        continue;
-                    }
-                    dx = mef(2, cnt);
-                    dy = mef(3, cnt);
-                    i = mef(6, cnt);
-                    p = 0;
-                    if (rnd(35) == 0)
-                    {
-                        p = 3;
-                        if (dist(
-                                dx,
-                                dy,
-                                cdata[0].position.x,
-                                cdata[0].position.y)
-                            < 6)
-                        {
-                            sound = 6;
-                        }
-                    }
-                    for (int cnt = 0, cnt_end = (p); cnt < cnt_end; ++cnt)
-                    {
-                        x = rnd(2) + dx - rnd(2);
-                        y = rnd(2) + dy - rnd(2);
-                        if (x < 0 || y < 0 || x >= mdata(0) || y >= mdata(1))
-                        {
-                            f = 0;
-                            continue;
-                        }
-                        if (chipm(7, map(x, y, 0)) & 4)
-                        {
-                            map(x, y, 0) = 37;
-                            cnt = 0 - 1;
-                            continue;
-                        }
-                        addmef(x, y, 5, 24, rnd(15) + 20, 50, i);
-                        mapitem_fire(x, y);
-                    }
-                }
-            }
-        }
-        if (mef(0, cnt) == 7)
-        {
-            txtef(3);
-            txt(lang(u8" *"s, u8"*"s) + mef(4, cnt) + lang(u8"* "s, u8"*"s));
-        }
-        if (mef(4, cnt) != -1)
-        {
-            --mef(4, cnt);
-            if (mef(4, cnt) == 0)
-            {
-                delmef(cnt);
-            }
-        }
-    }
-    if (sound != 0)
-    {
-        snd(sound);
-    }
+    mef_update();
     gspd = cdata[0].current_speed * (100 + cdata[0].speed_percentage) / 100;
     if (gspd < 10)
     {
         gspd = 10;
     }
     turncost = (mdata(9) - cdata[0].turn_cost) / gspd + 1;
-    if (evnum != 0)
+    if (event_was_set())
     {
-        evproc = 1;
-        proc_event();
-        evproc = 0;
-        --evnum;
-        evlist(evnum) = 0;
-        if (chatteleport == 1)
-        {
-            chatteleport = 0;
-            return turn_result_t::exit_map;
-        }
-        return turn_result_t::turn_begin;
+        return event_start_proc(); // TODO avoid evnum side effect
     }
     if (cdata[0].state != 1)
     {
@@ -67007,7 +66460,7 @@ turn_result_t turn_begin()
             if (gdata_left_minutes_of_executing_quest <= 0)
             {
                 gdata_left_minutes_of_executing_quest = 0;
-                evadd(14);
+                event_add(14);
             }
         }
         gdata_second = gdata_second % 60;
@@ -67355,7 +66808,7 @@ void label_2736()
             }
         }
         snd(74);
-        evadd(10);
+        event_add(10);
         gdata_play_days += gdata_hour / 24;
         gdata_day += gdata_hour / 24;
         gdata_hour = gdata_hour % 24;
@@ -67442,7 +66895,6 @@ void label_2736()
 
 turn_result_t pass_one_turn(bool label_2738_flg)
 {
-    int ef = 0;
     if (label_2738_flg)
     {
         while (ct < ELONA_MAX_CHARACTERS)
@@ -67514,7 +66966,7 @@ turn_result_t pass_one_turn(bool label_2738_flg)
                     u8"Strange power prevents you from returning."s));
                 goto label_2740_internal;
             }
-            if (gdata_is_returning_or_escaping <= 0 && evnum == 0)
+            if (gdata_is_returning_or_escaping <= 0 && !event_was_set())
             {
                 f = 0;
                 for (int cnt = 1; cnt < 16; ++cnt)
@@ -67618,89 +67070,7 @@ turn_result_t pass_one_turn(bool label_2738_flg)
     tc = cc;
     if (map(cdata[tc].position.x, cdata[tc].position.y, 8) != 0)
     {
-        ef = map(cdata[tc].position.x, cdata[tc].position.y, 8) - 1;
-        if (mef(0, ef) == 3)
-        {
-            if (cdata[tc].is_floating() == 0 || cdata[tc].gravity > 0)
-            {
-                if (sdata(63, tc) / 50 < 7)
-                {
-                    if (is_in_fov(tc))
-                    {
-                        snd(46);
-                        txt(lang(
-                            name(tc) + u8"は酸に焼かれた。"s,
-                            name(tc) + u8" melt"s + _s(tc) + u8"."s));
-                    }
-                    if (mef(6, ef) == 0)
-                    {
-                        if (tc != 0)
-                        {
-                            hostileaction(0, tc);
-                        }
-                    }
-                    int stat = dmghp(
-                        tc, rnd(mef(5, ef) / 25 + 5) + 1, -15, 63, mef(5, ef));
-                    if (stat == 0)
-                    {
-                        check_kill(mef(6, ef), tc);
-                    }
-                }
-            }
-        }
-        if (mef(0, ef) == 5)
-        {
-            if (is_in_fov(tc))
-            {
-                snd(6);
-                txt(lang(
-                    name(tc) + u8"は燃えた。"s,
-                    name(tc) + u8" "s + is(tc) + u8" burnt."s));
-            }
-            if (mef(6, ef) == 0)
-            {
-                if (tc != 0)
-                {
-                    hostileaction(0, tc);
-                }
-            }
-            int stat =
-                dmghp(tc, rnd(mef(5, ef) / 15 + 5) + 1, -9, 50, mef(5, ef));
-            if (stat == 0)
-            {
-                check_kill(mef(6, ef), tc);
-            }
-        }
-        if (mef(0, ef) == 6)
-        {
-            if (cdata[tc].is_floating() == 0 || cdata[tc].gravity > 0)
-            {
-                if (is_in_fov(tc))
-                {
-                    snd(46);
-                    txt(lang(
-                        name(tc) + u8"は地面の液体を浴びた。"s,
-                        name(tc) + u8" step"s + _s(tc) + u8" in the pool."s));
-                }
-                wet(tc, 25);
-                if (mef(6, ef) == 0)
-                {
-                    if (tc != 0)
-                    {
-                        hostileaction(0, tc);
-                    }
-                }
-                potionspill = 1;
-                efstatus = static_cast<curse_state_t>(mef(8, ef)); // TODO
-                dbid = mef(7, ef);
-                access_item_db(15);
-                if (cdata[tc].state == 0)
-                {
-                    check_kill(mef(6, ef), tc);
-                }
-                delmef(ef);
-            }
-        }
+        mef_proc(tc);
     }
     if (cdata[cc].buffs[0].id != 0)
     {

--- a/event.cpp
+++ b/event.cpp
@@ -1,0 +1,76 @@
+#include "event.hpp"
+#include "enums.hpp"
+#include "variables.hpp"
+
+namespace elona
+{
+
+int evproc = 0;
+
+// TODO add serialization routines local to this file
+
+int event_id()
+{
+    if (evnum <= 0)
+    {
+        return -1;
+    }
+    return evlist(evnum - 1);
+}
+
+bool event_was_set()
+{
+    return evnum != 0;
+}
+
+int event_find(int prm_288)
+{
+    int f_at_m17 = 0;
+    f_at_m17 = 0;
+    for (int cnt = 0, cnt_end = (evnum); cnt < cnt_end; ++cnt)
+    {
+        if (evlist(cnt) == prm_288)
+        {
+            f_at_m17 = 1;
+        }
+    }
+    return f_at_m17;
+}
+
+void event_add(int prm_289, int prm_290, int prm_291)
+{
+    if (evproc)
+    {
+        evlist(evnum) = evlist(evnum - 1);
+        evdata1(evnum) = evdata1(evnum - 1);
+        evdata2(evnum) = evdata2(evnum - 1);
+        evlist(evnum - 1) = prm_289;
+        evdata1(evnum - 1) = prm_290;
+        evdata2(evnum - 1) = prm_291;
+    }
+    else
+    {
+        evlist(evnum) = prm_289;
+        evdata1(evnum) = prm_290;
+        evdata2(evnum) = prm_291;
+    }
+    ++evnum;
+    return;
+}
+
+turn_result_t event_start_proc()
+{
+    evproc = 1;
+    proc_event();
+    evproc = 0;
+    --evnum;
+    evlist(evnum) = 0;
+    if (chatteleport == 1)
+    {
+        chatteleport = 0;
+        return turn_result_t::exit_map;
+    }
+    return turn_result_t::turn_begin;
+}
+
+} // namespace elona

--- a/event.hpp
+++ b/event.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace elona
+{
+
+enum class turn_result_t;
+
+int event_id();
+bool event_was_set();
+void event_add(int = 0, int = 0, int = 0);
+int event_find(int = 0);
+turn_result_t event_start_proc();
+
+void proc_event();
+
+} // namespace elona

--- a/init.cpp
+++ b/init.cpp
@@ -7,6 +7,7 @@
 #include "config.hpp"
 #include "ctrl_file.hpp"
 #include "elona.hpp"
+#include "event.hpp"
 #include "filesystem.hpp"
 #include "fish.hpp"
 #include "foobar_save.hpp"
@@ -18,6 +19,7 @@
 #include "log.hpp"
 #include "macro.hpp"
 #include "main.hpp"
+#include "mef.hpp"
 #include "race.hpp"
 #include "range.hpp"
 #include "audio.hpp"
@@ -245,7 +247,7 @@ void initialize_elona()
     SDIM4(promptl, 50, 3, 20);
     SDIM3(description, 1000, 3);
     SDIM1(msgtempprev);
-    DIM3(mef, 9, 200);
+    DIM3(mef, 9, MEF_MAX);
     DIM3(adata, 40, 500);
     DIM3(qdata, 20, 500);
     SDIM3(qname, 40, 500);
@@ -2493,8 +2495,8 @@ void initialize_game()
         }
         create_all_adventurers();
         mode = 2;
-        evadd(2);
-        evadd(24);
+        event_add(2);
+        event_add(24);
         sceneid = 0;
         do_play_scene();
     }

--- a/initialize_map.cpp
+++ b/initialize_map.cpp
@@ -6,7 +6,9 @@
 #include "ctrl_file.hpp"
 #include "draw.hpp"
 #include "elona.hpp"
+#include "event.hpp"
 #include "item.hpp"
+#include "map_cell.hpp"
 #include "variables.hpp"
 
 
@@ -207,7 +209,7 @@ label_1741_internal:
         generate_random_nefia();
         if (gdata_current_dungeon_level == adata(10, gdata_current_map))
         {
-            evadd(4);
+            event_add(4);
         }
     }
     if (adata(16, gdata_current_map) == 101)
@@ -468,7 +470,7 @@ label_1741_internal:
         cdata[rc].ai_calm = 3;
         mdata(13) = 79;
         map_placeplayer();
-        evadd(30);
+        event_add(30);
     }
     if (gdata_current_map == 43 || gdata_current_map == 45)
     {
@@ -2231,7 +2233,7 @@ label_1741_internal:
                 cdatan(0, rc) += u8" Lv"s + cdata[rc].level;
             }
             gdatan(1) = random_title(2);
-            evadd(23);
+            event_add(23);
         }
         if (encounter == 3)
         {
@@ -2272,7 +2274,7 @@ label_1741_internal:
                 r2 = 1;
                 gain_level(rc);
             }
-            evadd(11);
+            event_add(11);
             for (int cnt = 0, cnt_end = (6 + rnd(6)); cnt < cnt_end; ++cnt)
             {
                 flt();
@@ -2322,7 +2324,7 @@ label_1741_internal:
         }
         if (gdata(186) <= gdata_current_dungeon_level)
         {
-            evadd(29);
+            event_add(29);
         }
         else
         {
@@ -2343,7 +2345,7 @@ label_1741_internal:
                 mdatan(0) = lang(u8"レシマス最深層"s, u8"The Depth"s);
                 if (gdata_main_quest_flag < 170)
                 {
-                    evadd(3);
+                    event_add(3);
                 }
                 x = 16;
                 y = 13;
@@ -3138,21 +3140,21 @@ label_1744_internal:
     {
         if (gdata_current_dungeon_level == 3)
         {
-            evadd(22, gdata_belongs_to_mages_guild);
+            event_add(22, gdata_belongs_to_mages_guild);
         }
     }
     if (adata(16, gdata_current_map) == 14)
     {
         if (gdata_current_dungeon_level == 3)
         {
-            evadd(22, gdata_belongs_to_thieves_guild);
+            event_add(22, gdata_belongs_to_thieves_guild);
         }
     }
     if (adata(16, gdata_current_map) == 11)
     {
         if (gdata_current_dungeon_level == 3)
         {
-            evadd(22, gdata_belongs_to_fighters_guild);
+            event_add(22, gdata_belongs_to_fighters_guild);
         }
     }
     if (gdata_current_map == 5)
@@ -3166,7 +3168,7 @@ label_1744_internal:
         if (gdata_has_not_been_to_vernis == 0)
         {
             gdata_has_not_been_to_vernis = 1;
-            evadd(12);
+            event_add(12);
         }
     }
     if (gdata_current_map == 15)
@@ -3294,7 +3296,7 @@ label_1744_internal:
                                 {
                                     if (qdata(12, cnt2) == gdata_current_map)
                                     {
-                                        evadd(16, cnt2, cnt);
+                                        event_add(16, cnt2, cnt);
                                         cdata[cnt].is_escorted() = false;
                                         break;
                                     }

--- a/magic.cpp
+++ b/magic.cpp
@@ -14,6 +14,8 @@
 #include "item_db.hpp"
 #include "macro.hpp"
 #include "map.hpp"
+#include "map_cell.hpp"
+#include "mef.hpp"
 #include "trait.hpp"
 #include "variables.hpp"
 #include "wish.hpp"
@@ -3402,24 +3404,24 @@ label_2181_internal:
             }
             if (efid == 634)
             {
-                addmef(x, y, 4, 20, rnd(4) + 2, efp, cc);
+                mef_add(x, y, 4, 20, rnd(4) + 2, efp, cc);
             }
             if (efid == 455)
             {
-                addmef(x, y, 3, 19, rnd(10) + 5, efp, cc);
+                mef_add(x, y, 3, 19, rnd(10) + 5, efp, cc);
             }
             if (efid == 456)
             {
-                addmef(x, y, 5, 24, rnd(10) + 5, efp, cc);
+                mef_add(x, y, 5, 24, rnd(10) + 5, efp, cc);
                 mapitem_fire(x, y);
             }
             if (efid == 436)
             {
-                addmef(x, y, 1, 11, -1, efp * 2);
+                mef_add(x, y, 1, 11, -1, efp * 2);
             }
             if (efid == 437)
             {
-                addmef(x, y, 2, 30, 8 + rnd((15 + efp / 25)), efp);
+                mef_add(x, y, 2, 30, 8 + rnd((15 + efp / 25)), efp);
             }
         }
         break;
@@ -4222,7 +4224,7 @@ label_2181_internal:
                 }
                 if (rnd(40) == 0)
                 {
-                    addmef(dx, dy, 5, 24, rnd(4) + 3, 50);
+                    mef_add(dx, dy, 5, 24, rnd(4) + 3, 50);
                 }
                 if (map(dx, dy, 1) != 0)
                 {
@@ -4399,7 +4401,7 @@ label_2181_internal:
                 name(tc) + u8"は炎に包まれた。"s,
                 name(tc) + u8" "s + is(tc) + u8" surrounded by flames."s));
         }
-        addmef(
+        mef_add(
             cdata[tc].position.x,
             cdata[tc].position.y,
             5,

--- a/map_cell.cpp
+++ b/map_cell.cpp
@@ -1,0 +1,276 @@
+#include "map_cell.hpp"
+#include "character.hpp"
+#include "elona.hpp"
+#include "item.hpp"
+#include "map.hpp"
+#include "variables.hpp"
+
+namespace elona
+{
+
+int tc_at_m81 = 0;
+
+void cell_featset(
+    int prm_592,
+    int prm_593,
+    int prm_594,
+    int prm_595,
+    int prm_596,
+    int prm_597)
+{
+    elona_vector1<int> feat_at_m80;
+    if (prm_594 != -1)
+    {
+        feat_at_m80 = prm_594;
+    }
+    else
+    {
+        feat_at_m80 = map(prm_592, prm_593, 6) % 1000;
+    }
+    if (prm_595 != -1)
+    {
+        feat_at_m80(1) = prm_595;
+    }
+    else
+    {
+        feat_at_m80(1) = map(prm_592, prm_593, 6) / 1000 % 100;
+    }
+    if (prm_596 != -1)
+    {
+        feat_at_m80(2) = prm_596;
+    }
+    else
+    {
+        feat_at_m80(2) = map(prm_592, prm_593, 6) / 100000 % 100;
+    }
+    if (prm_597 != -1)
+    {
+        feat_at_m80(3) = prm_597;
+    }
+    else
+    {
+        feat_at_m80(3) = map(prm_592, prm_593, 6) / 10000000;
+    }
+    map(prm_592, prm_593, 6) = feat_at_m80 + feat_at_m80(1) * 1000
+        + feat_at_m80(2) * 100000 + feat_at_m80(3) * 10000000;
+    return;
+}
+
+
+
+int cell_featread(int prm_598, int prm_599, int)
+{
+    feat(0) = map(prm_598, prm_599, 6) % 1000;
+    feat(1) = map(prm_598, prm_599, 6) / 1000 % 100;
+    feat(2) = map(prm_598, prm_599, 6) / 100000 % 100;
+    feat(3) = map(prm_598, prm_599, 6) / 10000000;
+    return 0;
+}
+
+
+
+void cell_featclear(int prm_601, int prm_602)
+{
+    map(prm_601, prm_602, 6) = 0;
+    return;
+}
+
+
+
+void cell_check(int prm_603, int prm_604)
+{
+    cellaccess = 1;
+    cellchara = -1;
+    cellfeat = -1;
+    if (prm_603 < 0 || prm_603 >= mdata(0) || prm_604 < 0
+        || prm_604 >= mdata(1))
+    {
+        cellaccess = 0;
+        return;
+    }
+    if (map(prm_603, prm_604, 1) != 0)
+    {
+        cellchara = map(prm_603, prm_604, 1) - 1;
+        cellaccess = 0;
+    }
+    if (map(prm_603, prm_604, 6) != 0)
+    {
+        cellfeat = map(prm_603, prm_604, 6) / 1000 % 100;
+        if (chipm(7, map(prm_603, prm_604, 6) % 1000) & 4)
+        {
+            cellaccess = 0;
+        }
+    }
+    if (chipm(7, map(prm_603, prm_604, 0)) & 4)
+    {
+        cellaccess = 0;
+    }
+    return;
+}
+
+
+
+void cell_swap(int prm_605, int prm_606, int prm_607, int prm_608)
+{
+    int x2_at_m81 = 0;
+    int y2_at_m81 = 0;
+    if (gdata_mount != 0)
+    {
+        if (gdata_mount == prm_605 || gdata_mount == prm_606)
+        {
+            return;
+        }
+    }
+    tc_at_m81 = prm_606;
+    if (tc_at_m81 == -1)
+    {
+        if (map(prm_607, prm_608, 1) != 0)
+        {
+            tc_at_m81 = map(prm_607, prm_608, 1) - 1;
+        }
+    }
+    if (tc_at_m81 != -1)
+    {
+        map(cdata[prm_605].position.x, cdata[prm_605].position.y, 1) =
+            tc_at_m81 + 1;
+        x2_at_m81 = cdata[tc_at_m81].position.x;
+        y2_at_m81 = cdata[tc_at_m81].position.y;
+        cdata[tc_at_m81].position.x = cdata[prm_605].position.x;
+        cdata[tc_at_m81].position.y = cdata[prm_605].position.y;
+    }
+    else
+    {
+        map(cdata[prm_605].position.x, cdata[prm_605].position.y, 1) = 0;
+        x2_at_m81 = prm_607;
+        y2_at_m81 = prm_608;
+    }
+    map(x2_at_m81, y2_at_m81, 1) = prm_605 + 1;
+    cdata[prm_605].position.x = x2_at_m81;
+    cdata[prm_605].position.y = y2_at_m81;
+    if (prm_605 == 0 || tc_at_m81 == 0)
+    {
+        if (gdata_mount)
+        {
+            cdata[gdata_mount].position.x = cdata[0].position.x;
+            cdata[gdata_mount].position.y = cdata[0].position.y;
+        }
+    }
+    return;
+}
+
+
+
+void cell_movechara(int cc, int x, int y)
+{
+    if (map(x, y, 1) != 0)
+    {
+        if (map(x, y, 1) - 1 == cc)
+        {
+            return;
+        }
+        cell_swap(cc, tc_at_m81);
+    }
+    else
+    {
+        map(cdata[cc].position.x, cdata[cc].position.y, 1) = 0;
+        cdata[cc].position = {x, y};
+        map(x, y, 1) = cc + 1;
+    }
+}
+
+int cell_itemlist(int prm_625, int prm_626)
+{
+    listmax = 0;
+    for (const auto& cnt : items(-1))
+    {
+        if (inv[cnt].number > 0)
+        {
+            if (inv[cnt].position.x == prm_625
+                && inv[cnt].position.y == prm_626)
+            {
+                list(0, listmax) = cnt;
+                ++listmax;
+            }
+        }
+    }
+    return rtval;
+}
+
+// Returns pair of number of items and the last item on the cell.
+std::pair<int, int> cell_itemoncell(const position_t& pos)
+{
+    int number{};
+    int item{};
+
+    for (const auto& ci : items(-1))
+    {
+        if (inv[ci].number > 0 && inv[ci].position == pos)
+        {
+            ++number;
+            item = ci;
+        }
+    }
+
+    return std::make_pair(number, item);
+}
+
+void cell_setchara(int cc, int x, int y)
+{
+    map(x, y, 1) = cc + 1;
+    cdata[cc].position = position_t{x, y};
+}
+
+
+
+void cell_removechara(int x, int y)
+{
+    map(x, y, 1) = 0;
+}
+
+
+
+int cell_findspace(int prm_796, int prm_797, int prm_798)
+{
+    int f_at_m130 = 0;
+    int dy_at_m130 = 0;
+    int dx_at_m130 = 0;
+    f_at_m130 = 0;
+    for (int cnt = 0, cnt_end = (prm_798 * 2 + 1); cnt < cnt_end; ++cnt)
+    {
+        dy_at_m130 = prm_797 + cnt - 1;
+        if (dy_at_m130 < 0 || dy_at_m130 >= mdata(1))
+        {
+            continue;
+        }
+        for (int cnt = 0, cnt_end = (prm_798 * 2 + 1); cnt < cnt_end; ++cnt)
+        {
+            dx_at_m130 = prm_796 + cnt - 1;
+            if (dx_at_m130 < 0 || dx_at_m130 >= mdata(0))
+            {
+                continue;
+            }
+            if (map(dx_at_m130, dy_at_m130, 1) != 0)
+            {
+                continue;
+            }
+            if (chipm(7, map(dx_at_m130, dy_at_m130, 0)) & 4)
+            {
+                continue;
+            }
+            if (chipm(7, map(dx_at_m130, dy_at_m130, 6) % 1000) & 4)
+            {
+                continue;
+            }
+            rtval(0) = dx_at_m130;
+            rtval(1) = dy_at_m130;
+            f_at_m130 = 1;
+        }
+        if (f_at_m130)
+        {
+            break;
+        }
+    }
+    return f_at_m130;
+}
+
+} // namespace elona

--- a/map_cell.hpp
+++ b/map_cell.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <unordered_map>
+
+namespace elona
+{
+
+struct position_t;
+
+std::pair<int, int> cell_itemoncell(const position_t& pos);
+int cell_featread(int = 0, int = 0, int = 0);
+int cell_findspace(int = 0, int = 0, int = 0);
+int cell_itemlist(int = 0, int = 0);
+void cell_check(int = 0, int = 0);
+void cell_featclear(int = 0, int = 0);
+void cell_featset(int = 0, int = 0, int = 0, int = 0, int = 0, int = 0);
+void cell_movechara(int = 0, int = 0, int = 0);
+void cell_refresh(int = 0, int = 0);
+void cell_removechara(int = 0, int = 0);
+void cell_setchara(int = 0, int = 0, int = 0);
+void cell_swap(int = 0, int = 0, int = 0, int = 0);
+
+} // namespace elona

--- a/mef.cpp
+++ b/mef.cpp
@@ -1,0 +1,360 @@
+#include "mef.hpp"
+#include "ability.hpp"
+#include "audio.hpp"
+#include "character.hpp"
+#include "event.hpp"
+#include "map.hpp"
+#include "variables.hpp"
+
+namespace elona
+{
+
+int i_at_m79 = 0;
+
+void initialize_mef()
+{
+    DIM3(mefsubref, 6, 6);
+    mefsubref(0, 1) = 144;
+    mefsubref(1, 1) = 624;
+    mefsubref(0, 2) = 272;
+    mefsubref(1, 2) = 624;
+    mefsubref(2, 2) = 1;
+    mefsubref(0, 3) = 304;
+    mefsubref(1, 3) = 624;
+    mefsubref(2, 3) = 1;
+    mefsubref(0, 4) = 368;
+    mefsubref(1, 4) = 624;
+    mefsubref(0, 5) = 464;
+    mefsubref(1, 5) = 624;
+}
+
+void mef_delete(int prm_581)
+{
+    if (mef(0, prm_581) == 7)
+    {
+        event_add(21, mef(2, prm_581), mef(3, prm_581));
+    }
+    map(mef(2, prm_581), mef(3, prm_581), 8) = 0;
+    mef(0, prm_581) = 0;
+    i_at_m79 = 199;
+    for (int cnt = 0, cnt_end = (MEF_MAX - prm_581); cnt < cnt_end; ++cnt)
+    {
+        if (mef(0, i_at_m79) != 0)
+        {
+            for (int cnt = 0; cnt < 9; ++cnt)
+            {
+                mef(cnt, prm_581) = mef(cnt, i_at_m79);
+            }
+            map(mef(2, i_at_m79), mef(3, i_at_m79), 8) = prm_581 + 1;
+            mef(0, i_at_m79) = 0;
+            break;
+        }
+        --i_at_m79;
+    }
+    return;
+}
+
+
+
+void mef_add(
+    int pos_x,
+    int pos_y,
+    int prm_584,
+    int prm_585,
+    int prm_586,
+    int effect_power,
+    int chara,
+    int prm_589,
+    int prm_590,
+    int prm_591)
+{
+    int p_at_m79 = 0;
+    p_at_m79 = map(pos_x, pos_y, 0);
+    if (prm_584 == 5)
+    {
+        if (chipm(0, p_at_m79) == 3)
+        {
+            return;
+        }
+    }
+    if (map(pos_x, pos_y, 8) != 0)
+    {
+        i_at_m79 = map(pos_x, pos_y, 8) - 1;
+    }
+    else
+    {
+        i_at_m79 = -1;
+        for (int cnt = 0; cnt < MEF_MAX; ++cnt)
+        {
+            if (mef(0, cnt) == 0)
+            {
+                i_at_m79 = cnt;
+                break;
+            }
+        }
+        if (i_at_m79 == -1)
+        {
+            i_at_m79 = rnd(MEF_MAX);
+            map(mef(2, i_at_m79), mef(3, i_at_m79), 8) = 0;
+        }
+    }
+    mef(0, i_at_m79) = prm_584;
+    mef(1, i_at_m79) = prm_585 + prm_591 * 10000;
+    mef(2, i_at_m79) = pos_x;
+    mef(3, i_at_m79) = pos_y;
+    mef(4, i_at_m79) = prm_586;
+    mef(5, i_at_m79) = effect_power;
+    mef(6, i_at_m79) = chara;
+    mef(7, i_at_m79) = prm_589;
+    mef(8, i_at_m79) = prm_590;
+    map(pos_x, pos_y, 8) = i_at_m79 + 1;
+    return;
+}
+
+void mef_update()
+{
+    int sound = 0;
+    for (int cnt = 0; cnt < MEF_MAX; ++cnt)
+    {
+        if (mef(0, cnt) == 0)
+        {
+            break;
+        }
+        if (mef(0, cnt) == 5)
+        {
+            if (mdata(14) == 2)
+            {
+                if (mdata(6) != 1)
+                {
+                    if (gdata_weather == 3 || gdata_weather == 4)
+                    {
+                        mef_delete(cnt);
+                        continue;
+                    }
+                    dx = mef(2, cnt);
+                    dy = mef(3, cnt);
+                    i = mef(6, cnt);
+                    p = 0;
+                    if (rnd(35) == 0)
+                    {
+                        p = 3;
+                        if (dist(
+                                dx,
+                                dy,
+                                cdata[0].position.x,
+                                cdata[0].position.y)
+                            < 6)
+                        {
+                            sound = 6;
+                        }
+                    }
+                    for (int cnt = 0, cnt_end = (p); cnt < cnt_end; ++cnt)
+                    {
+                        x = rnd(2) + dx - rnd(2);
+                        y = rnd(2) + dy - rnd(2);
+                        if (x < 0 || y < 0 || x >= mdata(0) || y >= mdata(1))
+                        {
+                            f = 0;
+                            continue;
+                        }
+                        if (chipm(7, map(x, y, 0)) & 4)
+                        {
+                            map(x, y, 0) = 37;
+                            cnt = 0 - 1;
+                            continue;
+                        }
+                        mef_add(x, y, 5, 24, rnd(15) + 20, 50, i);
+                        mapitem_fire(x, y);
+                    }
+                }
+            }
+        }
+        if (mef(0, cnt) == 7)
+        {
+            txtef(3);
+            txt(lang(u8" *"s, u8"*"s) + mef(4, cnt) + lang(u8"* "s, u8"*"s));
+        }
+        if (mef(4, cnt) != -1)
+        {
+            --mef(4, cnt);
+            if (mef(4, cnt) == 0)
+            {
+                mef_delete(cnt);
+            }
+        }
+    }
+    if (sound != 0)
+    {
+        snd(sound);
+    }
+}
+
+void mef_proc(int tc)
+{
+    int ef = map(cdata[tc].position.x, cdata[tc].position.y, 8) - 1;
+    if (mef(0, ef) == 0)
+    {
+        return;
+    }
+    if (mef(0, ef) == 3)
+    {
+        if (cdata[tc].is_floating() == 0 || cdata[tc].gravity > 0)
+        {
+            if (sdata(63, tc) / 50 < 7)
+            {
+                if (is_in_fov(tc))
+                {
+                    snd(46);
+                    txt(lang(
+                            name(tc) + u8"は酸に焼かれた。"s,
+                            name(tc) + u8" melt"s + _s(tc) + u8"."s));
+                }
+                if (mef(6, ef) == 0)
+                {
+                    if (tc != 0)
+                    {
+                        hostileaction(0, tc);
+                    }
+                }
+                int stat = dmghp(
+                    tc, rnd(mef(5, ef) / 25 + 5) + 1, -15, 63, mef(5, ef));
+                if (stat == 0)
+                {
+                    check_kill(mef(6, ef), tc);
+                }
+            }
+        }
+    }
+    if (mef(0, ef) == 5)
+    {
+        if (is_in_fov(tc))
+        {
+            snd(6);
+            txt(lang(
+                    name(tc) + u8"は燃えた。"s,
+                    name(tc) + u8" "s + is(tc) + u8" burnt."s));
+        }
+        if (mef(6, ef) == 0)
+        {
+            if (tc != 0)
+            {
+                hostileaction(0, tc);
+            }
+        }
+        int stat =
+            dmghp(tc, rnd(mef(5, ef) / 15 + 5) + 1, -9, 50, mef(5, ef));
+        if (stat == 0)
+        {
+            check_kill(mef(6, ef), tc);
+        }
+    }
+    if (mef(0, ef) == 6)
+    {
+        if (cdata[tc].is_floating() == 0 || cdata[tc].gravity > 0)
+        {
+            if (is_in_fov(tc))
+            {
+                snd(46);
+                txt(lang(
+                        name(tc) + u8"は地面の液体を浴びた。"s,
+                        name(tc) + u8" step"s + _s(tc) + u8" in the pool."s));
+            }
+            wet(tc, 25);
+            if (mef(6, ef) == 0)
+            {
+                if (tc != 0)
+                {
+                    hostileaction(0, tc);
+                }
+            }
+            potionspill = 1;
+            efstatus = static_cast<curse_state_t>(mef(8, ef)); // TODO
+            dbid = mef(7, ef);
+            access_item_db(15);
+            if (cdata[tc].state == 0)
+            {
+                check_kill(mef(6, ef), tc);
+            }
+            mef_delete(ef);
+        }
+    }
+}
+
+// returns true if turn ended
+bool mef_proc_from_movement(int cc)
+{
+    int i = map(cdata[cc].position.x, cdata[cc].position.y, 8) - 1;
+    if (mef(0, i) == 0)
+    {
+        return false;
+    }
+    if (mef(0, i) == 1)
+    {
+        if (cdatan(2, cc) != u8"spider"s)
+        {
+            if (rnd(mef(5, i) + 25) < rnd(sdata(10, cc) + sdata(12, cc) + 1)
+                || cdata[cc].weight > 100)
+            {
+                if (is_in_fov(cc))
+                {
+                    txt(lang(
+                            name(cc) + u8"は蜘蛛の巣を振り払った。"s,
+                            name(cc) + u8" destroy"s + _s(cc)
+                            + u8" the cobweb."s));
+                }
+                mef_delete(i);
+            }
+            else
+            {
+                mef(5, i) = mef(5, i) * 3 / 4;
+                if (is_in_fov(cc))
+                {
+                    txt(lang(
+                            name(cc) + u8"は蜘蛛の巣にひっかかった。"s,
+                            name(cc) + u8" "s + is(cc)
+                            + u8" caught in a cobweb."s));
+                }
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+// returns true if caller needs to return directly after
+bool mef_proc_from_physical_attack(int tc)
+{
+    int i = map(cdata[tc].position.x, cdata[tc].position.y, 8) - 1;
+    if (mef(0, i) == 0)
+    {
+        return false;
+    }
+    if (mef(0, i) == 2)
+    {
+        if (rnd(2) == 0)
+        {
+            if (is_in_fov(cc))
+            {
+                txt(lang(
+                        name(cc) + u8"は霧の中の幻影を攻撃した。"s,
+                        name(cc) + u8" attack"s + _s(cc)
+                        + u8" an illusion in the mist."s));
+            }
+            return true;
+        }
+    }
+    return false;
+}
+
+void mef_clear_all()
+{
+    for (int cnt = 0; cnt < MEF_MAX; ++cnt)
+    {
+        mef(0, cnt) = 0;
+    }
+}
+
+
+
+
+} // namespace elona

--- a/mef.hpp
+++ b/mef.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+namespace elona
+{
+
+#define MEF_MAX 200
+
+void initialize_mef();
+void mef_add(
+    int = 0,
+    int = 0,
+    int = 0,
+    int = 0,
+    int = 0,
+    int = 0,
+    int = 0,
+    int = 0,
+    int = 0,
+    int = 0);
+void mef_delete(int = 0);
+void mef_update();
+void mef_proc(int);
+bool mef_proc_from_movement(int);
+bool mef_proc_from_physical_attack(int);
+void mef_clear_all();
+
+} // namespace elona

--- a/proc_event.cpp
+++ b/proc_event.cpp
@@ -5,7 +5,10 @@
 #include "character.hpp"
 #include "config.hpp"
 #include "elona.hpp"
+#include "event.hpp"
 #include "item.hpp"
+#include "map_cell.hpp"
+#include "mef.hpp"
 #include "random.hpp"
 #include "variables.hpp"
 
@@ -16,7 +19,7 @@ namespace elona
 
 void proc_event()
 {
-    switch (evid())
+    switch (event_id())
     {
     case 8: hunt_all_targets(); break;
     case 14:
@@ -823,7 +826,7 @@ void proc_event()
                     }
                     if (rnd(10) == 0 || f == 1)
                     {
-                        addmef(dx, dy, 5, 24, rnd(15) + 20, 50);
+                        mef_add(dx, dy, 5, 24, rnd(15) + 20, 50);
                     }
                     if (map(dx, dy, 1) != 0)
                     {
@@ -879,7 +882,7 @@ void proc_event()
                 x = rnd(mdata(0));
                 y = rnd(mdata(1));
             }
-            addmef(
+            mef_add(
                 x,
                 y,
                 5,

--- a/talk_npc.cpp
+++ b/talk_npc.cpp
@@ -4,10 +4,12 @@
 #include "calc.hpp"
 #include "character.hpp"
 #include "elona.hpp"
+#include "event.hpp"
 #include "i18n.hpp"
 #include "item.hpp"
 #include "item_db.hpp"
 #include "macro.hpp"
+#include "map_cell.hpp"
 #include "variables.hpp"
 
 
@@ -361,7 +363,7 @@ talk_result_t talk_npc()
         {
             if (tc >= 16)
             {
-                if (evid() == -1)
+                if (event_id() == -1)
                 {
                     ELONA_APPEND_RESPONSE(
                         56,
@@ -374,7 +376,7 @@ talk_result_t talk_npc()
     }
     if (cdata[tc].id == 335)
     {
-        if (evid() == -1)
+        if (event_id() == -1)
         {
             ELONA_APPEND_RESPONSE(
                 60, lang(u8"暗い場所に移ろう"s, u8"I'll buy you."s));
@@ -515,7 +517,7 @@ talk_result_t talk_npc()
             {
                 if ((cdata[tc].character_role < 2000
                      || cdata[tc].character_role >= 3000)
-                    && evid() == -1)
+                    && event_id() == -1)
                 {
                     ELONA_APPEND_RESPONSE(
                         44, lang(u8"解雇する"s, u8"You are fired."s));
@@ -1294,7 +1296,7 @@ talk_result_t talk_npc()
                 }
                 if (cdata[rc].is_escorted() == 1)
                 {
-                    evadd(15, cdata[rc].id);
+                    event_add(15, cdata[rc].id);
                 }
                 del_chara(rc);
                 buff = lang(_thanks(2), u8"Thanks!"s);
@@ -1327,7 +1329,7 @@ talk_result_t talk_npc()
         chatesc = 1;
         ELONA_TALK_SCENE_CUT();
         marry = tc;
-        evadd(13);
+        event_add(13);
         return talk_result_t::talk_end;
     }
     if (chatval == 39)
@@ -1743,7 +1745,7 @@ talk_result_t talk_npc()
     {
         if (gdata_left_turns_of_timestop == 0)
         {
-            evadd(25);
+            event_add(25);
         }
         return talk_result_t::talk_end;
     }
@@ -1929,7 +1931,7 @@ talk_result_t talk_npc()
         buff = s;
         return talk_result_t::talk_npc;
     }
-    if (evid() == 11)
+    if (event_id() == 11)
     {
         levelexitby = 4;
         chatteleport = 1;

--- a/talk_unique.cpp
+++ b/talk_unique.cpp
@@ -26,7 +26,7 @@ talk_result_t talk_unique()
         listmax = 0;
         buff = lang(
             u8"ここまで辿り着くとはな…どうやら《混沌》は、自ら創りしネフィアの安定さえも望まぬらしい。しかし、私とてここで死ぬつもりなどないのだ。"s,
-            u8"So you've made it this far. Event_Idently, <Chaos> wants no poise even within their own creation...Nefia. Well, it seems they have left me no choice but to whip you!"s);
+            u8"So you've made it this far. Evidently, <Chaos> wants no poise even within their own creation...Nefia. Well, it seems they have left me no choice but to whip you!"s);
         tc = tc * 1 + 0;
         ELONA_APPEND_RESPONSE(0, i18n::_(u8"ui", u8"more"));
         chatesc = 1;

--- a/talk_unique.cpp
+++ b/talk_unique.cpp
@@ -3,10 +3,12 @@
 #include "calc.hpp"
 #include "character.hpp"
 #include "elona.hpp"
+#include "event.hpp"
 #include "i18n.hpp"
 #include "item.hpp"
 #include "item_db.hpp"
 #include "macro.hpp"
+#include "map_cell.hpp"
 #include "variables.hpp"
 
 
@@ -24,7 +26,7 @@ talk_result_t talk_unique()
         listmax = 0;
         buff = lang(
             u8"ここまで辿り着くとはな…どうやら《混沌》は、自ら創りしネフィアの安定さえも望まぬらしい。しかし、私とてここで死ぬつもりなどないのだ。"s,
-            u8"So you've made it this far. Evidently, <Chaos> wants no poise even within their own creation...Nefia. Well, it seems they have left me no choice but to whip you!"s);
+            u8"So you've made it this far. Event_Idently, <Chaos> wants no poise even within their own creation...Nefia. Well, it seems they have left me no choice but to whip you!"s);
         tc = tc * 1 + 0;
         ELONA_APPEND_RESPONSE(0, i18n::_(u8"ui", u8"more"));
         chatesc = 1;
@@ -32,7 +34,7 @@ talk_result_t talk_unique()
         gdata_main_quest_flag = 170;
         return talk_result_t::talk_end;
     case 23:
-        if (evid() == 1)
+        if (event_id() == 1)
         {
             if (jp)
             {
@@ -2106,7 +2108,7 @@ talk_result_t talk_unique()
                 ELONA_APPEND_RESPONSE(0, i18n::_(u8"ui", u8"bye"));
                 chatesc = 1;
                 ELONA_TALK_SCENE_CUT();
-                evadd(20, tc);
+                event_add(20, tc);
                 return talk_result_t::talk_end;
             }
             if (chatval == 2)

--- a/variables.hpp
+++ b/variables.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "elona.hpp"
 #include "position.hpp"
 #include "enums.hpp"
@@ -25,6 +27,14 @@ ELONA_EXTERN(int anic);
 ELONA_EXTERN(elona_vector1<int> ap);
 ELONA_EXTERN(int wishfilter);
 ELONA_EXTERN(int nooracle);
+
+// mef.cpp
+ELONA_EXTERN(elona_vector2<int> mef);
+ELONA_EXTERN(elona_vector2<int> mefsubref);
+
+// map_cell.cpp
+ELONA_EXTERN(int cellchara);
+ELONA_EXTERN(int cellfeat);
 
 ELONA_EXTERN(elona_vector1<int> _randcolor);
 ELONA_EXTERN(elona_vector1<int> aniref);
@@ -228,8 +238,6 @@ ELONA_EXTERN(elona_vector1<int> eqring1);
 ELONA_EXTERN(elona_vector2<int> itemmemory);
 ELONA_EXTERN(elona_vector2<int> list);
 ELONA_EXTERN(elona_vector2<int> mapsync);
-ELONA_EXTERN(elona_vector2<int> mef);
-ELONA_EXTERN(elona_vector2<int> mefsubref);
 ELONA_EXTERN(elona_vector2<int> npcmemory);
 ELONA_EXTERN(elona_vector2<int> pcc);
 ELONA_EXTERN(elona_vector2<int> picfood);
@@ -571,10 +579,6 @@ int cargocheck();
 int carmor(int = 0);
 int cbreeder(int = 0);
 int cdbit(int = 0, int = 0);
-int cell_featread(int = 0, int = 0, int = 0);
-int cell_findspace(int = 0, int = 0, int = 0);
-int cell_itemlist(int = 0, int = 0);
-std::pair<int, int> cell_itemoncell(const position_t& pos);
 int chara_anorexia(int = 0);
 bool chara_unequip(int);
 int characreate(int = 0, int = 0, int = 0, int = 0);
@@ -604,8 +608,6 @@ bool encfindspec(int = 0, int = 0);
 int encflt(int = 0, int = 0);
 int eqweaponheavy();
 int eqweaponlight();
-int evfind(int = 0);
-int evid();
 int exist_questtarget();
 int findally(int = 0);
 int findbuff(int = 0, int = 0);
@@ -826,17 +828,6 @@ std::string yourself(int = 0);
 void actionproc();
 void addbuilding(int = 0, int = 0, int = 0, int = 0);
 void addefmap(int = 0, int = 0, int = 0, int = 0, int = 0, int = 0);
-void addmef(
-    int = 0,
-    int = 0,
-    int = 0,
-    int = 0,
-    int = 0,
-    int = 0,
-    int = 0,
-    int = 0,
-    int = 0,
-    int = 0);
 void addnews(int = 0, int = 0, int = 0, const std::string& = "");
 void addnews2(const std::string&, int = 0);
 void addnewstopic(const std::string&, const std::string&);
@@ -857,15 +848,7 @@ void cardplayeradd(int = 0, int = 0, int = 0);
 void cardplayerinit(int = 0, int = 0);
 void cardpos(int = 0, int = 0);
 void cdbitmod(int = 0, int = 0, int = 0);
-void cell_check(int = 0, int = 0);
 void cell_draw();
-void cell_featclear(int = 0, int = 0);
-void cell_featset(int = 0, int = 0, int = 0, int = 0, int = 0, int = 0);
-void cell_movechara(int = 0, int = 0, int = 0);
-void cell_refresh(int = 0, int = 0);
-void cell_removechara(int = 0, int = 0);
-void cell_setchara(int = 0, int = 0, int = 0);
-void cell_swap(int = 0, int = 0, int = 0, int = 0);
 void chara_preparepic(int = 0, int = 0);
 void chara_vanquish(int = 0);
 void chara_vomit(int = 0);
@@ -888,7 +871,6 @@ void cutname(std::string&, int = 0);
 void del_chara(int = 0);
 void delbottomcard(int = 0);
 void delbuff(int = 0, int = 0);
-void delmef(int = 0);
 void dipcursed(int = 0, int = 0);
 void display_customkey(const std::string&, int, int);
 void display_key(int = 0, int = 0, int = 0);
@@ -907,7 +889,6 @@ void egoadd(int = 0, int = 0);
 void encremove(int = 0, int = 0, int = 0);
 void eqrandweaponmage(int = 0);
 void equipinfo(int = 0, int = 0, int = 0);
-void evadd(int = 0, int = 0, int = 0);
 void exittempinv();
 void fileadd(const fs::path& filepath, int = 0);
 void fillbg(int = 0, int = 0, int = 0, int = 0, int = 0);
@@ -1377,7 +1358,6 @@ void conquer_lesimas();
 void play_the_last_scene_again();
 turn_result_t pc_died();
 void show_game_score_ranking();
-void proc_event();
 void lenfix(std::string&, int = 0);
 void lovemiracle(int = 0);
 void make_dish(int = 0, int = 0);

--- a/wish.cpp
+++ b/wish.cpp
@@ -4,10 +4,12 @@
 #include "calc.hpp"
 #include "character.hpp"
 #include "debug.hpp"
+#include "event.hpp"
 #include "i18n.hpp"
 #include "input.hpp"
 #include "item.hpp"
 #include "item_db.hpp"
+#include "map_cell.hpp"
 #include "optional.hpp"
 #include "variables.hpp"
 
@@ -350,7 +352,7 @@ bool grant_special_wishing(const std::string& wish)
         wish == u8"仲間" || wish == u8"friend" || wish == u8"company"
         || wish == u8"ally")
     {
-        evadd(12);
+        event_add(12);
     }
     else if (
         wish == u8"金" || wish == u8"金貨" || wish == u8"富" || wish == u8"財産"


### PR DESCRIPTION
# Related Issues

#284

# Summary
Moves map effect/cell/event methods to `mef.cpp`/`map_cell.cpp`/`event.cpp`.

# TODO
- [ ] Merge changes from #286 up to here.
