### PR TITLE
API: Add LuaCharacter.experience

### DIFF
--- a/doc/api/classes/LuaCharacter.luadoc
+++ b/doc/api/classes/LuaCharacter.luadoc
@@ -37,6 +37,9 @@
 --- [RW] The role this character takes on.
 -- @tfield num character_role
 
+--- [RW] The character's current experience points.
+-- @tfield num experience
+
 --- Damages this character.
 -- @tparam num amount the amount to damage
 -- @tparam[opt] Enums.DamageSource source the source of the damage (defaults to the unseen hand)

--- a/lua_env/lua_api.cpp
+++ b/lua_env/lua_api.cpp
@@ -708,13 +708,11 @@ void LuaCharacter::damage_hp(character& self, int amount)
 
 void LuaCharacter::damage_hp_source(character& self, int amount, damage_source_t source)
 {
-    assert(amount > 0);
     elona::dmghp(self.index, amount, static_cast<int>(source));
 }
 
 void LuaCharacter::damage_hp_chara(character& self, int amount, const lua_character_handle handle)
 {
-    assert(amount > 0);
     elona::dmghp(self.index, amount, conv_chara(handle).index);
 }
 
@@ -797,7 +795,8 @@ void init_usertypes(lua_env& lua)
                                         "index", sol::readonly(&character::index),
                                         "id", sol::readonly(&character::id),
                                         "position", &character::position,
-                                        "name", sol::property([](character& c) { return elona::cdatan(0, c.index); })
+                                        "name", sol::property([](character& c) { return elona::cdatan(0, c.index); }),
+                                        "experience", &character::experience
         );
     lua.get_state()->new_usertype<item>( "LuaItem",
                                      "curse_state", &item::curse_state,


### PR DESCRIPTION
# Summary
Adds `LuaCharacter.experience`.

Mainly needed for reproducing #595.

# TODO
- [x] Created a binding in `lua_api.cpp` inside the appropriate namespace.
- [x] Set the binding on the correct table in `lua::init()`.
- [x] ~~Updated `.luacheckrc` with the new table value.~~
- [x] Added LDoc documentation in `doc/api`.
- [x] ~~Added tests inside `tests/lua_api.cpp`.~~
