### PR TITLE
Fix exp overflow

### DIFF
--- a/ability.cpp
+++ b/ability.cpp
@@ -298,9 +298,10 @@ int skillexp(int id, int cc, int experience, int prm_572, int prm_573)
         {
             if (prm_573 != 1000)
             {
-                exp2_at_m77 = rnd(cdata[cc].required_experience * exp_at_m77
-                                      / 1000 / (cdata[cc].level + prm_573)
-                                  + 1)
+                exp2_at_m77 =
+                    rnd(double(cdata[cc].required_experience) * exp_at_m77
+                            / 1000 / (cdata[cc].level + prm_573)
+                        + 1)
                     + rnd(2);
                 cdata[cc].experience += exp2_at_m77;
                 if (cc == 0)

--- a/random.hpp
+++ b/random.hpp
@@ -33,9 +33,8 @@ inline void randomize(
 // [0, max)
 inline int rnd(int max)
 {
-    assert(max > 0);
-
-    return std::uniform_int_distribution<>{0, max - 1}(detail::engine);
+    return std::uniform_int_distribution<>{
+        0, std::max(0, max - 1)}(detail::engine);
 }
 
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #536.


# Summary

- Fix formula to avoid overflow.
- Delete `assert` in `rnd()`.
- Limit range of `rnd()`. If passing 0 or smaller to `rnd`, it just returns 0.