### PR TITLE
Improve handling of numpad with shift/allow usage of numpad enter

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -217,6 +217,10 @@ void config_query_language()
         {
             break;
         }
+        if (getkey(snail::key::keypad_enter))
+        {
+            break;
+        }
         if (getkey(snail::key::space))
         {
             break;
@@ -476,7 +480,7 @@ void load_config(const fs::path& json_file)
             }),
         std::make_unique<config_string>(
             u8"key_get2",
-            u8"0",
+            u8"0 ",
             [&](auto value) { key_get2 = std::string{value}; }),
         std::make_unique<config_string>(
             u8"key_drop",

--- a/message.cpp
+++ b/message.cpp
@@ -6,6 +6,7 @@
 #include "map.hpp"
 #include "ui.hpp"
 #include "variables.hpp"
+#include <ctype.h>
 
 
 namespace elona
@@ -109,7 +110,9 @@ void key_check(int prm_299)
                 await(10);
                 bool any_key_pressed = false;
 
-                if (getkey(snail::key::space) || getkey(snail::key::enter))
+                if (getkey(snail::key::space)
+                    || getkey(snail::key::enter)
+                    || getkey(snail::key::keypad_enter))
                 {
                     any_key_pressed = true;
                 }
@@ -160,6 +163,14 @@ void key_check(int prm_299)
         objprm(0, ""s);
     }
     {
+        // Holding down a numpad key sometimes sets "key" to a
+        // non-numpad number key, and these get passed to the player
+        // as a mispress, so counteract that here.
+        if (key.size() == 1 && isdigit(static_cast<unsigned char>(key(0)[0])))
+        {
+            key = "";
+        }
+
         // Experimental implementation
         if (getkey(snail::key::keypad_0))
             key = "0 ";
@@ -209,15 +220,54 @@ void key_check(int prm_299)
         {
             p_at_m19 = 3;
         }
-        if (getkey(snail::key::pageup))
+        else if (getkey(snail::key::pageup))
         {
             p_at_m19 = 6;
         }
-        if (getkey(snail::key::end))
+        else if (getkey(snail::key::end))
         {
             p_at_m19 = 9;
         }
-        if (getkey(snail::key::pagedown))
+        else if (getkey(snail::key::pagedown))
+        {
+            p_at_m19 = 12;
+        }
+
+        // Handle the case of the current key matching the movement
+        // keybindings set in the user's config.
+        else if (key == key_west)
+        {
+            p_at_m19 = 1;
+        }
+        else if (key == key_north)
+        {
+            p_at_m19 = 2;
+        }
+        else if (key == key_east)
+        {
+            p_at_m19 = 4;
+        }
+        else if (key == key_south)
+        {
+            p_at_m19 = 8;
+        }
+        else if (key == key_northwest)
+        {
+            p_at_m19 = 3;
+        }
+        else if (key == key_northeast)
+        {
+            p_at_m19 = 6;
+        }
+        else if (key == key_southwest)
+        {
+            p_at_m19 = 9;
+        }
+        else if (key == key_southeast)
+        {
+            p_at_m19 = 12;
+        }
+        else if (key == key_southeast)
         {
             p_at_m19 = 12;
         }

--- a/snail/hsp/sdl.cpp
+++ b/snail/hsp/sdl.cpp
@@ -167,7 +167,7 @@ struct MessageBox
         buffer += input.get_text();
         if (!input.is_ime_active())
         {
-            if (input.is_pressed(key::enter))
+            if (input.is_pressed(key::enter) || input.is_pressed(key::keypad_enter))
             {
                 // New line.
                 buffer += '\n';

--- a/snail/input.cpp
+++ b/snail/input.cpp
@@ -398,6 +398,7 @@ void input::_handle_event(const ::SDL_TextInputEvent& event)
     if (_is_ime_active) // event.text is IME-translated.
     {
         _keys[static_cast<size_t>(snail::key::enter)]._release();
+        _keys[static_cast<size_t>(snail::key::keypad_enter)]._release();
         _is_ime_active = false;
     }
 }

--- a/std.cpp
+++ b/std.cpp
@@ -843,6 +843,7 @@ void stick(int& out, int allow_repeat_keys)
     out += check_key_pressed(3, snail::key::down, false);
     out += check_key_pressed(4, snail::key::space, false);
     out += check_key_pressed(5, snail::key::enter, false);
+    out += check_key_pressed(5, snail::key::keypad_enter, false);
     out += check_key_pressed(6, snail::key::ctrl, true);
     out += check_key_pressed(7, snail::key::escape, false);
     // out += check_key_pressed(8,  /* Mouse left */,  false);


### PR DESCRIPTION
# Related Issues

Closes #442. Closes #275.


# Summary
Allows the numpad enter key to be used wherever enter can be used, and allows shift to be used with the numpad movement keys.