### PR TITLE
Add new option "restock_interval"

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -254,6 +254,10 @@ void load_config()
             5,
             [&](auto value) { config::instance().walkwait = value; }),
         std::make_unique<config_integer>(
+            u8"restock_interval",
+            3,
+            [&](auto value) { config::instance().restock_interval = value; }),
+        std::make_unique<config_integer>(
             u8"runWait",
             2,
             [&](auto value) { config::instance().runwait = value; }),

--- a/config.hpp
+++ b/config.hpp
@@ -46,6 +46,7 @@ public:
     int netchat;
     int netwish;
     int objectshadow;
+    int restock_interval;
     int runscroll;
     int runwait;
     int scroll;

--- a/set_option.cpp
+++ b/set_option.cpp
@@ -354,6 +354,7 @@ std::vector<config_menu> create_config_menu()
         config::instance().autosave,
         lang(u8"有効", u8"On"),
         lang(u8"無効", u8"Off"));
+    ELONA_CONFIG_ITEM(lang(u8"入荷頻度", u8"Restock Interval"));
 
 #undef ELONA_CONFIG_ITEM
 #undef ELONA_CONFIG_ITEM_YESNO
@@ -678,6 +679,21 @@ void set_option()
                 if (cnt == 1)
                 {
                     mes(""s + config::instance().msgtrans * 10 + u8" %"s);
+                }
+            }
+            else if (submenu == 8)
+            {
+                if (cnt == 4)
+                {
+                    const auto value = config::instance().restock_interval;
+                    if (value)
+                    {
+                        mes(std::to_string(value) + lang(u8"日", u8" day" + _s2(value)));
+                    }
+                    else
+                    {
+                        mes(lang(u8"毎回更新", u8"Every time"));
+                    }
                 }
             }
         }
@@ -1429,6 +1445,22 @@ void set_option()
                     }
                     snd(20);
                     set_config(u8"autosave", config::instance().autosave);
+                    reset_page = true;
+                    continue;
+                }
+                if (cs == 4)
+                {
+                    config::instance().restock_interval += p;
+                    if (config::instance().restock_interval > 10)
+                    {
+                        config::instance().restock_interval = 10;
+                    }
+                    else if (config::instance().restock_interval < 0)
+                    {
+                        config::instance().restock_interval = 0;
+                    }
+                    snd(20);
+                    set_config(u8"restock_interval", config::instance().restock_interval);
                     reset_page = true;
                     continue;
                 }

--- a/shop.cpp
+++ b/shop.cpp
@@ -2,6 +2,7 @@
 #include "ability.hpp"
 #include "calc.hpp"
 #include "character.hpp"
+#include "config.hpp"
 #include "ctrl_file.hpp"
 #include "item.hpp"
 #include "item_db.hpp"
@@ -696,10 +697,18 @@ void shop_refresh()
             inv[ci].value = inv[ci].value * 3 / 2;
         }
     }
-    cdata[tc].time_to_restore = gdata_hour + gdata_day * 24
-        + gdata_month * 24 * 30 + gdata_year * 24 * 30 * 12
-        + 168 * (1 + (cdata[tc].character_role == 1009));
-    return;
+    if (config::instance().restock_interval)
+    {
+        cdata[tc].time_to_restore = gdata_hour + gdata_day * 24
+            + gdata_month * 24 * 30 + gdata_year * 24 * 30 * 12
+            + 24 * config::instance().restock_interval;
+    }
+    else
+    {
+        cdata[tc].time_to_restore = gdata_hour + gdata_day * 24
+            + gdata_month * 24 * 30 + gdata_year * 24 * 30 * 12
+            - 1;
+    }
 }
 
 void calc_number_of_items_sold_at_shop()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #343.


# Summary

Add new option "restock_interval". It represents interval until a shopkeeper restock his/her goods. (0-10 days)

If you set to 0, shopkeeper's inventory is updated every time you talk to him/her.