### PR TITLE
Fix being unable to cancel number prompt

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -173,7 +173,7 @@ void input_number_dialog(int x, int y, int max_number)
     int number = max_number;
     if (strlen_u(std::to_string(max_number)) >= 3)
     {
-        dx += std::to_string(max_number).size() * 8;
+        dx += strlen_u(std::to_string(max_number)) * 8;
     }
     pos(x + 24, y + 4);
     gfini(dx - 42, 35);
@@ -198,6 +198,11 @@ void input_number_dialog(int x, int y, int max_number)
         if (key == key_enter)
         {
             f = 1;
+            break;
+        }
+        if (key == key_cancel)
+        {
+            f = -1;
             break;
         }
         if (key == key_west)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #322.


# Summary

Add missing condition and handle `key_cancel` correctly. I split 1 function into 2 functions, `input_text_dialog()` and `input_number_dialog()`, and at that time I deleted these lines, I guess.