### PR TITLE
[WIP] Load mods besides "core"

### DIFF
--- a/doc/api/event_eventkind.luadoc
+++ b/doc/api/event_eventkind.luadoc
@@ -7,8 +7,9 @@
 -- Event.register(Event.EventKind.CharaMoved, my_chara_moved_handler)
 module "Event.EventKind"
 
---- Fired after the game has finished initially loading.
---- This will only ever be fired once per game session.
+--- Fired after the game has finished initially loading. This will
+--- only ever be fired once per game session. The starting map will be
+--- initialized before this is called.
 -- @event GameInitialized
 
 --- Fired after a map has been initially created.
@@ -87,6 +88,9 @@ module "Event.EventKind"
 
 --- Fired before the current map is unloaded.
 -- @event MapUnloading
+
+--- Fired when all mods have finished loading.
+-- @event AllModsLoaded
 
 --- Fired when the startup script finished loading. This is only valid
 --- when the startup script feature is used.

--- a/runtime/mods/kiroku/init.lua
+++ b/runtime/mods/kiroku/init.lua
@@ -1,0 +1,28 @@
+local Event = Elona.require("Event")
+local GUI = Elona.require("GUI")
+
+local function on_chara_killed()
+   Store.global.killed = Store.global.killed + 1
+   if Store.global.report then
+      GUI.txt("Killed: " .. Store.global.killed .. " so far. ")
+   end
+end
+
+local function on_map_initialized()
+   GUI.txt("You've killed " .. Store.global.killed .. " things so far. ")
+end
+
+local function init_store()
+   if not Store.killed then
+      Store.global.killed = 0
+   end
+   Store.global.report = true
+end
+
+Event.register(Event.EventKind.CharaKilled, on_chara_killed)
+Event.register(Event.EventKind.MapInitialized, on_map_initialized)
+Event.register(Event.EventKind.GameInitialized, init_store)
+
+return {
+   Store = Store
+}

--- a/runtime/mods/kiroku/init.lua
+++ b/runtime/mods/kiroku/init.lua
@@ -9,14 +9,16 @@ local function on_chara_killed()
 end
 
 local function on_map_initialized()
-   GUI.txt("You've killed " .. Store.global.killed .. " things so far. ")
+   if Store.global.report then
+      GUI.txt("You've killed " .. Store.global.killed .. " things so far. ")
+   end
 end
 
 local function init_store()
-   if not Store.killed then
+   if not Store.global.killed then
       Store.global.killed = 0
    end
-   Store.global.report = true
+   Store.global.report = false
 end
 
 Event.register(Event.EventKind.CharaKilled, on_chara_killed)

--- a/runtime/mods/kiroku/init.lua
+++ b/runtime/mods/kiroku/init.lua
@@ -21,7 +21,7 @@ end
 
 Event.register(Event.EventKind.CharaKilled, on_chara_killed)
 Event.register(Event.EventKind.MapInitialized, on_map_initialized)
-Event.register(Event.EventKind.GameInitialized, init_store)
+Event.register(Event.EventKind.AllModsLoaded, init_store)
 
 return {
    Store = Store

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -771,8 +771,9 @@ int run()
     init_assets();
     initialize_elona();
 
-    lua::lua->scan_all_mods(filesystem::dir::mods());
-    lua::lua->load_core_mod(filesystem::dir::mods());
+    lua::lua.scan_all_mods(filesystem::dir::mods());
+    lua::lua.load_core_mod();
+    lua::lua.load_all_mods();
 
     start_elona();
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -771,7 +771,7 @@ int run()
     init_assets();
     initialize_elona();
 
-    lua::lua.scan_all_mods(filesystem::dir::mods());
+    lua::lua->scan_all_mods(filesystem::dir::mods());
 
     start_elona();
 
@@ -1119,8 +1119,8 @@ void initialize_game()
     bool script_loaded = false;
     autopick::instance().load(playerid);
 
-    lua::lua.load_core_mod();
-    lua::lua.load_all_mods();
+    lua::lua->load_core_mod();
+    lua::lua->load_all_mods();
 
     mtilefilecur = -1;
     firstturn = 1;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -772,8 +772,6 @@ int run()
     initialize_elona();
 
     lua::lua.scan_all_mods(filesystem::dir::mods());
-    lua::lua.load_core_mod();
-    lua::lua.load_all_mods();
 
     start_elona();
 
@@ -1120,6 +1118,9 @@ void initialize_game()
 {
     bool script_loaded = false;
     autopick::instance().load(playerid);
+
+    lua::lua.load_core_mod();
+    lua::lua.load_all_mods();
 
     mtilefilecur = -1;
     firstturn = 1;

--- a/src/lua_env/event_manager.cpp
+++ b/src/lua_env/event_manager.cpp
@@ -52,6 +52,8 @@ void init_event_kinds(sol::table& Event)
         "AllTurnsFinished",
         event_kind_t::all_turns_finished,
 
+        "AllModsLoaded",
+        event_kind_t::all_mods_loaded,
         "ScriptLoaded",
         event_kind_t::script_loaded);
 }

