### PR TITLE
Save foobar version and add migration code

### DIFF
--- a/ctrl_file.cpp
+++ b/ctrl_file.cpp
@@ -438,21 +438,21 @@ void fmode_7_8(bool read, const fs::path& dir)
     }
 
     {
-        const auto filepath = dir / u8"foobar_save.s1";
+        const auto filepath = dir / u8"foobar_data.s1";
         if (read)
         {
             if (fs::exists(filepath))
             {
                 std::ifstream in{filepath.native(), std::ios::binary};
                 putit::binary_iarchive ar{in};
-                ar.load(foobar_save);
+                ar.load(foobar_data);
             }
         }
         else
         {
             std::ofstream out{filepath.native(), std::ios::binary};
             putit::binary_oarchive ar{out};
-            ar.save(foobar_save);
+            ar.save(foobar_data);
         }
     }
 

--- a/elonacore.cpp
+++ b/elonacore.cpp
@@ -11990,6 +11990,30 @@ void create_cnpc()
 
 
 
+// TODO: Delete this function when v1.0.0 stable is released.
+// Save data in v0.2.5 is not compatible with that in v0.2.6 or later. To make
+// matters worse, foobar's version is not saved in v0.2.5 save. As a result, we
+// cannot migrate save data in a usual way, `migrate_save_data()` function.
+// This function
+// 1. Delete old meta data file, `foobar_save.s1`.
+// 2. Set v0.2.5 to foobar_data.
+// Now, you can detect that the version is v0.2.5 and use usual migration code,
+// `migrate_save_data()`.
+void migrate_save_data_from_025_to_026(const fs::path& save_dir)
+{
+    const auto old_meta_data_filepath = save_dir / "foobar_save.s1";
+
+    if (fs::exists(old_meta_data_filepath))
+        // v0.2.6 or later
+        return;
+
+    // v0.2.5
+    fs::remove(old_meta_data_filepath);
+    foobar_data.version = {0, 2, 5, "", "", ""};
+}
+
+
+
 void load_save_data(const fs::path& base_save_dir)
 {
     ELONA_LOG("Load save data: " << playerid);
@@ -12035,6 +12059,7 @@ void load_save_data(const fs::path& base_save_dir)
         }
     }
     ELONA_LOG("asd " << save_dir);
+    migrate_save_data_from_025_to_026(save_dir);
     ctrl_file(file_operation2_t::_7, save_dir);
     migrate_save_data();
     set_item_info();

--- a/gdata.cpp
+++ b/gdata.cpp
@@ -7,14 +7,7 @@ namespace elona
 {
 
 
-foobar_save_t foobar_save;
-
-
-void foobar_save_t::initialize()
-{
-    version = latest_version;
-}
-
+foobar_data_t foobar_data;
 
 
 void modify_crowd_density(int cc, int delta)

--- a/gdata.hpp
+++ b/gdata.hpp
@@ -134,27 +134,25 @@ namespace elona
 {
 
 
-struct foobar_save_t
+struct foobar_data_t
 {
     // NOTE: Don't add new fields unless you add them to serialization, which
     // will break save compatibility.
-    bool is_autodig_enabled{};
     version_t version;
-
-
-    void initialize();
+    bool is_autodig_enabled{};
 
 
     template <typename Archive>
     void serialize(Archive& ar)
     {
         // WARNING: Changing this will break save compatibility!
+        ar(version);
         ar(is_autodig_enabled);
     }
 };
 
 
-extern foobar_save_t foobar_save;
+extern foobar_data_t foobar_data;
 
 
 // TODO: Make gdata class and make this function method.

--- a/init.cpp
+++ b/init.cpp
@@ -806,8 +806,6 @@ int run()
     const fs::path config_file = filesystem::dir::exe() / u8"config.json";
     initialize_cat_db();
 
-    foobar_save.initialize();
-
     load_config2(config_file);
 
     title(u8"Elona Foobar version "s + latest_version.short_string(),

--- a/testing.cpp
+++ b/testing.cpp
@@ -62,8 +62,6 @@ void pre_init()
     initialize_cat_db();
     configure_lua();
 
-    foobar_save.initialize();
-
     load_config2(fs::path("tests/data/config.json"));
 
     title(u8"Elona Foobar version "s + latest_version.short_string());

--- a/tests/serialization.cpp
+++ b/tests/serialization.cpp
@@ -133,5 +133,5 @@ TEST_CASE("Test ability data compatibility", "[C++: Serialization]")
 TEST_CASE("Test foobar save data compatibility", "[C++: Serialization]")
 {
     load_previous_savefile();
-    REQUIRE(elona::foobar_save.is_autodig_enabled == 0);
+    REQUIRE(elona::foobar_data.is_autodig_enabled == 0);
 }

--- a/turn_sequence.cpp
+++ b/turn_sequence.cpp
@@ -2339,11 +2339,11 @@ label_2747:
 
     if (key == key_autodig)
     {
-        foobar_save.is_autodig_enabled = !foobar_save.is_autodig_enabled;
+        foobar_data.is_autodig_enabled = !foobar_data.is_autodig_enabled;
         txt(i18n::_(
             u8"ui",
             u8"autodig",
-            foobar_save.is_autodig_enabled ? u8"enabled" : u8"disabled"));
+            foobar_data.is_autodig_enabled ? u8"enabled" : u8"disabled"));
         goto label_2747;
     }
 
@@ -2483,7 +2483,7 @@ label_2747:
         // Autodig
         int x = cdata[0].next_position.x;
         int y = cdata[0].next_position.y;
-        if (foobar_save.is_autodig_enabled)
+        if (foobar_data.is_autodig_enabled)
         {
             if (0 <= x && x < mdata(0) && 0 <= y && y < mdata(1)
                 && (chipm(7, map(x, y, 0)) & 4) && chipm(0, map(x, y, 0)) != 3

--- a/ui.cpp
+++ b/ui.cpp
@@ -887,7 +887,7 @@ void render_hud()
         sy -= 20;
     }
 
-    if (foobar_save.is_autodig_enabled)
+    if (foobar_data.is_autodig_enabled)
     {
         pos(sx, sy);
         gcopy(3, 0, 416, 50 + en * 30, 15);


### PR DESCRIPTION

# Related Issues

Close #580.


# Summary

Currently, `foobar_save.s1` does not have foobar's version so...
1. delete old meta data file, `foobar_save.s1`,
2. set v0.2.5 to `foobar_data`.

Now, you can detect that the version is v0.2.5 and write migration code in `migrate_save_data()`.

Then, when saving in v0.2.6 or later, write meta data into `foobar_data.s1`. Its filename differs from old one so we can know if the save data is created in v0.2.5 or not.