### PR TITLE
Fix filepath handling

### DIFF
--- a/src/cat.cpp
+++ b/src/cat.cpp
@@ -1,8 +1,16 @@
 #include "cat.hpp"
-#include "defines.hpp"
 #include <iostream>
 #include <string>
+#include "defines.hpp"
 using namespace std::string_literals;
+
+
+#ifdef ELONA_OS_WINDOWS
+#define ELONA_luaL_dofile luaL_dowfile
+#else
+#define ELONA_luaL_dofile luaL_dofile
+#endif
+
 
 namespace elona
 {
@@ -24,13 +32,7 @@ void engine::initialize()
 
 void engine::load(const fs::path& filepath)
 {
-#ifdef ELONA_OS_WINDOWS
-    std::wstring filepath_str = filepath.native();
-    if (luaL_dowfile(ptr(), filepath_str.c_str()) != 0)
-#else
-    std::string filepath_str = filesystem::to_narrow_path(filepath);
-    if (luaL_dofile(ptr(), filepath_str.c_str()) != 0)
-#endif
+    if (ELONA_luaL_dofile(ptr(), filepath.native().c_str()) != 0)
     {
         const char* error_msg = lua_tostring(ptr(), -1);
         throw std::runtime_error(

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -3,14 +3,6 @@
 #include "defines.hpp"
 #include "util.hpp"
 
-#if defined(ELONA_OS_WINDOWS)
-// For WideCharToMultiByte().
-#include <windows.h>
-#define USE_UTF16_AS_FILEPATH 1
-#else
-#define USE_UTF16_AS_FILEPATH 0
-#endif
-
 // For get_executable_path()
 #if defined(ELONA_OS_WINDOWS)
 #include <windows.h> // GetModuleFileName
@@ -24,26 +16,10 @@
 #error Unsupported OS
 #endif
 
-#include <iostream>
+
 
 namespace
 {
-
-
-#if USE_UTF16_AS_FILEPATH
-int get_needed_buffer_size(const wchar_t* str)
-{
-    return WideCharToMultiByte(CP_THREAD_ACP, 0, str, -1, NULL, 0, NULL, NULL);
-}
-
-
-int utf16_to_ansi(const wchar_t* from, char* to, int buffer_size)
-{
-    return WideCharToMultiByte(
-        CP_THREAD_ACP, 0, from, -1, to, buffer_size, NULL, NULL);
-}
-#endif
-
 
 
 fs::path get_executable_path()
@@ -147,25 +123,6 @@ std::string make_preferred_path_in_utf8(const fs::path& path)
         path_.make_preferred().native());
 }
 
-
-std::string to_narrow_path(const fs::path& path)
-{
-#if USE_UTF16_AS_FILEPATH
-    const auto wide_c_str = path.native().c_str();
-
-    int needed_length = get_needed_buffer_size(wide_c_str);
-    if (needed_length == 0)
-        throw std::runtime_error(u8"Error: in to_narrow_path()");
-    auto buffer = std::make_unique<char[]>(needed_length);
-    int used_length = utf16_to_ansi(wide_c_str, buffer.get(), needed_length);
-    if (used_length == 0)
-        throw std::runtime_error(u8"Error: in to_narrow_path()");
-
-    return std::string{buffer.get()};
-#else
-    return path.native();
-#endif
-}
 
 
 std::string to_utf8_path(const fs::path& path)

--- a/src/filesystem.hpp
+++ b/src/filesystem.hpp
@@ -40,7 +40,6 @@ fs::path user();
 fs::path path(const std::string&);
 fs::path u8path(const std::string&);
 std::string make_preferred_path_in_utf8(const fs::path& path);
-std::string to_narrow_path(const fs::path& path);
 std::string to_utf8_path(const fs::path& path);
 
 

--- a/src/snail/font.cpp
+++ b/src/snail/font.cpp
@@ -16,7 +16,7 @@ font_t::font_t(const fs::path& filepath, int size, style_t style)
     , _style(style)
     , _ptr(
           detail::enforce_ttf(
-              ::TTF_OpenFont(filepath.string().c_str(), size)),
+              ::TTF_OpenFont(filesystem::to_utf8_path(filepath).c_str(), size)),
           ::TTF_CloseFont)
 {
     ::TTF_SetFontStyle(ptr(), static_cast<int>(style));

--- a/src/snail/hsp.hpp
+++ b/src/snail/hsp.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+#include "../filesystem.hpp"
 #include "blend_mode.hpp"
 #include "color.hpp"
 #include "font.hpp"
@@ -7,7 +9,6 @@
 #include "rect.hpp"
 #include "size.hpp"
 #include "window.hpp"
-#include <string>
 
 namespace elona
 {
@@ -41,7 +42,7 @@ void boxf(int x1, int y1, int x2, int y2, const color& color);
 void boxf(const color& color);
 void buffer(int window_id, int width, int height);
 void color(int r, int g, int b);
-void font(int size, font_t::style_t style, const std::string& filename);
+void font(int size, font_t::style_t style, const fs::path& filepath);
 void gcopy(int window_id, int src_x, int src_y, int src_width, int src_height);
 int ginfo(int type);
 void gmode(int mode, int width, int height, int alpha);

--- a/src/snail/hsp/headless.cpp
+++ b/src/snail/hsp/headless.cpp
@@ -60,7 +60,7 @@ void color(int, int, int)
 {
 }
 
-void font(int, snail::font_t::style_t, const std::string&)
+void font(int, snail::font_t::style_t, const fs::path&)
 {
 }
 

--- a/src/snail/hsp/sdl.cpp
+++ b/src/snail/hsp/sdl.cpp
@@ -1,16 +1,17 @@
 #include "../application.hpp"
-#include "../input.hpp"
-#include "../font.hpp"
 #include "../color.hpp"
+#include "../font.hpp"
+#include "../input.hpp"
 // TODO: this dependency is not good.
+#include <iostream>
+#include <unordered_map>
 #include "../../config.hpp"
 #include "../detail/sdl.hpp"
 #include "../window.hpp"
-#include <unordered_map>
-#include <iostream>
 
 
-namespace {
+namespace
+{
 
 struct font_cache_key
 {
@@ -505,7 +506,7 @@ void color(int r, int g, int b)
         detail::current_tex_buffer().color);
 }
 
-void font(int size, font_t::style_t style, const std::string& filename)
+void font(int size, font_t::style_t style, const fs::path& filepath)
 {
     auto& renderer = application::instance().get_renderer();
     if (renderer.font().size() == size && renderer.font().style() == style)
@@ -521,10 +522,7 @@ void font(int size, font_t::style_t style, const std::string& filename)
         const auto inserted = font_detail::font_cache.emplace(
             std::piecewise_construct,
             std::forward_as_tuple(size, style),
-            std::forward_as_tuple(
-                filename,
-                size,
-                style));
+            std::forward_as_tuple(filepath, size, style));
         renderer.set_font(inserted.first->second);
     }
 }
@@ -933,4 +931,3 @@ void title(const std::string& title_str,
 } // namespace hsp
 } // namespace snail
 } // namespace elona
-

--- a/src/std.cpp
+++ b/src/std.cpp
@@ -354,13 +354,12 @@ void exec(const std::string&, int)
 
 
 
-
-
 void font(int size, snail::font_t::style_t style)
 {
-    const auto& filename = filesystem::path(u8"font")
-        / lang(config::instance().font1, config::instance().font2);
-    snail::hsp::font(size, style, filesystem::make_preferred_path_in_utf8(filename));
+    const auto& filepath = filesystem::path(u8"font")
+        / filesystem::u8path(lang(
+              config::instance().font1, config::instance().font2));
+    snail::hsp::font(size, style, filepath);
 }
 
 


### PR DESCRIPTION
# Summary

Fix handling of font's filepath which contains non-ASCII characters.

On Windows, when constructor of `boost::filesystem::path` receives `char*` or `std::string`, it regard the passed string as ANSI filepath, not UTF8 filepath although we always encode string in UTF8. To avoid this problem, we prepare `elona::filesystem::u8path`, which is similar to `std::filesystem::u8path` provided in C++17 or later, but the function is not used in this case.