### PR TITLE
Change naming convention of save

### DIFF
--- a/character_making.cpp
+++ b/character_making.cpp
@@ -893,7 +893,7 @@ main_menu_result_t character_making_final_phase()
         {
             cmname = randomname();
         }
-        playerid = u8"sav_"s + cmname;
+        playerid = fs::unique_path().string();
         if (range::any_of(
                 filesystem::dir_entries{filesystem::dir::save(),
                                         filesystem::dir_entries::type::all},

--- a/character_making.cpp
+++ b/character_making.cpp
@@ -887,7 +887,6 @@ main_menu_result_t character_making_final_phase()
         {
             return main_menu_result_t::character_making_final_phase;
         }
-        inputlog = filesystem::normalize_as_filename(inputlog);
         cmname = ""s + inputlog;
         if (cmname == ""s || cmname == u8" "s)
         {

--- a/filesystem.cpp
+++ b/filesystem.cpp
@@ -175,35 +175,5 @@ std::string to_utf8_path(const fs::path& path)
 
 
 
-std::string normalize_as_filename(const std::string& str)
-{
-    std::string ret{str};
-
-    for (const auto invalid_char : {
-             '"',
-             '\\',
-             '<',
-             '>',
-             '/',
-             '?',
-             '|',
-             '*',
-             ':',
-             '.',
-         })
-    {
-        ret =
-            strutil::replace(ret, std::string{invalid_char}, std::string{'_'});
-    }
-    if (!ret.empty() && ret.back() == ' ')
-    {
-        ret = ret.substr(0, ret.size() - 1);
-    }
-
-    return ret;
-}
-
-
-
 } // namespace filesystem
 } // namespace elona

--- a/filesystem.hpp
+++ b/filesystem.hpp
@@ -43,8 +43,6 @@ std::string make_preferred_path_in_utf8(const fs::path& path);
 std::string to_narrow_path(const fs::path& path);
 std::string to_utf8_path(const fs::path& path);
 
-std::string normalize_as_filename(const std::string&);
-
 
 
 struct dir_entries

--- a/init.cpp
+++ b/init.cpp
@@ -197,6 +197,7 @@ void start_elona()
             if (fs::exists(
                     filesystem::dir::save(u8"sav_" + defload) / u8"header.txt"))
             {
+                // TODO: Delete it when v1.0.0 stable is released.
                 defload = u8"sav_"s + defload;
             }
             else


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #550.


# Summary


- Change naming convention of save folder from `sav_XXX` to random name(generated by `boost::filesystem::unique_path()`).
- Due to the first change, validation of character's name comes to be unnecessary. Now, there are no limit of your character name!