### PR TITLE
Set the relocated character's index value

### DIFF
--- a/character.cpp
+++ b/character.cpp
@@ -2083,6 +2083,7 @@ int chara_relocate(int prm_784, int prm_785, int prm_786)
     sdata.clear(prm_784);
     cdata(tc_at_m125) = cdata(prm_784);
     cdata(prm_784).clear();
+    cdata(tc_at_m125).index = tc_at_m125;
     for (int cnt = 0; cnt < 10; ++cnt)
     {
         cdatan(cnt, tc_at_m125) = cdatan(cnt, prm_784);


### PR DESCRIPTION
# Summary

Sets the `index` member of characters that are relocated. Before it wasn't getting set after relocation, and strange things were happening.