### PR TITLE
Cut down warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,11 +278,12 @@ if(WITH_TESTS STREQUAL "BENCH")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 endif()
 
-# Force GCC to output warnings about undefined symbols
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    string(APPEND CMAKE_SHARED_LINKER_FLAGS " -Wl,--no-undefined")
+    # Force GCC to output warnings about undefined symbols
+    string(APPEND CMAKE_CXX_FLAGS " -Wl,--no-undefined")
+    # Disable deprecated declarations, because it causes warnings with Boost locale's use of auto_ptr
+    string(APPEND CMAKE_CXX_FLAGS " -Wno-deprecated-declarations")
 endif()
-
 
 # My libraries
 add_subdirectory(snail)

--- a/calc.cpp
+++ b/calc.cpp
@@ -1256,8 +1256,8 @@ int calctraincost(int skill_id, int cc, bool discount)
 
 int calclearncost(int skill_id, int cc, bool discount)
 {
-    (void)skill_id;
-    (void)cc;
+    UNUSED(skill_id);
+    UNUSED(cc);
 
     int platinum = 15 + 3 * gdata_number_of_learned_skills_by_trainer;
     return discount ? platinum * 2 / 3 : platinum;

--- a/cat.hpp
+++ b/cat.hpp
@@ -5,6 +5,7 @@
 #include <lua.hpp>
 #include "filesystem.hpp"
 #include "lib/noncopyable.hpp"
+#include "macro.hpp"
 #include "optional.hpp"
 
 
@@ -116,7 +117,7 @@ private:
             std::nullptr_t> = nullptr>
     T to_cpp_type(int index)
     {
-        (void)index;
+        UNUSED(index);
         return nullptr;
     }
 

--- a/cell_draw.cpp
+++ b/cell_draw.cpp
@@ -355,7 +355,7 @@ void initialize_cloud_data()
 void render_cloud()
 {
     static int dummy = ((void)initialize_cloud_data(), 0);
-    (void)dummy;
+    UNUSED(dummy);
 
     for (size_t i = 0; i < clouds.size(); ++i)
     {

--- a/character.cpp
+++ b/character.cpp
@@ -2217,6 +2217,7 @@ int chara_relocate(int prm_784, int prm_785, int prm_786)
         cdata[tc_at_m125].relationship = relationship;
         cdata[tc_at_m125].original_relationship = original_relationship;
         cdata[tc_at_m125].hate = hate;
+        cdata[tc_at_m125].enemy_id = enemy_id;
         cdata[tc_at_m125].hp = hp;
         map(cdata[tc_at_m125].position.x, cdata[tc_at_m125].position.y, 1) =
             tc_at_m125 + 1;

--- a/config.cpp
+++ b/config.cpp
@@ -4,6 +4,7 @@
 #include <stdexcept>
 #include "elona.hpp"
 #include "json.hpp"
+#include "macro.hpp"
 #include "range.hpp"
 #include "snail/window.hpp"
 #include "variables.hpp"
@@ -1025,7 +1026,7 @@ void set_config(const std::string& key, const std::string& value1, int value2)
     }
 
     options.get<picojson::object>()[key] = picojson::value{value1};
-    (void)value2; // TODO
+    UNUSED(value2); // TODO
 
     {
         std::ofstream file{(filesystem::dir::exe() / u8"config.json").native(),

--- a/draw.cpp
+++ b/draw.cpp
@@ -278,7 +278,7 @@ void show_hp_bar(show_hp_bar_side side, int inf_clocky)
 void initialize_damage_popups()
 {
     damage_popups_active = 0;
-    for (int i = 0; i < max_damage_popups; i++)
+    for (size_t i = 0; i < max_damage_popups; i++)
     {
         damage_popups.emplace_back(damage_popup_t{});
     }
@@ -329,7 +329,7 @@ void clear_damage_popups()
 }
 
 
-void show_damage_popups(int inf_ver)
+void show_damage_popups()
 {
     if (config::instance().damage_popup == 0)
     {

--- a/draw.hpp
+++ b/draw.hpp
@@ -27,7 +27,7 @@ void add_damage_popup(
     int character,
     const snail::color& color);
 void clear_damage_popups();
-void show_damage_popups(int inf_ver);
+void show_damage_popups();
 
 void draw_emo(int = 0, int = 0, int = 0);
 void load_pcc_part(int cc, int body_part, const char* body_part_str);

--- a/elonacore.cpp
+++ b/elonacore.cpp
@@ -10667,7 +10667,7 @@ void show_item_description()
             int npc_count{};
             for (const auto& discord : the_character_db)
             {
-                (void)discord;
+                UNUSED(discord);
                 ++npc_count;
             }
             const auto percentage = std::min(100 * card_count / npc_count, 100);
@@ -17354,7 +17354,7 @@ void proc_autopick()
                 }
             }
             elona::ci = ci;
-            (void)do_open_command();
+            (void)do_open_command(); // Result is unused.
             break;
         }
         if (did_something && !op.sound.empty())

--- a/i18n.hpp
+++ b/i18n.hpp
@@ -9,8 +9,9 @@
 #include "cat.hpp"
 #include "character.hpp"
 #include "filesystem.hpp"
-#include "optional.hpp"
 #include "item.hpp"
+#include "macro.hpp"
+#include "optional.hpp"
 
 
 using namespace std::literals::string_literals;
@@ -189,6 +190,8 @@ std::string format_function_type(hil::FunctionCall const& func, bool const& valu
 template <typename Head>
 std::string format_function_type(hil::FunctionCall const& func, Head const& head)
 {
+    UNUSED(head);
+
     return "<unknown function (" + func.name + ")>";
 }
 
@@ -198,6 +201,9 @@ void fmt_internal(const hil::Context& ctxt,
                   int count,
                   std::vector<optional<std::string>>& formatted)
 {
+    UNUSED(ctxt);
+    UNUSED(count);
+    UNUSED(formatted);
 }
 
 

--- a/macro.hpp
+++ b/macro.hpp
@@ -69,3 +69,5 @@
 
 #define ELONA_GET_SELECTED_INDEX_THIS_PAGE(var) \
     ELONA_GET_SELECTED_ITEM_BASE(var, i, 0)
+
+#define UNUSED(x) (void)x

--- a/main_menu.cpp
+++ b/main_menu.cpp
@@ -205,7 +205,6 @@ main_menu_result_t main_menu_wrapper()
     // Start off in the title menu.
     main_menu_result_t result = main_title_menu();
     bool finished = false;
-    bool game_initialized = false;
     while (!finished)
     {
         switch (result)

--- a/set_option.cpp
+++ b/set_option.cpp
@@ -410,8 +410,6 @@ void set_option()
     int cfg_sound2 = config::instance().sound;
     int cfg_music2 = config::instance().music;
     int cfg_fullscreen2 = config::instance().fullscreen;
-    int windoww2 = windoww;
-    int windowh2 = windowh;
 
     const auto display_modes = snail::application::instance().get_display_modes();
     std::string default_display_mode = snail::application::instance().get_default_display_mode();
@@ -1251,9 +1249,6 @@ void set_option()
                         display_mode_index = static_cast<int>(display_mode_names.size()) - 1;
                     }
                     cfg_display_mode = display_mode_names[display_mode_index];
-                    auto display_mode = display_modes.at(cfg_display_mode);
-                    windoww2 = display_mode.w;
-                    windowh2 = display_mode.h;
                     set_config(u8"display_mode", cfg_display_mode);
                     snd(20);
                     reset_page = true;

--- a/snail/audio/sdl.cpp
+++ b/snail/audio/sdl.cpp
@@ -22,9 +22,6 @@ constexpr int temporary_channels_size = 6;
 
 std::vector<Mix_Chunk*> chunks;
 
-int envwprev{};
-int musicprev{};
-
 Mix_Music* played_music = nullptr;
 } // namespace
 

--- a/snail/input.cpp
+++ b/snail/input.cpp
@@ -409,6 +409,8 @@ void input::_handle_event(const ::SDL_TextInputEvent& event)
 
 void input::_handle_event(const ::SDL_TextEditingEvent& event)
 {
+    (void)event;
+
     _is_ime_active = true;
 }
 

--- a/std.cpp
+++ b/std.cpp
@@ -15,9 +15,10 @@
 #include "defines.hpp"
 #include "elona.hpp"
 #include "log.hpp"
+#include "macro.hpp"
 #include "util.hpp"
 #include "variables.hpp"
-#if defined(ELONA_OS_WINDOWS)
+#ifdef ELONA_OS_WINDOWS
 #include <windows.h> // MessageBoxA
 #endif
 
@@ -124,9 +125,9 @@ void bcopy(const fs::path& from, const fs::path& to)
 // fullscreen
 void bgscr(int window_id, int width, int height, int, int)
 {
-    (void)window_id;
-    (void)width;
-    (void)height;
+    UNUSED(window_id);
+    UNUSED(width);
+    UNUSED(height);
 }
 
 
@@ -249,8 +250,8 @@ void buffer(int window_id, int width, int height)
 
 void chgdisp(int, int width, int height)
 {
-    (void)width;
-    (void)height;
+    UNUSED(width);
+    UNUSED(height);
 }
 
 
@@ -339,6 +340,8 @@ int dialog(const std::string& message, int option)
 #elif defined(ELONA_OS_MACOS)
     return dialog_macos(message, option);
 #else
+    UNUSED(message);
+    UNUSED(option);
     return 0;
 #endif
 }
@@ -383,7 +386,7 @@ void getstr(
     char delimiter,
     int limit)
 {
-    (void)limit;
+    UNUSED(limit);
     auto pos = source.find(delimiter, offset);
     if (pos == std::string::npos)
     {
@@ -594,16 +597,16 @@ void mkdir(const fs::path& path)
 
 void mmload(const fs::path& filepath, int id, int mode)
 {
-    (void)filepath;
-    (void)id;
-    (void)mode;
+    UNUSED(filepath);
+    UNUSED(id);
+    UNUSED(mode);
 }
 
 
 
 void mmplay(int id)
 {
-    (void)id;
+    UNUSED(id);
 }
 
 
@@ -771,8 +774,8 @@ void objsel(int)
 
 void pget(int x, int y)
 {
-    (void)x;
-    (void)y;
+    UNUSED(x);
+    UNUSED(y);
 }
 
 
@@ -809,12 +812,12 @@ void redraw()
 
 void screen(int window_id, int width, int height, int mode, int x, int y)
 {
-    (void)window_id;
-    (void)width;
-    (void)height;
-    (void)mode;
-    (void)x;
-    (void)y;
+    UNUSED(window_id);
+    UNUSED(width);
+    UNUSED(height);
+    UNUSED(mode);
+    UNUSED(x);
+    UNUSED(y);
 }
 
 
@@ -822,7 +825,7 @@ void screen(int window_id, int width, int height, int mode, int x, int y)
 int stick(int allow_repeat_keys)
 {
     auto check_key_pressed = [allow_repeat_keys](
-                                 int n, snail::key key, bool is_modifier) {
+                                 int n, snail::key key) {
         if ((1 << n) & allow_repeat_keys)
         {
             return (1 << n) * snail::input::instance().is_pressed(key);
@@ -836,18 +839,18 @@ int stick(int allow_repeat_keys)
 
     int ret{};
 
-    ret += check_key_pressed(0, snail::key::left, false);
-    ret += check_key_pressed(1, snail::key::up, false);
-    ret += check_key_pressed(2, snail::key::right, false);
-    ret += check_key_pressed(3, snail::key::down, false);
-    ret += check_key_pressed(4, snail::key::space, false);
-    ret += check_key_pressed(5, snail::key::enter, false);
-    ret += check_key_pressed(5, snail::key::keypad_enter, false);
-    ret += check_key_pressed(6, snail::key::ctrl, true);
-    ret += check_key_pressed(7, snail::key::escape, false);
+    ret += check_key_pressed(0, snail::key::left);
+    ret += check_key_pressed(1, snail::key::up);
+    ret += check_key_pressed(2, snail::key::right);
+    ret += check_key_pressed(3, snail::key::down);
+    ret += check_key_pressed(4, snail::key::space);
+    ret += check_key_pressed(5, snail::key::enter);
+    ret += check_key_pressed(5, snail::key::keypad_enter);
+    ret += check_key_pressed(6, snail::key::ctrl);
+    ret += check_key_pressed(7, snail::key::escape);
     // ret += check_key_pressed(8,  /* Mouse left */,  false);
-    // ret += check_key_pressed(9,  /* Mouse right */, false);
-    ret += check_key_pressed(10, snail::key::tab, false);
+    // ret += check_key_pressed(9,  /* Mouse right */);
+    ret += check_key_pressed(10, snail::key::tab);
 
     if (allow_repeat_keys == 15)
     {
@@ -918,8 +921,8 @@ void title(const std::string& title_str,
 
 void width(int width, int height, int, int)
 {
-    (void)width;
-    (void)height;
+    UNUSED(width);
+    UNUSED(height);
 }
 
 
@@ -1012,8 +1015,8 @@ void set_color_mod(int r, int g, int b, int window_id)
 
 void gfini(int width, int height)
 {
-    (void)width;
-    (void)height;
+    UNUSED(width);
+    UNUSED(height);
     // gf_detail::rect = {detail::current_tex_buffer().x,
     // detail::current_tex_buffer().y, width, height}; const auto texture =
     // snail::application::instance().get_renderer().render_target();
@@ -1025,9 +1028,9 @@ void gfini(int width, int height)
 
 void gfdec(int r, int g, int b)
 {
-    (void)r;
-    (void)g;
-    (void)b;
+    UNUSED(r);
+    UNUSED(g);
+    UNUSED(b);
     // gf_detail::map([](uint8_t v_, int v)
     //     {
     //         v = std::min(v, static_cast<int>(v_));
@@ -1040,9 +1043,9 @@ void gfdec(int r, int g, int b)
 
 void gfdec2(int r, int g, int b)
 {
-    (void)r;
-    (void)g;
-    (void)b;
+    UNUSED(r);
+    UNUSED(g);
+    UNUSED(b);
     // gf_detail::map([](uint8_t v_, int v)
     //     {
     //         v = std::min(v, static_cast<int>(v_) - 1);
@@ -1055,9 +1058,9 @@ void gfdec2(int r, int g, int b)
 
 void gfinc(int r, int g, int b)
 {
-    (void)r;
-    (void)g;
-    (void)b;
+    UNUSED(r);
+    UNUSED(g);
+    UNUSED(b);
     // gf_detail::map([](uint8_t v_, int v)
     //     {
     //         v = std::min(v, 255 - static_cast<int>(v_));
@@ -1090,6 +1093,8 @@ int aplobj(const std::string&, int)
 
 void apledit(int& out, int kind, int column_no)
 {
+    UNUSED(column_no);
+
     if (kind == 0)
     {
         // Current position of cursor

--- a/ui.cpp
+++ b/ui.cpp
@@ -214,7 +214,8 @@ void initialize_ui_constants()
     inf_mpy = inf_ver - 12;
     inf_msgx = inf_raderw;
     inf_msgspace = 15;
-    inf_maxmsglen = (windoww - inf_msgx - 28) / inf_mesfont * 2 - 1;
+    int inf_maxmsglen_i = std::max((windoww - inf_msgx - 28) / inf_mesfont * 2 - 1, 0);
+    inf_maxmsglen = static_cast<size_t>(inf_maxmsglen_i);
     inf_maxlog = (inf_msgy - 100) / inf_msgspace + 3;
     inf_very = windowh - inf_verh;
     screenmsgy = inf_screeny + inf_tiles * 2;
@@ -974,7 +975,7 @@ void render_hud()
             inf_clocky);
     }
 
-    show_damage_popups(inf_ver);
+    show_damage_popups();
 }
 
 void load_continuous_action_animation()

--- a/variables.hpp
+++ b/variables.hpp
@@ -519,7 +519,7 @@ ELONA_EXTERN(int inf_clockh);
 ELONA_EXTERN(int inf_clockw);
 ELONA_EXTERN(int inf_clockx);
 ELONA_EXTERN(int inf_maxlog);
-ELONA_EXTERN(int inf_maxmsglen);
+ELONA_EXTERN(size_t inf_maxmsglen);
 ELONA_EXTERN(int inf_mesfont);
 ELONA_EXTERN(int inf_msgline);
 ELONA_EXTERN(int inf_msgspace);


### PR DESCRIPTION
# Related Issues

Close #548.


# Summary
- Reduce the number of warnings. With GCC, the only remaining warning is in Boost.Locale.
```
In file included from /home/ruin/build/boost_1_66_0/boost/locale/encoding_utf.hpp:11,
                 from /home/ruin/build/boost_1_66_0/boost/locale/encoding.hpp:18,
                 from /home/ruin/build/boost_1_66_0/boost/locale.hpp:16,
                 from /home/ruin/build/elonafoobar/filesystem.cpp:2:
/home/ruin/build/boost_1_66_0/boost/locale/utf.hpp: In static member function ‘static boost::locale::utf::code_point boost::locale::utf::utf_traits<CharType, 1>::decode(Iterator&, Iterator) [with Iterator = const char*; CharType = char]’:
/home/ruin/build/boost_1_66_0/boost/locale/utf.hpp:224:17: warning: this statement may fall through [-Wimplicit-fallthrough=]
                 c = (c << 6) | ( tmp & 0x3F);
                 ^
/home/ruin/build/boost_1_66_0/boost/locale/utf.hpp:225:13: note: here
             case 2:
             ^~~~
/home/ruin/build/boost_1_66_0/boost/locale/utf.hpp:231:17: warning: this statement may fall through [-Wimplicit-fallthrough=]
                 c = (c << 6) | ( tmp & 0x3F);
                 ^
/home/ruin/build/boost_1_66_0/boost/locale/utf.hpp:232:13: note: here
             case 1:
             ^~~~
```

It originates in a library, however. 
- There was also another warning caused by `auto_ptr` being deprecated, also in Boost.Locale. It seemed to be the only usage of it anywhere, so I added `-Wno-deprecated-declarations` to suppress it.
- Refactor `inf_maxmsglen` to be `size_t`, and ensures the cast from `int` to `size_t` is sane enough.
- Add an `UNUSED` macro and use it where needed.
- Remove unnecessary parameters in `stick()` and `show_damage_popups()`.