### PR TITLE
Fix crash in using deck

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -150,7 +150,8 @@ reset_page:
             && (p != -1 || key == key_identify))
         {
             item tmp = inv[ci];
-            itemcreate(ci, 504, -1, -1, 0);
+            inv[ci].number = 0;
+            itemcreate(0, 504, -1, -1, 0);
             inv[ci].subname = list(0, pagesize * page + cs);
             inv[ci].identification_state =
                 identification_state_t::completely_identified;
@@ -158,7 +159,8 @@ reset_page:
             int page_bk = page;
             int cs_bk = cs;
             show_item_description();
-            inv[ci] = tmp;
+            inv[ci].number = 0;
+            inv[tmp.index] = tmp;
             pagesize = pagesize_bk;
             page = page_bk;
             cs = cs_bk;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #476.


# Summary

It is work-around. We should refactor the structure of `struct item` and rewrite this code.

1. Store the deck to variable `tmp`.
1. Delete the deck by assigning 0 to `item#number`.
1. Invoke `itemcreate()` to create a card. Your inventory has at least 1 empty slot because the deck was deleted just now.
1. Show information about the card.
1. Delete the card by assigning 0 to `item#number`.
1. Restore the deck from `tmp`.
