### PR TITLE
Adjust keywait for numpad wait/enter and shortcut key

### DIFF
--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -12321,7 +12321,7 @@ label_2128_internal:
     gcopy(4, 0, 0, 144, 144);
     gmode(2);
     await(config::instance().wait1);
-    key_check(1);
+    key_check(key_wait_delay_t::walk_run);
     x = cdata[0].position.x;
     y = cdata[0].position.y;
     if (key == key_alter)

--- a/src/enums.hpp
+++ b/src/enums.hpp
@@ -19,6 +19,12 @@ enum stick_key {
     tab          = 1 << 10,
 };
 
+enum class key_wait_delay_t {
+    always,
+    walk_run,
+    none,
+};
+
 enum class curse_state_t
 {
     doomed,

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -606,7 +606,8 @@ void key_check(int prm_299)
         key_shift = 0;
     }
 
-    if (snail::input::instance().is_pressed(snail::key::enter))
+    if (snail::input::instance().is_pressed(snail::key::enter)
+        || snail::input::instance().is_pressed(snail::key::keypad_enter))
     {
         key = key_enter;
         delay_enter = true;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -519,62 +519,59 @@ void key_check(int prm_299)
     {
         if (getkey(snail::key::home))
         {
-            p_at_m19 = 3;
+            p_at_m19 = stick_key::up | stick_key::left;
         }
         else if (getkey(snail::key::pageup))
         {
-            p_at_m19 = 6;
+            p_at_m19 = stick_key::up | stick_key::right;
         }
         else if (getkey(snail::key::end))
         {
-            p_at_m19 = 9;
+            p_at_m19 = stick_key::down | stick_key::left;
         }
         else if (getkey(snail::key::pagedown))
         {
-            p_at_m19 = 12;
-        }
-        else if (getkey(snail::key::clear))
-        {
-            key = key_wait;
+            p_at_m19 = stick_key::down | stick_key::right;
         }
 
         // Handle the case of the current key matching the movement
         // keybindings set in the user's config.
         else if (key == key_west)
         {
-            p_at_m19 = 1;
+            p_at_m19 = stick_key::left;
         }
         else if (key == key_north)
         {
-            p_at_m19 = 2;
+            p_at_m19 = stick_key::up;
         }
         else if (key == key_east)
         {
-            p_at_m19 = 4;
+            p_at_m19 = stick_key::right;
         }
         else if (key == key_south)
         {
-            p_at_m19 = 8;
+            p_at_m19 = stick_key::down;
         }
         else if (key == key_northwest)
         {
-            p_at_m19 = 3;
+            p_at_m19 = stick_key::up | stick_key::left;
         }
         else if (key == key_northeast)
         {
-            p_at_m19 = 6;
+            p_at_m19 = stick_key::up | stick_key::right;
         }
         else if (key == key_southwest)
         {
-            p_at_m19 = 9;
+            p_at_m19 = stick_key::down | stick_key::left;
         }
         else if (key == key_southeast)
         {
-            p_at_m19 = 12;
+            p_at_m19 = stick_key::down | stick_key::right;
         }
-        else if (key == key_southeast)
+        else if (key == key_wait)
         {
-            p_at_m19 = 12;
+            p_at_m19 = 0;
+            delay_keypress = true;
         }
     }
     if (getkey(snail::key::ctrl))
@@ -757,24 +754,29 @@ void key_check(int prm_299)
             delay_keypress = true;
         }
     }
-    if (p_at_m19 == 3)
+    if (p_at_m19 == (stick_key::up | stick_key::left))
     {
         key = key_northwest;
         delay_keypress = true;
     }
-    if (p_at_m19 == 6)
+    if (p_at_m19 == (stick_key::up | stick_key::right))
     {
         key = key_northeast;
         delay_keypress = true;
     }
-    if (p_at_m19 == 9)
+    if (p_at_m19 == (stick_key::down | stick_key::left))
     {
         key = key_southwest;
         delay_keypress = true;
     }
-    if (p_at_m19 == 12)
+    if (p_at_m19 == (stick_key::down | stick_key::right))
     {
         key = key_southeast;
+        delay_keypress = true;
+    }
+    if (getkey(snail::key::clear))
+    {
+        key = key_wait;
         delay_keypress = true;
     }
 