--- a/src/lua_env/event_manager.hpp
+++ b/src/lua_env/event_manager.hpp
@@ -50,6 +50,7 @@ enum class event_kind_t : unsigned
     player_turn,
     all_turns_finished,
 
+    all_mods_loaded,
     script_loaded,
 
     COUNT // for iterating over all event kinds
@@ -161,7 +162,6 @@ public:
             {
                 sol::error err = result;
                 error_handler_(err.what());
-                return;
             }
         }
     }
@@ -178,6 +178,7 @@ public:
             {
                 sol::error err = result;
                 error_handler_(err.what());
+                // TODO: Don't prevent later callbacks from running?
                 return none;
             }
             else

--- a/src/lua_env/lua_api.cpp
+++ b/src/lua_env/lua_api.cpp
@@ -1179,6 +1179,7 @@ void Debug::report_error(const std::string& message)
     }
 
     ELONA_LOG("Script error: " << message);
+    std::cerr << "Script error: " << message << std::endl;
 }
 
 void Debug::dump_characters()

--- a/src/lua_env/lua_api.cpp
+++ b/src/lua_env/lua_api.cpp
@@ -1634,7 +1634,12 @@ sol::optional<sol::table> api_manager::try_find_api(
     return result;
 }
 
-void api_manager::load_core(lua_env& lua, const fs::path& mods_dir)
+void api_manager::add_api(const std::string& module_namespace, sol::table& module_table)
+{
+    api_env["Elona"][module_namespace] = module_table;
+}
+
+void api_manager::load_core(lua_env& lua, const fs::path& core_mod_dir)
 {
     // Don't load the core mod again if it's already loaded, because
     // all the tables will be read-only.
@@ -1644,7 +1649,7 @@ void api_manager::load_core(lua_env& lua, const fs::path& mods_dir)
     }
 
     auto result = lua.get_state()->safe_script_file(
-        filesystem::make_preferred_path_in_utf8(mods_dir / "core" / "init.lua"),
+        filesystem::make_preferred_path_in_utf8(core_mod_dir / "init.lua"),
         api_env);
     if (!result.valid())
     {

--- a/src/lua_env/lua_api.hpp
+++ b/src/lua_env/lua_api.hpp
@@ -65,6 +65,13 @@ public:
         const std::string& module_name);
 
     /***
+     * Adds a new API from the return value of a mod's init.lua file.
+     * It would then be accessable by calling
+     * Elona.require("mod_name", "api_table").
+     */
+    void add_api(const std::string& module_namespace, sol::table& module_table);
+
+    /***
      * Returns the reference to the core API table "Elona" in the API
      * environment. This is so other internal C++ mechanisms can add
      * their own API methods to it.

--- a/src/lua_env/lua_env.cpp
+++ b/src/lua_env/lua_env.cpp
@@ -171,24 +171,33 @@ end
 }
 
 
-void lua_env::load_mod(const fs::path& path, mod_info& mod)
+void lua_env::load_mod(mod_info& mod)
 {
     setup_and_lock_mod_globals(mod);
 
-    auto result = this->lua->safe_script_file(
-        filesystem::make_preferred_path_in_utf8(path / mod.name / "init.lua"),
-        mod.env);
-    if (!result.valid())
+    if (mod.path) // Skip initializing mods not created from files.
     {
-        sol::error err = result;
-        report_error(err);
-        throw std::runtime_error("Failed initializing mod "s + mod.name);
+        auto result = this->lua->safe_script_file(
+            filesystem::make_preferred_path_in_utf8(*mod.path / u8"init.lua"s),
+            mod.env);
+        if (result.valid())
+        {
+            sol::table api_table = result.get<sol::table>();
+            api_mgr->add_api(mod.name, api_table);
+        }
+        else
+        {
+            sol::error err = result;
+            report_error(err);
+            throw std::runtime_error("Failed initializing mod "s + mod.name);
+        }
     }
 }
 
 void lua_env::scan_all_mods(const fs::path& mods_dir)
 {
-    if (stage != mod_loading_stage_t::not_started)
+    if (stage != mod_loading_stage_t::not_started
+          && stage != mod_loading_stage_t::scan_finished)
     {
         throw std::runtime_error("Mods have already been scanned!");
     }
@@ -210,14 +219,14 @@ void lua_env::scan_all_mods(const fs::path& mods_dir)
             }
 
             std::unique_ptr<mod_info> info =
-                std::make_unique<mod_info>(mod_name, get_state());
+                std::make_unique<mod_info>(mod_name, entry.path(), get_state());
             this->mods.emplace(mod_name, std::move(info));
         }
     }
     stage = mod_loading_stage_t::scan_finished;
 }
 
-void lua_env::load_core_mod(const fs::path& mods_dir)
+void lua_env::load_core_mod()
 {
     if (stage != mod_loading_stage_t::scan_finished)
     {
@@ -233,11 +242,11 @@ void lua_env::load_core_mod(const fs::path& mods_dir)
 
     // Load the core mod before any others. The core API table will be
     // modified in-place by the Lua API code.
-    api_mgr->load_core(*this, mods_dir);
+    api_mgr->load_core(*this, *val->second->path);
     stage = mod_loading_stage_t::core_mod_loaded;
 }
 
-void lua_env::load_all_mods(const fs::path& mods_dir)
+void lua_env::load_all_mods()
 {
     if (stage != mod_loading_stage_t::core_mod_loaded)
     {
@@ -246,13 +255,13 @@ void lua_env::load_all_mods(const fs::path& mods_dir)
     for (auto& pair : this->mods)
     {
         auto& mod = pair.second;
-        if (mod->name == "core")
+        if (mod->name == "core" || mod->name == "script")
         {
             continue;
         }
         else
         {
-            load_mod(mods_dir, *mod);
+            load_mod(*mod);
         }
         ELONA_LOG("Loaded mod " << mod->name);
     }
@@ -272,7 +281,7 @@ void lua_env::run_startup_script(const std::string& name)
     }
 
     std::unique_ptr<mod_info> script_mod =
-        std::make_unique<mod_info>("script", get_state());
+        std::make_unique<mod_info>("script", none, get_state());
     setup_and_lock_mod_globals(*script_mod);
 
     lua->safe_script_file(
@@ -315,7 +324,8 @@ void lua_env::reload()
     clear(); // Unload character/item handles while they're still available.
     get_state()->set("_IS_TEST", config::instance().is_test);
     scan_all_mods(filesystem::dir::mods());
-    load_core_mod(filesystem::dir::mods());
+    load_core_mod();
+    load_all_mods();
 }
 
 int deny(
@@ -425,7 +435,7 @@ void lua_env::load_mod_from_script(
     }
 
     std::unique_ptr<mod_info> info =
-        std::make_unique<mod_info>(name, get_state());
+        std::make_unique<mod_info>(name, none, get_state());
 
     if (readonly)
     {

--- a/src/lua_env/lua_env.cpp
+++ b/src/lua_env/lua_env.cpp
@@ -269,6 +269,7 @@ void lua_env::load_all_mods()
         ELONA_LOG("Loaded mod " << mod->name);
     }
 
+    event_mgr->run_callbacks<event_kind_t::all_mods_loaded>();
     stage = mod_loading_stage_t::all_mods_loaded;
 }
 
@@ -415,6 +416,7 @@ void lua_env::clear()
             on_chara_unloaded(cdata[i]);
         }
     }
+    event_mgr->clear();
     clear_mod_stores();
     mods.clear();
     lua->collect_garbage();

--- a/src/lua_env/lua_env.cpp
+++ b/src/lua_env/lua_env.cpp
@@ -182,8 +182,11 @@ void lua_env::load_mod(mod_info& mod)
             mod.env);
         if (result.valid())
         {
-            sol::table api_table = result.get<sol::table>();
-            api_mgr->add_api(mod.name, api_table);
+            sol::optional<sol::table> api_table = result.get<sol::table>();
+            if (api_table)
+            {
+                api_mgr->add_api(mod.name, *api_table);
+            }
         }
         else
         {

--- a/src/testing.cpp
+++ b/src/testing.cpp
@@ -108,8 +108,12 @@ void pre_init()
     config::instance().is_test = true;
 
     lua::lua->scan_all_mods(filesystem::dir::mods());
-    lua::lua->load_core_mod(filesystem::dir::mods());
+    lua::lua->load_core_mod();
+    lua::lua->load_all_mods();
     configure_lua();
+
+    lua::lua->get_event_manager()
+        .run_callbacks<lua::event_kind_t::game_initialized>();
 }
 
 void post_run()
@@ -129,6 +133,9 @@ void reset_state()
     elona::jp = 1;
     elona::en = 0;
     set_item_info();
+
+    lua::lua->get_event_manager()
+        .run_callbacks<lua::event_kind_t::game_initialized>();
 }
 
 } // namespace testing

--- a/src/tests/data/mods/test/init.lua
+++ b/src/tests/data/mods/test/init.lua
@@ -1,0 +1,7 @@
+local function hello()
+   return "Hello!"
+end
+
+return {
+   Hello = {hello = hello}
+}

--- a/src/tests/lua_api.cpp
+++ b/src/tests/lua_api.cpp
@@ -10,6 +10,7 @@ using namespace elona;
 
 void lua_testcase(const std::string& filename)
 {
+    std::cout << "TEST FILE: " << filename << std::endl;
     elona::testing::reset_state();
     elona::fixlv = 0;
     elona::lua::lua->get_state()->open_libraries(sol::lib::io, sol::lib::os);

--- a/src/tests/lua_api.cpp
+++ b/src/tests/lua_api.cpp
@@ -23,12 +23,28 @@ TEST_CASE("test Elona.require", "[Lua: API]")
 {
     elona::lua::lua_env lua;
     lua.scan_all_mods(filesystem::dir::mods());
-    lua.load_core_mod(filesystem::dir::mods());
+    lua.load_core_mod();
 
     REQUIRE_NOTHROW(lua.load_mod_from_script("test", R"(
 local Rand = Elona.require("Rand")
 assert(Rand ~= nil)
 assert(type(Rand.coinflip) == "function")
+)"));
+}
+
+TEST_CASE("test Elona.require from other mods", "[Lua: API]")
+{
+    elona::lua::lua_env lua;
+    lua.scan_all_mods(filesystem::dir::mods());
+    lua.scan_all_mods(filesystem::dir::exe() / u8"tests/data/mods");
+    lua.load_core_mod();
+    lua.load_all_mods();
+
+    REQUIRE_NOTHROW(lua.load_mod_from_script("test_require_from_mods", R"(
+local Hello = Elona.require("test", "Hello")
+assert(Hello ~= nil)
+assert(type(Hello.hello) == "function")
+assert(Hello.hello() == "Hello!")
 )"));
 }
 


### PR DESCRIPTION
# Summary
- Allows loading of mods inside the `mods` folder besides `core`.
- Allows mods to return an API table at the end of `init.lua`, for declaring public exports.
- Implements `Elona.require` for mods besides `core` (`Elona.require("some_mod", "MyModule")`)
- Adds `AllModsLoaded` callback, for safely calling initialization functions after mods have loaded successfully.

# TODO
- [x] Remove test mod.