### PR TITLE
Refactor gmode()

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -53,7 +53,7 @@ void play_animation_8(int anicol)
         pos(anidx - inf_tiles / 2, anidy - inf_tiles / 2);
         gcopy(4, 0, 0, inf_tiles * 2, inf_tiles * 2);
         pos(anidx + inf_tiles / 2, anidy + 16);
-        grotate(1, 0, 960, 5 * i, i + 40, i + 40);
+        grotate(1, 0, 960, i + 40, i + 40, 5 * i);
         redraw();
         await(config::instance().animewait);
     }
@@ -120,13 +120,7 @@ void play_animation_6_5_7_11(int animeid, int anicol)
         for (int j = 0; j < 15; ++j)
         {
             pos(ax + ax2(j), ay + ay2(j) + acnt2 / ap(j));
-            grotate(
-                1,
-                0,
-                960,
-                acnt2 * ap(j),
-                inf_tiles - acnt2 * 2,
-                inf_tiles - acnt2 * 2);
+            grotate(1, 0, 960, inf_tiles - acnt2 * 2, inf_tiles - acnt2 * 2, acnt2 * ap(j));
         }
         redraw();
     }
@@ -175,15 +169,7 @@ void play_animation_3(int anicol, int anisound)
                         255 - c_col(1, anicol),
                         255 - c_col(2, anicol),
                         7);
-                    grotate(
-                        7,
-                        cnt2 * 48,
-                        0,
-                        std::atan2(
-                            tlocx - cdata[cc].position.x,
-                            cdata[cc].position.y - tlocy),
-                        inf_tiles,
-                        inf_tiles);
+                    grotate(7, cnt2 * 48, 0, inf_tiles, inf_tiles, std::atan2( tlocx - cdata[cc].position.x, cdata[cc].position.y - tlocy));
                     set_color_mod(255, 255, 255, 7);
                 }
             }
@@ -368,15 +354,7 @@ void play_animation_0(int anicol, int anisound)
                             255 - c_col(1, anicol),
                             255 - c_col(2, anicol),
                             7);
-                        grotate(
-                            7,
-                            ap(cnt) * 48,
-                            0,
-                            std::atan2(
-                                tlocx - cdata[cc].position.x,
-                                cdata[cc].position.y - tlocy),
-                            48,
-                            48);
+                        grotate(7, ap(cnt) * 48, 0, inf_tiles, inf_tiles, std::atan2( tlocx - cdata[cc].position.x, cdata[cc].position.y - tlocy));
                         set_color_mod(255, 255, 255, 7);
                     }
                 }
@@ -420,15 +398,7 @@ void play_animation_15()
             if (ay < inf_screenh * inf_tiles + inf_screeny - inf_tiles / 2)
             {
                 pos(ax + inf_tiles / 2, ay);
-                grotate(
-                    1,
-                    0,
-                    960,
-                    std::atan2(
-                        anix - cdata[cc].position.x,
-                        cdata[cc].position.y - aniy),
-                    inf_tiles,
-                    inf_tiles);
+                grotate(1, 0, 960, inf_tiles, inf_tiles, std::atan2( anix - cdata[cc].position.x, cdata[cc].position.y - aniy));
             }
         }
         redraw();
@@ -507,15 +477,7 @@ void play_animation_ranged_attack(int animeid, int anicol, int anisound)
         gsel(0);
         gmode(2, inf_tiles, inf_tiles);
         pos(ax + inf_tiles / 2, ay);
-        grotate(
-            1,
-            0,
-            960,
-            std::atan2(
-                cdata[tc].position.x - cdata[cc].position.x,
-                cdata[cc].position.y - cdata[tc].position.y),
-            inf_tiles,
-            inf_tiles);
+        grotate(1, 0, 960, inf_tiles, inf_tiles, std::atan2( cdata[tc].position.x - cdata[cc].position.x, cdata[cc].position.y - cdata[tc].position.y));
         redraw();
         gmode(0);
         pos(ax, ay - inf_tiles / 2);
@@ -548,7 +510,7 @@ void play_animation_9()
         pos(anidx - 16, anidy - 16);
         gcopy(4, 0, 0, 64, 64);
         pos(anidx + 16, anidy + 16);
-        grotate(1, 0, 960, 0.5 * cnt - 0.8, cnt * 8 + 18, cnt * 8 + 18);
+        grotate(1, 0, 960, cnt * 8 + 18, cnt * 8 + 18, 0.5 * cnt - 0.8);
         redraw();
         await(config::instance().animewait);
     }
@@ -623,18 +585,12 @@ void play_animation_12()
                     + (sx(cnt) < 4) * ((1 + (cnt % 2 == 0)) * -1) * cnt2
                     + (sx(cnt) > -4) * (1 + (cnt % 2 == 0)) * cnt2,
                 anidy + sy(cnt) + cnt2 * cnt2 / 3);
-            grotate(1, anix1, 0, 0.4 * cnt, 6, 6);
+            grotate(1, anix1, 0, inf_tiles, inf_tiles, 6, 6, 0.4 * cnt);
         }
         if (ap == 0)
         {
             pos(anidx + sx + 24, anidy + sy + 10);
-            grotate(
-                1,
-                0,
-                960,
-                0.5 * cnt - 0.8,
-                cnt * 10 + aniref,
-                cnt * 10 + aniref);
+            grotate(1, 0, 960, inf_tiles, inf_tiles, cnt * 10 + aniref, cnt * 10 + aniref, 0.5 * cnt - 0.8);
         }
         if (ap == 1)
         {
@@ -1004,16 +960,10 @@ void play_animation_14_16(int animeid)
                     + (sx(cnt) < 4) * ((1 + (cnt % 2 == 0)) * -1) * cnt2
                     + (sx(cnt) > -4) * (1 + (cnt % 2 == 0)) * cnt2,
                 ay + sy(cnt) + cnt2 * cnt2 / 3);
-            grotate(1, 864, 0, 0.4 * cnt, 24, 24);
+            grotate(1, 864, 0, inf_tiles, inf_tiles, 24, 24, 0.4 * cnt);
         }
         pos(ax + sx + 24, ay + sy + 10);
