### PR TITLE
Check generation count of certain unique monsters

### DIFF
--- a/get_random_npc_id.cpp
+++ b/get_random_npc_id.cpp
@@ -34,6 +34,8 @@ void get_random_npc_id()
             continue;
         if (fltselect != data.fltselect)
             continue;
+        if (fltselect == 2 && npcmemory(1, data.id) != 0)
+            continue;
         if (flttypemajor != 0 && flttypemajor != data.category)
             continue;
         if (!fltnrace(0).empty() && fltnrace(0) != data.race)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #446.


# Summary


Now, they appear only once except for scroll of ally.