### PR TITLE
Fix PC dying in main scenario

### DIFF
--- a/character.cpp
+++ b/character.cpp
@@ -1837,6 +1837,9 @@ void chara_mod_impression(int cc, int delta)
 
 void chara_vanquish(int cc)
 {
+    if (cc == 0)
+        return;
+
     if (cc == gdata_mount)
     {
         ride_end();


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #471.


# Summary

`chara_find()` returns 0 if not found, and the result is passed to `chara_vanquish()`. Then, PC is killed by the function.

Now, `chara_vanquish()` does not kill PC.