### PR TITLE
Add note to avoid overwriting files in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To debug with Visual Studio, open `bin\ElonaFoobar.sln`.
 
 # How To Play
 
-1. If not done already, copy the `data`, `graphic`, `map`, `original`, `sound` and `user` folders from vanilla v1.22 to the directory containing the executable.
+1. If not done already, copy the `data`, `graphic`, `map`, `original`, `sound` and `user` folders from vanilla v1.22 to the directory containing the executable. Make sure not to overwrite any files that already exist, as they have been updated in this version.
 2. Execute `bin/ElonaFoobar`, `bin/ElonaFoobar.app` or `bin/Debug/ElonaFoobar.exe`.
 
 


### PR DESCRIPTION
# Related Issues

Close #538.


# Summary
Adds note that files that already exist should not be overwritten by vanilla 1.22 files.