### PR TITLE
Preallocate memory for damage popups

### DIFF
--- a/draw.cpp
+++ b/draw.cpp
@@ -26,21 +26,15 @@ struct damage_popup_t
     int character;
     snail::color color;
 
-
-    damage_popup_t(
-        const std::string& text,
-        int character,
-        const snail::color& color)
-        : frame(0)
-        , text(text)
-        , character(character)
-        , color(color)
-    {
-    }
+    damage_popup_t() : frame(-1),
+                       text(std::string()),
+                       character(-1),
+                       color(snail::color(255, 255, 255, 255)) {}
 };
 
 
 std::vector<damage_popup_t> damage_popups;
+int damage_popups_active = 0;
 
 
 
@@ -278,38 +272,74 @@ void show_hp_bar(show_hp_bar_side side, int inf_clocky)
 }
 
 
+void initialize_damage_popups()
+{
+    damage_popups_active = 0;
+    for (int i = 0; i < max_damage_popups; i++)
+    {
+        damage_popups.emplace_back(damage_popup_t{});
+    }
+}
 
 void add_damage_popup(
     const std::string& text,
     int character,
     const snail::color& color)
 {
-    if (damage_popups.size() == max_damage_popups)
+    if (damage_popups_active == max_damage_popups)
     {
         // Substitute a new damage popup for popup whose frame is the maximum.
         auto oldest = std::max_element(
             std::begin(damage_popups),
             std::end(damage_popups),
             [](const auto& a, const auto& b) { return a.frame < b.frame; });
-        *oldest = damage_popup_t{text, character, color};
+        oldest->frame = 0;
+        oldest->text = text;
+        oldest->character = character;
+        oldest->color = color;
     }
     else
     {
-        damage_popups.emplace_back(text, character, color);
+        for (auto&& damage_popup : damage_popups)
+        {
+            if (damage_popup.frame == -1)
+            {
+                damage_popup.frame = 0;
+                damage_popup.text = text;
+                damage_popup.character = character;
+                damage_popup.color = color;
+                ++damage_popups_active;
+                break;
+            }
+        }
     }
 }
 
 
 void clear_damage_popups()
 {
-    damage_popups.clear();
+    for (auto&& damage_popup : damage_popups)
+    {
+        damage_popup.frame = -1;
+    }
+    damage_popups_active = 0;
 }
 
 
 void show_damage_popups(int inf_ver)
 {
+    if (damage_popups_active == 0)
+    {
+        return;
+    }
+
     for (auto&& damage_popup : damage_popups)
     {
+        if (damage_popup.frame == -1)
+        {
+            continue;
+        }
+
         const auto& cc = cdata[damage_popup.character];
         if (gdata(20) != 40)
         {
@@ -358,13 +388,13 @@ void show_damage_popups(int inf_ver)
         color(0, 0, 0);
 
         ++damage_popup.frame;
+
+        if (damage_popup.frame > 20)
+        {
+            damage_popup = {};
+            --damage_popups_active;
+        }
     }
-    damage_popups.erase(
-        std::remove_if(
-            std::begin(damage_popups),
-            std::end(damage_popups),
-            [](const auto& d) { return d.frame > 20; }),
-        std::end(damage_popups));
 }
 
 void draw_emo(int cc, int x, int y)

--- a/draw.hpp
+++ b/draw.hpp
@@ -21,6 +21,7 @@ enum class show_hp_bar_side
 
 void show_hp_bar(show_hp_bar_side side, int inf_clocky);
 
+void initialize_damage_popups();
 void add_damage_popup(
     const std::string& text,
     int character,

--- a/init.cpp
+++ b/init.cpp
@@ -657,6 +657,7 @@ void initialize_elona()
     initialize_recipe();
     initialize_nefia_names();
     initialize_home_adata();
+    initialize_damage_popups();
     load_character_sprite();
     if (config::instance().music == 1 && DMINIT() == 0)
     {


### PR DESCRIPTION
# Related Issues

Closes #443.

# Summary
Allocates memory for damage popups at game start and reinitializes them when they become invalid.