### PR TITLE
Fix DLL loading error

### DIFF
--- a/deps/install.bat
+++ b/deps/install.bat
@@ -17,14 +17,6 @@ copy SDL2-2.0.8\include\* .\include > nul
 copy SDL2-2.0.8\lib\x64\* .\lib > nul
 rd /s /q SDL2-2.0.8
 
-echo Downloading SDL2_image...
-powershell -Command "(New-Object Net.WebClient).DownloadFile('http://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-2.0.3-VC.zip', 'SDL2_image-devel-2.0.3-VC.zip')"
-
-7z x SDL2_image-devel-2.0.3-VC.zip > nul
-copy SDL2_image-2.0.3\include\* .\include > nul
-copy SDL2_image-2.0.3\lib\x64\* .\lib > nul
-rd /s /q SDL2_image-2.0.3
-
 echo Downloading SDL2_mixer...
 powershell -Command "(New-Object Net.WebClient).DownloadFile('http://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.0.2-VC.zip', 'SDL2_mixer-devel-2.0.2-VC.zip')"
 
@@ -40,6 +32,14 @@ powershell -Command "(New-Object Net.WebClient).DownloadFile('https://www.libsdl
 copy SDL2_ttf-2.0.14\include\* .\include > nul
 copy SDL2_ttf-2.0.14\lib\x64\* .\lib > nul
 rd /s /q SDL2_ttf-2.0.14
+
+echo Downloading SDL2_image...
+powershell -Command "(New-Object Net.WebClient).DownloadFile('http://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-2.0.3-VC.zip', 'SDL2_image-devel-2.0.3-VC.zip')"
+
+7z x SDL2_image-devel-2.0.3-VC.zip > nul
+copy SDL2_image-2.0.3\include\* .\include > nul
+copy SDL2_image-2.0.3\lib\x64\* .\lib > nul
+rd /s /q SDL2_image-2.0.3
 
 echo Downloading lua...
 powershell -Command "(New-Object Net.WebClient).DownloadFile('http://downloads.sourceforge.net/luabinaries/lua-5.3.4_Win64_vc14_lib.zip', 'lua-5.3.4_Win64_vc14_lib.zip')"

--- a/deps/install.bat
+++ b/deps/install.bat
@@ -7,8 +7,11 @@ if errorlevel 1 (
     EXIT /B
 )
 
+
 mkdir include lib > nul 2>&1
 
+
+: SDL2
 echo Downloading SDL2...
 powershell -Command "(New-Object Net.WebClient).DownloadFile('http://www.libsdl.org/release/SDL2-devel-2.0.8-VC.zip', 'SDL2-devel-2.0.8-VC.zip')"
 
@@ -17,6 +20,8 @@ copy SDL2-2.0.8\include\* .\include > nul
 copy SDL2-2.0.8\lib\x64\* .\lib > nul
 rd /s /q SDL2-2.0.8
 
+
+: SDL2 Mixer
 echo Downloading SDL2_mixer...
 powershell -Command "(New-Object Net.WebClient).DownloadFile('http://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.0.2-VC.zip', 'SDL2_mixer-devel-2.0.2-VC.zip')"
 
@@ -25,6 +30,8 @@ copy SDL2_mixer-2.0.2\include\* .\include > nul
 copy SDL2_mixer-2.0.2\lib\x64\* .\lib > nul
 rd /s /q SDL2_mixer-2.0.2
 
+
+: SDL2 TTF
 echo Downloading SDL2_ttf...
 powershell -Command "(New-Object Net.WebClient).DownloadFile('https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-2.0.14-VC.zip', 'SDL2_ttf-devel-2.0.14-VC.zip')"
 
@@ -33,6 +40,8 @@ copy SDL2_ttf-2.0.14\include\* .\include > nul
 copy SDL2_ttf-2.0.14\lib\x64\* .\lib > nul
 rd /s /q SDL2_ttf-2.0.14
 
+
+: SDL2 Image
 echo Downloading SDL2_image...
 powershell -Command "(New-Object Net.WebClient).DownloadFile('http://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-2.0.3-VC.zip', 'SDL2_image-devel-2.0.3-VC.zip')"
 
@@ -41,6 +50,8 @@ copy SDL2_image-2.0.3\include\* .\include > nul
 copy SDL2_image-2.0.3\lib\x64\* .\lib > nul
 rd /s /q SDL2_image-2.0.3
 
+
+: Lua
 echo Downloading lua...
 powershell -Command "(New-Object Net.WebClient).DownloadFile('http://downloads.sourceforge.net/luabinaries/lua-5.3.4_Win64_vc14_lib.zip', 'lua-5.3.4_Win64_vc14_lib.zip')"
 
@@ -48,6 +59,7 @@ powershell -Command "(New-Object Net.WebClient).DownloadFile('http://downloads.s
 copy lua53\include\* .\include > nul
 copy lua53\lua53.lib .\lib > nul
 rd /s /q lua53
+
 
 del /s /q *.zip > nul
 

--- a/deps/install.bat
+++ b/deps/install.bat
@@ -7,7 +7,7 @@ if errorlevel 1 (
     EXIT /B
 )
 
-mkdir include lib > nul
+mkdir include lib > nul 2>&1
 
 echo Downloading SDL2...
 powershell -Command "(New-Object Net.WebClient).DownloadFile('http://www.libsdl.org/release/SDL2-devel-2.0.8-VC.zip', 'SDL2-devel-2.0.8-VC.zip')"


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #313.


# Summary

- Suppress mkdir's warning when directory already exists.
- Use SDL2_image's `zlib1.dll`, instead of SDL2_TTF's.