### PR TITLE
Delete unused prototype declarations

### DIFF
--- a/src/ctrl_file.cpp
+++ b/src/ctrl_file.cpp
@@ -1282,7 +1282,7 @@ void fmode_10()
              filesystem::dir_entries::type::file,
              std::regex{u8R"(.*\..*)"}))
     {
-        elona_delete(entry.path());
+        fs::remove_all(entry.path());
     }
 }
 
@@ -1290,7 +1290,7 @@ void fmode_10()
 // deletes a saved game.
 void fmode_9()
 {
-    elona_delete(filesystem::dir::save(playerid));
+    fs::remove_all(filesystem::dir::save(playerid));
 }
 
 
@@ -1312,31 +1312,31 @@ void fmode_11_12(file_operation_t file_operation)
     if (!fs::exists(filepath))
         return;
 
-    elona_delete(filepath);
+    fs::remove_all(filepath);
     fileadd(filepath, 1);
     if (file_operation == file_operation_t::_11)
     {
         filepath = filesystem::dir::tmp() / (u8"cdata_"s + mid + u8".s2");
-        elona_delete(filepath);
+        fs::remove_all(filepath);
         fileadd(filepath, 1);
         filepath = filesystem::dir::tmp() / (u8"sdata_"s + mid + u8".s2");
-        elona_delete(filepath);
+        fs::remove_all(filepath);
         fileadd(filepath, 1);
         filepath = filesystem::dir::tmp() / (u8"cdatan_"s + mid + u8".s2");
-        elona_delete(filepath);
+        fs::remove_all(filepath);
         fileadd(filepath, 1);
         filepath = filesystem::dir::tmp() / (u8"inv_"s + mid + u8".s2");
-        elona_delete(filepath);
+        fs::remove_all(filepath);
         fileadd(filepath, 1);
     }
     filepath = filesystem::dir::tmp() / (u8"mdata_"s + mid + u8".s2");
-    elona_delete(filepath);
+    fs::remove_all(filepath);
     fileadd(filepath, 1);
     filepath = filesystem::dir::tmp() / (u8"mdatan_"s + mid + u8".s2");
-    elona_delete(filepath);
+    fs::remove_all(filepath);
     fileadd(filepath, 1);
     filepath = filesystem::dir::tmp() / (u8"mef_"s + mid + u8".s2");
-    elona_delete(filepath);
+    fs::remove_all(filepath);
     fileadd(filepath, 1);
 }
 
@@ -1353,7 +1353,7 @@ void fmode_13()
              filesystem::dir_entries::type::file,
              std::regex{u8R"(.*_)"s + area + u8R"(_.*\..*)"}))
     {
-        elona_delete(entry.path());
+        fs::remove_all(entry.path());
         fileadd(entry.path(), 1);
     }
 }

--- a/src/elona.hpp
+++ b/src/elona.hpp
@@ -354,15 +354,6 @@ DEFINE_CMP(<=)
 
 void await(int msec);
 
