### PR TITLE
Feature/fix up #466

### DIFF
--- a/draw.cpp
+++ b/draw.cpp
@@ -362,6 +362,9 @@ void show_damage_popups(int inf_ver)
         int mondmgpos{};
         for (auto&& damage_popup2 : damage_popups)
         {
+            if (damage_popup2.frame == -1)
+                continue;
+
             if (damage_popup.frame >= damage_popup2.frame)
             {
                 if (cc.position == cdata[damage_popup2.character].position)

--- a/draw.cpp
+++ b/draw.cpp
@@ -26,10 +26,13 @@ struct damage_popup_t
     int character;
     snail::color color;
 
-    damage_popup_t() : frame(-1),
-                       text(std::string()),
-                       character(-1),
-                       color(snail::color(255, 255, 255, 255)) {}
+    damage_popup_t()
+        : frame(-1)
+        , text(std::string())
+        , character(-1)
+        , color(snail::color(255, 255, 255, 255))
+    {
+    }
 };
 
 


### PR DESCRIPTION
# Summary

#466 does not check whether damage popups are invalid or not when searching the popup which is displayed at the same position.