### PR TITLE
Fix enter key not working sometimes

### DIFF
--- a/snail/input.cpp
+++ b/snail/input.cpp
@@ -357,6 +357,11 @@ void input::_update()
 
 void input::_handle_event(const ::SDL_KeyboardEvent& event)
 {
+    if (_is_ime_active)
+    {
+        _is_ime_active = false;
+    }
+
     const auto k = sdlkey2key(event.keysym.sym);
     if (k == key::none)
         return;


### PR DESCRIPTION
# Related Issues

Close #242.


# Summary

Turns off the IME if a keyboard input event is received instead of a text editing/text input event.