### PR TITLE
Use omake's formula for casino cure corruption potion reward

### DIFF
--- a/casino.cpp
+++ b/casino.cpp
@@ -1267,7 +1267,7 @@ bool casino_blackjack()
                 + u8" has been added to your loot list!"s));
         if (winrow > 3)
         {
-            if (rnd(200) < winrow * 5 + 5)
+            if (winrow + 1 > rnd(10))
             {
                 flt();
                 itemcreate(-1, 559, -1, -1, 0);


### PR DESCRIPTION
<!-- For bug report -->
# Related Issues

Closes #457.


# Summary
Changes the formula for the potion of cure corruption reward from blackjack to use omake's formula. The chance is `(wins + 1)` out of 10, so 4 wins makes a 50% chance.