-// CANNOT BE IMPLEMENTED
-void axobj(int, const std::string&, int, int);
-
-
-void bcopy(const fs::path& from, const fs::path& to);
-
-// fullscreen
-void bgscr(int window_id, int width, int height, int, int);
-
 
 void boxf(
     int x1,
@@ -375,19 +366,9 @@ void boxf(const snail::color& color = {0, 0, 0, 0});
 
 void buffer(int window_id, int width = 0, int heihgt = 0);
 
-void chgdisp(int, int width, int height);
-
-
-void clrobj(int);
-
 
 void color(int r, int g, int b);
 
-
-
-void delcom(int);
-
-void elona_delete(const fs::path& filename);
 
 int dialog(const std::string& message, int = 0);
 
@@ -480,34 +461,11 @@ void line(int x, int y);
 
 
 
-void memcpy(
-    elona_vector2<int>& src,
-    int src_i,
-    int src_j,
-    elona_vector2<int>& dst,
-    int dst_i,
-    int dst_j,
-    size_t size);
-
-
-// void memexpand(void* memory, size_t size)
-// {
-// }
-#define memexpand(a, b)
-
-// void memfile(void* buf)
-// {
-// }
-#define memfile(a)
-
-
 void mes(const std::string& text);
 
 void mes(int n);
 
 void mesbox(std::string& buffer, bool text = false);
-
-void mkdir(const fs::path& path);
 
 void mmload(const fs::path& filepath, int id, int mode = 0);
 
@@ -528,11 +486,7 @@ int notesel(std::string&);
 void noteunsel();
 
 
-void objmode(int, int = 0);
-
 void objprm(int, const std::string&);
-
-void objsel(int);
 
 
 
@@ -545,8 +499,6 @@ void pos(int x, int y = 0);
 
 
 void redraw();
-
-void screen(int window_id, int width, int height, int mode, int x, int y);
 
 
 int stick(int allow_repeat_keys = 0);
@@ -562,8 +514,6 @@ void title(
     snail::window::fullscreen_mode_t fullscreen_mode =
         snail::window::fullscreen_mode_t::windowed);
 
-void width(int width, int height, int, int);
-
 
 int wpeek(int x, size_t index);
 
@@ -575,8 +525,6 @@ void wpoke(int& x, size_t index, int y);
 
 
 
-void func_1(const std::string&, int);
-
 void gfini(int width, int height);
 
 void gfdec(int r, int g, int b);
@@ -586,11 +534,6 @@ void gfdec2(int r, int g, int b);
 void gfinc(int r, int g, int b);
 
 void ematan(int, int, int);
-
-
-int aplsel(const std::string&);
-
-int aplobj(const std::string&, int);
 
 void apledit(int&, int, int = 0);
 
@@ -603,20 +546,7 @@ int DIGETJOYNUM();
 
 void DIGETJOYSTATE(int, int);
 
-void HMMBITON(int&, int);
-
-void HMMBITOFF(int&, int);
-
 int HMMBITCHECK(int, int);
-
-
-int sockopen(int, const std::string&, int);
-
-void sockclose();
-
-int sockget(const std::string&, int);
-
-int sockput(const std::string&);
 
 void netinit();
 
@@ -632,38 +562,9 @@ void netdlname(const std::string&);
 void netrequest(const std::string&);
 
 
-void GetLastError();
-
 int CreateMutexA(int, int, const std::string&);
 
 
-void CloseHandle(int id);
-
-int func_3();
-
-
-int LCMapStringA(int, int, const std::string&, int, const std::string&, int);
-
-
-int GetUserDefaultLCID();
-
-void AppendMenuA();
-
-void CheckMenuRadioItem();
-
-void CreateMenu();
-
-
-void CreatePopupMenu();
-
-void DrawMenuBar();
-
-void SetMenu();
-
-
-void keybd_event(int, int = 0, int = 0);
-
-void GetKeyboardState(elona_vector1<int>&);
 
 int timeGetTime();
 
@@ -680,12 +581,6 @@ int ImmGetOpenStatus(int);
 
 
 void onkey_0();
-
-
-void onkey_1();
-
-
-void end();
 
 
 
@@ -705,15 +600,6 @@ void bload(
 void bsave(const fs::path& filename, const std::string& data);
 void bsave(const fs::path& filename, int data);
 void bsave(const fs::path& filename, elona_vector1<int>& data);
-
-
-void memcpy_(
-    std::string& dst,
-    std::string& src,
-    int size,
-    int dst_offset = 0,
-    int src_offset = 0);
-
 
 
 template <typename T>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -113,22 +113,6 @@ void backup_config_files()
 
 
 
-void check_double_launching()
-{
-    mutex_handle = CreateMutexA(0, 0, u8"Elona"s);
-    if (func_3() == 183)
-    {
-        dialog(
-            lang(
-                u8"二重起動のため終了します。"s,
-                u8"The program is already running."s),
-            1);
-        end();
-        return;
-    }
-    return;
-}
-
 void initialize_directories()
 {
     const boost::filesystem::path paths[] = {filesystem::dir::save(),
@@ -394,8 +378,6 @@ void initialize_config(const fs::path& config_file)
 
     backup_config_files();
 
-    check_double_launching();
-
     initialize_directories();
 
     // The config setup routine needs these variables allocated to
@@ -419,16 +401,6 @@ void initialize_elona()
            : filesystem::path("locale") / "en");
 
     initialize_ui_constants();
-    if (config::instance().fullscreen != 0)
-    {
-        chgdisp(1, windoww, windowh);
-        bgscr(0, windoww, windowh, 0, 0);
-        width(windoww, windowh, 0, 0);
-    }
-    else
-    {
-        screen(0, windoww, windowh, 0, windowx, windowy);
-    }
     gsel(0);
     boxf();
     redraw();

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -309,11 +309,7 @@ bool input_text_dialog(
 
     for (int cnt = 0;; ++cnt)
     {
-        if (ginfo(2) == 0)
-        {
-            objsel(1);
-        }
-        else
+        if (ginfo(2) != 0)
         {
             objprm(1, ""s);
             inputlog = "";
@@ -419,7 +415,6 @@ bool input_text_dialog(
         redraw();
     }
     gmode(2);
-    clrobj(1);
     if (en)
     {
         inputlog = strutil::replace(inputlog, u8"\"", u8"'");

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1452,9 +1452,7 @@ label_0313_internal:
     }
     if (strlen_u(s_) > 66)
     {
-        len_ = zentohan(s_, buf_, 0);
-        SDIM2(buf_, len_);
-        zentohan(s_, s_, len_);
+        s_ = zentohan(s_);
     }
     skip_ = 0;
     return s_;

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -20,6 +20,41 @@ std::string chatreadurl;
 std::string votereadurl;
 
 
+namespace
+{
+
+
+
+int sockopen(int, const std::string&, int)
+{
+    return 0;
+}
+
+
+
+void sockclose()
+{
+}
+
+
+
+int sockget(const std::string&, int)
+{
+    return 0;
+}
+
+
+
+int sockput(const std::string&)
+{
+    return 0;
+}
+
+
+
+} // namespace
+
+
 
 namespace elona
 {
@@ -357,7 +392,7 @@ int net_dllist(const std::string& prm_886, int prm_887)
     file_at_m147 = (filesystem::dir::user() / u8"net.tmp").generic_string();
     if (fs::exists(file_at_m147))
     {
-        elona_delete(file_at_m147);
+        fs::remove_all(file_at_m147);
     }
     netdlname(file_at_m147);
     netload(u8"cliplog.txt"s);
@@ -442,7 +477,7 @@ int net_dl(const std::string& prm_888, const std::string& prm_889)
 {
     if (fs::exists(filesystem::dir::user() / prm_889))
     {
-        elona_delete(filesystem::dir::user() / prm_889);
+        fs::remove_all(filesystem::dir::user() / prm_889);
     }
     neturl(u8"http://homepage3.nifty.com/rfish/userfile/"s);
     netdlname((filesystem::dir::user() / prm_889).generic_string());

--- a/src/std.cpp
+++ b/src/std.cpp
@@ -107,31 +107,6 @@ void await(int msec)
 
 
 
-// CANNOT BE IMPLEMENTED
-void axobj(int, const std::string&, int, int)
-{
-}
-
-
-
-void bcopy(const fs::path& from, const fs::path& to)
-{
-    ELONA_LOG("Copy file: from " << from << " to " << to);
-    fs::copy_file(from, to, fs::copy_option::overwrite_if_exists);
-}
-
-
-
-// fullscreen
-void bgscr(int window_id, int width, int height, int, int)
-{
-    UNUSED(window_id);
-    UNUSED(width);
-    UNUSED(height);
-}
-
-
-
 void boxf(int x1, int y1, int x2, int y2, const snail::color& color)
 {
     snail::hsp::boxf(x1, y1, x2, y2, color);
@@ -248,37 +223,12 @@ void buffer(int window_id, int width, int height)
 
 
 
-void chgdisp(int, int width, int height)
-{
-    UNUSED(width);
-    UNUSED(height);
-}
-
-
-
-void clrobj(int)
-{
-}
-
-
-
 void color(int r, int g, int b)
 {
     snail::hsp::color(r, g, b);
 }
 
 
-
-void delcom(int)
-{
-}
-
-
-
-void elona_delete(const fs::path& filename)
-{
-    fs::remove_all(filename);
-}
 
 #if defined(ELONA_OS_WINDOWS)
 std::wstring get_utf16(const std::string& str)
@@ -539,41 +489,6 @@ void line(int x, int y)
 
 
 
-void memcpy(
-    elona_vector2<int>& src,
-    int src_i,
-    int src_j,
-    elona_vector2<int>& dst,
-    int dst_i,
-    int dst_j,
-    size_t size)
-{
-    const auto len = length(src);
-    const auto len2 = length2(src);
-    auto count = size;
-    for (size_t i = 0; i < len2; ++i)
-    {
-        for (size_t j = 0; j < len; ++j)
-        {
-            src(src_j + j, src_i + i) = dst(dst_j + j, dst_i + i);
-            count -= sizeof(int);
-            if (count == 0)
-                return;
-        }
-    }
-}
-
-
-
-// void memexpand(void* memory, size_t size)
-// {
-// }
-
-// void memfile(void* buf)
-// {
-// }
-
-
 void mes(const std::string& text)
 {
     snail::hsp::mes(text);
@@ -591,13 +506,6 @@ void mes(int n)
 void mesbox(std::string& buffer, bool text)
 {
     snail::hsp::mesbox(buffer, text);
-}
-
-
-
-void mkdir(const fs::path& path)
-{
-    fs::create_directory(path);
 }
 
 
@@ -761,19 +669,7 @@ void noteunsel()
 
 
 
-void objmode(int, int)
-{
-}
-
-
-
 void objprm(int, const std::string&)
-{
-}
-
-
-
-void objsel(int)
 {
 }
 
@@ -813,18 +709,6 @@ void pos(int x, int y)
 void redraw()
 {
     snail::hsp::redraw();
-}
-
-
-
-void screen(int window_id, int width, int height, int mode, int x, int y)
-{
-    UNUSED(window_id);
-    UNUSED(width);
-    UNUSED(height);
-    UNUSED(mode);
-    UNUSED(x);
-    UNUSED(y);
 }
 
 
@@ -926,14 +810,6 @@ void title(
 
 
 
-void width(int width, int height, int, int)
-{
-    UNUSED(width);
-    UNUSED(height);
-}
-
-
-
 int wpeek(int x, size_t index)
 {
     if (index == 0)
@@ -965,12 +841,6 @@ void wpoke(int& x, size_t index, int y)
 
 
 // imported functions
-
-
-
-void func_1(const std::string&, int)
-{
-}
 
 
 
@@ -1084,20 +954,6 @@ void ematan(int, int, int)
 
 
 
-int aplsel(const std::string&)
-{
-    return 0;
-}
-
-
-
-int aplobj(const std::string&, int)
-{
-    return 0;
-}
-
-
-
 void apledit(int& out, int kind, int column_no)
 {
     UNUSED(column_no);
@@ -1125,21 +981,6 @@ void func_2(int, int, int, int, int, int)
 
 
 
-void memcpy_(
-    std::string& dst,
-    std::string& src,
-    int size,
-    int dst_offset,
-    int src_offset)
-{
-    for (int i = 0; i < size; ++i)
-    {
-        dst[i + dst_offset] = src[i + src_offset];
-    }
-}
-
-
-
 void DIINIT()
 {
 }
@@ -1159,50 +1000,9 @@ void DIGETJOYSTATE(int, int)
 
 
 
-void HMMBITON(int& x, int n)
-{
-    x |= 1 << n;
-}
-
-
-
-void HMMBITOFF(int& x, int n)
-{
-    x &= ~(1 << n);
-}
-
-
-
 int HMMBITCHECK(int x, int n)
 {
     return x & (1 << n) ? 1 : 0;
-}
-
-
-
-int sockopen(int, const std::string&, int)
-{
-    return 0;
-}
-
-
-
-void sockclose()
-{
-}
-
-
-
-int sockget(const std::string&, int)
-{
-    return 0;
-}
-
-
-
-int sockput(const std::string&)
-{
-    return 0;
 }
 
 
@@ -1238,94 +1038,6 @@ void netdlname(const std::string&)
 
 
 void netrequest(const std::string&)
-{
-}
-
-
-
-void GetLastError()
-{
-}
-
-
-
-int CreateMutexA(int, int, const std::string&)
-{
-    return 42; // Any positive number.
-}
-
-
-
-void CloseHandle(int)
-{
-}
-
-
-
-int func_3()
-{
-    return 0;
-}
-
-
-
-int LCMapStringA(int, int, const std::string&, int, const std::string&, int)
-{
-    return 0;
-}
-
-
-
-int GetUserDefaultLCID()
-{
-    return 0;
-}
-
-
-
-void AppendMenuA()
-{
-}
-
-
-
-void CheckMenuRadioItem()
-{
-}
-
-
-
-void CreateMenu()
-{
-}
-
-
-
-void CreatePopupMenu()
-{
-}
-
-
-
-void DrawMenuBar()
-{
-}
-
-
-
-void SetMenu()
-{
-}
-
-
-
-void keybd_event(int, int, int)
-{
-}
-
-
-
-void GetKeyboardState(elona_vector1<int>&)
 {
 }
 
@@ -1367,18 +1079,6 @@ int ImmGetOpenStatus(int)
 void onkey_0()
 {
     snail::hsp::onkey_0();
-}
-
-
-
-void onkey_1()
-{
-}
-
-
-
-void end()
-{
 }
 
 

--- a/src/tcg.cpp
+++ b/src/tcg.cpp
@@ -112,20 +112,21 @@ int emax_at_tcg = 0;
 
 int cdbit(int prm_985, int prm_986)
 {
-    return HMMBITCHECK(card_at_tcg(30 + prm_985 / 32, prm_986), prm_985 % 32);
+    return (card_at_tcg(30, prm_986) & (1 << prm_985)) ? 1 : 0;
 }
 
 
 
 void cdbitmod(int prm_987, int prm_988, int prm_989)
 {
-    if (prm_989 == 0)
+    if (prm_989)
     {
-        HMMBITOFF(card_at_tcg(30 + prm_987 / 32, prm_988), prm_987 % 32);
-        return;
+        card_at_tcg(30, prm_988) |= (1 << prm_987);
     }
-    HMMBITON(card_at_tcg(30 + prm_987 / 32, prm_988), prm_987 % 32);
-    return;
+    else
+    {
+        card_at_tcg(30, prm_988) &= ~(1 << prm_987);
+    }
 }
 
 

--- a/src/testing.cpp
+++ b/src/testing.cpp
@@ -43,7 +43,7 @@ void start_in_debug_map()
     initialize_debug_globals();
 
     elona::playerid = player_id;
-    elona_delete(save_dir / elona::playerid);
+    fs::remove_all(save_dir / elona::playerid);
 
     gdata_current_map = 9999; // Debug map
     gdata_current_dungeon_level = 2;
@@ -87,7 +87,7 @@ void pre_init()
 
 void post_run()
 {
-    elona_delete(save_dir / player_id);
+    fs::remove_all(save_dir / player_id);
     finish_elona();
 }
 

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -15,6 +15,15 @@ int talkref = 0;
 elona_vector1<int> p_at_m41;
 
 
+
+std::string zentohan(const std::string& str)
+{
+    // TODO: Implement.
+    return str;
+}
+
+
+
 std::string cnvrank(int n)
 {
     if (jp)

--- a/src/variables.hpp
+++ b/src/variables.hpp
@@ -818,7 +818,7 @@ int roundmargin(int = 0, int = 0);
 int route_info(int&, int&, int = 0);
 int talk_conv(std::string&, int = 0);
 int winposy(int = 0, int = 0);
-int zentohan(const std::string&, std::string&, int = 0);
+std::string zentohan(const std::string&);
 std::string _aru(int = 0);
 std::string _da(int = 0);
 std::string _dana(int = 0);


### PR DESCRIPTION
# Summary

Delete unused functions and their prototype declarations mainly in `src/elona.hpp`. Most of them are HSP built-in or imported DLL functions.