### PR TITLE
Add itemname/itembasename as I18N functions

### DIFF
--- a/src/i18n.cpp
+++ b/src/i18n.cpp
@@ -90,10 +90,6 @@ void store::visit(const hcl::Value& value,
 }
 
 
-// TODO
-// "${your(_1)}${get(_2, core.locale.ability, name)} skill increases."
-
-
 #define ELONA_DEFINE_I18N_BUILTIN(func_name, return_value) \
     if(func.name == func_name) \
     { \
@@ -115,6 +111,21 @@ inline std::string builtin_s(const hil::FunctionCall& func, int chara_index)
         needs_e = func.args[1].as<bool>();
     }
     return _s(chara_index, needs_e);
+}
+
+inline std::string builtin_itemname(const hil::FunctionCall& func, const item& item)
+{
+    int number = item.number;
+    bool needs_the = true;
+    if(func.args.size() > 1)
+    {
+        number = func.args[1].as<int>();
+    }
+    if(func.args.size() > 2)
+    {
+        needs_the = func.args[2].as<bool>();
+    }
+    return itemname(item.index, number, needs_the ? 0 : 1);
 }
 
 std::string format_builtins_bool(const hil::FunctionCall& func, bool value)
@@ -174,8 +185,8 @@ std::string format_builtins_character(const hil::FunctionCall& func, const chara
 
 std::string format_builtins_item(const hil::FunctionCall& func, const item& item)
 {
-    ELONA_DEFINE_I18N_BUILTIN("name", itemname(item.index));
-    ELONA_DEFINE_I18N_BUILTIN("basename", ioriginalnameref(item.id));
+    ELONA_DEFINE_I18N_BUILTIN("itemname", builtin_itemname(func, item));
+    ELONA_DEFINE_I18N_BUILTIN("itembasename", ioriginalnameref(item.id));
 
     // English only
     ELONA_DEFINE_I18N_BUILTIN("is", is2(item.number));

--- a/src/tests/i18n.cpp
+++ b/src/tests/i18n.cpp
@@ -67,8 +67,8 @@ TEST_CASE("test format item by function", "[I18N: Formatting]")
     testing::start_in_debug_map();
     item& i = testing::create_item(PUTITORO_PROTO_ID, 3);
 
-    REQUIRE(i18n::fmt_hil("${name(_1)}", i) == u8"3個のプチトロ"s);
-    REQUIRE(i18n::fmt_hil("${basename(_1)}", i) == u8"プチトロ"s);
+    REQUIRE(i18n::fmt_hil("${itemname(_1)}", i) == u8"3個のプチトロ"s);
+    REQUIRE(i18n::fmt_hil("${itembasename(_1)}", i) == u8"プチトロ"s);
 }
 
 

--- a/src/tests/i18n_builtins.cpp
+++ b/src/tests/i18n_builtins.cpp
@@ -121,6 +121,32 @@ TEST_CASE("test i18n builtin: basename()", "[I18N: Builtins]")
     REQUIRE(i18n::fmt_hil("${basename(_1)}", chara) == u8"putit");
 }
 
