### PR TITLE
Fix bad allocation when opening journal

### DIFF
--- a/menu.cpp
+++ b/menu.cpp
@@ -4903,14 +4903,13 @@ label_1970_internal:
 
 menu_result menu_journal()
 {
+
     menu_result result = { false, false, turn_result_t::none };
     curmenu = 1;
-    listmax = 0;
     page = 99;
     pagesize = 40;
     cs = 0;
     cc = 0;
-    listmax = noteinfo();
     keyrange = 0;
     key_list(0) = key_enter;
     buff = newsbuff;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #283.


# Summary

Calling `noteinfo()` without `noteset()` causes bad alloc error. Deleted it.