### PR TITLE
Rework name splitting algorithm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ if(WITH_TESTS STREQUAL "TESTS")
   # Test sources
   set(TEST_SOURCES
     tests/tests.cpp
+    tests/elonacore.cpp
     tests/serialization.cpp
     ${CORE_SOURCES}
     )

--- a/elonacore.cpp
+++ b/elonacore.cpp
@@ -1218,41 +1218,54 @@ int winposy(int prm_539, int prm_540)
 
 
 
-void cutname(std::string& prm_541, int prm_542)
+void cutname(std::string& utf8_string, int max_length_charwise)
 {
-    int len_at_m71 = 0;
-    elona_vector1<std::string> buf_at_m71;
-    int p_at_m71 = 0;
-    if (strlen_u(prm_541) > size_t(prm_542))
+    if (max_length_charwise == 0)
     {
-        len_at_m71 = zentohan(prm_541, buf_at_m71, 0);
-        SDIM2(buf_at_m71, len_at_m71);
-        zentohan(prm_541, prm_541, len_at_m71);
-        if (strlen_u(prm_541) > size_t(prm_542))
+        utf8_string = std::string();
+        return;
+    }
+
+    int current_char = 0;
+    size_t current_byte = 0;
+    bool multibyte = false;
+    while (current_char < max_length_charwise && current_byte < utf8_string.size())
+    {
+        if (static_cast<unsigned char>(utf8_string[current_byte]) > 0x7F)
         {
-            len_at_m71 = 0;
-            while (1)
+            current_byte++;
+            current_char++;
+            while ((static_cast<unsigned char>(utf8_string[current_byte] & 0xC0)) == 0x80)
             {
-                if (len_at_m71 >= prm_542)
+                // Fullwidth characters count as length 2.
+                if (!multibyte)
+                {
+                    current_char++;
+                    multibyte = true;
+                }
+                if (current_char > max_length_charwise)
+                {
+                    current_byte--;
+                    break;
+                }
+
+                current_byte++;
+                if (current_byte > utf8_string.size())
                 {
                     break;
                 }
-                p_at_m71 = prm_541[len_at_m71];
-                if ((p_at_m71 >= 129 && p_at_m71 <= 159)
-                    || (p_at_m71 >= 224 && p_at_m71 <= 252))
-                {
-                    p_at_m71 = 2;
-                }
-                else
-                {
-                    p_at_m71 = 1;
-                }
-                len_at_m71 += p_at_m71;
             }
-            prm_541 = strmid(prm_541, 0, len_at_m71) + u8".."s;
         }
+        else
+        {
+            current_char++;
+            current_byte++;
+        }
+
+        multibyte = false;
     }
-    return;
+
+    utf8_string = utf8_string.substr(0, current_byte);
 }
 
 

--- a/tests/elonacore.cpp
+++ b/tests/elonacore.cpp
@@ -1,0 +1,48 @@
+#include "../thirdparty/catch2/catch.hpp"
+
+#include "tests.hpp"
+#include "../testing.hpp"
+#include "../variables.hpp"
+
+using namespace Catch;
+using namespace elona::testing;
+using namespace std::literals::string_literals;
+
+TEST_CASE("Test cutname", "[C++: Misc.]")
+{
+    auto cutname = [](std::string str, int max_char_length) {
+                       elona::cutname(str, max_char_length);
+                       return str;
+                   };
+
+    REQUIRE(cutname(u8"", 0) == u8"");
+    REQUIRE(cutname(u8"", 99) == u8"");
+
+    REQUIRE(cutname(u8"タイム・デューク シュハード", 0) == u8"");
+    REQUIRE(cutname(u8"タイム・デューク シュハード", 99) == u8"タイム・デューク シュハード");
+
+    REQUIRE(cutname(u8"タイム・デューク シュハード", 1) == u8"");
+    REQUIRE(cutname(u8"タイム・デューク シュハード", 6) == u8"タイム");
+    REQUIRE(cutname(u8"タイム・デューク シュハード", 7) == u8"タイム");
+    REQUIRE(cutname(u8"タイム・デューク シュハード", 8) == u8"タイム・");
+    REQUIRE(cutname(u8"タイム・デューク シュハード", 9) == u8"タイム・");
+    REQUIRE(cutname(u8"タイム・デューク シュハード", 10) == u8"タイム・デ");
+    REQUIRE(cutname(u8"タイム・デューク シュハード", 16) == u8"タイム・デューク");
+    REQUIRE(cutname(u8"タイム・デューク シュハード", 17) == u8"タイム・デューク ");
+    REQUIRE(cutname(u8"タイム・デューク シュハード", 18) == u8"タイム・デューク ");
+    REQUIRE(cutname(u8"タイム・デューク シュハード", 19) == u8"タイム・デューク シ");
+    REQUIRE(cutname(u8"タイム・デューク シュハード", 25) == u8"タイム・デューク シュハー");
+    REQUIRE(cutname(u8"タイム・デューク シュハード", 26) == u8"タイム・デューク シュハー");
+    REQUIRE(cutname(u8"タイム・デューク シュハード", 27) == u8"タイム・デューク シュハード");
+    REQUIRE(cutname(u8"タイム・デューク シュハード", 28) == u8"タイム・デューク シュハード");
+    REQUIRE(cutname(u8"タイム・デューク シュハード", 29) == u8"タイム・デューク シュハード");
+
+    REQUIRE(cutname(u8"Gentleness of Immortality Sonya", 1) == u8"G");
+    REQUIRE(cutname(u8"Gentleness of Immortality Sonya", 2) == u8"Ge");
+    REQUIRE(cutname(u8"Gentleness of Immortality Sonya", 30) ==
+            u8"Gentleness of Immortality Sony");
+    REQUIRE(cutname(u8"Gentleness of Immortality Sonya", 31) ==
+            u8"Gentleness of Immortality Sonya");
+    REQUIRE(cutname(u8"Gentleness of Immortality Sonya", 32) ==
+            u8"Gentleness of Immortality Sonya");
+}


### PR DESCRIPTION
<!-- For bug report -->
# Related Issues

Close #454.


# Summary
- Reworks `cutname` to recognize UTF-8 multibyte sequences. In strings with multibyte sequences, each multibyte sequence counts as length 2.
- Added a test for `cutname`.
