### PR TITLE
Fix not being able to quit in the casino

### DIFF
--- a/casino.cpp
+++ b/casino.cpp
@@ -990,7 +990,7 @@ bool casino_blackjack()
     casino_choose_card();
     if (rtval == 0)
     {
-        return false;
+        return true;
     }
     stake = rtval;
     winrow = 0;


### PR DESCRIPTION
# Related Issues

Close #456.


# Summary
The wrong value to indicate the casino routine had finished was being returned.