### PR TITLE
Replace message mark widthwise instead of bytewise

### DIFF
--- a/doc/api/gui.luadoc
+++ b/doc/api/gui.luadoc
@@ -6,6 +6,9 @@ module "GUI"
 -- @tparam string message the message to print
 function txt(message) end
 
+--- Starts a new message line in the HUD message window.
+function txtnew() end
+
 --- Sets the color of the text printed with GUI.txt.
 --- Valid colors are 0 - 20.
 --- 0 - white

--- a/src/lua_env/lua_api.cpp
+++ b/src/lua_env/lua_api.cpp
@@ -803,6 +803,7 @@ void Input::bind(sol::table& Elona)
 namespace GUI
 {
 void txt(const std::string&);
+void txtnew();
 void txt_color(int);
 
 void bind(sol::table&);
@@ -811,6 +812,11 @@ void bind(sol::table&);
 void GUI::txt(const std::string& message)
 {
     elona::txt(message);
+}
+
+void GUI::txtnew()
+{
+    elona::txtnew();
 }
 
 void GUI::txt_color(int color)
@@ -826,6 +832,7 @@ void GUI::bind(sol::table& Elona)
 {
     sol::table GUI = Elona.create_named("GUI");
     GUI.set_function("txt", GUI::txt);
+    GUI.set_function("txtnew", GUI::txtnew);
     GUI.set_function("txt_color", GUI::txt_color);
 }
 

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -29,20 +29,24 @@ void msg_write(std::string& message)
 {
     constexpr const auto musical_note = u8"♪";
 
-    for (auto pos = message.find(musical_note); pos != std::string::npos;
-         pos = message.find(musical_note))
+    for (auto pos = strutil::find_widthwise(message, musical_note);
+         pos.first != std::string::npos;
+         pos = strutil::find_widthwise(message, musical_note))
     {
+        auto bytewise_pos = pos.first;
+        auto widthwise_pos = pos.second;
+
         const auto symbol_type =
-            elona::stoi(message.substr(pos + std::strlen(musical_note), 1));
+            elona::stoi(message.substr(bytewise_pos + std::strlen(musical_note), 1));
         if (jp && symbol_type == 0)
         {
             break;
         }
-        message = message.substr(0, pos) + u8"  "
+        message = message.substr(0, bytewise_pos) + u8"  "
             + message.substr(
-                  pos + std::strlen(musical_note) + (symbol_type != 0));
+                  bytewise_pos + std::strlen(musical_note) + (symbol_type != 0));
         elona::pos(
-            (message_width + pos) * inf_mesfont / 2 + inf_msgx + 7 + en * 3,
+            (message_width + widthwise_pos) * inf_mesfont / 2 + inf_msgx + 7 + en * 3,
             (inf_msgline - 1) * inf_msgspace + inf_msgy + 5);
         gmode(2);
         gcopy(3, 600 + symbol_type * 24, 360, 16, 16);

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -110,6 +110,28 @@ inline size_t byte_count(char c)
 
 
 
+inline std::pair<size_t, size_t>
+find_widthwise(std::string str, std::string pattern)
+{
+    size_t w{};
+    auto pos = str.find(pattern);
+    if (pos == std::string::npos)
+        return std::pair<size_t, size_t>(std::string::npos, std::string::npos);
+
+    for (size_t i = 0; i < pos;)
+    {
+        const auto byte = byte_count(str[i]);
+        const auto char_width = byte == 1 ? 1 : 2;
+
+        i += byte;
+        w += char_width;
+    }
+
+    return std::pair<size_t, size_t>(pos, w);
+}
+
+
+
 inline std::string take_by_width(const std::string& str, size_t width)
 {
     size_t w{};


### PR DESCRIPTION
# Related Issues

Close #666.

# Summary
Replaces marks in messages by width instead of byte. Japanese characters in UTF-8 could be composed of 3 bytes, causing printing by byte position to drift.

# Playtest script
```lua
local Event = Elona.require("Event")
local Rand = Elona.require("Rand")
local GUI = Elona.require("GUI")

local function message_en()
   local text = "\""
   for i=0, Rand.rnd(5) do
      text = text .. "hmm"
   end
   text = text .. "♪1\""

   GUI.txt(text)
end

local function message()
   local text = "「"
   for i=0, Rand.rnd(5) do
      text = text .. "ふ〜ん"
   end
   text = text .. "♪1」"

   GUI.txt(text)
end

Event.register(Event.EventKind.AllTurnsFinished, message)
Event.register(Event.EventKind.AllTurnsFinished, message_en)
```