### PR TITLE
Fix locked attributes being reset

### DIFF
--- a/character_making.cpp
+++ b/character_making.cpp
@@ -14,12 +14,21 @@
 #include "ui.hpp"
 #include "variables.hpp"
 
-namespace elona
-{
 
+namespace
+{
 elona_vector1<std::string> cmrace;
 std::string cmclass;
 elona_vector1<int> cmstats;
+elona_vector1<int> cmlock;
+}
+
+
+
+namespace elona
+{
+
+
 
 main_menu_result_t character_making_select_race()
 {
@@ -362,9 +371,10 @@ main_menu_result_t character_making_select_class(bool advanced_to_next_menu)
     }
 }
 
+
+
 main_menu_result_t character_making_role_attributes(bool advanced_to_next_menu)
 {
-    elona_vector1<int> cmlock;
     bool minimum{};
     if (advanced_to_next_menu)
     {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #282.


# Summary

`cmlock` was allocated in `character_making_role_attributes()`, so reset when this function was called. However, we have to store the previous locked attributes status even when you go to next phase in character making and go back. This pull request declares `cmlock` as file local variables, not function local one. This solution is not good because global state should be avoided even if it is file local. We have to refactor it.