### PR TITLE
Add length limiting option to message box input

### DIFF
--- a/input.cpp
+++ b/input.cpp
@@ -252,7 +252,8 @@ void input_text_dialog(
     int y,
     int val2,
     bool is_cancelable,
-    bool as_filename)
+    bool as_filename,
+    bool max_length)
 {
     int ime_esc = 0;
 
@@ -326,12 +327,30 @@ void input_text_dialog(
             {
                 p(4) += 1;
             }
+            p(4) = std::min(p(4), 20);
         }
+        noteget(s, 0);
+
+        if (max_length && p(4) == 20)
+        {
+            if (inputlog(0).back() != '\n')
+            {
+                cutname(inputlog, 20);
+            }
+            cutname(s, 20);
+        }
+        else if (!max_length && p(4) > 18)
+        {
+            p(4) = 18;
+            cutname(s, 18);
+            s += u8"…";
+            p(4) += 2;
+        }
+
         gmode(4, -1, -1, p(1) / 2 + 50);
         pos(x + 34 + p(4) * 8, y + 5);
         gcopy(3, 0, 336, 12, 24);
         gmode(2);
-        noteget(s, 0);
         color(255, 255, 255);
         pos(x + 36, y + 9);
         mes(s);

--- a/input.cpp
+++ b/input.cpp
@@ -253,7 +253,7 @@ void input_text_dialog(
     int val2,
     bool is_cancelable,
     bool as_filename,
-    bool max_length)
+    bool limit_length)
 {
     int ime_esc = 0;
 
@@ -331,7 +331,7 @@ void input_text_dialog(
         }
         noteget(s, 0);
 
-        if (max_length && p(4) == 20)
+        if (limit_length && p(4) == 20)
         {
             if (inputlog(0).back() != '\n')
             {
@@ -339,7 +339,7 @@ void input_text_dialog(
             }
             cutname(s, 20);
         }
-        else if (!max_length && p(4) > 18)
+        else if (!limit_length && p(4) > 18)
         {
             p(4) = 18;
             cutname(s, 18);

--- a/input.hpp
+++ b/input.hpp
@@ -34,7 +34,7 @@ void input_text_dialog(
     int val2,
     bool is_cancelable = true,
     bool as_filename = false,
-    bool max_length = true);
+    bool limit_length = true);
 
 
 } // namespace elona

--- a/input.hpp
+++ b/input.hpp
@@ -33,7 +33,8 @@ void input_text_dialog(
     int y,
     int val2,
     bool is_cancelable = true,
-    bool as_filename = false);
+    bool as_filename = false,
+    bool max_length = true);
 
 
 } // namespace elona


### PR DESCRIPTION
# Related Issues

Close #452.


# Summary
Adds a flag (default `true`) that limits the length of text in the input box. If `false`, it still prevents too large textures by cutting off the presented text and adding ellipses, but it will still return the fully typed in text. If the input length becomes a problem (like for wishing) it can be set to `false`.