-        grotate(
-            1,
-            0,
-            960,
-            0.5 * cnt - 0.8,
-            cnt * 10 + aniref * 3,
-            cnt * 10 + aniref * 3);
+        grotate(1, 0, 960, inf_tiles, inf_tiles, cnt * 10 + aniref * 3, cnt * 10 + aniref * 3, 0.5 * cnt - 0.8);
         redraw();
         gmode(0);
         pos(ax - 16, ay - 16);

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -163,7 +163,7 @@ void play_animation_3(int anicol, int anisound)
                 {
                     pos((anidx - scx) * inf_tiles + inf_screenx + inf_tiles / 2,
                         (anidy - scy) * inf_tiles + inf_screeny + 16);
-                    gmode(2, inf_tiles, inf_tiles);
+                    gmode(2);
                     set_color_mod(
                         255 - c_col(0, anicol),
                         255 - c_col(1, anicol),
@@ -239,7 +239,7 @@ void play_animation_17_2(int animeid, int anicol, int anisound)
                     {
                         pos(sx * inf_tiles + inf_screenx,
                             sy * inf_tiles + inf_screeny);
-                        gmode(2, 48, 48);
+                        gmode(2);
                         set_color_mod(
                             255 - c_col(0, anicol),
                             255 - c_col(1, anicol),
@@ -258,7 +258,7 @@ void play_animation_17_2(int animeid, int anicol, int anisound)
             if (anidy < inf_screenh * inf_tiles + inf_screeny - inf_tiles / 2)
             {
                 pos(anidx, anidy);
-                gmode(4, 96, 96, 250 - cnt * cnt * 2);
+                gmode(4, 250 - cnt * cnt * 2);
                 gcopy_c(7, cnt * 96, 0, 96, 96);
             }
         }
@@ -348,7 +348,7 @@ void play_animation_0(int anicol, int anisound)
                         < inf_screenh * inf_tiles + inf_screeny - inf_tiles / 2)
                     {
                         pos(ax(cnt), ay(cnt));
-                        gmode(2, inf_tiles, inf_tiles);
+                        gmode(2);
                         set_color_mod(
                             255 - c_col(0, anicol),
                             255 - c_col(1, anicol),
@@ -392,7 +392,7 @@ void play_animation_15()
         gcopy(0, ax, ay - inf_tiles / 2, inf_tiles, inf_tiles);
         gmode(2);
         gsel(0);
-        gmode(2, inf_tiles, inf_tiles);
+        gmode(2);
         if (ax + inf_tiles / 2 < windoww)
         {
             if (ay < inf_screenh * inf_tiles + inf_screeny - inf_tiles / 2)
@@ -475,7 +475,7 @@ void play_animation_ranged_attack(int animeid, int anicol, int anisound)
         gcopy(0, ax, ay - inf_tiles / 2, inf_tiles, inf_tiles);
         gmode(2);
         gsel(0);
-        gmode(2, inf_tiles, inf_tiles);
+        gmode(2);
         pos(ax + inf_tiles / 2, ay);
         grotate(1, 0, 960, inf_tiles, inf_tiles, std::atan2( cdata[tc].position.x - cdata[cc].position.x, cdata[cc].position.y - cdata[tc].position.y));
         redraw();
@@ -573,7 +573,7 @@ void play_animation_12()
     {
         gmode(2);
         int cnt2 = cnt * 2;
-        gmode(2, inf_tiles, inf_tiles);
+        gmode(2);
         if (critical)
         {
             pos(anidx - 24, anidy - 32);
@@ -708,7 +708,7 @@ void play_animation_19()
             af = 1;
             int cnt2 = cnt;
             int anidy = ay(cnt) * clamp((20 - ap(cnt)), 0, 6) / 6 - 96;
-            gmode(2, 96, 96);
+            gmode(2);
             pos(ax(cnt), anidy);
             gcopy(
                 7,
@@ -809,7 +809,7 @@ void play_animation_22()
                 continue;
             }
             af = 1;
-            gmode(2, 96, 96);
+            gmode(2);
             if (ap(cnt) < 9)
             {
                 ax(cnt) -= 16 + cnt % (windoww / 30);
@@ -883,7 +883,7 @@ void play_animation_21()
                 continue;
             }
             af = 1;
-            gmode(2, 96, 96);
+            gmode(2);
             if (ap(cnt) < 10)
             {
                 pos(ax(cnt), ay(cnt));
@@ -953,7 +953,7 @@ void play_animation_14_16(int animeid)
     {
         gmode(2);
         int cnt2 = cnt * 2;
-        gmode(2, inf_tiles, inf_tiles);
+        gmode(2);
         for (int cnt = 0, cnt_end = (aniref); cnt < cnt_end; ++cnt)
         {
             pos(ax + 24 + sx(cnt)
@@ -1000,7 +1000,7 @@ void play_animation(int animeid)
         update_screen();
     }
 
-    gmode(2, inf_tiles, inf_tiles);
+    gmode(2);
 
     int anicol = 0;
     int anisound = 0;

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -273,7 +273,7 @@ void play_animation_17_2(int animeid, int anicol, int anisound)
             {
                 pos(anidx, anidy);
                 gmode(4, 96, 96, 250 - cnt * cnt * 2);
-                grotate_(7, cnt * 96, 0, 96, 96);
+                gcopy_c(7, cnt * 96, 0, 96, 96);
             }
         }
         redraw();

--- a/src/blending.cpp
+++ b/src/blending.cpp
@@ -724,7 +724,14 @@ label_1925_internal:
         }
         pos(wx + 37, wy + 70 + cnt * 19);
         gmode(2, item_chips[550].width, item_chips[550].height);
-        grotate_(1, 0, 960, inf_tiles, inf_tiles);
+        gcopy_c(
+            1,
+            0,
+            960,
+            item_chips[550].width,
+            item_chips[550].height,
+            inf_tiles,
+            inf_tiles);
         pos(wx + 330, wy + 53 + cnt * 19);
         if (blendchecklist(cnt) == 1)
         {
@@ -872,10 +879,12 @@ label_1928_internal:
         prepare_item_image(p(1), inv[p].color, inv[p].param1);
         pos(wx + 37, wy + 69 + cnt * 19);
         gmode(2, item_chips[p(1)].width, item_chips[p(1)].height);
-        grotate_(
+        gcopy_c(
             1,
             0,
             960,
+            item_chips[p(1)].width,
+            item_chips[p(1)].height,
             item_chips[p(1)].width * inf_tiles / item_chips[p(1)].height,
             inf_tiles);
         if (inv[p].body_part != 0)

--- a/src/blending.cpp
+++ b/src/blending.cpp
@@ -723,7 +723,7 @@ label_1925_internal:
             boxf(wx + 70, wy + 60 + cnt * 19, ww - 100, 18, {12, 14, 16, 16});
         }
         pos(wx + 37, wy + 70 + cnt * 19);
-        gmode(2, item_chips[550].width, item_chips[550].height);
+        gmode(2);
         gcopy_c(
             1,
             0,
@@ -878,7 +878,7 @@ label_1928_internal:
         p(1) = inv[p].image % 1000;
         prepare_item_image(p(1), inv[p].color, inv[p].param1);
         pos(wx + 37, wy + 69 + cnt * 19);
-        gmode(2, item_chips[p(1)].width, item_chips[p(1)].height);
+        gmode(2);
         gcopy_c(
             1,
             0,

--- a/src/building.cpp
+++ b/src/building.cpp
@@ -559,7 +559,7 @@ void show_home_value()
     x = ww / 5 * 2;
     y = wh - 80;
     pos(wx + ww / 4, wy + wh / 2);
-    gmode(4, 180, 300, 50);
+    gmode(4, 50);
     gcopy_c(4, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, 180, 300, x, y);
     gmode(2);
     calc_home_rank();
@@ -603,7 +603,7 @@ void show_home_value()
         p(1) = inv[p].image % 1000;
         prepare_item_image(p(1), inv[p].color, inv[p].param1);
         pos(wx + 37, cnt * 16 + wy + 138);
-        gmode(2, item_chips[p(1)].width, item_chips[p(1)].height);
+        gmode(2);
         gcopy_c(
             1,
             0,

--- a/src/building.cpp
+++ b/src/building.cpp
@@ -558,9 +558,9 @@ void show_home_value()
     ++cmbg;
     x = ww / 5 * 2;
     y = wh - 80;
-    gmode(4, 180, 300, 50);
     pos(wx + ww / 4, wy + wh / 2);
-    grotate_(4, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, x, y);
+    gmode(4, 180, 300, 50);
+    gcopy_c(4, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, 180, 300, x, y);
     gmode(2);
     calc_home_rank();
     s(0) = i18n::s.get("core.locale.building.home.rank.type.base");
@@ -604,10 +604,12 @@ void show_home_value()
         prepare_item_image(p(1), inv[p].color, inv[p].param1);
         pos(wx + 37, cnt * 16 + wy + 138);
         gmode(2, item_chips[p(1)].width, item_chips[p(1)].height);
-        grotate_(
+        gcopy_c(
             1,
             0,
             960,
+            item_chips[p(1)].width,
+            item_chips[p(1)].height,
             item_chips[p(1)].width * inf_tiles / item_chips[p(1)].height,
             inf_tiles);
         pos(wx + 68, cnt * 16 + wy + 138);

--- a/src/casino.cpp
+++ b/src/casino.cpp
@@ -222,9 +222,9 @@ void label_1870()
         {
             break;
         }
-        gmode(4, x(1), y(1), cnt * 25);
         pos(x + x(1) / 2 - 10 + cnt, y + y(1) / 2);
-        grotate_(2, 0, 0, x(1), y(1));
+        gmode(4, x(1), y(1), cnt * 25);
+        gcopy_c(2, 0, 0, x(1), y(1));
         if (atxpic != 0)
         {
             x(0) = 345;
@@ -272,10 +272,12 @@ void label_1870()
                 gcopy(2, x, y, x(1), y(1));
                 pos(x + x(1) / 2, y + y(1) / 2);
                 gmode(2, inf_tiles, inf_tiles);
-                grotate_(
+                gcopy_c(
                     1,
                     mattile % 33 * 32,
                     mattile / 33 * 32,
+                    inf_tiles,
+                    inf_tiles,
                     cnt2 * 9,
                     cnt2 * 9);
             }
@@ -299,9 +301,9 @@ void label_1871()
         gmode(0);
         pos(x - 50, y - 50);
         gcopy(2, x - 50, y - 50, 100 + x(1), y(1) + 100);
-        gmode(4, x(1), y(1), 250 - cnt * 25);
         pos(x + x(1) / 2 - 2 * cnt, y + y(1) / 2);
-        grotate_(2, 0, 0, x(1), y(1));
+        gmode(4, x(1), y(1), 250 - cnt * 25);
+        gcopy_c(2, 0, 0, x(1), y(1));
         await(15);
         redraw();
     }

--- a/src/casino.cpp
+++ b/src/casino.cpp
@@ -250,13 +250,7 @@ void label_1870()
             {
                 p(1) = 5;
             }
-            grotate(
-                p(1),
-                atxpic(1) % 33 * 32,
-                atxpic(1) / 33 * 32,
-                p_double,
-                cnt * (atxpic(2) / 10),
-                cnt * (atxpic(3) / 10));
+            grotate(p(1), atxpic(1) % 33 * 32, atxpic(1) / 33 * 32, inf_tiles, inf_tiles, cnt * (atxpic(2) / 10), cnt * (atxpic(3) / 10), p_double);
         }
         if (mattile != -1)
         {

--- a/src/casino.cpp
+++ b/src/casino.cpp
@@ -223,7 +223,7 @@ void label_1870()
             break;
         }
         pos(x + x(1) / 2 - 10 + cnt, y + y(1) / 2);
-        gmode(4, x(1), y(1), cnt * 25);
+        gmode(4, cnt * 25);
         gcopy_c(2, 0, 0, x(1), y(1));
         if (atxpic != 0)
         {
@@ -235,7 +235,7 @@ void label_1870()
             pos(x - atxpic(2) / 2, y - atxpic(3) / 2);
             gcopy(2, x - atxpic(2) / 2, y - atxpic(3) / 2, x(1), y(1));
             pos(x, y);
-            gmode(2, inf_tiles, inf_tiles);
+            gmode(2);
             double p_double;
             if (cnt == 10)
             {
@@ -265,7 +265,7 @@ void label_1870()
                 pos(x, y);
                 gcopy(2, x, y, x(1), y(1));
                 pos(x + x(1) / 2, y + y(1) / 2);
-                gmode(2, inf_tiles, inf_tiles);
+                gmode(2);
                 gcopy_c(
                     1,
                     mattile % 33 * 32,
@@ -296,7 +296,7 @@ void label_1871()
         pos(x - 50, y - 50);
         gcopy(2, x - 50, y - 50, 100 + x(1), y(1) + 100);
         pos(x + x(1) / 2 - 2 * cnt, y + y(1) / 2);
-        gmode(4, x(1), y(1), 250 - cnt * 25);
+        gmode(4, 250 - cnt * 25);
         gcopy_c(2, 0, 0, x(1), y(1));
         await(15);
         redraw();

--- a/src/casino_card.cpp
+++ b/src/casino_card.cpp
@@ -82,7 +82,7 @@ void showcard2(int prm_425, int prm_426)
     std::string s_at_cardcontrol;
     int tx_at_cardcontrol = 0;
     font(43 - en * 2, snail::font_t::style_t::bold);
-    gmode(2, 64, 96);
+    gmode(2);
     pos(card_at_cardcontrol(3, prm_425), card_at_cardcontrol(4, prm_425));
     if (card_at_cardcontrol(2, prm_425) == 1)
     {
@@ -93,12 +93,12 @@ void showcard2(int prm_425, int prm_426)
         gcopy(3, 672, 216, 64, 96);
         if (prm_426 == 0)
         {
-            gmode(4, inf_tiles, inf_tiles, 220);
+            gmode(4, 220);
             if (card_at_cardcontrol(1, prm_425) == 0)
             {
                 pos(card_at_cardcontrol(3, prm_425) + 32,
                     card_at_cardcontrol(4, prm_425) + 36);
-                gmode(4, inf_tiles, inf_tiles, 220);
+                gmode(4, 220);
                 gcopy_c(5, 144, 240, inf_tiles, inf_tiles, 64, 104);
                 col_at_cardcontrol(0) = 140;
                 col_at_cardcontrol(1) = 140;
@@ -108,7 +108,7 @@ void showcard2(int prm_425, int prm_426)
             {
                 pos(card_at_cardcontrol(3, prm_425) + 32,
                     card_at_cardcontrol(4, prm_425) + 40);
-                gmode(4, inf_tiles, inf_tiles, 220);
+                gmode(4, 220);
                 gcopy_c(5, 1104, 288, inf_tiles, inf_tiles, 64, 104);
                 col_at_cardcontrol(0) = 255;
                 col_at_cardcontrol(1) = 140;
@@ -118,7 +118,7 @@ void showcard2(int prm_425, int prm_426)
             {
                 pos(card_at_cardcontrol(3, prm_425) + 32,
                     card_at_cardcontrol(4, prm_425) + 50);
-                gmode(4, inf_tiles, inf_tiles, 220);
+                gmode(4, 220);
                 gcopy_c(5, 480, 336, inf_tiles, inf_tiles, 64, 84);
                 col_at_cardcontrol(0) = 240;
                 col_at_cardcontrol(1) = 240;
@@ -128,7 +128,7 @@ void showcard2(int prm_425, int prm_426)
             {
                 pos(card_at_cardcontrol(3, prm_425) + 28,
                     card_at_cardcontrol(4, prm_425) + 48);
-                gmode(4, inf_tiles, inf_tiles, 220);
+                gmode(4, 220);
                 gcopy_c(5, 1200, 288, inf_tiles, inf_tiles, 64, 80);
                 col_at_cardcontrol(0) = 140;
                 col_at_cardcontrol(1) = 255;
@@ -138,7 +138,7 @@ void showcard2(int prm_425, int prm_426)
             {
                 pos(card_at_cardcontrol(3, prm_425) + 28,
                     card_at_cardcontrol(4, prm_425) + 44);
-                gmode(4, inf_tiles, inf_tiles, 220);
+                gmode(4, 220);
                 gcopy_c(5, 1296, 336, inf_tiles, inf_tiles, 72, 86);
                 col_at_cardcontrol(0) = 250;
                 col_at_cardcontrol(1) = 250;
@@ -362,7 +362,7 @@ int opencard2(int prm_428, int prm_429)
         }
         pos(card_at_cardcontrol(3, prm_428) + 32,
             card_at_cardcontrol(4, prm_428) + 48);
-        gmode(2, 64, 96);
+        gmode(2);
         gcopy_c(3, 736, 216, 64, 96, 64 - cnt * 14, 96);
         await(10);
         redraw();
@@ -380,7 +380,7 @@ int trashcard(int prm_430)
         pos(card_at_cardcontrol(3, prm_430) - 8,
             card_at_cardcontrol(4, prm_430) - 8);
         gcopy(3, 528, 216, 80, 112);
-        gmode(2, 64, 96);
+        gmode(2);
         if (cnt == 20)
         {
             redraw();

--- a/src/casino_card.cpp
+++ b/src/casino_card.cpp
@@ -98,7 +98,8 @@ void showcard2(int prm_425, int prm_426)
             {
                 pos(card_at_cardcontrol(3, prm_425) + 32,
                     card_at_cardcontrol(4, prm_425) + 36);
-                grotate_(5, 144, 240, 64, 104);
+                gmode(4, inf_tiles, inf_tiles, 220);
+                gcopy_c(5, 144, 240, inf_tiles, inf_tiles, 64, 104);
                 col_at_cardcontrol(0) = 140;
                 col_at_cardcontrol(1) = 140;
                 col_at_cardcontrol(2) = 255;
@@ -107,7 +108,8 @@ void showcard2(int prm_425, int prm_426)
             {
                 pos(card_at_cardcontrol(3, prm_425) + 32,
                     card_at_cardcontrol(4, prm_425) + 40);
-                grotate_(5, 1104, 288, 64, 104);
+                gmode(4, inf_tiles, inf_tiles, 220);
+                gcopy_c(5, 1104, 288, inf_tiles, inf_tiles, 64, 104);
                 col_at_cardcontrol(0) = 255;
                 col_at_cardcontrol(1) = 140;
                 col_at_cardcontrol(2) = 140;
@@ -116,7 +118,8 @@ void showcard2(int prm_425, int prm_426)
             {
                 pos(card_at_cardcontrol(3, prm_425) + 32,
                     card_at_cardcontrol(4, prm_425) + 50);
-                grotate_(5, 480, 336, 64, 84);
+                gmode(4, inf_tiles, inf_tiles, 220);
+                gcopy_c(5, 480, 336, inf_tiles, inf_tiles, 64, 84);
                 col_at_cardcontrol(0) = 240;
                 col_at_cardcontrol(1) = 240;
                 col_at_cardcontrol(2) = 240;
@@ -125,7 +128,8 @@ void showcard2(int prm_425, int prm_426)
             {
                 pos(card_at_cardcontrol(3, prm_425) + 28,
                     card_at_cardcontrol(4, prm_425) + 48);
-                grotate_(5, 1200, 288, 64, 80);
+                gmode(4, inf_tiles, inf_tiles, 220);
+                gcopy_c(5, 1200, 288, inf_tiles, inf_tiles, 64, 80);
                 col_at_cardcontrol(0) = 140;
                 col_at_cardcontrol(1) = 255;
                 col_at_cardcontrol(2) = 140;
@@ -134,7 +138,8 @@ void showcard2(int prm_425, int prm_426)
             {
                 pos(card_at_cardcontrol(3, prm_425) + 28,
                     card_at_cardcontrol(4, prm_425) + 44);
-                grotate_(5, 1296, 336, 72, 86);
+                gmode(4, inf_tiles, inf_tiles, 220);
+                gcopy_c(5, 1296, 336, inf_tiles, inf_tiles, 72, 86);
                 col_at_cardcontrol(0) = 250;
                 col_at_cardcontrol(1) = 250;
                 col_at_cardcontrol(2) = 105;
@@ -343,7 +348,6 @@ int opencard2(int prm_428, int prm_429)
             pos(card_at_cardcontrol(3, prm_428) - 8,
                 card_at_cardcontrol(4, prm_428) - 8);
             gcopy(3, 528, 216, 80, 112);
-            gmode(2, 64, 96);
         }
         else
         {
@@ -355,11 +359,11 @@ int opencard2(int prm_428, int prm_429)
                 card_at_cardcontrol(4, prm_428) - wy - 4,
                 80,
                 112);
-            gmode(2, 64, 96);
         }
         pos(card_at_cardcontrol(3, prm_428) + 32,
             card_at_cardcontrol(4, prm_428) + 48);
-        grotate_(3, 736, 216, 64 - cnt * 14, 96);
+        gmode(2, 64, 96);
+        gcopy_c(3, 736, 216, 64, 96, 64 - cnt * 14, 96);
         await(10);
         redraw();
     }

--- a/src/casino_card.cpp
+++ b/src/casino_card.cpp
@@ -388,7 +388,7 @@ int trashcard(int prm_430)
         }
         pos(card_at_cardcontrol(3, prm_430) + 32,
             card_at_cardcontrol(4, prm_430) + 48);
-        grotate(3, 736, 216, 0.015 * cnt * cnt, 64 - cnt * 3, 96 - cnt * 4);
+        grotate(3, 736, 216, 64, 96, 64 - cnt * 3, 96 - cnt * 4, 0.015 * cnt * cnt);
         await(10);
         redraw();
     }

--- a/src/cell_draw.cpp
+++ b/src/cell_draw.cpp
@@ -545,14 +545,14 @@ void draw_character_sprite_in_world_map(
     int direction)
 {
     // Shadow
-    gmode(6, 32, 16, 85);
     pos(x + 24, y + 27);
-    grotate_(3, 240, 384, 20, 10);
+    gmode(6, 32, 16, 85);
+    gcopy_c(3, 240, 384, 32, 16, 20, 10);
 
     // Character sprite
-    gmode(2, 32, 48);
     pos(x + 24, y + 14);
-    grotate_(texture_id, frame, direction * 48, 16, 24);
+    gmode(2, 32, 48);
+    gcopy_c(texture_id, frame, direction * 48, 32, 48, 16, 24);
 }
 
 
@@ -565,14 +565,14 @@ void draw_character_sprite_in_water(
     int direction)
 {
     // Upper body
-    gmode(2, 32, 28);
     pos(x + 24, y + 16);
-    grotate_(texture_id, frame, direction * 48, 24, 24);
+    gmode(2, 32, 28);
+    gcopy_c(texture_id, frame, direction * 48, 32, 28, 24, 24);
 
     // Lower body
-    gmode(4, 32, 20, 146);
     pos(x + 24, y + 36);
-    grotate_(texture_id, frame, direction * 48 + 28, 24, 16);
+    gmode(4, 32, 20, 146);
+    gcopy_c(texture_id, frame, direction * 48 + 28, 32, 20, 24, 16);
 }
 
 
@@ -591,9 +591,9 @@ void draw_character_sprite(
     gcopy(3, 240, 384, 32, 16);
 
     // Character sprite
-    gmode(2, 32, 48);
     pos(x + 24, y + dy + 8);
-    grotate_(texture_id, frame, direction * 48, 24, 40);
+    gmode(2, 32, 48);
+    gcopy_c(texture_id, frame, direction * 48, 32, 48, 24, 40);
 }
 
 
@@ -782,9 +782,16 @@ void draw_items(int x, int y, int dx, int dy, int scrturn)
                 prepare_item_image(p_, i_, inv[items[i]].param1);
                 if (mdata(6) == 1)
                 {
-                    gmode(2, item_chips[p_].width, item_chips[p_].height);
                     pos(dx + 24, dy + 24 - stack_height / 2);
-                    grotate_(1, 0, 960, 24, 24);
+                    gmode(2, item_chips[p_].width, item_chips[p_].height);
+                    gcopy_c(
+                        1,
+                        0,
+                        960,
+                        item_chips[p_].width,
+                        item_chips[p_].height,
+                        24,
+                        24);
                 }
                 else
                 {
@@ -871,9 +878,16 @@ void draw_items(int x, int y, int dx, int dy, int scrturn)
             }
             if (mdata(6) == 1)
             {
-                gmode(2, item_chips[p_].width, item_chips[p_].height);
                 pos(dx + 24, dy + 24);
-                grotate_(1, 0, 960, 24, 24);
+                gmode(2, item_chips[p_].width, item_chips[p_].height);
+                gcopy_c(
+                    1,
+                    0,
+                    960,
+                    item_chips[p_].width,
+                    item_chips[p_].height,
+                    24,
+                    24);
             }
             else
             {
@@ -1007,12 +1021,19 @@ void draw_npc(int x, int y, int dx, int dy, int ani_, int ground_)
                 gsel(0);
                 if (mdata(6) == 1)
                 {
-                    gmode(6, 32, 16, 85);
                     pos(dx + 24, dy + 32);
-                    grotate_(3, 240, 384, 20, 10);
-                    gmode(2, chara_chips[p_].width, chara_chips[p_].height);
+                    gmode(6, 32, 16, 85);
+                    gcopy_c(3, 240, 384, 32, 16, 20, 10);
                     pos(dx + 24, dy + 24 - chara_chips[p_].offset_y / 4);
-                    grotate_(5, 0, 960, 24, chara_chips[p_].height / 2);
+                    gmode(2, chara_chips[p_].width, chara_chips[p_].height);
+                    gcopy_c(
+                        5,
+                        0,
+                        960,
+                        chara_chips[p_].width,
+                        chara_chips[p_].height,
+                        24,
+                        chara_chips[p_].height / 2);
                     if (cdata[c_].emotion_icon != 0)
                     {
                         draw_emo(

--- a/src/cell_draw.cpp
+++ b/src/cell_draw.cpp
@@ -651,13 +651,7 @@ void draw_efmap(int x, int y, int dx, int dy, bool update_frame)
         {
             gmode(4, 32, 32, efmap(1, x, y) * 12 + 30);
             pos(dx + 24, dy + 24);
-            grotate(
-                3,
-                mefsubref(0, p_) + efmap(3, x, y) * 32,
-                mefsubref(1, p_),
-                0.785 * efmap(2, x, y),
-                32,
-                32);
+            grotate(3, mefsubref(0, p_) + efmap(3, x, y) * 32, mefsubref(1, p_), 32, 32, 0.785 * efmap(2, x, y));
         }
         else
         {

--- a/src/cell_draw.cpp
+++ b/src/cell_draw.cpp
@@ -214,7 +214,7 @@ int shadowmap[] = {
 
 void render_shadow_low(int light)
 {
-    gmode(6, inf_tiles, inf_tiles, light);
+    gmode(6, light);
 
     for (const auto& pos : loop_xy<int>(inf_screenw, inf_screenh))
     {
@@ -396,7 +396,7 @@ void render_shadow(int p_, int dx_, int dy_)
 
 void render_shadow_high(int light, int sxfix_, int syfix_)
 {
-    gmode(6, inf_tiles, inf_tiles, light);
+    gmode(6, light);
 
     if (scrollanime == 0)
     {
@@ -483,7 +483,7 @@ void render_cloud()
 
     for (size_t i = 0; i < clouds.size(); ++i)
     {
-        gmode(5, -1, -1, 7 + i * 2);
+        gmode(5, 7 + i * 2);
         int x = (clouds[i].x0 - cdata[0].position.x * inf_tiles + sxfix) * 100
                 / (40 + i * 5)
             + scrturn * 100 / (50 + i * 20);
@@ -546,12 +546,12 @@ void draw_character_sprite_in_world_map(
 {
     // Shadow
     pos(x + 24, y + 27);
-    gmode(6, 32, 16, 85);
+    gmode(6, 85);
     gcopy_c(3, 240, 384, 32, 16, 20, 10);
 
     // Character sprite
     pos(x + 24, y + 14);
-    gmode(2, 32, 48);
+    gmode(2);
     gcopy_c(texture_id, frame, direction * 48, 32, 48, 16, 24);
 }
 
@@ -566,12 +566,12 @@ void draw_character_sprite_in_water(
 {
     // Upper body
     pos(x + 24, y + 16);
-    gmode(2, 32, 28);
+    gmode(2);
     gcopy_c(texture_id, frame, direction * 48, 32, 28, 24, 24);
 
     // Lower body
     pos(x + 24, y + 36);
-    gmode(4, 32, 20, 146);
+    gmode(4, 146);
     gcopy_c(texture_id, frame, direction * 48 + 28, 32, 20, 24, 16);
 }
 
@@ -586,13 +586,13 @@ void draw_character_sprite(
     int dy = 0)
 {
     // Shadow
-    gmode(6, -1, -1, 110);
+    gmode(6, 110);
     pos(x + 8, y + 20);
     gcopy(3, 240, 384, 32, 16);
 
     // Character sprite
     pos(x + 24, y + dy + 8);
-    gmode(2, 32, 48);
+    gmode(2);
     gcopy_c(texture_id, frame, direction * 48, 32, 48, 24, 40);
 }
 
@@ -607,7 +607,7 @@ bool is_night()
 
 void draw_one_map_tile(int x, int y, int tile, int dx = 0)
 {
-    gmode(0, inf_tiles, inf_tiles);
+    gmode(0);
     pos(x, y);
     gcopy(
         2,
@@ -621,7 +621,7 @@ void draw_one_map_tile(int x, int y, int tile, int dx = 0)
 
 void draw_blood_pool_and_fragments(int x, int y)
 {
-    gmode(2, inf_tiles, inf_tiles);
+    gmode(2);
     if (map(x, y, 7) != 0 && mapsync(x, y) == msync)
     {
         if (const auto fragments = map(x, y, 7) / 10)
@@ -649,13 +649,13 @@ void draw_efmap(int x, int y, int dx, int dy, bool update_frame)
         }
         if (mefsubref(2, p_) == 1)
         {
-            gmode(4, 32, 32, efmap(1, x, y) * 12 + 30);
+            gmode(4, efmap(1, x, y) * 12 + 30);
             pos(dx + 24, dy + 24);
             grotate(3, mefsubref(0, p_) + efmap(3, x, y) * 32, mefsubref(1, p_), 32, 32, 0.785 * efmap(2, x, y));
         }
         else
         {
-            gmode(4, 32, 32, 150);
+            gmode(4, 150);
             pos(dx + 8, dy + 8);
             gcopy(
                 3,
@@ -664,7 +664,7 @@ void draw_efmap(int x, int y, int dx, int dy, bool update_frame)
                 32,
                 32);
         }
-        gmode(2, inf_tiles, inf_tiles);
+        gmode(2);
     }
 }
 
@@ -777,7 +777,7 @@ void draw_items(int x, int y, int dx, int dy, int scrturn)
                 if (mdata(6) == 1)
                 {
                     pos(dx + 24, dy + 24 - stack_height / 2);
-                    gmode(2, item_chips[p_].width, item_chips[p_].height);
+                    gmode(2);
                     gcopy_c(
                         1,
                         0,
@@ -792,8 +792,7 @@ void draw_items(int x, int y, int dx, int dy, int scrturn)
                     if (config::instance().objectshadow
                         && item_chips[p_].shadow)
                     {
-                        gmode(
-                            2, item_chips[p_].width, item_chips[p_].height, 70);
+                        gmode(2, 70);
                         if (item_chips[p_].height == inf_tiles)
                         {
                             pos(dx + item_chips[p_].width / 2
@@ -873,7 +872,7 @@ void draw_items(int x, int y, int dx, int dy, int scrturn)
             if (mdata(6) == 1)
             {
                 pos(dx + 24, dy + 24);
-                gmode(2, item_chips[p_].width, item_chips[p_].height);
+                gmode(2);
                 gcopy_c(
                     1,
                     0,
@@ -887,7 +886,7 @@ void draw_items(int x, int y, int dx, int dy, int scrturn)
             {
                 if (config::instance().objectshadow && item_chips[p_].shadow)
                 {
-                    gmode(2, item_chips[p_].width, item_chips[p_].height, 80);
+                    gmode(2, 80);
                     if (item_chips[p_].height == inf_tiles)
                     {
                         pos(dx + item_chips[p_].width / 2
@@ -990,10 +989,10 @@ void draw_npc(int x, int y, int dx, int dy, int ani_, int ground_)
                 p_ = cdata[c_].image % 1000;
                 if (cdata[c_].is_hung_on_sand_bag())
                 {
-                    gmode(2, 48, 96, 80);
+                    gmode(2, 80);
                     pos(dx + 26 - 11, dy - 32 + 11);
                     func_2(1, 96, 816, -80, 48, 96);
-                    gmode(2, -1, -1, 255);
+                    gmode(2, 255);
                     pos(dx, dy - 63);
                     gcopy(1, 96, 816, 48, 96);
                     chara_chips[p_].offset_y += 24;
@@ -1016,10 +1015,10 @@ void draw_npc(int x, int y, int dx, int dy, int ani_, int ground_)
                 if (mdata(6) == 1)
                 {
                     pos(dx + 24, dy + 32);
-                    gmode(6, 32, 16, 85);
+                    gmode(6, 85);
                     gcopy_c(3, 240, 384, 32, 16, 20, 10);
                     pos(dx + 24, dy + 24 - chara_chips[p_].offset_y / 4);
-                    gmode(2, chara_chips[p_].width, chara_chips[p_].height);
+                    gmode(2);
                     gcopy_c(
                         5,
                         0,
@@ -1038,7 +1037,7 @@ void draw_npc(int x, int y, int dx, int dy, int ani_, int ground_)
                 {
                     if (chipm(0, ground_) == 3)
                     {
-                        gmode(4, inf_tiles, inf_tiles, 100);
+                        gmode(4, 100);
                         pos(dx,
                             dy + 16 - chara_chips[p_].offset_y
                                 - (chipm(0, ground_) == 3) * -16);
@@ -1048,7 +1047,7 @@ void draw_npc(int x, int y, int dx, int dy, int ani_, int ground_)
                             976,
                             chara_chips[p_].width,
                             chara_chips[p_].height - 16);
-                        gmode(2, inf_tiles, inf_tiles);
+                        gmode(2);
                         pos(dx,
                             dy - chara_chips[p_].offset_y
                                 - (chipm(0, ground_) == 3) * -16);
@@ -1061,10 +1060,10 @@ void draw_npc(int x, int y, int dx, int dy, int ani_, int ground_)
                     }
                     else
                     {
-                        gmode(6, -1, -1, 110);
+                        gmode(6, 110);
                         pos(dx + 8, dy + 20);
                         gcopy(3, 240, 384, 32, 16);
-                        gmode(2, inf_tiles, inf_tiles);
+                        gmode(2);
                         pos(dx,
                             dy - chara_chips[p_].offset_y
                                 - (chipm(0, ground_) == 3) * -16);
@@ -1215,7 +1214,7 @@ void cell_draw()
                 {
                     py_ -= syfix;
                 }
-                gmode(5, inf_tiles, inf_tiles, 50 + flick_);
+                gmode(5, 50 + flick_);
                 pos(px_, py_);
                 gcopy(3, 800, 208, 144, 48);
             }
@@ -1235,7 +1234,7 @@ void cell_draw()
                 }
 
                 // Spot light for PC (top 2 thirds)
-                gmode(5, inf_tiles, inf_tiles, 50 + flick_);
+                gmode(5, 50 + flick_);
                 pos(px_ - 48, py_ - 48);
                 gcopy(3, 800, 112, 144, 96);
 
@@ -1352,11 +1351,7 @@ void cell_draw()
                                      6))
                         * light.brightness;
                     pos(dx_, dy_ - light.dy);
-                    gmode(
-                        5,
-                        inf_tiles,
-                        inf_tiles,
-                        light.alpha_base + rnd(light.alpha_random + 1));
+                    gmode(5, light.alpha_base + rnd(light.alpha_random + 1));
                     gcopy(
                         3,
                         192 + light.x * 48 + rnd(light.frame + 1) * inf_tiles,

--- a/src/character_making.cpp
+++ b/src/character_making.cpp
@@ -112,7 +112,7 @@ main_menu_result_t character_making_select_race()
             x = ww / 5 * 2;
             y = wh - 80;
             pos(wx + ww / 4, wy + wh / 2);
-            gmode(4, 180, 300, 50);
+            gmode(4, 50);
             gcopy_c(
                 2, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, 180, 300, x, y);
             gmode(2);
@@ -219,7 +219,7 @@ main_menu_result_t character_making_select_sex(bool advanced_to_next_menu)
         x = ww / 2;
         y = wh - 60;
         pos(wx + ww / 2, wy + wh / 2);
-        gmode(4, 180, 300, 30);
+        gmode(4, 30);
         gcopy_c(2, 0, 0, 180, 300, x, y);
         gmode(2);
         display_topic(lang(u8"性別の候補"s, u8"Gender"s), wx + 28, wy + 30);
@@ -323,7 +323,7 @@ main_menu_result_t character_making_select_class(bool advanced_to_next_menu)
             x = ww / 5 * 2;
             y = wh - 80;
             pos(wx + ww / 4, wy + wh / 2);
-            gmode(4, 180, 300, 50);
+            gmode(4, 50);
             gcopy_c(
                 2, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, 180, 300, x, y);
             gmode(2);
@@ -462,7 +462,7 @@ main_menu_result_t character_making_role_attributes(bool advanced_to_next_menu)
         x = 150;
         y = 240;
         pos(wx + 85, wy + wh / 2);
-        gmode(4, 180, 300, 30);
+        gmode(4, 30);
         gcopy_c(2, 0, 0, 180, 300, x, y);
         gmode(2);
         display_topic(lang(u8"能力"s, u8"Attributes"s), wx + 28, wy + 30);
@@ -486,7 +486,7 @@ main_menu_result_t character_making_role_attributes(bool advanced_to_next_menu)
             if (cnt >= 2)
             {
                 pos(wx + 198, wy + 76 + cnt * 23);
-                gmode(2, inf_tiles, inf_tiles);
+                gmode(2);
                 gcopy_c(1, (cnt - 2) * inf_tiles, 672, inf_tiles, inf_tiles);
                 pos(wx + 210, wy + 66 + cnt * 23);
                 mes(""s + list(0, cnt) / 1000000);
@@ -666,7 +666,7 @@ main_menu_result_t character_making_select_alias(bool advanced_to_next_menu)
             x = ww / 3 * 2;
             y = wh - 80;
             pos(wx + ww / 2, wy + wh / 2);
-            gmode(4, 180, 300, 40);
+            gmode(4, 40);
             gcopy_c(
                 2, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, 180, 300, x, y);
             gmode(2);
@@ -957,7 +957,7 @@ void show_race_or_class_info(int val0)
     {
         chara_preparepic(ref1);
         pos(wx + 480, wy + 96);
-        gmode(4, chara_chips[ref1].width, chara_chips[ref1].height, 40);
+        gmode(4, 40);
         gcopy_c(
             5,
             0,
@@ -968,7 +968,7 @@ void show_race_or_class_info(int val0)
             chara_chips[ref1].height * 2);
         chara_preparepic(ref2);
         pos(wx + 350, wy + 96);
-        gmode(4, chara_chips[ref1].width, chara_chips[ref1].height, 40);
+        gmode(4, 40);
         gcopy_c(
             5,
             0,
@@ -1074,7 +1074,7 @@ void show_race_or_class_info(int val0)
                 color(120, 120, 120);
             }
             pos(cnt * 150 + tx + 13, ty + 7);
-            gmode(2, inf_tiles, inf_tiles);
+            gmode(2);
             gcopy_c(1, (cnt2 * 3 + cnt) * inf_tiles, 672, inf_tiles, inf_tiles);
             pos(cnt * 150 + tx + 32, ty);
             mes(strmid(
@@ -1107,7 +1107,7 @@ void show_race_or_class_info(int val0)
     if (r != 0)
     {
         pos(tx + 13, ty + 6);
-        gmode(2, inf_tiles, inf_tiles);
+        gmode(2);
         gcopy_c(1, 0, 672, inf_tiles, inf_tiles);
         pos(tx + 32, ty);
         mes(s);
@@ -1127,7 +1127,7 @@ void show_race_or_class_info(int val0)
                 lenfix(s, 16);
             }
             pos(tx + 13, ty + 6);
-            gmode(2, inf_tiles, inf_tiles);
+            gmode(2);
             gcopy_c(
                 1,
                 (the_ability_db[cnt]->related_basic_attribute - 10) * inf_tiles,

--- a/src/character_making.cpp
+++ b/src/character_making.cpp
@@ -111,9 +111,10 @@ main_menu_result_t character_making_select_race()
             ++cmbg;
             x = ww / 5 * 2;
             y = wh - 80;
-            gmode(4, 180, 300, 50);
             pos(wx + ww / 4, wy + wh / 2);
-            grotate_(2, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, x, y);
+            gmode(4, 180, 300, 50);
+            gcopy_c(
+                2, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, 180, 300, x, y);
             gmode(2);
             display_topic(
                 lang(u8"選択できる種族"s, u8"Race"s), wx + 28, wy + 30);
@@ -217,9 +218,9 @@ main_menu_result_t character_making_select_sex(bool advanced_to_next_menu)
             (windoww - 370) / 2 + inf_screenx, winposy(168, 1) - 20, 370, 168);
         x = ww / 2;
         y = wh - 60;
-        gmode(4, 180, 300, 30);
         pos(wx + ww / 2, wy + wh / 2);
-        grotate_(2, 0, 0, x, y);
+        gmode(4, 180, 300, 30);
+        gcopy_c(2, 0, 0, 180, 300, x, y);
         gmode(2);
         display_topic(lang(u8"性別の候補"s, u8"Gender"s), wx + 28, wy + 30);
         listn(0, 0) = cnven(i18n::_(u8"ui", u8"male"));
@@ -321,9 +322,10 @@ main_menu_result_t character_making_select_class(bool advanced_to_next_menu)
             ++cmbg;
             x = ww / 5 * 2;
             y = wh - 80;
-            gmode(4, 180, 300, 50);
             pos(wx + ww / 4, wy + wh / 2);
-            grotate_(2, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, x, y);
+            gmode(4, 180, 300, 50);
+            gcopy_c(
+                2, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, 180, 300, x, y);
             gmode(2);
             display_topic(
                 lang(u8"選択できる職業"s, u8"Class"s), wx + 28, wy + 30);
@@ -459,9 +461,9 @@ main_menu_result_t character_making_role_attributes(bool advanced_to_next_menu)
             (windoww - 360) / 2 + inf_screenx, winposy(352, 1) - 20, 360, 352);
         x = 150;
         y = 240;
-        gmode(4, 180, 300, 30);
         pos(wx + 85, wy + wh / 2);
-        grotate_(2, 0, 0, x, y);
+        gmode(4, 180, 300, 30);
+        gcopy_c(2, 0, 0, 180, 300, x, y);
         gmode(2);
         display_topic(lang(u8"能力"s, u8"Attributes"s), wx + 28, wy + 30);
         font(12 + sizefix - en * 2);
@@ -485,7 +487,7 @@ main_menu_result_t character_making_role_attributes(bool advanced_to_next_menu)
             {
                 pos(wx + 198, wy + 76 + cnt * 23);
                 gmode(2, inf_tiles, inf_tiles);
-                grotate_(1, (cnt - 2) * inf_tiles, 672, inf_tiles, inf_tiles);
+                gcopy_c(1, (cnt - 2) * inf_tiles, 672, inf_tiles, inf_tiles);
                 pos(wx + 210, wy + 66 + cnt * 23);
                 mes(""s + list(0, cnt) / 1000000);
                 if (cmlock(cnt - 2) == 1)
@@ -663,9 +665,10 @@ main_menu_result_t character_making_select_alias(bool advanced_to_next_menu)
             ++cmbg;
             x = ww / 3 * 2;
             y = wh - 80;
-            gmode(4, 180, 300, 40);
             pos(wx + ww / 2, wy + wh / 2);
-            grotate_(2, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, x, y);
+            gmode(4, 180, 300, 40);
+            gcopy_c(
+                2, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, 180, 300, x, y);
             gmode(2);
             display_topic(
                 lang(u8"異名の候補"s, u8"Alias List"s), wx + 28, wy + 30);
@@ -952,21 +955,26 @@ void show_race_or_class_info(int val0)
     }
     else
     {
-        gmode(4, chara_chips[ref1].width, chara_chips[ref1].height, 40);
         chara_preparepic(ref1);
         pos(wx + 480, wy + 96);
-        grotate_(
+        gmode(4, chara_chips[ref1].width, chara_chips[ref1].height, 40);
+        gcopy_c(
             5,
             0,
             960,
+            chara_chips[ref1].width,
+            chara_chips[ref1].height,
             chara_chips[ref1].width * 2,
             chara_chips[ref1].height * 2);
         chara_preparepic(ref2);
         pos(wx + 350, wy + 96);
-        grotate_(
+        gmode(4, chara_chips[ref1].width, chara_chips[ref1].height, 40);
+        gcopy_c(
             5,
             0,
             960,
+            chara_chips[ref1].width,
+            chara_chips[ref1].height,
             chara_chips[ref1].width * 2,
             chara_chips[ref1].height * 2);
         gmode(2);
@@ -1067,8 +1075,7 @@ void show_race_or_class_info(int val0)
             }
             pos(cnt * 150 + tx + 13, ty + 7);
             gmode(2, inf_tiles, inf_tiles);
-            grotate_(
-                1, (cnt2 * 3 + cnt) * inf_tiles, 672, inf_tiles, inf_tiles);
+            gcopy_c(1, (cnt2 * 3 + cnt) * inf_tiles, 672, inf_tiles, inf_tiles);
             pos(cnt * 150 + tx + 32, ty);
             mes(strmid(
                     i18n::_(u8"ability", std::to_string(r), u8"name"),
@@ -1101,7 +1108,7 @@ void show_race_or_class_info(int val0)
     {
         pos(tx + 13, ty + 6);
         gmode(2, inf_tiles, inf_tiles);
-        grotate_(1, 0, 672, inf_tiles, inf_tiles);
+        gcopy_c(1, 0, 672, inf_tiles, inf_tiles);
         pos(tx + 32, ty);
         mes(s);
         ty += 14;
@@ -1121,7 +1128,7 @@ void show_race_or_class_info(int val0)
             }
             pos(tx + 13, ty + 6);
             gmode(2, inf_tiles, inf_tiles);
-            grotate_(
+            gcopy_c(
                 1,
                 (the_ability_db[cnt]->related_basic_attribute - 10) * inf_tiles,
                 672,

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1221,7 +1221,14 @@ label_1857_internal:
         mes(s(1));
         pos(wx + 37, wy + 69 + cnt * 19 + 2);
         gmode(2, inf_tiles, inf_tiles);
-        grotate_(1, 0, 960, item_chips[p(1)].width, item_chips[p(1)].height);
+        gcopy_c(
+            1,
+            0,
+            960,
+            inf_tiles,
+            inf_tiles,
+            item_chips[p(1)].width,
+            item_chips[p(1)].height);
     }
     if (keyrange != 0)
     {

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1220,7 +1220,7 @@ label_1857_internal:
         pos(wx + 308, wy + 66 + cnt * 19 + 2);
         mes(s(1));
         pos(wx + 37, wy + 69 + cnt * 19 + 2);
-        gmode(2, inf_tiles, inf_tiles);
+        gmode(2);
         gcopy_c(
             1,
             0,

--- a/src/ctrl_inventory.cpp
+++ b/src/ctrl_inventory.cpp
@@ -843,7 +843,7 @@ label_2060_internal:
             gcopy(3, 288 + invicon(p) * 48, 48, 48, 48);
             if (invctrl == p)
             {
-                gmode(5, -1, -1, 70);
+                gmode(5, 70);
                 pos(x + cnt * 44 + 20, y - 24);
                 gcopy(3, 288 + invicon(p) * 48, 48, 48, 48);
                 gmode(2);
@@ -1043,7 +1043,7 @@ label_2061_internal:
         p(1) = inv[p].image % 1000;
         prepare_item_image(p(1), inv[p].color, inv[p].param1);
         pos(wx + 37, wy + 69 + cnt * 19);
-        gmode(2, item_chips[p(1)].width, item_chips[p(1)].height);
+        gmode(2);
         gcopy_c(
             1,
             0,

--- a/src/ctrl_inventory.cpp
+++ b/src/ctrl_inventory.cpp
@@ -1044,10 +1044,12 @@ label_2061_internal:
         prepare_item_image(p(1), inv[p].color, inv[p].param1);
         pos(wx + 37, wy + 69 + cnt * 19);
         gmode(2, item_chips[p(1)].width, item_chips[p(1)].height);
-        grotate_(
+        gcopy_c(
             1,
             0,
             960,
+            item_chips[p(1)].width,
+            item_chips[p(1)].height,
             item_chips[p(1)].width * inf_tiles / item_chips[p(1)].height,
             inf_tiles);
         if (inv[p].body_part != 0)

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -604,7 +604,7 @@ void prepare_item_image(int id, int color, int character_image)
             chara_chips[character_id].width - 16,
             chara_chips[character_id].height - 8);
         set_color_mod(255, 255, 255, 5);
-        gmode(4, -1, -1, 192);
+        gmode(4, 192);
         pos(0, 960 + (chara_chips[character_id].height == inf_tiles) * 48);
         set_color_mod(
             255 - c_col(0, color),
@@ -825,7 +825,7 @@ void show_damage_popups()
 
 void draw_emo(int cc, int x, int y)
 {
-    gmode(2, 16, 16);
+    gmode(2);
     pos(x + 16, y);
     gcopy(3, 32 + cdata[cc].emotion_icon % 100 * 16, 608, 16, 16);
 }
@@ -842,7 +842,7 @@ void load_pcc_part(int cc, int body_part, const char* body_part_str)
     pos(128, 0);
     picload(filepath, 1);
     boxf(256, 0, 128, 198);
-    gmode(4, -1, -1, 256);
+    gmode(4, 256);
     pget(128, 0);
     pos(256, 0);
     gcopy(10 + cc, 128, 0, 128, 198);

--- a/src/elona.hpp
+++ b/src/elona.hpp
@@ -420,6 +420,23 @@ void gcopy(
     int dst_width = -1,
     int dst_height = -1);
 
+void gcopy_c(
+    int window_id,
+    int src_x,
+    int src_y,
+    int src_width,
+    int src_height);
+
+void gcopy_c(
+    int window_id,
+    int src_x,
+    int src_y,
+    int src_width,
+    int src_height,
+    int dst_width,
+    int dst_height);
+
+
 bool getkey(snail::key);
 
 void getstr(
@@ -433,13 +450,6 @@ int ginfo(int type);
 
 
 void gmode(int mode, int width = -1, int height = -1, int alpha = 255);
-
-void grotate_(
-    int window_id,
-    int src_x,
-    int src_y,
-    int dst_width = 0,
-    int dst_height = 0);
 
 void grotate(
     int window_id,

--- a/src/elona.hpp
+++ b/src/elona.hpp
@@ -449,7 +449,10 @@ void getstr(
 int ginfo(int type);
 
 
-void gmode(int mode, int width = -1, int height = -1, int alpha = 255);
+
+void gmode(int mode, int alpha = 255);
+
+
 
 void grotate(
     int window_id,

--- a/src/elona.hpp
+++ b/src/elona.hpp
@@ -455,9 +455,19 @@ void grotate(
     int window_id,
     int src_x,
     int src_y,
-    double angle,
-    int dst_width = 0,
-    int dst_height = 0);
+    int src_width,
+    int src_height,
+    double angle);
+
+void grotate(
+    int window_id,
+    int src_x,
+    int src_y,
+    int src_width,
+    int src_height,
+    int dst_width,
+    int dst_height,
+    double angle);
 
 void gsel(int window_id);
 

--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -12021,7 +12021,7 @@ label_2128_internal:
     if (key_alt == 0)
     {
         pos(x, y - 48);
-        grotate_(3, 212, 432, 28, 28);
+        grotate(3, 212, 432, 0, 28, 28);
         pos(x, y + 48);
         grotate(3, 212, 432, 1.0 * 3.14, 28, 28);
         pos(x + 48, y);
@@ -19569,7 +19569,7 @@ label_2684_internal:
         }
         pos(windoww / 2, y + 4);
         gmode(6, 344, 72, 70);
-        grotate_(3, 456, 144, dx, 72);
+        gcopy_c(3, 456, 144, 344, 72, dx, 72);
     }
     x = 40;
     for (int cnt = 0, cnt_end = (noteinfo()); cnt < cnt_end; ++cnt)
@@ -20173,9 +20173,9 @@ void conquer_lesimas()
     cmbg = 0;
     x = ww / 3 - 20;
     y = wh - 140;
-    gmode(4, 180, 300, 250);
     pos(wx + ww - 120, wy + wh / 2);
-    grotate_(4, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, x, y);
+    gmode(4, 180, 300, 250);
+    gcopy_c(4, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, 180, 300, x, y);
     gmode(2);
     display_topic(lang(u8"制覇までの軌跡"s, u8"Trace"s), wx + 28, wy + 40);
     font(14 - en * 2);
@@ -20459,10 +20459,12 @@ void show_game_score_ranking()
         chara_preparepic(elona::stoi(s(1)));
         pos(x - 22, y + 12);
         gmode(2, chara_chips[p].width, chara_chips[p].height);
-        grotate_(
+        gcopy_c(
             5,
             0,
             960,
+            chara_chips[p].width,
+            chara_chips[p].height,
             chara_chips[p].width / (1 + (chara_chips[p].height > inf_tiles)),
             inf_tiles);
         color(0, 0, 0);

--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -2254,7 +2254,7 @@ void animeload(int prm_807, int prm_808)
     }
     for (int cnt = 0, cnt_end = (i_at_m133); cnt < cnt_end; ++cnt)
     {
-        gmode(2, 96, 96);
+        gmode(2);
         pos(dx_at_m133 + 24, dy_at_m133 + 8);
         grotate(7, cnt * 96, 0, 96, 96, r_at_m133 * cnt);
         gmode(0);
@@ -2359,7 +2359,7 @@ void animeblood(int cc, int animation_type, int element)
     for (int cnt = 0; cnt < 6; ++cnt)
     {
         cnt2_at_m133 = cnt * 2;
-        gmode(2, inf_tiles, inf_tiles);
+        gmode(2);
         if (ele2_at_m133)
         {
             pos(dx_at_m133 - 24, dy_at_m133 - 32 + dy_at_m133(1));
@@ -6121,7 +6121,7 @@ void label_1746()
     set_color_mod(255 - shadow, 255 - shadow, 255 - shadow, 6);
     gcopy(6, 0, 0, 33 * inf_tiles, 25 * inf_tiles);
     set_color_mod(255, 255, 255, 6);
-    gmode(4, -1, -1, 30);
+    gmode(4, 30);
     if (mdata(2) == 0)
     {
         pos(0, 192);
@@ -6139,7 +6139,7 @@ void label_1746()
     }
     gmode(0);
     gsel(0);
-    gmode(2, 24, 24);
+    gmode(2);
     return;
 }
 
@@ -12009,7 +12009,7 @@ int ask_direction()
     t = 0;
 label_2128_internal:
     ++t;
-    gmode(4, 28, 28, 200 - t / 2 % 20 * (t / 2 % 20));
+    gmode(4, 200 - t / 2 % 20 * (t / 2 % 20));
     x = (cdata[0].position.x - scx) * inf_tiles + inf_screenx + 24;
     y = (cdata[0].position.y - scy) * inf_tiles + inf_screeny + 24;
     if (key_alt == 0)
@@ -13886,7 +13886,7 @@ void label_2151()
     msg_halt();
     for (int cnt = 0; cnt < 20; ++cnt)
     {
-        gmode(4, -1, -1, cnt * 10);
+        gmode(4, cnt * 10);
         label_2149();
         await(config::instance().animewait * 10);
     }
@@ -19433,7 +19433,7 @@ label_2682_internal:
         {
             redraw();
             pos(0, 0);
-            gmode(4, -1, -1, cnt * 15);
+            gmode(4, cnt * 15);
             pos(0, 0);
             gcopy(4, 0, 0, windoww, windowh);
             gmode(2);
@@ -19562,7 +19562,7 @@ label_2684_internal:
             dx = 0;
         }
         pos(windoww / 2, y + 4);
-        gmode(6, 344, 72, 70);
+        gmode(6, 70);
         gcopy_c(3, 456, 144, 344, 72, dx, 72);
     }
     x = 40;
@@ -19582,7 +19582,7 @@ label_2684_internal:
         {
             scene_cut = 1;
         }
-        gmode(4, -1, -1, cnt * 16);
+        gmode(4, cnt * 16);
         pos(0, 0);
         gcopy(4, 0, 0, windoww, windowh);
         redraw();
@@ -20168,7 +20168,7 @@ void conquer_lesimas()
     x = ww / 3 - 20;
     y = wh - 140;
     pos(wx + ww - 120, wy + wh / 2);
-    gmode(4, 180, 300, 250);
+    gmode(4, 250);
     gcopy_c(4, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, 180, 300, x, y);
     gmode(2);
     display_topic(lang(u8"制覇までの軌跡"s, u8"Trace"s), wx + 28, wy + 40);
@@ -20452,7 +20452,7 @@ void show_game_score_ranking()
         p = elona::stoi(s(1)) % 1000;
         chara_preparepic(elona::stoi(s(1)));
         pos(x - 22, y + 12);
-        gmode(2, chara_chips[p].width, chara_chips[p].height);
+        gmode(2);
         gcopy_c(
             5,
             0,

--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -2256,7 +2256,7 @@ void animeload(int prm_807, int prm_808)
     {
         gmode(2, 96, 96);
         pos(dx_at_m133 + 24, dy_at_m133 + 8);
-        grotate(7, cnt * 96, 0, r_at_m133 * cnt, 96, 96);
+        grotate(7, cnt * 96, 0, 96, 96, r_at_m133 * cnt);
         gmode(0);
         redraw();
         pos(dx_at_m133 - 24, dy_at_m133 - 40);
@@ -2374,13 +2374,7 @@ void animeblood(int cc, int animation_type, int element)
                         * cnt2_at_m133,
                 dy_at_m133 + y_at_m133(cnt) + cnt2_at_m133 * cnt2_at_m133 / 2
                     - 12 + cnt);
-            grotate(
-                1,
-                0,
-                960,
-                0.2 * cnt,
-                24 - cnt2_at_m133 * 2,
-                24 - cnt2_at_m133 * 2);
+            grotate(1, 0, 960, inf_tiles, inf_tiles, 24 - cnt2_at_m133 * 2, 24 - cnt2_at_m133 * 2, 0.2 * cnt);
         }
         gmode(0);
         redraw();
@@ -12021,22 +12015,22 @@ label_2128_internal:
     if (key_alt == 0)
     {
         pos(x, y - 48);
-        grotate(3, 212, 432, 0, 28, 28);
+        grotate(3, 212, 432, 28, 28, 0);
         pos(x, y + 48);
-        grotate(3, 212, 432, 1.0 * 3.14, 28, 28);
+        grotate(3, 212, 432, 28, 28, 1.0 * 3.14);
         pos(x + 48, y);
-        grotate(3, 212, 432, 0.5 * 3.14, 28, 28);
+        grotate(3, 212, 432, 28, 28, 0.5 * 3.14);
         pos(x - 48, y);
-        grotate(3, 212, 432, 1.5 * 3.14, 28, 28);
+        grotate(3, 212, 432, 28, 28, 1.5 * 3.14);
     }
     pos(x - 48, y - 48);
-    grotate(3, 212, 432, 1.75 * 3.14, 28, 28);
+    grotate(3, 212, 432, 28, 28, 1.75 * 3.14);
     pos(x + 48, y + 48);
-    grotate(3, 212, 432, 0.75 * 3.14, 28, 28);
+    grotate(3, 212, 432, 28, 28, 0.75 * 3.14);
     pos(x + 48, y - 48);
-    grotate(3, 212, 432, 0.25 * 3.14, 28, 28);
+    grotate(3, 212, 432, 28, 28, 0.25 * 3.14);
     pos(x - 48, y + 48);
-    grotate(3, 212, 432, 1.25 * 3.14, 28, 28);
+    grotate(3, 212, 432, 28, 28, 1.25 * 3.14);
     redraw();
     gmode(0);
     pos(x - 48 - 24, y - 48 - 24);

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -390,7 +390,7 @@ bool input_text_dialog(
             }
         }
 
-        gmode(4, -1, -1, p(1) / 2 + 50);
+        gmode(4, p(1) / 2 + 50);
         pos(x + 34 + p(4) * 8, y + 5);
         gcopy(3, 0, 336, 12, 24);
         gmode(2);

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1246,7 +1246,7 @@ label_2181_internal:
         gmode(2);
         pos(wx, wy);
         gcopy(4, 0, 0, ww, wh);
-        gmode(1, inf_tiles, inf_tiles);
+        gmode(1);
         for (int cnt = 0; cnt < 5; ++cnt)
         {
             y = cnt + inv[ci].param2 - 2;

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -77,7 +77,7 @@ main_menu_result_t main_title_menu()
     x = ww / 5 * 4;
     y = wh - 80;
     pos(wx + 160, wy + wh / 2);
-    gmode(4, 180, 300, 50);
+    gmode(4, 50);
     gcopy_c(2, cmbg / 2 * 180, cmbg % 2 * 300, 180, 300, x, y);
     gmode(2);
     if (jp)

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -76,9 +76,9 @@ main_menu_result_t main_title_menu()
     cmbg = 4;
     x = ww / 5 * 4;
     y = wh - 80;
-    gmode(4, 180, 300, 50);
     pos(wx + 160, wy + wh / 2);
-    grotate_(2, cmbg / 2 * 180, cmbg % 2 * 300, x, y);
+    gmode(4, 180, 300, 50);
+    gcopy_c(2, cmbg / 2 * 180, cmbg % 2 * 300, 180, 300, x, y);
     gmode(2);
     if (jp)
     {

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -348,13 +348,10 @@ label_2699_internal:
         {
             gcopy(3, 360, 144, 48, 48);
         }
-        gmode(
-            5 - 1,
-            -1,
-            (t + cnt) % 10 * (t + cnt) % 10 * 12 * ((t + cnt) % 50 < 10));
+        gmode(4, (t + cnt) % 10 * (t + cnt) % 10 * 12 * ((t + cnt) % 50 < 10));
         if (cs == cnt)
         {
-            gmode(5, -1, -1, 140);
+            gmode(5, 140);
         }
         pos(x(cnt) + tx, y(cnt) + ty);
         if (cnt == 0 || cnt == 4 || cnt == 8)
@@ -664,7 +661,7 @@ label_2705_internal:
     x = ww / 5 * 2;
     y = wh - 80;
     pos(wx + ww / 4, wy + wh / 2);
-    gmode(4, 180, 300, 50);
+    gmode(4, 50);
     gcopy_c(p, cmbg % 4 * 180, cmbg / 4 % 2 * 300, 180, 300, x, y);
     gmode(2);
     keyrange = 0;
@@ -1244,7 +1241,7 @@ label_2729_internal:
     x = 240;
     y = 320;
     pos(wx + 190, wy + 220);
-    gmode(4, 180, 300, 100);
+    gmode(4, 100);
     gcopy_c(7, 0, 0, 180, 300, x, y);
     gmode(2);
     keyrange = 0;
@@ -1421,7 +1418,7 @@ label_2029_internal:
         }
         i = list(0, p);
         pos(wx + 40, wy + 74 + cnt * 19);
-        gmode(2, inf_tiles, inf_tiles);
+        gmode(2);
         gcopy_c(
             1,
             (the_ability_db[i]->related_basic_attribute - 10) * inf_tiles,
@@ -1646,7 +1643,7 @@ label_2009_internal:
         }
         i = list(0, p);
         pos(wx + 40, wy + 74 + cnt * 19);
-        gmode(2, inf_tiles, inf_tiles);
+        gmode(2);
         gcopy_c(
             1,
             (the_ability_db[list(0, p)]->related_basic_attribute - 10)
@@ -2209,7 +2206,7 @@ label_20331:
     gsel(0);
     if (returnfromportrait == 0)
     {
-        gmode(6, -1, -1, 80);
+        gmode(6, 80);
         pos(wx + 4, wy + 4);
         gcopy(7, 0, 0, 700, 400);
         gmode(2);
@@ -2357,7 +2354,7 @@ label_2035_internal:
         if (cdata[cc].has_own_sprite() == 1)
         {
             pos(wx + 596 + 22, wy + 86 + 24);
-            gmode(2, 32, 48);
+            gmode(2);
             gcopy_c(10 + cc, 32, 0, 32, 48, 24, 40);
         }
         else
@@ -2365,7 +2362,7 @@ label_2035_internal:
             i = cdata[cc].image % 1000;
             chara_preparepic(cdata[cc]);
             pos(wx + 596 + 22, wy + 86 + 24);
-            gmode(2, chara_chips[i].width, chara_chips[i].height);
+            gmode(2);
             gcopy_c(
                 5,
                 0,
@@ -2407,7 +2404,7 @@ label_2035_internal:
         for (int cnt = 0; cnt < 8; ++cnt)
         {
             pos(wx + 37, wy + 157 + cnt * 15);
-            gmode(2, inf_tiles, inf_tiles);
+            gmode(2);
             gcopy_c(1, cnt * inf_tiles, 672, inf_tiles, inf_tiles);
             pos(wx + 54, wy + 151 + cnt * 15);
             color(20, 10, 0);
@@ -2618,7 +2615,7 @@ label_2035_internal:
             y = wy + 151 + cnt % 3 * 32;
             if (cdata[cc].buffs[cnt].id == 0)
             {
-                gmode(4, -1, -1, 120);
+                gmode(4, 120);
                 pos(x, y);
                 gcopy(3, 320, 160, 32, 32);
                 gmode(2);
@@ -2734,7 +2731,7 @@ label_2035_internal:
                     p(1) = the_ability_db[i]->related_basic_attribute - 10;
                 }
                 pos(wx + 38, wy + 75 + cnt * 19);
-                gmode(2, inf_tiles, inf_tiles);
+                gmode(2);
                 gcopy_c(1, p(1) * inf_tiles, 672, inf_tiles, inf_tiles);
                 s = i18n::_(u8"ability", std::to_string(i), u8"name");
                 if (i >= 50 && i < 100)
@@ -3178,7 +3175,7 @@ label_2052_internal:
             p(2) = inv[p(1)].image;
             prepare_item_image(p(2), inv[p(1)].color, inv[p(1)].param1);
             pos(wx + 126, wy + 70 + cnt * 19);
-            gmode(2, inf_tiles, inf_tiles);
+            gmode(2);
             gcopy_c(
                 1,
                 0,
@@ -3438,7 +3435,7 @@ label_1861_internal:
         p(1) = matref(2, i);
         prepare_item_image(p(1), 0);
         pos(wx + 47, wy + 69 + cnt * 19 + 2);
-        gmode(2, inf_tiles, inf_tiles);
+        gmode(2);
         gcopy_c(
             1,
             0,
@@ -3828,7 +3825,7 @@ label_2041_internal:
     else if (cdata[cc].has_own_sprite() == 1)
     {
         pos(wx + 280, wy + 130);
-        gmode(2, 32, 48);
+        gmode(2);
         gcopy_c(10 + cc, f / 4 % 4 * 32, f / 16 % 4 * 48, 32, 48, 48, 80);
     }
     else
@@ -3836,7 +3833,7 @@ label_2041_internal:
         i = cdata[cc].image % 1000;
         chara_preparepic(cdata[cc]);
         pos(wx + 280, wy + 130);
-        gmode(2, chara_chips[i].width, chara_chips[i].height);
+        gmode(2);
         gcopy_c(5, 0, 960, chara_chips[i].width, chara_chips[i].height);
     }
     gmode(2);
@@ -4071,7 +4068,7 @@ int label_2044()
         }
         window2(wx + 234, wy + 60, 88, 120, 1, 1);
         pos(wx + 280, wy + 120);
-        gmode(2, 32, 48);
+        gmode(2);
         gcopy_c(10 + cc, f / 4 % 4 * 32, f / 16 % 4 * 48, 32, 48, 48, 80);
         gmode(2);
         font(14 - en * 2);
@@ -5578,7 +5575,7 @@ label_1982_internal:
         i(1) = cdata[list(0, p)].image / 1000;
         chara_preparepic(cdata[list(0, p)]);
         pos(wx + 40, wy + 74 + cnt * 19 - 8);
-        gmode(2, chara_chips[i].width, chara_chips[i].height);
+        gmode(2);
         gcopy_c(
             5,
             0,
@@ -5722,7 +5719,7 @@ label_1986_internal:
         i = list(0, p);
         prepare_item_image(429, 0);
         pos(wx + 38, wy + 73 + cnt * 19);
-        gmode(2, inf_tiles, inf_tiles);
+        gmode(2);
         gcopy_c(1, 0, 960, inf_tiles, inf_tiles);
         s = ioriginalnameref(i);
         cs_list(cs == cnt, s, wx + 84, wy + 66 + cnt * 19 - 1);
@@ -5863,7 +5860,7 @@ label_1990_internal:
         i(1) = cdata[list(0, p)].image / 1000;
         chara_preparepic(cdata[list(0, p)]);
         pos(wx + 40, wy + 74 + cnt * 19 - 8);
-        gmode(2, chara_chips[i].width, chara_chips[i].height);
+        gmode(2);
         gcopy_c(
             5,
             0,
@@ -6925,7 +6922,7 @@ label_1961_internal:
             i(1) = cdata[list(0, p)].image / 1000;
             chara_preparepic(cdata[list(0, p)]);
             pos(wx + 40, wy + 74 + cnt * 19 - 8);
-            gmode(2, chara_chips[i].width, chara_chips[i].height);
+            gmode(2);
             gcopy_c(
                 5,
                 0,
@@ -7320,7 +7317,7 @@ label_2016_internal:
     x = ww / 5 * 3;
     y = wh - 80;
     pos(wx + ww / 3 * 2, wy + wh / 2);
-    gmode(4, 180, 300, 50);
+    gmode(4, 50);
     gcopy_c(4, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, 180, 300, x, y);
     gmode(2);
     display_topic(lang(u8"題名"s, u8"Title"s), wx + 28, wy + 36);

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -663,9 +663,9 @@ label_2705_internal:
     cmbg = page % 5;
     x = ww / 5 * 2;
     y = wh - 80;
-    gmode(4, 180, 300, 50);
     pos(wx + ww / 4, wy + wh / 2);
-    grotate_(p, cmbg % 4 * 180, cmbg / 4 % 2 * 300, x, y);
+    gmode(4, 180, 300, 50);
+    gcopy_c(p, cmbg % 4 * 180, cmbg / 4 % 2 * 300, 180, 300, x, y);
     gmode(2);
     keyrange = 0;
     for (int cnt = 0, cnt_end = (pagesize); cnt < cnt_end; ++cnt)
@@ -1243,9 +1243,9 @@ label_2729_internal:
     gcopy(4, 0, 0, 736, 448);
     x = 240;
     y = 320;
-    gmode(4, 180, 300, 100);
     pos(wx + 190, wy + 220);
-    grotate_(7, 0, 0, x, y);
+    gmode(4, 180, 300, 100);
+    gcopy_c(7, 0, 0, 180, 300, x, y);
     gmode(2);
     keyrange = 0;
     for (int cnt = 0, cnt_end = (pagesize); cnt < cnt_end; ++cnt)
@@ -1422,7 +1422,7 @@ label_2029_internal:
         i = list(0, p);
         pos(wx + 40, wy + 74 + cnt * 19);
         gmode(2, inf_tiles, inf_tiles);
-        grotate_(
+        gcopy_c(
             1,
             (the_ability_db[i]->related_basic_attribute - 10) * inf_tiles,
             672,
@@ -1647,7 +1647,7 @@ label_2009_internal:
         i = list(0, p);
         pos(wx + 40, wy + 74 + cnt * 19);
         gmode(2, inf_tiles, inf_tiles);
-        grotate_(
+        gcopy_c(
             1,
             (the_ability_db[list(0, p)]->related_basic_attribute - 10)
                 * inf_tiles,
@@ -2358,7 +2358,7 @@ label_2035_internal:
         {
             pos(wx + 596 + 22, wy + 86 + 24);
             gmode(2, 32, 48);
-            grotate_(10 + cc, 32, 0, 24, 40);
+            gcopy_c(10 + cc, 32, 0, 32, 48, 24, 40);
         }
         else
         {
@@ -2366,10 +2366,12 @@ label_2035_internal:
             chara_preparepic(cdata[cc]);
             pos(wx + 596 + 22, wy + 86 + 24);
             gmode(2, chara_chips[i].width, chara_chips[i].height);
-            grotate_(
+            gcopy_c(
                 5,
                 0,
                 960,
+                chara_chips[i].width,
+                chara_chips[i].height,
                 chara_chips[i].width
                     / (1 + (chara_chips[i].height > inf_tiles)),
                 inf_tiles);
@@ -2406,7 +2408,7 @@ label_2035_internal:
         {
             pos(wx + 37, wy + 157 + cnt * 15);
             gmode(2, inf_tiles, inf_tiles);
-            grotate_(1, cnt * inf_tiles, 672, inf_tiles, inf_tiles);
+            gcopy_c(1, cnt * inf_tiles, 672, inf_tiles, inf_tiles);
             pos(wx + 54, wy + 151 + cnt * 15);
             color(20, 10, 0);
             mes(i18n::_(u8"ui", u8"attribute", u8"_"s + cnt));
@@ -2733,7 +2735,7 @@ label_2035_internal:
                 }
                 pos(wx + 38, wy + 75 + cnt * 19);
                 gmode(2, inf_tiles, inf_tiles);
-                grotate_(1, p(1) * inf_tiles, 672, inf_tiles, inf_tiles);
+                gcopy_c(1, p(1) * inf_tiles, 672, inf_tiles, inf_tiles);
                 s = i18n::_(u8"ability", std::to_string(i), u8"name");
                 if (i >= 50 && i < 100)
                 {
@@ -3177,8 +3179,14 @@ label_2052_internal:
             prepare_item_image(p(2), inv[p(1)].color, inv[p(1)].param1);
             pos(wx + 126, wy + 70 + cnt * 19);
             gmode(2, inf_tiles, inf_tiles);
-            grotate_(
-                1, 0, 960, item_chips[p(2)].width, item_chips[p(2)].height);
+            gcopy_c(
+                1,
+                0,
+                960,
+                inf_tiles,
+                inf_tiles,
+                item_chips[p(2)].width,
+                item_chips[p(2)].height);
             if (showresist)
             {
                 equipinfo(p(1), wx + 320, wy + 60 + cnt * 19 + 2);
@@ -3431,7 +3439,14 @@ label_1861_internal:
         prepare_item_image(p(1), 0);
         pos(wx + 47, wy + 69 + cnt * 19 + 2);
         gmode(2, inf_tiles, inf_tiles);
-        grotate_(1, 0, 960, item_chips[p(1)].width, item_chips[p(1)].height);
+        gcopy_c(
+            1,
+            0,
+            960,
+            inf_tiles,
+            inf_tiles,
+            item_chips[p(1)].width,
+            item_chips[p(1)].height);
     }
     if (keyrange != 0)
     {
@@ -3814,7 +3829,7 @@ label_2041_internal:
     {
         pos(wx + 280, wy + 130);
         gmode(2, 32, 48);
-        grotate_(10 + cc, f / 4 % 4 * 32, f / 16 % 4 * 48, 48, 80);
+        gcopy_c(10 + cc, f / 4 % 4 * 32, f / 16 % 4 * 48, 32, 48, 48, 80);
     }
     else
     {
@@ -3822,7 +3837,7 @@ label_2041_internal:
         chara_preparepic(cdata[cc]);
         pos(wx + 280, wy + 130);
         gmode(2, chara_chips[i].width, chara_chips[i].height);
-        grotate_(5, 0, 960, chara_chips[i].width, chara_chips[i].height);
+        gcopy_c(5, 0, 960, chara_chips[i].width, chara_chips[i].height);
     }
     gmode(2);
     font(14 - en * 2);
@@ -4057,7 +4072,7 @@ int label_2044()
         window2(wx + 234, wy + 60, 88, 120, 1, 1);
         pos(wx + 280, wy + 120);
         gmode(2, 32, 48);
-        grotate_(10 + cc, f / 4 % 4 * 32, f / 16 % 4 * 48, 48, 80);
+        gcopy_c(10 + cc, f / 4 % 4 * 32, f / 16 % 4 * 48, 32, 48, 48, 80);
         gmode(2);
         font(14 - en * 2);
         cs_listbk();
@@ -5564,10 +5579,12 @@ label_1982_internal:
         chara_preparepic(cdata[list(0, p)]);
         pos(wx + 40, wy + 74 + cnt * 19 - 8);
         gmode(2, chara_chips[i].width, chara_chips[i].height);
-        grotate_(
+        gcopy_c(
             5,
             0,
             960,
+            chara_chips[i].width,
+            chara_chips[i].height,
             chara_chips[i].width / (1 + (chara_chips[i].height > inf_tiles)),
             inf_tiles);
         i = list(0, p);
@@ -5706,7 +5723,7 @@ label_1986_internal:
         prepare_item_image(429, 0);
         pos(wx + 38, wy + 73 + cnt * 19);
         gmode(2, inf_tiles, inf_tiles);
-        grotate_(1, 0, 960, inf_tiles, inf_tiles);
+        gcopy_c(1, 0, 960, inf_tiles, inf_tiles);
         s = ioriginalnameref(i);
         cs_list(cs == cnt, s, wx + 84, wy + 66 + cnt * 19 - 1);
         pos(wx + 400, wy + 66 + cnt * 19 + 2);
@@ -5847,10 +5864,12 @@ label_1990_internal:
         chara_preparepic(cdata[list(0, p)]);
         pos(wx + 40, wy + 74 + cnt * 19 - 8);
         gmode(2, chara_chips[i].width, chara_chips[i].height);
-        grotate_(
+        gcopy_c(
             5,
             0,
             960,
+            chara_chips[i].width,
+            chara_chips[i].height,
             chara_chips[i].width / (1 + (chara_chips[i].height > inf_tiles)),
             inf_tiles);
         pos(wx + 84, wy + 66 + cnt * 19 + 2);
@@ -6907,10 +6926,12 @@ label_1961_internal:
             chara_preparepic(cdata[list(0, p)]);
             pos(wx + 40, wy + 74 + cnt * 19 - 8);
             gmode(2, chara_chips[i].width, chara_chips[i].height);
-            grotate_(
+            gcopy_c(
                 5,
                 0,
                 960,
+                chara_chips[i].width,
+                chara_chips[i].height,
                 chara_chips[i].width
                     / (1 + (chara_chips[i].height > inf_tiles)),
                 inf_tiles);
@@ -7298,9 +7319,9 @@ label_2016_internal:
     display_window((windoww - 500) / 2 + inf_screenx, winposy(400), 500, 400);
     x = ww / 5 * 3;
     y = wh - 80;
-    gmode(4, 180, 300, 50);
     pos(wx + ww / 3 * 2, wy + wh / 2);
-    grotate_(4, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, x, y);
+    gmode(4, 180, 300, 50);
+    gcopy_c(4, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, 180, 300, x, y);
     gmode(2);
     display_topic(lang(u8"題名"s, u8"Title"s), wx + 28, wy + 36);
     keyrange = 0;

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -251,7 +251,7 @@ void txt_conv()
             if (config::instance().msgtrans)
             {
                 p_at_txtfunc = (windoww - inf_msgx) / 192;
-                gmode(4, -1, -1, config::instance().msgtrans * 20);
+                gmode(4, config::instance().msgtrans * 20);
                 for (int i = 0; i < p_at_txtfunc + 1; ++i)
                 {
                     if (i == p_at_txtfunc)

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -716,7 +716,7 @@ label_1402_internal:
     x = ww / 5 * 3;
     y = wh - 80;
     pos(wx + ww / 3 * 2, wy + wh / 2);
-    gmode(4, 180, 300, 50);
+    gmode(4, 50);
     gcopy_c(4, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, 180, 300, x, y);
     gmode(2);
     s(0) = lang(u8"投票項目"s, u8"Choice"s);

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -715,9 +715,9 @@ label_1402_internal:
     display_window((windoww - 640) / 2 + inf_screenx, winposy(448), 640, 448);
     x = ww / 5 * 3;
     y = wh - 80;
-    gmode(4, 180, 300, 50);
     pos(wx + ww / 3 * 2, wy + wh / 2);
-    grotate_(4, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, x, y);
+    gmode(4, 180, 300, 50);
+    gcopy_c(4, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, 180, 300, x, y);
     gmode(2);
     s(0) = lang(u8"投票項目"s, u8"Choice"s);
     s(1) = "";

--- a/src/proc_event.cpp
+++ b/src/proc_event.cpp
@@ -684,7 +684,7 @@ void proc_event()
         picload(filesystem::dir::graphic() / u8"bg22.bmp");
         gsel(4);
         pos(windoww / 2 - 1, windowh / 2 - 1);
-        gmode(0, 640, 480);
+        gmode(0);
         gcopy_c(7, 0, 0, 640, 480, windoww + 4, windowh + 4);
         gsel(7);
         picload(filesystem::dir::graphic() / u8"anime9.bmp");
@@ -721,7 +721,7 @@ void proc_event()
                 ++p;
             }
             pos(dx, dy);
-            gmode(4, 192, 48, 255 - p * 5);
+            gmode(4, 255 - p * 5);
             gcopy_c(
                 7,
                 i / 2 % 2 * 192,
@@ -743,7 +743,7 @@ void proc_event()
                 p(1) = i % 3;
             }
             pos(dx, dy - clamp(i * 3 / 2, 0, 18) - 16);
-            gmode(2, 96, 48);
+            gmode(2);
             gcopy_c(
                 7,
                 p(1) * 96,
@@ -758,7 +758,7 @@ void proc_event()
                 ++p(3);
             }
             pos(dx, dy - clamp(p(2) * 2, 0, 40));
-            gmode(4, 96, 96, clamp(p(2) * 6, 0, 100));
+            gmode(4, clamp(p(2) * 6, 0, 100));
             gcopy_c(
                 7,
                 0,
@@ -768,7 +768,7 @@ void proc_event()
                 clamp(p(2) * 8, 0, 240),
                 clamp(p(2) * 5, 0, 96));
             pos(dx, dy - clamp(p(3) * 2, 0, 160) - 6);
-            gmode(4, 96, 96, p(3) * 10);
+            gmode(4, p(3) * 10);
             gcopy_c(
                 7,
                 96,
@@ -778,7 +778,7 @@ void proc_event()
                 clamp(p(3) * 10, 0, 96),
                 clamp(p(3) * 10, 0, 96));
             pos(dx, dy - 4);
-            gmode(4, 192, 80, clamp(p(3) * 5, 0, 100));
+            gmode(4, clamp(p(3) * 5, 0, 100));
             gcopy_c(
                 7,
                 i / 4 % 2 * 192,
@@ -788,7 +788,7 @@ void proc_event()
                 clamp(p(2) * 8, 0, 400),
                 clamp(p(2), 0, 48));
             pos(dx, dy - 48 - clamp(p(3) * 2, 0, 148));
-            gmode(4, 192, 96, p(3) * 10);
+            gmode(4, p(3) * 10);
             gcopy_c(7, i / 3 % 2 * 192, 192, 96, 96, 192, 96);
             redraw();
             await(config::instance().animewait * 3.5);

--- a/src/proc_event.cpp
+++ b/src/proc_event.cpp
@@ -685,7 +685,7 @@ void proc_event()
         gsel(4);
         pos(windoww / 2 - 1, windowh / 2 - 1);
         gmode(0, 640, 480);
-        grotate_(7, 0, 0, windoww + 4, windowh + 4);
+        gcopy_c(7, 0, 0, 640, 480, windoww + 4, windowh + 4);
         gsel(7);
         picload(filesystem::dir::graphic() / u8"anime9.bmp");
         gsel(0);
@@ -720,12 +720,14 @@ void proc_event()
             {
                 ++p;
             }
-            gmode(4, 192, 48, 255 - p * 5);
             pos(dx, dy);
-            grotate_(
+            gmode(4, 192, 48, 255 - p * 5);
+            gcopy_c(
                 7,
                 i / 2 % 2 * 192,
                 408,
+                192,
+                48,
                 clamp(p * 32, 0, 192),
                 clamp(p * 8, 0, 48));
             if (i > 14)
@@ -740,33 +742,54 @@ void proc_event()
             {
                 p(1) = i % 3;
             }
-            gmode(2, 96, 48);
             pos(dx, dy - clamp(i * 3 / 2, 0, 18) - 16);
-            grotate_(
-                7, p(1) * 96, 288, clamp(i * 12, 0, 144), clamp(i * 6, 0, 72));
+            gmode(2, 96, 48);
+            gcopy_c(
+                7,
+                p(1) * 96,
+                288,
+                96,
+                48,
+                clamp(i * 12, 0, 144),
+                clamp(i * 6, 0, 72));
             if (i > 4)
             {
                 ++p(2);
                 ++p(3);
             }
-            gmode(4, 96, 96, clamp(p(2) * 6, 0, 100));
             pos(dx, dy - clamp(p(2) * 2, 0, 40));
-            grotate_(7, 0, 0, clamp(p(2) * 8, 0, 240), clamp(p(2) * 5, 0, 96));
-            gmode(4, 96, 96, p(3) * 10);
+            gmode(4, 96, 96, clamp(p(2) * 6, 0, 100));
+            gcopy_c(
+                7,
+                0,
+                0,
+                96,
+                96,
+                clamp(p(2) * 8, 0, 240),
+                clamp(p(2) * 5, 0, 96));
             pos(dx, dy - clamp(p(3) * 2, 0, 160) - 6);
-            grotate_(
-                7, 96, 0, clamp(p(3) * 10, 0, 96), clamp(p(3) * 10, 0, 96));
-            gmode(4, 192, 80, clamp(p(3) * 5, 0, 100));
+            gmode(4, 96, 96, p(3) * 10);
+            gcopy_c(
+                7,
+                96,
+                0,
+                96,
+                96,
+                clamp(p(3) * 10, 0, 96),
+                clamp(p(3) * 10, 0, 96));
             pos(dx, dy - 4);
-            grotate_(
+            gmode(4, 192, 80, clamp(p(3) * 5, 0, 100));
+            gcopy_c(
                 7,
                 i / 4 % 2 * 192,
                 96,
+                192,
+                80,
                 clamp(p(2) * 8, 0, 400),
                 clamp(p(2), 0, 48));
-            gmode(4, 192, 96, p(3) * 10);
             pos(dx, dy - 48 - clamp(p(3) * 2, 0, 148));
-            grotate_(7, i / 3 % 2 * 192, 96, 192, 96);
+            gmode(4, 192, 96, p(3) * 10);
+            gcopy_c(7, i / 3 % 2 * 192, 192, 96, 96, 192, 96);
             redraw();
             await(config::instance().animewait * 3.5);
         }

--- a/src/set_option.cpp
+++ b/src/set_option.cpp
@@ -561,7 +561,7 @@ void set_option()
         x = ww / 5 * 3;
         y = wh - 80;
         pos(wx + ww / 3, wy + wh / 2);
-        gmode(4, 180, 300, 50);
+        gmode(4, 50);
         gcopy_c(p, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, 180, 300, x, y);
         gmode(2);
         keyrange = 0;

--- a/src/set_option.cpp
+++ b/src/set_option.cpp
@@ -560,9 +560,9 @@ void set_option()
         }
         x = ww / 5 * 3;
         y = wh - 80;
-        gmode(4, 180, 300, 50);
         pos(wx + ww / 3, wy + wh / 2);
-        grotate_(p, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, x, y);
+        gmode(4, 180, 300, 50);
+        gcopy_c(p, cmbg / 4 % 4 * 180, cmbg / 4 / 4 % 2 * 300, 180, 300, x, y);
         gmode(2);
         keyrange = 0;
         for (int cnt = 0, cnt_end = (pagesize); cnt < cnt_end; ++cnt)

--- a/src/snail/hsp.hpp
+++ b/src/snail/hsp.hpp
@@ -53,19 +53,22 @@ void gcopy(
     int dst_height);
 int ginfo(int type);
 void gmode(int mode, int width, int height, int alpha);
-void grotate_(
-    int window_id,
-    int src_x,
-    int src_y,
-    int dst_width,
-    int dst_height);
 void grotate(
     int window_id,
     int src_x,
     int src_y,
-    double angle,
+    int src_width,
+    int src_height,
+    double angle);
+void grotate(
+    int window_id,
+    int src_x,
+    int src_y,
+    int src_width,
+    int src_height,
     int dst_width,
-    int dst_height);
+    int dst_height,
+    double angle);
 void gsel(int window_id);
 void line(int x1, int y1, int x2, int y2, const snail::color& color);
 void title(

--- a/src/snail/hsp.hpp
+++ b/src/snail/hsp.hpp
@@ -52,7 +52,7 @@ void gcopy(
     int dst_width,
     int dst_height);
 int ginfo(int type);
-void gmode(int mode, int width, int height, int alpha);
+void gmode(int mode, int alpha);
 void grotate(
     int window_id,
     int src_x,

--- a/src/snail/hsp/headless.cpp
+++ b/src/snail/hsp/headless.cpp
@@ -77,13 +77,19 @@ void gmode(int, int, int, int)
 {
 }
 
-void grotate_(int, int, int, int, int)
+
+
+void grotate(int, int, int, int, int, int, int, double)
 {
 }
 
-void grotate(int, int, int, double, int, int)
+
+
+void grotate(int, int, int, int, int, double)
 {
 }
+
+
 
 void gsel(int)
 {

--- a/src/snail/hsp/headless.cpp
+++ b/src/snail/hsp/headless.cpp
@@ -73,7 +73,7 @@ int ginfo(int)
     return 0;
 }
 
-void gmode(int, int, int, int)
+void gmode(int, int)
 {
 }
 

--- a/src/snail/hsp/sdl.cpp
+++ b/src/snail/hsp/sdl.cpp
@@ -104,8 +104,6 @@ struct TexBuffer
     snail::color color{0, 0, 0, 255};
     int x = 0;
     int y = 0;
-    int width = 32;
-    int height = 32;
     int mode = 2;
 };
 
@@ -651,13 +649,13 @@ int ginfo(int type)
     }
 }
 
-void gmode(int mode, int width, int height, int alpha)
+
+
+void gmode(int mode, int alpha)
 {
     detail::current_tex_buffer().mode = mode;
     detail::set_blend_mode();
 
-    detail::current_tex_buffer().width = width;
-    detail::current_tex_buffer().height = height;
     detail::current_tex_buffer().color.a = clamp(alpha, 0, 255);
 }
 

--- a/src/snail/hsp/sdl.cpp
+++ b/src/snail/hsp/sdl.cpp
@@ -661,43 +661,51 @@ void gmode(int mode, int width, int height, int alpha)
     detail::current_tex_buffer().color.a = clamp(alpha, 0, 255);
 }
 
-void grotate_(
+
+
+void grotate(
     int window_id,
     int src_x,
     int src_y,
-    int dst_width,
-    int dst_height)
+    int src_width,
+    int src_height,
+    double angle)
 {
-    grotate(window_id, src_x, src_y, 0, dst_width, dst_height);
+    grotate(
+        window_id,
+        src_x,
+        src_y,
+        src_width,
+        src_height,
+        src_width,
+        src_height,
+        angle);
 }
 
-void grotate2(
+
+
+void grotate(
     int window_id,
     int src_x,
     int src_y,
-    double angle,
+    int src_width,
+    int src_height,
     int dst_width,
-    int dst_height)
+    int dst_height,
+    double angle)
 {
+    assert(window_id != detail::current_buffer);
+
     detail::set_blend_mode();
     snail::detail::enforce_sdl(::SDL_SetTextureAlphaMod(
         detail::tex_buffers[window_id].texture,
         detail::current_tex_buffer().color.a));
 
-    if (window_id == detail::current_buffer)
-    {
-        assert(0);
-    }
-
     ::SDL_Rect src_rect{
         src_x,
         src_y,
-        detail::current_tex_buffer().width == -1
-            ? dst_width
-            : detail::current_tex_buffer().width,
-        detail::current_tex_buffer().height == -1
-            ? dst_height
-            : detail::current_tex_buffer().height,
+        src_width,
+        src_height,
     };
     ::SDL_Rect dst_rect{
         detail::current_tex_buffer().x - dst_width / 2,
@@ -731,87 +739,7 @@ void grotate2(
         ::SDL_FLIP_NONE));
 }
 
-void grotate(
-    int window_id,
-    int src_x,
-    int src_y,
-    double angle,
-    int dst_width,
-    int dst_height)
-{
-    if (angle != 0)
-    {
-        grotate2(window_id, src_x, src_y, angle, dst_width, dst_height);
-        return;
-    }
 
-    detail::set_blend_mode();
-    snail::detail::enforce_sdl(::SDL_SetTextureAlphaMod(
-        detail::tex_buffers[window_id].texture,
-        detail::current_tex_buffer().color.a));
-
-    if (window_id == detail::current_buffer)
-    {
-        auto tmp_buffer = detail::get_tmp_buffer(dst_width, dst_height);
-        application::instance().get_renderer().set_render_target(tmp_buffer);
-        if (window_id < 10)
-        {
-            application::instance().get_renderer().set_blend_mode(
-                blend_mode_t::none);
-            application::instance().get_renderer().set_draw_color({0, 0, 0, 0});
-        }
-        else
-        {
-            const auto save =
-                application::instance().get_renderer().blend_mode();
-            application::instance().get_renderer().set_blend_mode(
-                blend_mode_t::none);
-            application::instance().get_renderer().set_draw_color({0, 0, 0, 0});
-            application::instance().get_renderer().set_blend_mode(save);
-        }
-        application::instance().get_renderer().clear();
-        application::instance().get_renderer().render_image(
-            detail::tex_buffers[window_id].texture,
-            src_x,
-            src_y,
-            detail::current_tex_buffer().width == -1
-                ? dst_width
-                : detail::current_tex_buffer().width,
-            detail::current_tex_buffer().height == -1
-                ? dst_height
-                : detail::current_tex_buffer().height,
-            0,
-            0,
-            dst_width,
-            dst_height);
-
-        gsel(window_id);
-        application::instance().get_renderer().render_image(
-            tmp_buffer,
-            0,
-            0,
-            dst_width,
-            dst_height,
-            detail::current_tex_buffer().x - dst_width / 2,
-            detail::current_tex_buffer().y - dst_height / 2);
-        return;
-    }
-
-    application::instance().get_renderer().render_image(
-        detail::tex_buffers[window_id].texture,
-        src_x,
-        src_y,
-        detail::current_tex_buffer().width == -1
-            ? dst_width
-            : detail::current_tex_buffer().width,
-        detail::current_tex_buffer().height == -1
-            ? dst_height
-            : detail::current_tex_buffer().height,
-        detail::current_tex_buffer().x - dst_width / 2,
-        detail::current_tex_buffer().y - dst_height / 2,
-        dst_width,
-        dst_height);
-}
 
 void gsel(int window_id)
 {

--- a/src/std.cpp
+++ b/src/std.cpp
@@ -430,11 +430,26 @@ void grotate(
     int window_id,
     int src_x,
     int src_y,
-    double angle,
+    int src_width,
+    int src_height,
     int dst_width,
-    int dst_height)
+    int dst_height,
+    double angle)
 {
-    snail::hsp::grotate(window_id, src_x, src_y, angle, dst_width, dst_height);
+    snail::hsp::grotate(window_id, src_x, src_y, src_width, src_height, dst_width, dst_height, angle);
+}
+
+
+
+void grotate(
+    int window_id,
+    int src_x,
+    int src_y,
+    int src_width,
+    int src_height,
+    double angle)
+{
+    snail::hsp::grotate(window_id, src_x, src_y, src_width, src_height, angle);
 }
 
 

--- a/src/std.cpp
+++ b/src/std.cpp
@@ -411,9 +411,9 @@ int ginfo(int type)
 
 
 
-void gmode(int mode, int width, int height, int alpha)
+void gmode(int mode, int alpha)
 {
-    snail::hsp::gmode(mode, width, height, alpha);
+    snail::hsp::gmode(mode, alpha);
 }
 
 

--- a/src/std.cpp
+++ b/src/std.cpp
@@ -341,6 +341,30 @@ void gcopy(
 
 
 
+void gcopy_c(int window_id, int src_x, int src_y, int src_width, int src_height)
+{
+    gcopy_c(
+        window_id, src_x, src_y, src_width, src_height, src_width, src_height);
+}
+
+
+
+void gcopy_c(
+    int window_id,
+    int src_x,
+    int src_y,
+    int src_width,
+    int src_height,
+    int dst_width,
+    int dst_height)
+{
+    pos(ginfo(22) - dst_width / 2, ginfo(23) - dst_height / 2);
+    snail::hsp::gcopy(
+        window_id, src_x, src_y, src_width, src_height, dst_width, dst_height);
+}
+
+
+
 bool getkey(snail::key key)
 {
     return snail::input::instance().is_pressed(key);
@@ -398,18 +422,6 @@ template <typename T>
 constexpr T rad2deg(T rad)
 {
     return rad * 180.0 / 3.14159265358979323846264;
-}
-
-
-
-void grotate_(
-    int window_id,
-    int src_x,
-    int src_y,
-    int dst_width,
-    int dst_height)
-{
-    snail::hsp::grotate_(window_id, src_x, src_y, dst_width, dst_height);
 }
 
 

--- a/src/talk.cpp
+++ b/src/talk.cpp
@@ -2143,8 +2143,14 @@ void talk_window_show()
             chara_preparepic(cdata[tc]);
             pos(wx + 82, wy + 125 - chara_chips[p].offset_y);
             gmode(2, chara_chips[p].width, chara_chips[p].height);
-            grotate_(
-                5, 0, 960, chara_chips[p].width * 2, chara_chips[p].height * 2);
+            gcopy_c(
+                5,
+                0,
+                960,
+                chara_chips[p].width,
+                chara_chips[p].height,
+                chara_chips[p].width * 2,
+                chara_chips[p].height * 2);
         }
         else
         {

--- a/src/talk.cpp
+++ b/src/talk.cpp
@@ -2110,7 +2110,7 @@ void talk_window_init()
     wy = winposy(380);
     ww = 600;
     wh = 380;
-    gmode(6, -1, -1, 80);
+    gmode(6, 80);
     pos(wx + 4, wy - 16);
     gcopy(7, 0, 0, 600, 380);
 }
@@ -2142,7 +2142,7 @@ void talk_window_show()
             p(1) = cdata[tc].image / 1000;
             chara_preparepic(cdata[tc]);
             pos(wx + 82, wy + 125 - chara_chips[p].offset_y);
-            gmode(2, chara_chips[p].width, chara_chips[p].height);
+            gmode(2);
             gcopy_c(
                 5,
                 0,

--- a/src/tcg.cpp
+++ b/src/tcg.cpp
@@ -443,14 +443,14 @@ void tcgdrawcard(int prm_994, int prm_995)
             }
             x_at_tcg = basex_at_tcg + 20;
             y_at_tcg = basey_at_tcg + 490;
-            gmode(6, -1, -1, 140);
+            gmode(6, 140);
             pos(x_at_tcg - 6, y_at_tcg - 6);
             gcopy(7, 168, 144, 82, 106);
         }
         gmode(2);
         if (card_at_tcg(6, prm_994) == 2)
         {
-            gmode(4, -1, -1, card_at_tcg(7, prm_994) * 15);
+            gmode(4, card_at_tcg(7, prm_994) * 15);
         }
         pos(x_at_tcg, y_at_tcg);
         if (cdbit(1, prm_994) == 1
@@ -685,7 +685,7 @@ void tcgdraw()
             }
             if (chaintime_at_tcg > 5)
             {
-                gmode(5, -1, -1, clamp(chaintime_at_tcg * 3 - 40, 0, 255));
+                gmode(5, clamp(chaintime_at_tcg * 3 - 40, 0, 255));
                 cnt2_at_tcg = 0;
                 for (int cnt = 0; cnt < 10; ++cnt)
                 {
@@ -732,7 +732,7 @@ void tcgdraw()
                 mes(std::abs(efllist_at_tcg(1, cnt)));
                 color(0, 0, 0);
                 font(13 - en * 2);
-                gmode(5, -1, -1, (efllist_at_tcg(4, cnt) - 30) * 8);
+                gmode(5, (efllist_at_tcg(4, cnt) - 30) * 8);
                 pos(efllist_at_tcg(5, cnt) - 12, efllist_at_tcg(6, cnt) + 10);
                 gcopy(
                     7,
@@ -753,7 +753,7 @@ void tcgdraw()
                 mes(std::abs(efllist_at_tcg(1, cnt)));
                 color(0, 0, 0);
                 font(13 - en * 2);
-                gmode(5, -1, -1, (efllist_at_tcg(4, cnt) - 30) * 8);
+                gmode(5, (efllist_at_tcg(4, cnt) - 30) * 8);
                 pos(efllist_at_tcg(5, cnt), efllist_at_tcg(6, cnt) + 24);
                 gcopy(
                     7,
@@ -2222,12 +2222,12 @@ void label_1824()
         color(0, 0, 0);
         if (ccf_at_tcg == cnt)
         {
-            gmode(4, -1, -1, 255);
+            gmode(4, 255);
             color(255, 255, 255);
         }
         else
         {
-            gmode(4, -1, -1, 120);
+            gmode(4, 120);
             color(200, 200, 200);
         }
         pos(x_at_tcg, y_at_tcg);
@@ -2426,7 +2426,7 @@ void label_1825()
 
 void label_1826()
 {
-    gmode(4, -1, -1, 180);
+    gmode(4, 180);
     for (int cnt = 0; cnt < 2; ++cnt)
     {
         cnt2_at_tcg = cnt;
@@ -3103,10 +3103,10 @@ void label_1840()
             {
                 continue;
             }
-            gmode(4, 0, 0, clamp(p_at_tcg * 30 + 20, 0, 255));
+            gmode(4, clamp(p_at_tcg * 30 + 20, 0, 255));
             pos(x_at_tcg(cnt), y_at_tcg(cnt));
             gcopy(7, 192, 96, 36, 36);
-            gmode(4, 0, 0, 50 + i_at_tcg * 2);
+            gmode(4, 50 + i_at_tcg * 2);
             pos(x_at_tcg(cnt) + 13, y_at_tcg(cnt) + 11);
             gcopy(7, 336 + (cnt == 2) * 12, 96 + cnt % 2 * 24, 12, 12);
         }

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1207,7 +1207,7 @@ void render_hud()
     }
     pos(inf_clockarrowx, inf_clockarrowy);
     gmode(2, 48, 48);
-    grotate(3, 0, 288, 0.0174532925199433 * (gdata_hour * 30), 48, 48);
+    grotate(3, 0, 288, 48, 48, 0.0174532925199433 * (gdata_hour * 30));
     pos(inf_clockw - 3, inf_clocky + 17 + vfix);
     mes(""s + gdata_year + u8"/"s + gdata_month + u8"/"s + gdata_day);
     bmes(
@@ -1318,7 +1318,7 @@ void render_autoturn_animation()
     bmes(u8"AUTO TURN"s, sx + 43, sy + 6, {235, 235, 235});
     pos(sx + 18, sy + 12);
     gmode(2, 24, 24);
-    grotate(3, 72, 392, 0.0174532925199433 * (gdata_minute / 4 % 2 * 90));
+    grotate(3, 72, 392, 24, 24, 0.0174532925199433 * (gdata_minute / 4 % 2 * 90));
 
     if (cdata[0].continuous_action_id == 9 || cdata[0].continuous_action_id == 5
         || cdata[0].continuous_action_id == 8
@@ -1965,13 +1965,13 @@ void render_fishing_animation()
     {
         gmode(2, 48, 24);
         pos(sx + sx2, sy + sy2);
-        grotate(9, 0, 24, 0.5 * fishdir * 3.14, 48, 24);
+        grotate(9, 0, 24, 48, 24, 0.5 * fishdir * 3.14);
     }
     else
     {
         gmode(2, 48, 48);
         pos(sx + sx2, sy + sy2);
-        grotate(9, 0, 0, 0.5 * fishdir * 3.14, 48, 48);
+        grotate(9, 0, 0, 48, 48, 0.5 * fishdir * 3.14);
     }
     randomize();
 }

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1847,11 +1847,17 @@ void label_1445()
             {
                 dx = mdata(0);
             }
+            ap = map(dx, dy, 0);
             pos(x * evtiles, y * evtiles);
             gmode(0, inf_tiles, inf_tiles);
-            ap = map(dx, dy, 0);
-            grotate_(
-                2, ap % 33 * inf_tiles, ap / 33 * inf_tiles, evtiles, evtiles);
+            gcopy_c(
+                2,
+                ap % 33 * inf_tiles,
+                ap / 33 * inf_tiles,
+                inf_tiles,
+                inf_tiles,
+                evtiles,
+                evtiles);
         }
     }
 }
@@ -1930,16 +1936,17 @@ void render_fishing_animation()
     {
         sx2 = inf_tiles / 2 + rnd(3) - 1;
         sy2 = inf_tiles / 2 + 12;
-        gmode(2, 48, 48);
         pos(sx + sx2 + 1, sy + sy2 + 40);
-        grotate_(9, 48, 0, 48, 48);
+        gmode(2, 48, 48);
+        gcopy_c(9, 48, 0, 48, 48);
     }
     if (fishdir == 1)
     {
         sx2 = inf_tiles / 2 - 26;
         sy2 = inf_tiles / 2 - 12 + rnd(3) - 3;
         pos(sx + sx2 - 16, sy + sy2 + 25);
-        grotate_(9, 48, 0, 48, 48);
+        gmode(2, 48, 48);
+        gcopy_c(9, 48, 0, 48, 48);
     }
     if (fishdir == 2)
     {
@@ -1951,7 +1958,8 @@ void render_fishing_animation()
         sx2 = inf_tiles / 2 + 26;
         sy2 = inf_tiles / 2 - 12 + rnd(3) - 3;
         pos(sx + sx2 + 14, sy + sy2 + 25);
-        grotate_(9, 48, 0, 48, 48);
+        gmode(2, 48, 48);
+        gcopy_c(9, 48, 0, 48, 48);
     }
     if (fishdir == 2)
     {
@@ -2582,7 +2590,7 @@ void window2(
     case 6:
         pos(x + width / 2, y + height / 2);
         gmode(4, 228, 144, 180);
-        grotate_(3, 24, 72, width - 4, height - 4);
+        gcopy_c(3, 24, 72, 228, 144, width - 4, height - 4);
         break;
     default: break;
     }

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -188,7 +188,7 @@ void render_weather_effect_snow()
         auto&& particle = particles[i];
         if (i % 30 == 0)
         {
-            gmode(4, 8, 8, 100 + i % 150);
+            gmode(4, 100 + i % 150);
         }
         pos(particle.x, particle.y);
         gcopy(3, particle.x % 2 * 8, 600 + i % 6 * 8, 8, 8);
@@ -227,7 +227,7 @@ void render_weather_effect_etherwind()
         auto&& particle = particles[i];
         if (i % 20 == 0)
         {
-            gmode(4, 8, 8, 100 + i % 150);
+            gmode(4, 100 + i % 150);
         }
         pos(particle.x, particle.y);
         gcopy(3, 16 + particle.x % 2 * 8, 600 + i % 6 * 8, 8, 8);
@@ -317,7 +317,7 @@ void highlight_characters_in_pet_arena()
                 color);
             if (cc == camera)
             {
-                gmode(4, -1, -1, 120);
+                gmode(4, 120);
                 pos(x + 36, y + 32);
                 gcopy(3, 240, 410, 24, 16);
                 gmode(2);
@@ -802,7 +802,7 @@ void render_hud()
             {
                 if (cdata[0].continuous_action_id == 0)
                 {
-                    gmode(4, -1, -1, 150);
+                    gmode(4, 150);
                 }
             }
         }
@@ -1186,7 +1186,7 @@ void render_hud()
     gcopy(3, 448, 408, inf_clockw, inf_clockh);
     pos(inf_clockx + 78, inf_clocky + 8);
     gcopy(3, 448, 376, 128, 24);
-    gmode(4, -1, -1, 180);
+    gmode(4, 180);
     sx = windoww - 40;
     sy = inf_ver - 40;
     for (int cnt = 0; cnt < 16; ++cnt)
@@ -1206,7 +1206,7 @@ void render_hud()
         sy -= 32;
     }
     pos(inf_clockarrowx, inf_clockarrowy);
-    gmode(2, 48, 48);
+    gmode(2);
     grotate(3, 0, 288, 48, 48, 0.0174532925199433 * (gdata_hour * 30));
     pos(inf_clockw - 3, inf_clocky + 17 + vfix);
     mes(""s + gdata_year + u8"/"s + gdata_month + u8"/"s + gdata_day);
@@ -1317,7 +1317,7 @@ void render_autoturn_animation()
     font(13 - en * 2, snail::font_t::style_t::bold);
     bmes(u8"AUTO TURN"s, sx + 43, sy + 6, {235, 235, 235});
     pos(sx + 18, sy + 12);
-    gmode(2, 24, 24);
+    gmode(2);
     grotate(3, 72, 392, 24, 24, 0.0174532925199433 * (gdata_minute / 4 % 2 * 90));
 
     if (cdata[0].continuous_action_id == 9 || cdata[0].continuous_action_id == 5
@@ -1777,7 +1777,7 @@ void fade_out()
     }
     for (int cnt = 0; cnt < 30; ++cnt)
     {
-        gmode(4, 0, 0, 10 + cnt * 5);
+        gmode(4, 10 + cnt * 5);
         await(20);
         pos(0, 0);
         gcopy(4, 0, 0, windoww, windowh);
@@ -1804,7 +1804,7 @@ void animation_fade_in()
 {
     for (int cnt = 0; cnt < 30; ++cnt)
     {
-        gmode(4, 0, 0, 10 + cnt * 5);
+        gmode(4, 10 + cnt * 5);
         await(20);
         pos(0, 0);
         gcopy(4, 0, 0, windoww, windowh);
@@ -1849,7 +1849,7 @@ void label_1445()
             }
             ap = map(dx, dy, 0);
             pos(x * evtiles, y * evtiles);
-            gmode(0, inf_tiles, inf_tiles);
+            gmode(0);
             gcopy_c(
                 2,
                 ap % 33 * inf_tiles,
@@ -1931,13 +1931,13 @@ void render_fishing_animation()
     gcopy(9, 116, 18, 14, 10 - ap);
     sx = (cdata[0].position.x - scx) * inf_tiles + inf_screenx;
     sy = (cdata[0].position.y - scy) * inf_tiles + inf_screeny;
-    gmode(2, 48, 48);
+    gmode(2);
     if (fishdir == 0)
     {
         sx2 = inf_tiles / 2 + rnd(3) - 1;
         sy2 = inf_tiles / 2 + 12;
         pos(sx + sx2 + 1, sy + sy2 + 40);
-        gmode(2, 48, 48);
+        gmode(2);
         gcopy_c(9, 48, 0, 48, 48);
     }
     if (fishdir == 1)
@@ -1945,7 +1945,7 @@ void render_fishing_animation()
         sx2 = inf_tiles / 2 - 26;
         sy2 = inf_tiles / 2 - 12 + rnd(3) - 3;
         pos(sx + sx2 - 16, sy + sy2 + 25);
-        gmode(2, 48, 48);
+        gmode(2);
         gcopy_c(9, 48, 0, 48, 48);
     }
     if (fishdir == 2)
@@ -1958,18 +1958,18 @@ void render_fishing_animation()
         sx2 = inf_tiles / 2 + 26;
         sy2 = inf_tiles / 2 - 12 + rnd(3) - 3;
         pos(sx + sx2 + 14, sy + sy2 + 25);
-        gmode(2, 48, 48);
+        gmode(2);
         gcopy_c(9, 48, 0, 48, 48);
     }
     if (fishdir == 2)
     {
-        gmode(2, 48, 24);
+        gmode(2);
         pos(sx + sx2, sy + sy2);
         grotate(9, 0, 24, 48, 24, 0.5 * fishdir * 3.14);
     }
     else
     {
-        gmode(2, 48, 48);
+        gmode(2);
         pos(sx + sx2, sy + sy2);
         grotate(9, 0, 0, 48, 48, 0.5 * fishdir * 3.14);
     }
@@ -2102,7 +2102,7 @@ void display_customkey(const std::string& key, int x, int y)
     pos(624, 30);
     gcopy(3, 0, 30, 24, 18);
     bmes(key, 629, 31, {250, 240, 230}, {50, 60, 80});
-    gmode(2, inf_tiles, inf_tiles);
+    gmode(2);
     gsel(0);
     pos(x, y);
     gcopy(3, 624, 30, 24, 18);
@@ -2197,7 +2197,7 @@ void drawmenu(int prm_742)
         gcopy(3, 288 + p(cnt) * 48, 48, 48, 48);
         if (curmenu == cnt)
         {
-            gmode(5, -1, -1, 70);
+            gmode(5, 70);
             pos(x_at_m107 + cnt * 50 + 20, y_at_m107 - 24);
             gcopy(3, 288 + p(cnt) * 48, 48, 48, 48);
             gmode(2);
@@ -2428,7 +2428,7 @@ void showscroll(const std::string& title, int x, int y, int width, int height)
 {
     if (windowshadow != 0)
     {
-        gmode(6, -1, -1, 80);
+        gmode(6, 80);
         draw_scroll(x + 3, y + 3, width, height);
         windowshadow = 0;
         gmode(2);
@@ -2471,7 +2471,7 @@ void window(int x, int y, int width, int height, bool shadow)
 {
     if (shadow)
     {
-        gmode(2, -1, -1, 127);
+        gmode(2, 127);
         set_color_mod(31, 31, 31, 3);
     }
     else
@@ -2589,13 +2589,13 @@ void window2(
     case 5: break;
     case 6:
         pos(x + width / 2, y + height / 2);
-        gmode(4, 228, 144, 180);
+        gmode(4, 180);
         gcopy_c(3, 24, 72, 228, 144, width - 4, height - 4);
         break;
     default: break;
     }
 
-    gmode(2, 16, 16);
+    gmode(2);
     for (int cnt = 0, cnt_end = (width / 16 - 2); cnt < cnt_end; ++cnt)
     {
         pos(cnt * 16 + x + 16, y);


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

#603 


# Summary

Reduces global states and explicit parameters.

- Add `gcopy_c()`, a variation of `gcopy()`.
- Organize `grotate()`'s signature.
- Delete width/height from `gmode()`'s parameters.
