### PR TITLE
Delete unnecessary await()

### DIFF
--- a/building.cpp
+++ b/building.cpp
@@ -369,7 +369,7 @@ void start_home_map_mode()
     tile = 0;
     while (1)
     {
-        await();
+        await(10);
         int stat = target_position();
         if (stat == -1)
         {

--- a/character_status.cpp
+++ b/character_status.cpp
@@ -73,7 +73,6 @@ void modcorrupt(int prm_815)
             }
             for (int cnt = 0; cnt < 100000; ++cnt)
             {
-                await();
                 int tid = rnd(17) + 200;
                 int stat = get_trait_info(0, tid);
                 if (stat == 0 || traitref != 3)
@@ -134,7 +133,6 @@ void modcorrupt(int prm_815)
             cnt2_at_m134 = cnt;
             for (int cnt = 0; cnt < 100000; ++cnt)
             {
-                await();
                 int tid = rnd(17) + 200;
                 if (cnt == 0)
                 {

--- a/command.cpp
+++ b/command.cpp
@@ -1244,7 +1244,6 @@ label_1953_internal:
                                             * (sy + inf_tiles - windowh
                                                + inf_verh));
                         }
-                        await();
                     }
                 }
                 sx = x * inf_tiles + inf_screenx;

--- a/elona.hpp
+++ b/elona.hpp
@@ -351,7 +351,7 @@ DEFINE_CMP(<=)
 
 
 
-void await(int msec = 0);
+void await(int msec);
 
 // CANNOT BE IMPLEMENTED
 void axobj(int, const std::string&, int, int);

--- a/elonacore.cpp
+++ b/elonacore.cpp
@@ -6644,7 +6644,6 @@ void label_1750()
         {
             for (int cnt = 0;; ++cnt)
             {
-                await();
                 dx = clamp(rnd(cnt / 4 + 1) + 1, 1, mdata(0));
                 dy = clamp(rnd(cnt / 4 + 1) + 1, 1, mdata(1));
                 x = adata(1, p) + rnd(dx) - rnd(dx);
@@ -19784,7 +19783,6 @@ void do_play_scene()
     }
     scidx += s(0).size();
 label_2681:
-    await();
     int a{};
     stick(a, 128);
     if (a == 128)

--- a/initialize_map.cpp
+++ b/initialize_map.cpp
@@ -2569,7 +2569,6 @@ label_1741_internal:
                         {
                             for (int cnt = 0;; ++cnt)
                             {
-                                await();
                                 dx = clamp(rnd(cnt / 4 + 1) + 1, 1, mdata(0));
                                 dy = clamp(rnd(cnt / 4 + 1) + 1, 1, mdata(1));
                                 x = adata(1, p) + rnd(dx) - rnd(dx);

--- a/magic.cpp
+++ b/magic.cpp
@@ -2369,7 +2369,6 @@ label_2181_internal:
             int cnt2 = cnt;
             for (int cnt = 0; cnt < 2000; ++cnt)
             {
-                await();
                 p = rnd(67) + 400;
                 if (p == 441)
                 {
@@ -2493,7 +2492,6 @@ label_2181_internal:
     case 1105:
         for (int cnt = 0;; ++cnt)
         {
-            await();
             p = rnd(300) + 100;
             if (the_ability_db[p])
             {
@@ -2607,7 +2605,6 @@ label_2181_internal:
             int cnt2 = cnt;
             while (1)
             {
-                await();
                 p = rnd(300) + 100;
                 if (the_ability_db[p])
                 {
@@ -3995,7 +3992,6 @@ label_2181_internal:
             inv[ci].number = 0;
             for (int cnt = 0;; ++cnt)
             {
-                await();
                 flt(calcobjlv(efp / 10) + 5, calcfixlv(3));
                 if (cnt < 10)
                 {

--- a/main_menu.cpp
+++ b/main_menu.cpp
@@ -528,7 +528,6 @@ main_menu_result_t main_menu_incarnate()
         s = filesystem::to_utf8_path(entry.path().filename());
         const auto gene_header_filepath =
             filesystem::dir::save(s) / u8"gene_header.txt";
-        await();
         if (!fs::exists(gene_header_filepath))
         {
             continue;

--- a/mapgen.cpp
+++ b/mapgen.cpp
@@ -405,7 +405,6 @@ void map_placearena(int prm_939, int prm_940)
 {
     while (1)
     {
-        await();
         x = rnd(7) + 5;
         y = rnd(6) + 6;
         if (prm_940 == 0)

--- a/message.cpp
+++ b/message.cpp
@@ -962,7 +962,6 @@ void txt_conv()
         msgtemp(0) += u8" ";
         while (1)
         {
-            await();
             p_at_txtfunc = instr(msgtemp(0), 0, u8" ") + 1;
             if (p_at_txtfunc == 0)
             {

--- a/text.cpp
+++ b/text.cpp
@@ -3595,7 +3595,6 @@ void text_replace_tags_in_quest_text()
 {
     for (int cnt = 0; cnt < 20; ++cnt)
     {
-        await();
         p(0) = instr(buff, 0, u8"{"s);
         p(1) = instr(buff, p, u8"}"s);
         p(2) = buff(0).size();


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #333.


# Summary

## Cause of bug

`await()` post pending input events to `input` class, and this class increments key repeating count when receiving key pressing events. During seeing quest board, `await()` is called very frequently so key repeating count are also incremented frequently. In Foobar some of keys are not regarded as pressed if their repeating count are not equal to 0. Thus, ESC key does not work in front of quest board.

## Solution

Delete unnecessary `await()`, especially called without argument(default value: 0).