@@ -866,7 +868,7 @@ void key_check(int prm_299)
             }
             else if (p_at_m19 == 0)
             {
-                if (keybd_wait < 10)
+                if (keybd_wait < 20)
                 {
                     if (keybd_wait != 0)
                     {
@@ -926,9 +928,8 @@ void key_check(int prm_299)
     bool shortcut{};
     for (int i = 0; i < 10; ++i)
     {
-        const auto pressed = snail::input::instance().is_pressed(
-            snail::key(int(snail::key::key_0) + i),
-            prm_299 == 1 ? 1 : config::instance().keywait);
+        const auto pressed = snail::input::instance().was_pressed_just_now(
+            snail::key(int(snail::key::key_0) + i));
         if (pressed)
         {
             key = u8"sc";

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -431,12 +431,30 @@ bool input_text_dialog(
 }
 
 
-void key_check(int prm_299)
+bool is_keypress_delayed(int held_frames, int keywait, int initial_keywait)
+{
+    if (held_frames < initial_keywait)
+    {
+        if (held_frames == 0)
+        {
+            return false;
+        }
+    }
+    else if (held_frames % keywait == 0)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+void key_check(key_wait_delay_t delay_type)
 {
     static int prevjoy_at_m19{};
     bool delay_keypress = false;
     bool delay_enter = false;
-    static int keywait_enter{};
+    static int enter_held_frames{};
+    static int shortcut_held_frames{};
 
     if (msgalert == 1)
     {
@@ -614,7 +632,7 @@ void key_check(int prm_299)
     }
     else
     {
-        keywait_enter = 0;
+        enter_held_frames = 0;
     }
 
     if (config::instance().joypad)
@@ -664,7 +682,7 @@ void key_check(int prm_299)
                         key = key_cancel;
                         key_escape = 1;
                     }
-                    if (prm_299 == 0)
+                    if (delay_type == key_wait_delay_t::always)
                     {
                         int b_at_m19 = 0;
                         if (key == key_fire)
@@ -700,7 +718,7 @@ void key_check(int prm_299)
         {
             prevjoy_at_m19 = -1;
         }
-        else if (prm_299 == 2)
+        else if (delay_type == key_wait_delay_t::none)
         {
             return;
         }
@@ -830,13 +848,13 @@ void key_check(int prm_299)
         key = u8"F12";
     }
 
-    if (prm_299 == 2)
+    if (delay_type == key_wait_delay_t::none)
     {
         return;
     }
     if (delay_keypress)
     {
-        if (prm_299 == 1)
+        if (delay_type == key_wait_delay_t::walk_run)
         {
             if (keybd_attacking != 0)
             {
@@ -916,20 +934,23 @@ void key_check(int prm_299)
 
     if (delay_enter)
     {
-        if (keywait_enter < 20)
+        if (is_keypress_delayed(enter_held_frames, 1, 20))
         {
-            if (keywait_enter != 0)
-            {
-                key = "";
-            }
+            key = "";
         }
-        keywait_enter++;
+        enter_held_frames++;
     }
 
     bool shortcut{};
+    int shortcut_delay = config::instance().keywait;
+    if (delay_type == key_wait_delay_t::walk_run)
+    {
+        shortcut_delay = 1;
+    }
+
     for (int i = 0; i < 10; ++i)
     {
-        const auto pressed = snail::input::instance().was_pressed_just_now(
+        const auto pressed = snail::input::instance().is_pressed(
             snail::key(int(snail::key::key_0) + i));
         if (pressed)
         {
@@ -942,6 +963,19 @@ void key_check(int prm_299)
             keylog = "";
             shortcut = true;
         }
+    }
+
+    if (shortcut)
+    {
+        if (is_keypress_delayed(shortcut_held_frames, shortcut_delay, 20))
+        {
+            key = "";
+        }
+        ++shortcut_held_frames;
+    }
+    else
+    {
+        shortcut_held_frames = 0;
     }
 
     if (!shortcut && keyhalt != 0)

--- a/src/input.hpp
+++ b/src/input.hpp
@@ -1,5 +1,5 @@
 #pragma once
-
+#include "enums.hpp"
 
 
 namespace elona
@@ -35,7 +35,7 @@ bool input_text_dialog(
     bool is_cancelable = true,
     bool limit_length = true);
 
-void key_check(int = 0);
+void key_check(key_wait_delay_t = key_wait_delay_t::always);
 void wait_key_released();
 void wait_key_pressed(bool only_enter_or_cancel = false);
 

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -373,7 +373,7 @@ label_2699_internal:
     ++t;
     redraw();
     await(config::instance().wait1);
-    key_check(2);
+    key_check(key_wait_delay_t::none);
     if (key == key_north)
     {
         key = listn(1, 3);

--- a/src/turn_sequence.cpp
+++ b/src/turn_sequence.cpp
@@ -1749,7 +1749,7 @@ label_2747:
     }
 
     await(config::instance().wait1);
-    key_check(1);
+    key_check(key_wait_delay_t::walk_run);
 
     if (ginfo(2) != 0)
     {


### PR DESCRIPTION
# Summary
- Adjusts the numpad wait and enter keys to be delayed.
- Adjusts shortcut keys to ~~never repeat~~ properly repeat.
- Increases delay on wait keypress.