### PR TITLE
I18n: Rename he2, his2, him2 to he, his, him

### DIFF
--- a/src/i18n.cpp
+++ b/src/i18n.cpp
@@ -107,6 +107,36 @@ std::string format_builtins_argless(const hil::FunctionCall& func)
     return "<unknown function (" + func.name + ")>";
 }
 
+inline std::string builtin_he(const hil::FunctionCall& func, int chara_index)
+{
+    bool bilingual = false;
+    if(func.args.size() > 1)
+    {
+        bilingual = func.args[1].as<bool>();
+    }
+    return he(chara_index, bilingual);
+}
+
+inline std::string builtin_his(const hil::FunctionCall& func, int chara_index)
+{
+    bool bilingual = false;
+    if(func.args.size() > 1)
+    {
+        bilingual = func.args[1].as<bool>();
+    }
+    return his(chara_index, bilingual);
+}
+
+inline std::string builtin_him(const hil::FunctionCall& func, int chara_index)
+{
+    bool bilingual = false;
+    if(func.args.size() > 1)
+    {
+        bilingual = func.args[1].as<bool>();
+    }
+    return him(chara_index, bilingual);
+}
+
 inline std::string builtin_s(const hil::FunctionCall& func, int chara_index)
 {
     bool needs_e = false;
@@ -146,14 +176,11 @@ std::string format_builtins_character(
 {
     ELONA_DEFINE_I18N_BUILTIN("name", name(chara.index));
     ELONA_DEFINE_I18N_BUILTIN("basename", cdatan(0, chara.index));
-    ELONA_DEFINE_I18N_BUILTIN("he2", he(chara.index, 1));
-    ELONA_DEFINE_I18N_BUILTIN("his2", his(chara.index, 1));
-    ELONA_DEFINE_I18N_BUILTIN("him2", him(chara.index, 1));
+    ELONA_DEFINE_I18N_BUILTIN("he", builtin_he(func, chara.index));
+    ELONA_DEFINE_I18N_BUILTIN("his", builtin_his(func, chara.index));
+    ELONA_DEFINE_I18N_BUILTIN("him", builtin_him(func, chara.index));
 
     // English only
-    ELONA_DEFINE_I18N_BUILTIN("he", he(chara.index));
-    ELONA_DEFINE_I18N_BUILTIN("his", his(chara.index));
-    ELONA_DEFINE_I18N_BUILTIN("him", him(chara.index));
     ELONA_DEFINE_I18N_BUILTIN("s", builtin_s(func, chara.index));
     ELONA_DEFINE_I18N_BUILTIN("is", is(chara.index));
     ELONA_DEFINE_I18N_BUILTIN("have", have(chara.index));

--- a/src/tests/i18n_builtins.cpp
+++ b/src/tests/i18n_builtins.cpp
@@ -26,14 +26,14 @@ TEST_CASE("test i18n builtin: he()", "[I18N: Builtins]")
     SECTION("Japanese")
     {
         testing::set_japanese();
-        REQUIRE(i18n::fmt_hil("${he2(_1)}", you) == u8"彼");
-        REQUIRE(i18n::fmt_hil("${he2(_1)}", chara) == u8"彼女");
+        REQUIRE(i18n::fmt_hil("${he(_1, true)}", you) == u8"彼");
+        REQUIRE(i18n::fmt_hil("${he(_1, true)}", chara) == u8"彼女");
     }
     SECTION("English")
     {
         testing::set_english();
-        REQUIRE(i18n::fmt_hil("${he2(_1)}", you) == u8"he");
-        REQUIRE(i18n::fmt_hil("${he2(_1)}", chara) == u8"she");
+        REQUIRE(i18n::fmt_hil("${he(_1, true)}", you) == u8"he");
+        REQUIRE(i18n::fmt_hil("${he(_1, true)}", chara) == u8"she");
         REQUIRE(i18n::fmt_hil("${he(_1)}", you) == u8"you");
         REQUIRE(i18n::fmt_hil("${he(_1)}", chara) == u8"she");
         REQUIRE(i18n::fmt_hil("${he(_1)}", out_of_fov) == u8"it");
@@ -53,14 +53,14 @@ TEST_CASE("test i18n builtin: his()", "[I18N: Builtins]")
     SECTION("Japanese")
     {
         testing::set_japanese();
-        REQUIRE(i18n::fmt_hil("${his2(_1)}", you) == u8"あなたの");
-        REQUIRE(i18n::fmt_hil("${his2(_1)}", chara) == u8"彼女の");
+        REQUIRE(i18n::fmt_hil("${his(_1, true)}", you) == u8"あなたの");
+        REQUIRE(i18n::fmt_hil("${his(_1, true)}", chara) == u8"彼女の");
     }
     SECTION("English")
     {
         testing::set_english();
-        REQUIRE(i18n::fmt_hil("${his2(_1)}", you) == u8"your");
-        REQUIRE(i18n::fmt_hil("${his2(_1)}", chara) == u8"her");
+        REQUIRE(i18n::fmt_hil("${his(_1, true)}", you) == u8"your");
+        REQUIRE(i18n::fmt_hil("${his(_1, true)}", chara) == u8"her");
         REQUIRE(i18n::fmt_hil("${his(_1)}", you) == u8"your");
         REQUIRE(i18n::fmt_hil("${his(_1)}", chara) == u8"her");
         REQUIRE(i18n::fmt_hil("${his(_1)}", out_of_fov) == u8"its");
@@ -80,14 +80,14 @@ TEST_CASE("test i18n builtin: him()", "[I18N: Builtins]")
     SECTION("Japanese")
     {
         testing::set_japanese();
-        REQUIRE(i18n::fmt_hil("${him2(_1)}", you) == u8"彼");
-        REQUIRE(i18n::fmt_hil("${him2(_1)}", chara) == u8"彼女");
+        REQUIRE(i18n::fmt_hil("${him(_1, true)}", you) == u8"彼");
+        REQUIRE(i18n::fmt_hil("${him(_1, true)}", chara) == u8"彼女");
     }
     SECTION("English")
     {
         testing::set_english();
-        REQUIRE(i18n::fmt_hil("${him2(_1)}", you) == u8"him");
-        REQUIRE(i18n::fmt_hil("${him2(_1)}", chara) == u8"her");
+        REQUIRE(i18n::fmt_hil("${him(_1, true)}", you) == u8"him");
+        REQUIRE(i18n::fmt_hil("${him(_1, true)}", chara) == u8"her");
         REQUIRE(i18n::fmt_hil("${him(_1)}", you) == u8"yourself");
         REQUIRE(i18n::fmt_hil("${him(_1)}", chara) == u8"her");
         REQUIRE(i18n::fmt_hil("${him(_1)}", out_of_fov) == u8"it");


### PR DESCRIPTION
# Summary
Consolidate `he2`, `his2` and `him2` into single functions for I18N.