### PR TITLE
Allow number rollover in number input prompt

### DIFF
--- a/src/ctrl_inventory.cpp
+++ b/src/ctrl_inventory.cpp
@@ -1098,7 +1098,6 @@ label_2061_internal:
                 txt(i18n::s.get("core.locale.ui.inv.drop.how_many",
                                 inv[ci].number, inv[ci]));
                 display_msg(screenmsgy, 1);
-                inputlog = ""s + inv[ci].number;
                 input_number_dialog(
                     (windoww - 200) / 2 + inf_screenx,
                     winposy(60),
@@ -1226,7 +1225,6 @@ label_2061_internal:
                                     inv[ci].number, inv[ci]));
                 }
                 display_msg(screenmsgy, 2);
-                inputlog = ""s + inv[ci].number;
                 input_number_dialog(
                     (windoww - 200) / 2 + inf_screenx,
                     winposy(60),

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -160,13 +160,18 @@ void input_number_dialog(int x, int y, int max_number)
     dx = 8 * 16 + 60;
     font(16 - en * 2);
 
+    if (max_number < 1)
+    {
+        max_number = 1;
+    }
     int number = max_number;
     if (strlen_u(std::to_string(max_number)) >= 3)
     {
         dx += strlen_u(std::to_string(max_number)) * 8;
     }
     boxf(x + 24, y + 4, dx - 42, 35, {0, 0, 0, 127});
-    while (1)
+    inputlog = std::to_string(number);
+    while (true)
     {
         window2(x + 20, y, dx - 40, 36, 0, 2);
         draw("label_input", x + dx / 2 - 56, y - 32);
@@ -174,7 +179,7 @@ void input_number_dialog(int x, int y, int max_number)
         gcopy(3, 312, 336, 24, 24);
         pos(x + dx - 51, y + 4);
         gcopy(3, 336, 336, 24, 24);
-        const auto inputlog2 = inputlog + u8"(" + max_number + u8")";
+        const std::string inputlog2 = inputlog + u8"(" + max_number + u8")";
         pos(x + dx - 70 - strlen_u(inputlog2) * 8 + 8, y + 11);
         color(255, 255, 255);
         mes(inputlog2);
@@ -224,39 +229,39 @@ void input_number_dialog(int x, int y, int max_number)
         {
             snd(5);
             number -= 100;
-            if (number < 1)
+            while (number < 1)
             {
-                number = 1;
+                number += max_number;
             }
         }
         if (key == key_northeast)
         {
             snd(5);
             number += 100;
-            if (number > max_number)
+            while (number > max_number)
             {
-                number = max_number;
+                number -= max_number;
             }
         }
         if (key == key_southwest)
         {
             snd(5);
             number -= 10;
-            if (number < 1)
+            while (number < 1)
             {
-                number = 1;
+                number += max_number;
             }
         }
         if (key == key_southeast)
         {
             snd(5);
             number += 10;
-            if (number > max_number)
+            while (number > max_number)
             {
-                number = max_number;
+                number -= max_number;
             }
         }
-        inputlog = ""s + number;
+        inputlog = std::to_string(number);
     }
     if (f == -1)
     {

--- a/src/lua_env/lua_api.cpp
+++ b/src/lua_env/lua_api.cpp
@@ -738,9 +738,9 @@ bool Input::yes_no(const std::string& message)
 
 sol::optional<int> Input::prompt_number(const std::string& message, int max)
 {
-    if (max < 0)
+    if (max < 1)
     {
-        throw sol::error("Input.prompt_number called with max < 0");
+        throw sol::error("Input.prompt_number called with max < 1");
     }
 
     txt(message + " ");


### PR DESCRIPTION
# Related Issues

Close #667.

# Summary
Allows numbers to roll over in number input prompt. Also adds more validation to the input function.

# Playtest script
```lua
local Event = Elona.require("Event")
local Item = Elona.require("Item")
local Enums = Elona.require("Enums")
local GUI = Elona.require("GUI")
local Input = Elona.require("Input")
local Chara = Elona.require("Chara")

local function make_sandbag(x, y, chara_id)
   Item.create(x, y, 733, 1)
   local chara = Chara.create(x, y, chara_id)
   chara:set_flag(Enums.CharaFlag.IsHungOnSandBag, true)
   return chara
end

local function prompt(max)
   local result = Input.prompt_number("Which number?", max)

   if result then
      GUI.txt("Result: " .. result .. " ")
   else
      GUI.txt("Never mind. ")
   end
end

local function handle_chara_damaged(chara)
   if not Store.map_local.chara then
      return
   end

   prompt(1)
   prompt(2)
   prompt(2000)
end

local function setup()
   Store.map_local.chara = make_sandbag(25, 28, 3)
end

Event.register(Event.EventKind.CharaDamaged, handle_chara_damaged)
Event.register(Event.EventKind.ScriptLoaded, setup)

```