### PR TITLE
Don't copy files over if they exist on build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,40 +179,6 @@ else()
   message("Using provided dependency prefix ${CMAKE_PREFIX_PATH}")
 endif()
 
-# Kludgy function to work around the lack of directory support in copy_if_different
-function(copy_nonexisting src rel final)
-  file(GLOB_RECURSE allfiles RELATIVE "${rel}" "${src}/*")
-
-  foreach( each_file ${allfiles} )
-    set(destinationfile "${CMAKE_BINARY_DIR}/${final}/${each_file}")
-    set(sourcefile "${rel}/${each_file}")
-    add_custom_command(TARGET ${PROJECT_NAME}
-      POST_BUILD
-      COMMAND ${CMAKE_COMMAND}
-      -Ddestinationfile=${destinationfile}
-      -Dsourcefile=${sourcefile}
-      -P ${CMAKE_MODULE_PATH}/copy_nonexisting.cmake
-      )
-  endforeach(each_file)
-endfunction()
-
-# Copy folders
-copy_nonexisting("runtime" "${CMAKE_SOURCE_DIR}/runtime" ".")
-copy_nonexisting("data" "${CMAKE_SOURCE_DIR}/data" "data")
-copy_nonexisting("lang" "${CMAKE_SOURCE_DIR}/lang" "lang")
-
-# Copy assets from Elona 1.22 if they are present
-if(EXISTS "${CMAKE_PREFIX_PATH}/elona")
-  copy_nonexisting("${CMAKE_PREFIX_PATH}/elona/graphic" "${CMAKE_PREFIX_PATH}/elona/graphic" "graphic")
-  copy_nonexisting("${CMAKE_PREFIX_PATH}/elona/map" "${CMAKE_PREFIX_PATH}/elona/map" "map")
-  copy_nonexisting("${CMAKE_PREFIX_PATH}/elona/original" "${CMAKE_PREFIX_PATH}/elona/original" "original")
-  copy_nonexisting("${CMAKE_PREFIX_PATH}/elona/sound" "${CMAKE_PREFIX_PATH}/elona/sound" "sound")
-  copy_nonexisting("${CMAKE_PREFIX_PATH}/elona/user" "${CMAKE_PREFIX_PATH}/elona/user" "user")
-  message("Elona 1.22 distribution found.")
-else()
-  message(WARNING "Elona 1.22 distribution not found at ${CMAKE_PREFIX_PATH}/elona. The game cannot be run without assets. Please manually copy the 'graphic', 'map', 'original', 'sound' and 'user' directories from Elona 1.22 to the ElonaFoobar output path after building.")
-endif()
-
 if(WIN32)
   # Force FindBoost to look for libraries with -mt-sgd
   set(Boost_USE_STATIC_LIBS ON)
@@ -224,7 +190,7 @@ if(WIN32)
   # Specify dynamic libraries to copy to output folder after build
   file(GLOB copy_sources "${CMAKE_PREFIX_PATH}/lib/*${CMAKE_SHARED_LIBRARY_SUFFIX}")
   set(copy_dest "$<TARGET_FILE_DIR:${PROJECT_NAME}>")
-  message("Will copy libraries to ${copy_dest}")
+  message("Will copy libraries to output folder.")
 
   # Perform the copy
   foreach(copy_source ${copy_sources})
