### PR TITLE
Adjust PC's weight

### DIFF
--- a/food.cpp
+++ b/food.cpp
@@ -1343,7 +1343,11 @@ void apply_general_eating_effect()
     {
         if (rnd(10) == 0 || cdata[cc].nutrition >= 12000)
         {
-            modweight(cc, rnd(3) + 1, cdata[cc].nutrition >= 12000);
+            modweight(
+                cc,
+                rnd(3) + 1,
+                cdata[cc].nutrition >= 20000
+                    && rnd(30000 / std::max(1, cdata[cc].nutrition) + 2) == 0);
         }
     }
     if (cdata[cc].id == 261)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #459.


# Summary

## Vanilla

Weight will not be over the upper limit.

## Foobar(before)

Weight will be over the upper limit if the character's satiety is Bloated.

## Foobar(after)

Weight will be over the upper limit at random if the satiety is very high. This threshold("very high") can be over only by eating stomafillia.
