### PR TITLE
Delay enter if key_enter is already detected as key pressed

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -606,7 +606,8 @@ void key_check(key_wait_delay_t delay_type)
         key_shift = 0;
     }
 
-    if (snail::input::instance().is_pressed(snail::key::enter)
+    if (key == key_enter
+        || snail::input::instance().is_pressed(snail::key::enter)
         || snail::input::instance().is_pressed(snail::key::keypad_enter))
     {
         key = key_enter;


### PR DESCRIPTION
# Related issues
Closes #625.

# Summary
Delays the enter key if `key_enter` is already set in `key_check()` beforehand. Otherwise, those presses of the enter key won't be delayed.

# Playtest script
```lua
local Event = Elona.require("Event")
local Item = Elona.require("Item")
local Chara = Elona.require("Chara")

Event.register(Event.EventKind.ScriptLoaded, function() Item.create(Chara.player().position, 313, 1) end)
```