@@ -328,6 +294,41 @@ INSTALL(CODE "
     include(BundleUtilities)
     fixup_bundle(\"${APPS}\" \"\" \"${DIRS}\")
     " COMPONENT Runtime)
+
+# Kludgy function to work around the lack of directory support in copy_if_different
+function(copy_nonexisting src rel final)
+  file(GLOB_RECURSE allfiles RELATIVE "${rel}" "${src}/*")
+
+  foreach( each_file ${allfiles} )
+    set(destinationfile "$<TARGET_FILE_DIR:${PROJECT_NAME}>/${final}/${each_file}")
+    set(sourcefile "${rel}/${each_file}")
+    message(${destinationfile})
+    add_custom_command(TARGET ${PROJECT_NAME}
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND}
+      -Ddestinationfile=${destinationfile}
+      -Dsourcefile=${sourcefile}
+      -P ${CMAKE_MODULE_PATH}/copy_nonexisting.cmake
+      )
+  endforeach(each_file)
+endfunction()
+
+# Copy folders
+copy_nonexisting("runtime" "${CMAKE_SOURCE_DIR}/runtime" ".")
+copy_nonexisting("data" "${CMAKE_SOURCE_DIR}/data" "data")
+copy_nonexisting("lang" "${CMAKE_SOURCE_DIR}/lang" "lang")
+
+# Copy assets from Elona 1.22 if they are present
+if(EXISTS "${CMAKE_PREFIX_PATH}/elona")
+  copy_nonexisting("${CMAKE_PREFIX_PATH}/elona/graphic" "${CMAKE_PREFIX_PATH}/elona/graphic" "graphic")
+  copy_nonexisting("${CMAKE_PREFIX_PATH}/elona/map" "${CMAKE_PREFIX_PATH}/elona/map" "map")
+  copy_nonexisting("${CMAKE_PREFIX_PATH}/elona/original" "${CMAKE_PREFIX_PATH}/elona/original" "original")
+  copy_nonexisting("${CMAKE_PREFIX_PATH}/elona/sound" "${CMAKE_PREFIX_PATH}/elona/sound" "sound")
+  copy_nonexisting("${CMAKE_PREFIX_PATH}/elona/user" "${CMAKE_PREFIX_PATH}/elona/user" "user")
+  message("Elona 1.22 distribution found.")
+else()
+  message(WARNING "Elona 1.22 distribution not found at ${CMAKE_PREFIX_PATH}/elona. The game cannot be run without assets. Please manually copy the 'graphic', 'map', 'original', 'sound' and 'user' directories from Elona 1.22 to the ElonaFoobar output path after building.")
+endif()
 
 if((WITH_TESTS STREQUAL "TESTS") OR (WITH_TESTS STREQUAL "BENCH"))
   copy_nonexisting("tests/data" "${CMAKE_CURRENT_SOURCE_DIR}/tests/data" "tests/data")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,47 +179,35 @@ else()
   message("Using provided dependency prefix ${CMAKE_PREFIX_PATH}")
 endif()
 
+# Kludgy function to work around the lack of directory support in copy_if_different
+function(copy_nonexisting src rel final)
+  file(GLOB_RECURSE allfiles RELATIVE "${rel}" "${src}/*")
+
+  foreach( each_file ${allfiles} )
+    set(destinationfile "${CMAKE_BINARY_DIR}/${final}/${each_file}")
+    set(sourcefile "${rel}/${each_file}")
+    add_custom_command(TARGET ${PROJECT_NAME}
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND}
+      -Ddestinationfile=${destinationfile}
+      -Dsourcefile=${sourcefile}
+      -P ${CMAKE_MODULE_PATH}/copy_nonexisting.cmake
+      )
+  endforeach(each_file)
+endfunction()
 
 # Copy folders
-add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-                   COMMAND ${CMAKE_COMMAND} -E copy_directory
-                   "${CMAKE_CURRENT_SOURCE_DIR}/runtime"
-                   "$<TARGET_FILE_DIR:${PROJECT_NAME}>")
-
-add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-                   COMMAND ${CMAKE_COMMAND} -E copy_directory
-                   "${CMAKE_CURRENT_SOURCE_DIR}/data"
-                   "$<TARGET_FILE_DIR:${PROJECT_NAME}>/data")
-add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-                   COMMAND ${CMAKE_COMMAND} -E copy_directory
-                   "${CMAKE_CURRENT_SOURCE_DIR}/lang"
-                   "$<TARGET_FILE_DIR:${PROJECT_NAME}>/lang")
-
+copy_nonexisting("runtime" "${CMAKE_SOURCE_DIR}/runtime" ".")
+copy_nonexisting("data" "${CMAKE_SOURCE_DIR}/data" "data")
+copy_nonexisting("lang" "${CMAKE_SOURCE_DIR}/lang" "lang")
 
 # Copy assets from Elona 1.22 if they are present
 if(EXISTS "${CMAKE_PREFIX_PATH}/elona")
