### PR TITLE
Implement autonumlock/Add "Clear" as wait key

### DIFF
--- a/elonacore.cpp
+++ b/elonacore.cpp
@@ -913,8 +913,7 @@ void finish_elona()
     }
     if (config::instance().autonumlock)
     {
-        keybd_event(144);
-        keybd_event(144, 0, 2);
+        snail::input::instance().restore_numlock();
     }
     if (mutex_handle != 0)
     {

--- a/init.cpp
+++ b/init.cpp
@@ -797,8 +797,7 @@ void initialize_elona()
 
     if (config::instance().autonumlock)
     {
-        // TODO
-        // if NumLock key is pressed, send an event to release the key.
+        snail::input::instance().disable_numlock();
     }
 }
 

--- a/input.cpp
+++ b/input.cpp
@@ -488,6 +488,10 @@ void key_check(int prm_299)
         {
             p_at_m19 = 12;
         }
+        else if (getkey(snail::key::clear))
+        {
+            key = key_wait;
+        }
 
         // Handle the case of the current key matching the movement
         // keybindings set in the user's config.

--- a/main_menu.cpp
+++ b/main_menu.cpp
@@ -123,8 +123,7 @@ main_menu_result_t main_title_menu()
     {
         if (config::instance().autonumlock)
         {
-            // TODO
-            // if NumLock key is pressed, send an event to release the key.
+            snail::input::instance().disable_numlock();
         }
         tx += (rnd(10) + 2) * p(1);
         ty += (rnd(10) + 2) * p(2);

--- a/snail/input.cpp
+++ b/snail/input.cpp
@@ -3,6 +3,9 @@
 #include <algorithm>
 #include <iostream>
 #include <tuple>
+#ifdef _WIN32
+#include <windows.h> // GetKeyboardState, keybd_event
+#endif
 
 using namespace elona::snail;
 
@@ -305,6 +308,34 @@ bool input::was_pressed_just_now(key k) const
 bool input::is_ime_active() const
 {
     return _is_ime_active;
+}
+
+
+void input::disable_numlock()
+{
+    // SDL always reports numlock as being off when the program
+    // starts, even if it was on before. The Shift+numpad strangeness
+    // only happens on Windows, so it should be reasonable to use
+    // Windows APIs here.
+#ifdef _WIN32
+    if (GetKeyState(VK_NUMLOCK))
+    {
+        keybd_event(VK_NUMLOCK, 0x45, KEYEVENTF_EXTENDEDKEY, 0);
+        keybd_event(VK_NUMLOCK, 0x45, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
+        _needs_restore_numlock = true;
+    }
+#endif
+}
+
+void input::restore_numlock()
+{
+#ifdef _WIN32
+    if (!GetKeyState(VK_NUMLOCK) && _needs_restore_numlock)
+    {
+        keybd_event(VK_NUMLOCK, 0x45, KEYEVENTF_EXTENDEDKEY, 0);
+        keybd_event(VK_NUMLOCK, 0x45, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
+    }
+#endif
 }
 
 

--- a/snail/input.cpp
+++ b/snail/input.cpp
@@ -80,6 +80,7 @@ key sdlkey2key(::SDL_Keycode k)
     case SDLK_LEFT: return key::left;
     case SDLK_RIGHT: return key::right;
     case SDLK_INSERT: return key::insert;
+    case SDLK_CLEAR: return key::clear;
     case SDLK_NUMLOCKCLEAR: return key::numlock;
     case SDLK_CAPSLOCK: return key::capslock;
     case SDLK_HOME: return key::home;

--- a/snail/input.hpp
+++ b/snail/input.hpp
@@ -125,6 +125,7 @@ enum class key
     right,
 
     insert,
+    clear,
     numlock,
     capslock,
 

--- a/snail/input.hpp
+++ b/snail/input.hpp
@@ -260,6 +260,27 @@ public:
 
     bool is_ime_active() const;
 
+
+   /***
+    * Disables NumLock to prevent strange Windows-specific behavior when
+    * holding Shift and pressing a numpad key. What happens with NumLock
+    * enabled is the numpad key reverts to its non-NumLock functionality,
+    * but Shift becomes depressed for some reason. This prevents the
+    * player from running when holding Shift and pressing a numpad
+    * movement key. This does not happen on Linux, so it's probably a
+    * Windows-specific quirk.
+    *
+    * This method has no effect on platforms besides Windows.
+    */
+    void disable_numlock();
+
+    /***
+     * Restores NumLock if it was disabled at some point by disable_numlock().
+     *
+     * This method has no effect on platforms besides Windows.
+     */
+    void restore_numlock();
+
     std::string get_text()
     {
         std::string ret = _text;
@@ -284,6 +305,7 @@ private:
     std::array<button, static_cast<size_t>(key::_size)> _keys;
     std::string _text;
     bool _is_ime_active{};
+    bool _needs_restore_numlock{};
 
     input() = default;
 };


### PR DESCRIPTION
# Related Issues

Close #535.

# Summary
Implements the `autoNumlock` option for Windows and allows the Clear key (which is numpad key 5) to be used for passing turns. This does not fix the behavior of pressing Shift and using the numpad with NumLock on, as it appears to be a Windows-specific issue. It seems `autoNumlock` was a workaround to avoid the issues caused by turning NumLock on and trying to use it, so this might suffice.

The issue still outstanding is forcing Windows to keep Shift pressed when pressing a numpad key with shift pressed and NumLock on. I'm not sure this is feasible.