### PR TITLE
Add -y option(answer yes to all prompt) to 7z in appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,27 +48,27 @@ before_build:
 
   - |-
     %NEEDDEPENDS% appveyor DownloadFile http://www.libsdl.org/release/SDL2-devel-2.0.8-VC.zip
-    %NEEDDEPENDS% 7z x SDL2-devel-2.0.8-VC.zip > nul
+    %NEEDDEPENDS% 7z x -y SDL2-devel-2.0.8-VC.zip > nul
     %NEEDDEPENDS% copy SDL2-2.0.8\include\* %PREFIX%\include > nul
     %NEEDDEPENDS% copy SDL2-2.0.8\lib\x64\* %PREFIX%\lib > nul
   - |-
     %NEEDDEPENDS% appveyor DownloadFile http://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.0.2-VC.zip
-    %NEEDDEPENDS% 7z x SDL2_mixer-devel-2.0.2-VC.zip > nul
+    %NEEDDEPENDS% 7z x -y SDL2_mixer-devel-2.0.2-VC.zip > nul
     %NEEDDEPENDS% copy SDL2_mixer-2.0.2\include\* %PREFIX%\include > nul
     %NEEDDEPENDS% copy SDL2_mixer-2.0.2\lib\x64\* %PREFIX%\lib > nul
   - |-
     %NEEDDEPENDS% appveyor DownloadFile https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-devel-2.0.14-VC.zip
-    %NEEDDEPENDS% 7z x SDL2_ttf-devel-2.0.14-VC.zip > nul
+    %NEEDDEPENDS% 7z x -y SDL2_ttf-devel-2.0.14-VC.zip > nul
     %NEEDDEPENDS% copy SDL2_ttf-2.0.14\include\* %PREFIX%\include > nul
     %NEEDDEPENDS% copy SDL2_ttf-2.0.14\lib\x64\* %PREFIX%\lib > nul
   - |-
     %NEEDDEPENDS% appveyor DownloadFile http://downloads.sourceforge.net/luabinaries/lua-5.3.4_Win64_vc14_lib.zip
-    %NEEDDEPENDS% 7z x lua-5.3.4_Win64_vc14_lib.zip -olua53 > nul
+    %NEEDDEPENDS% 7z x -y lua-5.3.4_Win64_vc14_lib.zip -olua53 > nul
     %NEEDDEPENDS% copy lua53\include\* %PREFIX%\include > nul
     %NEEDDEPENDS% copy lua53\* %PREFIX%\lib > nul
   - |-
     %NEEDDEPENDS% appveyor DownloadFile http://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-2.0.3-VC.zip
-    %NEEDDEPENDS% 7z x SDL2_image-devel-2.0.3-VC.zip > nul
+    %NEEDDEPENDS% 7z x -y SDL2_image-devel-2.0.3-VC.zip > nul
     %NEEDDEPENDS% copy SDL2_image-2.0.3\include\* %PREFIX%\include > nul
     %NEEDDEPENDS% copy SDL2_image-2.0.3\lib\x64\* %PREFIX%\lib > nul
 
@@ -76,7 +76,7 @@ build_script:
   - chcp 65001
   - cd %PREFIX%
   - appveyor DownloadFile http://ylvania.style.coocan.jp/file/elona122.zip
-  - 7z x elona122.zip
+  - 7z x -y elona122.zip > nul
   - cd %APPVEYOR_BUILD_FOLDER%
   - mkdir bin
   - cd bin
@@ -105,7 +105,7 @@ after_build:
   - rd /q /s bin\ElonaFoobar\sound
   - rd /q /s bin\ElonaFoobar\user
   - cd bin
-  - 7z a ElonaFoobar-windows.zip ElonaFoobar
+  - 7z a -y ElonaFoobar-windows.zip ElonaFoobar
 
 artifacts:
   - path: bin\ElonaFoobar-windows.zip


### PR DESCRIPTION
# Summary

Finally, I found out the actual cause of #449. This is AppVeyor's log:

```
appveyor DownloadFile http://ylvania.style.coocan.jp/file/elona122.zip
Downloading elona122.zip (28,778,083 bytes)...100%
7z x elona122.zip
7-Zip [64] 16.04 : Copyright (c) 1999-2016 Igor Pavlov : 2016-10-04
Scanning the drive for archives:
1 file, 28778083 bytes (28 MiB)
Extracting archive: elona122.zip
--
Path = elona122.zip
Type = zip
Physical Size = 28778083
Would you like to replace the existing file:
  Path:     .\elona\data\board.txt
  Size:     14687 bytes (15 KiB)
  Modified: 2010-05-08 14:32:28
with the file from archive:
  Path:     elona\data\board.txt
  Size:     14687 bytes (15 KiB)
  Modified: 2010-05-08 14:32:28
? (Y)es / (N)o / (A)lways / (S)kip all / A(u)to rename all / (Q)uit? 
```

Add `-y` option(answer yes to all prompt) to all `7z` commands in appveyor.yml.