-  add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-                     COMMAND ${CMAKE_COMMAND} -E copy_directory
-                     "${CMAKE_PREFIX_PATH}/elona/graphic"
-                     "$<TARGET_FILE_DIR:${PROJECT_NAME}>/graphic")
-  add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-                     COMMAND ${CMAKE_COMMAND} -E copy_directory
-                     "${CMAKE_PREFIX_PATH}/elona/map"
-                     "$<TARGET_FILE_DIR:${PROJECT_NAME}>/map")
-  add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-                     COMMAND ${CMAKE_COMMAND} -E copy
-                     "${CMAKE_PREFIX_PATH}/elona/original/export.txt"
-                     "${CMAKE_PREFIX_PATH}/elona/original/face1.bmp"
-                     "${CMAKE_PREFIX_PATH}/elona/original/musiclist.txt"
-                     "$<TARGET_FILE_DIR:${PROJECT_NAME}>/original")
-  add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-                     COMMAND ${CMAKE_COMMAND} -E copy_directory
-                     "${CMAKE_PREFIX_PATH}/elona/sound"
-                     "$<TARGET_FILE_DIR:${PROJECT_NAME}>/sound")
-  add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-                     COMMAND ${CMAKE_COMMAND} -E copy_directory
-                     "${CMAKE_PREFIX_PATH}/elona/user"
-                     "$<TARGET_FILE_DIR:${PROJECT_NAME}>/user")
+  copy_nonexisting("${CMAKE_PREFIX_PATH}/elona/graphic" "${CMAKE_PREFIX_PATH}/elona/graphic" "graphic")
+  copy_nonexisting("${CMAKE_PREFIX_PATH}/elona/map" "${CMAKE_PREFIX_PATH}/elona/map" "map")
+  copy_nonexisting("${CMAKE_PREFIX_PATH}/elona/original" "${CMAKE_PREFIX_PATH}/elona/original" "original")
+  copy_nonexisting("${CMAKE_PREFIX_PATH}/elona/sound" "${CMAKE_PREFIX_PATH}/elona/sound" "sound")
+  copy_nonexisting("${CMAKE_PREFIX_PATH}/elona/user" "${CMAKE_PREFIX_PATH}/elona/user" "user")
   message("Elona 1.22 distribution found.")
 else()
   message(WARNING "Elona 1.22 distribution not found at ${CMAKE_PREFIX_PATH}/elona. The game cannot be run without assets. Please manually copy the 'graphic', 'map', 'original', 'sound' and 'user' directories from Elona 1.22 to the ElonaFoobar output path after building.")
@@ -342,8 +330,5 @@ INSTALL(CODE "
     " COMPONENT Runtime)
 
 if((WITH_TESTS STREQUAL "TESTS") OR (WITH_TESTS STREQUAL "BENCH"))
-  add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-                     COMMAND ${CMAKE_COMMAND} -E copy_directory
-                     "${CMAKE_CURRENT_SOURCE_DIR}/tests/data"
-                     "$<TARGET_FILE_DIR:${PROJECT_NAME}>/tests/data")
+  copy_nonexisting("tests/data" "${CMAKE_CURRENT_SOURCE_DIR}/tests/data" "tests/data")
 endif()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,6 +83,7 @@ build_script:
   - cmake -DCMAKE_PREFIX_PATH=%PREFIX% -DWITH_TESTS=TESTS %CMAKE_ARGS% ..
   - cmake --build .
   - cd %CONFIGURATION%
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   - ElonaFoobar.exe
   - cd %APPVEYOR_BUILD_FOLDER%
   - rd /q /s bin

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,7 +83,6 @@ build_script:
   - cmake -DCMAKE_PREFIX_PATH=%PREFIX% -DWITH_TESTS=TESTS %CMAKE_ARGS% ..
   - cmake --build .
   - cd %CONFIGURATION%
-  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   - ElonaFoobar.exe
   - cd %APPVEYOR_BUILD_FOLDER%
   - rd /q /s bin

--- a/cmake/copy_nonexisting.cmake
+++ b/cmake/copy_nonexisting.cmake
@@ -1,0 +1,4 @@
+if(NOT EXISTS ${destinationfile})
+  execute_process(COMMAND ${CMAKE_COMMAND}
+  -E copy ${sourcefile} ${destinationfile})
+endif()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #436.


# Summary
Introduces a function to replace `copy_if_different` since it lacks directory support. Now the config file and others shouldn't be overwritten on rebuild.