### PR TITLE
Replace gfdec/gfdec2() with set_color_mod()

### DIFF
--- a/animation.cpp
+++ b/animation.cpp
@@ -171,6 +171,7 @@ void play_animation_3(int anicol, int anisound)
                     pos((anidx - scx) * inf_tiles + inf_screenx + inf_tiles / 2,
                         (anidy - scy) * inf_tiles + inf_screeny + 16);
                     gmode(2, inf_tiles, inf_tiles);
+                    set_color_mod(255 - c_col(0, anicol), 255 - c_col(1, anicol), 255 - c_col(2, anicol), 7);
                     grotate(
                         7,
                         cnt2 * 48,
@@ -180,6 +181,7 @@ void play_animation_3(int anicol, int anisound)
                             cdata[cc].position.y - tlocy),
                         inf_tiles,
                         inf_tiles);
+                    set_color_mod(255, 255, 255, 7);
                 }
             }
         }
@@ -251,7 +253,9 @@ void play_animation_17_2(int animeid, int anicol, int anisound)
                         pos(sx * inf_tiles + inf_screenx,
                             sy * inf_tiles + inf_screeny);
                         gmode(2, 48, 48);
+                        set_color_mod(255 - c_col(0, anicol), 255 - c_col(1, anicol), 255 - c_col(2, anicol), 7);
                         gcopy(7, anip * 48, 96, 48, 48);
+                        set_color_mod(255, 255, 255, 7);
                     }
                 }
             }
@@ -356,6 +360,7 @@ void play_animation_0(int anicol, int anisound)
                     {
                         pos(ax(cnt), ay(cnt));
                         gmode(2, inf_tiles, inf_tiles);
+                        set_color_mod(255 - c_col(0, anicol), 255 - c_col(1, anicol), 255 - c_col(2, anicol), 7);
                         grotate(
                             7,
                             ap(cnt) * 48,
@@ -365,6 +370,7 @@ void play_animation_0(int anicol, int anisound)
                                 cdata[cc].position.y - tlocy),
                             48,
                             48);
+                        set_color_mod(255, 255, 255, 7);
                     }
                 }
             }

--- a/draw.cpp
+++ b/draw.cpp
@@ -397,7 +397,13 @@ void load_pcc_part(int cc, int body_part, const char* body_part_str)
         c_col(2, pcc(body_part, cc) / 1000));
     gmode(2);
     pos(0, 0);
+    set_color_mod(
+            255 - c_col(0, pcc(body_part, cc) / 1000),
+            255 - c_col(1, pcc(body_part, cc) / 1000),
+            255 - c_col(2, pcc(body_part, cc) / 1000),
+            10 + cc);
     gcopy(10 + cc, 256, 0, 128, 198);
+    set_color_mod(255, 255, 255, 10 + cc);
 }
 
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #328.


# Summary

This implementation is not complete, but it will take a bit long time to replace all `gfdec`/`gfdec2()`.