+TEST_CASE("test i18n builtin: itemname()", "[I18N: Builtins]")
+{
+    testing::start_in_debug_map();
+    testing::set_english();
+    item& item = testing::create_item(PUTITORO_PROTO_ID, 1);
+    update_slight();
+
+    REQUIRE(i18n::fmt_hil("${itemname(_1)}", item) == u8"a putitoro");
+    REQUIRE(i18n::fmt_hil("${itemname(_1, 1)}", item) == u8"a putitoro");
+    REQUIRE(i18n::fmt_hil("${itemname(_1, 2)}", item) == u8"2 putitoros");
+    REQUIRE(i18n::fmt_hil("${itemname(_1, 1, false)}", item) == u8"putitoro");
+    REQUIRE(i18n::fmt_hil("${itemname(_1, 2, false)}", item) == u8"2 putitoros");
+    REQUIRE(i18n::fmt_hil("${itemname(_1, 1, true)}", item) == u8"a putitoro");
+    REQUIRE(i18n::fmt_hil("${itemname(_1, 2, true)}", item) == u8"2 putitoros");
+}
+
+TEST_CASE("test i18n builtin: itembasename()", "[I18N: Builtins]")
+{
+    testing::start_in_debug_map();
+    testing::set_english();
+    item& item = testing::create_item(PUTITORO_PROTO_ID, 1);
+    update_slight();
+
+    REQUIRE(i18n::fmt_hil("${itembasename(_1)}", item) == u8"putitoro");
+}
+
 TEST_CASE("test i18n builtin: s()", "[I18N: Builtins]")
 {
     testing::start_in_debug_map();

--- a/src/thirdparty/microhil/hil.hpp
+++ b/src/thirdparty/microhil/hil.hpp
@@ -40,6 +40,8 @@ template<typename T> struct call_traits_ref {
 
 template<typename T> struct call_traits;
 template<> struct call_traits<bool> : public internal::call_traits_value<bool> {};
+template<> struct call_traits<int> : public internal::call_traits_value<int> {};
+template<> struct call_traits<int64_t> : public internal::call_traits_value<int64_t> {};
 template<> struct call_traits<std::string> : public internal::call_traits_ref<std::string> {};
 template<> struct call_traits<FunctionCall> : public internal::call_traits_ref<FunctionCall> {};
 
@@ -55,12 +57,15 @@ public:
     enum Type {
         NULL_TYPE,
         BOOL_TYPE,
+        INT_TYPE,
         IDENT_TYPE,
         FUNCTION_TYPE,
     };
 
     Value() : type_(NULL_TYPE), null_(nullptr) {}
     Value(bool v) : type_(BOOL_TYPE), bool_(v) {}
+    Value(int v) : type_(INT_TYPE), int_(v) {}
+    Value(int64_t v) : type_(INT_TYPE), int_(v) {}
     Value(const std::string& v) : type_(IDENT_TYPE), string_(new std::string(v)) {}
     Value(const char* v) : type_(IDENT_TYPE), string_(new std::string(v)) {}
     Value(const FunctionCall& v) : type_(FUNCTION_TYPE), func_(new FunctionCall(v)) {}
@@ -92,6 +97,7 @@ private:
     union {
         void* null_;
         bool bool_;
+        int64_t int_;
         std::string* string_;
         FunctionCall* func_;
     };
@@ -739,6 +745,7 @@ inline const char* Value::typeToString(Value::Type type)
     switch (type) {
     case NULL_TYPE:   return "null";
     case BOOL_TYPE:   return "bool";
+    case INT_TYPE:    return "int";
     case IDENT_TYPE:
         return "string";
     case FUNCTION_TYPE:  return "function call";
@@ -752,6 +759,7 @@ inline Value::Value(const Value& v) :
     switch (v.type_) {
     case NULL_TYPE: null_ = v.null_; break;
     case BOOL_TYPE: bool_ = v.bool_; break;
+    case INT_TYPE: int_ = v.int_; break;
     case IDENT_TYPE:
         string_ = new std::string(*v.string_);
         break;
@@ -769,6 +777,7 @@ inline Value::Value(Value&& v) noexcept :
     switch (v.type_) {
     case NULL_TYPE: null_ = v.null_; break;
     case BOOL_TYPE: bool_ = v.bool_; break;
+    case INT_TYPE: int_ = v.int_; break;
     case IDENT_TYPE:
         string_ = v.string_;
         break;
@@ -794,6 +803,7 @@ inline Value& Value::operator=(const Value& v)
     switch (v.type_) {
     case NULL_TYPE: null_ = v.null_; break;
     case BOOL_TYPE: bool_ = v.bool_; break;
+    case INT_TYPE: int_ = v.int_; break;
     case IDENT_TYPE:
         string_ = new std::string(*v.string_);
         break;
@@ -818,6 +828,7 @@ inline Value& Value::operator=(Value&& v) noexcept
     switch (v.type_) {
     case NULL_TYPE: null_ = v.null_; break;
     case BOOL_TYPE: bool_ = v.bool_; break;
+    case INT_TYPE: int_ = v.int_; break;
     case IDENT_TYPE:
         string_ = v.string_;
         break;
@@ -852,6 +863,16 @@ template<> struct Value::ValueConverter<bool>
     bool is(const Value& v) { return v.type() == Value::BOOL_TYPE; }
     bool to(const Value& v) { v.assureType<bool>(); return v.bool_; }
 };
+template<> struct Value::ValueConverter<int64_t>
+{
+    bool is(const Value& v) { return v.type() == Value::INT_TYPE; }
+    int64_t to(const Value& v) { v.assureType<int64_t>(); return v.int_; }
+};
+template<> struct Value::ValueConverter<int>
+{
+    bool is(const Value& v) { return v.type() == Value::INT_TYPE; }
+    int to(const Value& v) { v.assureType<int>(); return static_cast<int>(v.int_); }
+};
 template<> struct Value::ValueConverter<std::string>
 {
     bool is(const Value& v) { return v.type() == Value::IDENT_TYPE; }
@@ -866,6 +887,8 @@ template<> struct Value::ValueConverter<FunctionCall>
 namespace internal {
 template<typename T> inline const char* type_name();
 template<> inline const char* type_name<bool>() { return "bool"; }
+template<> inline const char* type_name<int>() { return "int"; }
+template<> inline const char* type_name<int64_t>() { return "int64_t"; }
 template<> inline const char* type_name<std::string>() { return "string"; }
 template<> inline const char* type_name<hil::FunctionCall>() { return "function call"; }
 } // namespace internal
@@ -1024,6 +1047,9 @@ inline bool Parser::parseFunction(Value& currentValue, std::string ident)
             break;
         case TokenType::BOOL:
             func.args.emplace_back(token().boolValue());
+            break;
+        case TokenType::NUMBER:
+            func.args.emplace_back(token().intValue());
             break;
         default:
             addError("error parsing function arguments: " + func.name);


### PR DESCRIPTION
# Summary
Adds `itemname` and `itembasename` as interpolation functions in translations. They are needed by many of the changes for externalizing text.