### PR TITLE
Fix too many blank lines in journal

### DIFF
--- a/std.cpp
+++ b/std.cpp
@@ -1276,8 +1276,7 @@ void noteadd(const std::string& text, int index, int overwrite)
     {
         index = lines.size();
     }
-
-    if (size_t(index) >= lines.size())
+    else if (size_t(index) >= lines.size())
     {
         lines.resize(index + 1);
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #326.


# Summary

Delete unnecessary reallocation of buffer. Even if the buffer size is enough to accept a new line, we resized buffer and inserted extra new lines before. As a result, there were too many extra blank lines in journal menu.