### PR TITLE
Fix being unable to dig wall

### DIFF
--- a/elonacore.cpp
+++ b/elonacore.cpp
@@ -14903,7 +14903,8 @@ void spot_digging()
 
 void spot_mining_or_wall()
 {
-    int countdig = 0;
+    static int countdig{};
+
     if (cdata[cc].continuous_action_id == 0)
     {
         cdata[cc].continuous_action_id = 5;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #342.


# Summary


The cause is that `countdig` was initialized every time.