### PR TITLE
Use tsl::ordered_map instead of std::unordered_map in HCL objects

### DIFF
--- a/README-jp.md
+++ b/README-jp.md
@@ -90,9 +90,10 @@ MIT Licenseです。詳細はLICENSEを参照してください。このライ�
 
 ## サードパーティーライブラリ
 
-* Catch2: thirdparty/catch2/LICENSEを参照してください。
-* hayai: thirdparty/hayai/LICENSEを参照してください。
-* sol2: thirdparty/sol2/LICENSEを参照してください。
+* Catch2: src/thirdparty/catch2/LICENSEを参照してください。
+* hayai: src/thirdparty/hayai/LICENSEを参照してください。
+* sol2: src/thirdparty/sol2/LICENSEを参照してください。
+* ordered_map: src/thirdparty/ordered_map/LICENSEを参照してください。
 * cmake/FindXXX.cmake: cmake/LICENSEを参照してください。
 
 ## Luaライブラリ

--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ contents in this repository. Note that images, sounds and fonts are not included
 
 ## Thirdparty libraries
 
-* Catch2: see thirdparty/catch2/LICENSE.
-* hayai: see thirdparty/hayai/LICENSE.
-* sol2: see thirdparty/sol2/LICENSE.
+* Catch2: see src/thirdparty/catch2/LICENSE.
+* hayai: see src/thirdparty/hayai/LICENSE.
+* sol2: see src/thirdparty/sol2/LICENSE.
+* ordered_map: see src/thirdparty/ordered_map/LICENSE.
 * cmake/FindXXX.cmake: see cmake/LICENSE.
 
 ## Lua libraries

--- a/runtime/locale/en/config.hcl
+++ b/runtime/locale/en/config.hcl
@@ -244,6 +244,22 @@ DOC
                 autodisable_numlock {
                     name = "Auto-Disable Numlock"
                 }
+                assign_z_key {
+                    name = "Assign z key"
+                    variants {
+                        quick_menu = "Quick menu"
+                        zap = "Zap"
+                        none = "Don't assign"
+                    }
+                }
+                assign_x_key {
+                    name = "Assign x key"
+                    variants {
+                        quick_inv = "Quick Inv"
+                        identify = "Identify"
+                        none = "Don't assign"
+                    }
+                }
                 walk_wait {
                     name = "Walk Speed"
                     doc = "Number of frames to wait between movement commands when walking."

--- a/runtime/locale/en/config.hcl
+++ b/runtime/locale/en/config.hcl
@@ -59,21 +59,55 @@ locale {
                 wait = "${_1} wait"
             }
         }
+
         menu {
             name = "Option"
-            language {
-                name = "Language"
 
-                language {
-                    name = "Language*"
+            game {
+                name = "Game Setting"
+                extra_help {
+                    name = "Extra Help"
+                    doc = "Show extra help popups for new players."
+                }
+                attack_neutral_npcs {
+                    name = "Attack Netural NPCs"
+                    doc = "Attack non-hostile, non-ally NPCs when running into them."
+                }
+                default_save {
+                    name = "Default Save"
+                    doc = "Saved game to be loaded on startup."
                     variants {
-                        jp = "Japanese"
-                        en = "English"
+                        "" = "None"
                     }
                 }
+                story {
+                    name = "Enable Cutscenes"
+                    doc = "Enable playback of the story cutscenes."
+                }
+                hide_autoidentify {
+                    name = "Hide Auto-Identify"
+                    doc = "Hide identify status updates from Sense Quality."
+                }
+                hide_shop_updates {
+                    name = "Hide Shop Updates"
+                    doc = "Hide daily shop reports of items sold for shops you own."
+                }
             }
+
             screen {
                 name = "Screen & Sound"
+                sound {
+                    name = "Sound*"
+                    yes_no = core.locale.config.common.yes_no.on_off
+                }
+                music {
+                    name = "Music*"
+                    variants {
+                        none = "None"
+                        direct_music = "Direct music"
+                        mci = "MCI"
+                    }
+                }
                 fullscreen {
                     name = "Screen Mode*"
                     variants {
@@ -86,18 +120,6 @@ locale {
                 display_mode {
                     name = "Screen Resolution*"
                     # Variants are injected at runtime.
-                }
-                sound {
-                    name = "Sound*"
-                    yes_no = core.locale.config.common.yes_no.on_off
-                }
-                music {
-                    name = "Music*"
-                    variants {
-                        none = "None"
-                        direct_music = "Direct music"
-                        mci = "MCI"
-                    }
                 }
                 high_quality_shadows {
                     name = "Shadow Quality"
@@ -121,6 +143,7 @@ Random events will still occur.
 DOC
                 }
             }
+
             net {
                 name = "Network Setting"
                 enabled {
@@ -136,6 +159,7 @@ DOC
                     name = "Use Custom Server"
                 }
             }
+
             anime {
                 name = "Animation Setting"
                 scroll {
@@ -215,69 +239,8 @@ DOC
                 }
             }
 
-            font {
-                name = "Font Setting"
-                doc = <<DOC
-Font-related settings.
-Place fonts (TTF format) in data/font. Please ensure the fonts are monospaced to avoid issues.
-DOC
-                vertical_offset {
-                    name = "Vertical Offset"
-                }
-                size_adjustment {
-                    name = "Size Adjustment"
-                }
-            }
-
-            game {
-                name = "Game Setting"
-                default_save {
-                    name = "Default Save"
-                    doc = "Saved game to be loaded on startup."
-                    variants {
-                        "" = "None"
-                    }
-                }
-                attack_neutral_npcs {
-                    name = "Attack Netural NPCs"
-                    doc = "Attack non-hostile, non-ally NPCs when running into them."
-                }
-                story {
-                    name = "Enable Cutscenes"
-                    doc = "Enable playback of the story cutscenes."
-                }
-                extra_help {
-                    name = "Extra Help"
-                    doc = "Show extra help popups for new players."
-                }
-                hide_autoidentify {
-                    name = "Hide Auto-Identify"
-                    doc = "Hide identify status updates from Sense Quality."
-                }
-                hide_shop_updates {
-                    name = "Hide Shop Updates"
-                    doc = "Hide daily shop reports of items sold for shops you own."
-                }
-            }
-
-            message {
-                name = "Message&Log"
-                add_timestamps {
-                    name = "Add time info"
-                }
-                transparency {
-                    name = "Transparency"
-                    doc = "Message box transparency."
-                    formatter = "${_1}*10 %"#TODO
-                }
-            }
-
             input {
                 name = "Input Setting"
-                joypad {
-                    name = "Game Pad"
-                    yes_no = core.locale.config.common.yes_no.unsupported #core.locale.config.common.yes_no.use_dont_use
-                }
                 autodisable_numlock {
                     name = "Auto-Disable Numlock"
                 }
@@ -321,6 +284,36 @@ DOC
                     doc = "Number of frames to wait between item selection when selecting quickly."
                     formatter = core.locale.config.common.formatter.wait
                 }
+                joypad {
+                    name = "Game Pad"
+                    yes_no = core.locale.config.common.yes_no.unsupported #core.locale.config.common.yes_no.use_dont_use
+                }
+            }
+
+            font {
+                name = "Font Setting"
+                doc = <<DOC
+Font-related settings.
+Place fonts (TTF format) in data/font. Please ensure the fonts are monospaced to avoid issues.
+DOC
+                vertical_offset {
+                    name = "Vertical Offset"
+                }
+                size_adjustment {
+                    name = "Size Adjustment"
+                }
+            }
+
+            message {
+                name = "Message&Log"
+                add_timestamps {
+                    name = "Add time info"
+                }
+                transparency {
+                    name = "Transparency"
+                    doc = "Message box transparency."
+                    formatter = "${_1}*10 %"#TODO
+                }
             }
 
             balance {
@@ -341,6 +334,18 @@ DOC
                 extra_class {
                     name = "Extra Class"
                     doc = "Enable extra classes in character creation."
+                }
+            }
+
+            language {
+                name = "Language"
+
+                language {
+                    name = "Language*"
+                    variants {
+                        jp = "Japanese"
+                        en = "English"
+                    }
                 }
             }
 

--- a/runtime/locale/jp/config.hcl
+++ b/runtime/locale/jp/config.hcl
@@ -207,6 +207,22 @@ locale {
                 autodisable_numlock {
                     name = "numlockを自動制御"
                 }
+                assign_z_key {
+                    name = "zキーの割当て"
+                    variants {
+                        quick_menu = "ｸｨｯｸﾒﾆｭｰ"
+                        zap = "道具を振る"
+                        none = "割当なし"
+                    }
+                }
+                assign_x_key {
+                    name = "xキーの割当て"
+                    variants {
+                        quick_inv = "ｸｲｯｸｲﾝﾍﾞﾝﾄﾘ"
+                        identify = "道具を調べる"
+                        none = "割当なし"
+                    }
+                }
                 walk_wait {
                     name = "歩きの速さ"
                     formatter = core.locale.config.common.formatter.wait

--- a/runtime/locale/jp/config.hcl
+++ b/runtime/locale/jp/config.hcl
@@ -63,33 +63,38 @@ locale {
                 wait = "${_1} wait"
             }
         }
+
         menu {
             name = "オプション"
-            language {
-                name = "言語(Language)"
 
-                language {
-                    name = "言語*"
+            game {
+                name = "ゲーム設定"
+                extra_help {
+                    name = "ノルンの冒険ガイド"
+                }
+                attack_neutral_npcs {
+                    name = "非好戦的NPCを攻撃"
+                }
+                default_save {
+                    name = "デフォルトセーブ"
                     variants {
-                        jp = "Japanese"
-                        en = "English"
+                        "" = "使用しない"
                     }
+                }
+                story {
+                    name = "シーンの再生"
+                    yes_no = core.locale.config.common.yes_no.saisei_suru_shinai
+                }
+                hide_autoidentify {
+                    name = "自然鑑定ﾒｯｾｰｼﾞの非表示"
+                }
+                hide_shop_updates {
+                    name = "店ﾒｯｾｰｼﾞの非表示"
                 }
             }
+
             screen {
                 name = "画面と音の設定"
-                fullscreen {
-                    name = "画面モード*"
-                    variants {
-                        windowed = "ウィンドウ"
-                        fullscreen = "フルスクリーン"
-                        desktop_fullscreen = "フルスクリーン2"
-                    }
-                }
-                display_mode {
-                    name = "画面の大きさ*"
-                    # Variants are injected at runtime.
-                }
                 sound {
                     name = "サウンドの再生*"
                     yes_no = core.locale.config.common.yes_no.ari_nashi
@@ -101,6 +106,18 @@ locale {
                         direct_music = "direct music"
                         mci = "MCI"
                     }
+                }
+                fullscreen {
+                    name = "画面モード*"
+                    variants {
+                        windowed = "ウィンドウ"
+                        fullscreen = "フルスクリーン"
+                        desktop_fullscreen = "フルスクリーン2"
+                    }
+                }
+                display_mode {
+                    name = "画面の大きさ*"
+                    # Variants are injected at runtime.
                 }
                 high_quality_shadows {
                     name = "光源の描写"
@@ -118,6 +135,7 @@ locale {
                     name = "イベントの短縮"
                 }
             }
+
             net {
                 name = "ネット機能の設定"
                 enabled {
@@ -134,6 +152,7 @@ locale {
                     yes_no = core.locale.config.common.yes_no.shiyou_suru_shinai
                 }
             }
+
             anime {
                 name = "アニメ設定"
                 scroll {
@@ -183,59 +202,8 @@ locale {
                 }
             }
 
-            font {
-                name = "フォント設定"
-                vertical_offset {
-                    name = "垂直オフセット"
-                }
-                size_adjustment {
-                    name = "サイズの調整"
-                }
-            }
-
-            game {
-                name = "ゲーム設定"
-                default_save {
-                    name = "デフォルトセーブ"
-                    variants {
-                        "" = "使用しない"
-                    }
-                }
-                attack_neutral_npcs {
-                    name = "非好戦的NPCを攻撃"
-                }
-                story {
-                    name = "シーンの再生"
-                    yes_no = core.locale.config.common.yes_no.saisei_suru_shinai
-                }
-                extra_help {
-                    name = "ノルンの冒険ガイド"
-                }
-                hide_autoidentify {
-                    name = "自然鑑定ﾒｯｾｰｼﾞの非表示"
-                }
-                hide_shop_updates {
-                    name = "店ﾒｯｾｰｼﾞの非表示"
-                }
-            }
-
-            message {
-                name = "メッセージとログ"
-                add_timestamps {
-                    name = "ﾒｯｾｰｼﾞに分表示追加"
-                }
-                transparency {
-                    name = "過去のﾒｯｾｰｼﾞの透過"
-                    formatter = "${_1}*10 %" #TODO
-                }
-            }
-
             input {
                 name = "入力設定"
-                joypad {
-                    name = "ゲームパッド"
-                    yes_no = core.locale.config.common.yes_no.unsupported # core.locale.config.common.yes_no.shiyou_suru_shinai
-                }
                 autodisable_numlock {
                     name = "numlockを自動制御"
                 }
@@ -271,6 +239,31 @@ locale {
                     name = "選択ウェイト(早い)"
                     formatter = core.locale.config.common.formatter.wait
                 }
+                joypad {
+                    name = "ゲームパッド"
+                    yes_no = core.locale.config.common.yes_no.unsupported # core.locale.config.common.yes_no.shiyou_suru_shinai
+                }
+            }
+
+            font {
+                name = "フォント設定"
+                vertical_offset {
+                    name = "垂直オフセット"
+                }
+                size_adjustment {
+                    name = "サイズの調整"
+                }
+            }
+
+            message {
+                name = "メッセージとログ"
+                add_timestamps {
+                    name = "ﾒｯｾｰｼﾞに分表示追加"
+                }
+                transparency {
+                    name = "過去のﾒｯｾｰｼﾞの透過"
+                    formatter = "${_1}*10 %" #TODO
+                }
             }
 
             balance {
@@ -284,6 +277,18 @@ locale {
                 }
                 extra_class {
                     name = "Extra職業"
+                }
+            }
+
+            language {
+                name = "言語(Language)"
+
+                language {
+                    name = "言語*"
+                    variants {
+                        jp = "Japanese"
+                        en = "English"
+                    }
                 }
             }
 

--- a/runtime/mods/core/config/config_def.hcl
+++ b/runtime/mods/core/config/config_def.hcl
@@ -100,8 +100,8 @@ config def {
             window_anime = false
 
             screen_refresh = {
-                default = 2
-                min = 0
+                default = 3
+                min = 1
                 max = 15
             }
         }
@@ -112,9 +112,21 @@ config def {
         options = {
             autodisable_numlock = true
 
+            assign_z_key = {
+                type = "enum"
+                default = "quick_menu"
+                variants = ["quick_menu", "zap", "none"]
+            }
+
+            assign_x_key = {
+                type = "enum"
+                default = "quick_inv"
+                variants = ["quick_inv", "identify", "none"]
+            }
+
             walk_wait = {
                 default = 5
-                min = 0
+                min = 1
                 max = 10
             }
 
@@ -126,13 +138,13 @@ config def {
 
             run_wait = {
                 default = 2
-                min = 0
+                min = 1
                 max = 10
             }
 
             attack_wait = {
                 default = 4
-                min = 0
+                min = 1
                 max = 10
             }
 

--- a/runtime/mods/core/config/config_def.hcl
+++ b/runtime/mods/core/config/config_def.hcl
@@ -1,7 +1,38 @@
 config def {
+    game = {
+        type = "section"
+        options = {
+            extra_help = true
+            attack_neutral_npcs = false
+
+            default_save = {
+                type = "runtime_enum"
+                default = ""
+                preload = true
+                translate_variants = false
+            }
+
+            story = true
+            hide_autoidentify = false
+            hide_shop_updates = false
+        }
+    }
+
     screen = {
         type = "section"
         options = {
+            sound = {
+                default = true
+                preload = true
+            }
+
+            music = {
+                type = "enum"
+                variants = ["none", "direct_music", "mci"]
+                default = "direct_music"
+                preload = true
+            }
+
             fullscreen = {
                 type = "enum"
                 preload = true
@@ -15,16 +46,6 @@ config def {
                 preload = true
             }
 
-            music = {
-                type = "enum"
-                variants = ["none", "direct_music", "mci"]
-                default = "direct_music"
-                preload = true
-            }
-            sound = {
-                default = true
-                preload = true
-            }
             high_quality_shadows = true
             object_shadows = true
             heartbeat = true
@@ -86,76 +107,9 @@ config def {
         }
     }
 
-
-    font = {
-        type = "section"
-        options = {
-            japanese = "Kochi Gothic.ttf"
-            english = "Bitstream Sans Vera Mono.ttf"
-
-            vertical_offset = {
-                default = -1
-                min = -10
-                max = 10
-            }
-            size_adjustment = {
-                default = 1
-                min = -5
-                max = 5
-            }
-        }
-    }
-
-    game = {
-        type = "section"
-        options = {
-            default_save = {
-                type = "runtime_enum"
-                default = ""
-                preload = true
-                translate_variants = false
-            }
-
-            attack_neutral_npcs = false
-            story = true
-            extra_help = true
-            hide_autoidentify = false
-            hide_shop_updates = false
-        }
-    }
-
-    debug = {
-        type = "section"
-        visible = false
-        options = {
-            wizard = {
-                default = false
-                preload = true
-            }
-            noa_debug = false
-        }
-    }
-
-    message = {
-        type = "section"
-        options = {
-            add_timestamps = false
-
-            transparency = {
-                default = 4
-                min = 0
-                max = 10
-            }
-        }
-    }
-
     input = {
         type = "section"
         options = {
-            joypad = {
-                default = false
-                preload = true
-            }
             autodisable_numlock = true
 
             walk_wait = {
@@ -205,6 +159,43 @@ config def {
                 min = 1
                 max = 20
             }
+
+            joypad = {
+                default = false
+                preload = true
+            }
+        }
+    }
+
+    font = {
+        type = "section"
+        options = {
+            japanese = "Kochi Gothic.ttf"
+            english = "Bitstream Sans Vera Mono.ttf"
+
+            vertical_offset = {
+                default = -1
+                min = -10
+                max = 10
+            }
+            size_adjustment = {
+                default = 1
+                min = -5
+                max = 5
+            }
+        }
+    }
+
+    message = {
+        type = "section"
+        options = {
+            add_timestamps = false
+
+            transparency = {
+                default = 4
+                min = 0
+                max = 10
+            }
         }
     }
 
@@ -224,6 +215,16 @@ config def {
 
             extra_class = {
                 default = false
+                preload = true
+            }
+        }
+    }
+
+    language = {
+        type = "section"
+        options = {
+            language = {
+                type = "runtime_enum"
                 preload = true
             }
         }
@@ -250,15 +251,7 @@ config def {
         }
     }
 
-    language = {
-        type = "section"
-        options = {
-            language = {
-                type = "runtime_enum"
-                preload = true
-            }
-        }
-    }
+    ### Hidden sections
 
     ui = {
         type = "section"
@@ -397,6 +390,18 @@ DOC
                 "f", "g", "h", "i", "j",
                 "k", "l", "m", "n", "o",
                 "p", "q", "r", "s"]
+        }
+    }
+
+    debug = {
+        type = "section"
+        visible = false
+        options = {
+            wizard = {
+                default = false
+                preload = true
+            }
+            noa_debug = false
         }
     }
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -9,7 +9,7 @@
 #include "snail/application.hpp"
 #include "snail/window.hpp"
 #include "variables.hpp"
-#include "thirdparty/microhcl/hcl.hpp"
+#include "hcl.hpp"
 
 
 namespace

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -267,6 +267,7 @@ void load_config(const fs::path& hcl_file)
     CONFIG_OPTION("input.attack_wait"s,               int,         config::instance().attackwait);
     CONFIG_OPTION("input.autodisable_numlock"s,       bool,        config::instance().autonumlock);
     CONFIG_OPTION("input.key_wait"s,                  int,         config::instance().keywait);
+    CONFIG_OPTION("input.walk_wait"s,                 int,         config::instance().walkwait);
     CONFIG_OPTION("input.run_wait"s,                  int,         config::instance().runwait);
     CONFIG_OPTION("input.start_run_wait"s,            int,         config::instance().startrun);
     CONFIG_OPTION("input.select_wait"s,               int,         config::instance().select_wait);
@@ -348,16 +349,43 @@ void load_config(const fs::path& hcl_file)
     CONFIG_KEY("key.message_log"s,      key_msglog);
 
     conf.bind_setter<hcl::List>("core.config.key.key_set",
-                    [&](auto values)
-                        {
-                            for_each_with_index(
-                                std::begin(values),
-                                std::end(values),
-                                [&](auto index, hcl::Value value) {
-                                    std::string s = value.as<std::string>();
-                                    key_select(index) = s;
-                                });
-                        });
+        [&](auto values) {
+                for_each_with_index(
+                    std::begin(values),
+                    std::end(values),
+                    [&](auto index, hcl::Value value) {
+                        std::string s = value.as<std::string>();
+                        key_select(index) = s;
+                    });
+            });
+
+    conf.bind_setter<std::string>("core.config.input.assign_z_key",
+        [&](auto value) {
+            if (value == "quick_menu")
+            {
+                key_quick = u8"z"s;
+                key_zap = u8"Z"s;
+            }
+            else if (value == "zap")
+            {
+                key_zap = u8"z"s;
+                key_quick = u8"Z"s;
+            }
+        });
+
+    conf.bind_setter<std::string>("core.config.input.assign_x_key",
+        [&](auto value) {
+            if (value == "quick_inv")
+            {
+                key_quickinv = u8"x"s;
+                key_inventory = u8"X"s;
+            }
+            else if (value == "identify")
+            {
+                key_inventory = u8"x"s;
+                key_quickinv = u8"X"s;
+            }
+        });
 
     std::ifstream ifs{filesystem::make_preferred_path_in_utf8(hcl_file.native())};
     conf.load(ifs, hcl_file.string(), false);
@@ -365,34 +393,14 @@ void load_config(const fs::path& hcl_file)
     key_prev = key_northwest;
     key_next = key_northeast;
 
-    if (config::instance().zkey == 0)
-    {
-        key_quick = u8"z"s;
-        key_zap = u8"Z"s;
-    }
-    else if (config::instance().zkey == 1)
-    {
-        key_zap = u8"z"s;
-        key_quick = u8"Z"s;
-    }
-    if (config::instance().xkey == 0)
-    {
-        key_quickinv = u8"x"s;
-        key_inventory = u8"X"s;
-    }
-    else if (config::instance().xkey == 1)
-    {
-        key_inventory = u8"x"s;
-        key_quickinv = u8"X"s;
-    }
-    if (config::instance().scrsync == 0)
-    {
-        config::instance().scrsync = 3;
-    }
-    if (config::instance().walkwait == 0)
-    {
-        config::instance().walkwait = 5;
-    }
+    // Keys set in assign_<...>_key may have been overwritten by other
+    // config values in the "key" section. To account for this, run
+    // the setters for assign_<...>_key again. This will do nothing if
+    // either option is "none", so the keys can stil be set to
+    // something else.
+    conf.run_setter("core.config.input.assign_x_key");
+    conf.run_setter("core.config.input.assign_z_key");
+
     if (config::instance().runwait < 1)
     {
         config::instance().runwait = 1;

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -6,7 +6,7 @@
 #include "elona.hpp"
 #include "log.hpp"
 #include "snail/window.hpp"
-#include <map>
+#include "thirdparty/ordered_map/ordered_map.h"
 #include <string>
 #include <iostream>
 
@@ -241,9 +241,9 @@ private:
     bool verify_types(const hcl::Value&, const std::string&);
 
     config_def def;
-    std::map<std::string, hcl::Value> storage;
-    std::map<std::string, std::function<hcl::Value(void)>> getters;
-    std::map<std::string, std::function<void(const hcl::Value&)>> setters;
+    tsl::ordered_map<std::string, hcl::Value> storage;
+    tsl::ordered_map<std::string, std::function<hcl::Value(void)>> getters;
+    tsl::ordered_map<std::string, std::function<void(const hcl::Value&)>> setters;
 };
 
 

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -92,8 +92,6 @@ public:
     int walkwait;
     bool windowanime;
     bool wizard;
-    bool xkey;
-    bool zkey;
 
     bool use_autopick;
     bool use_autopick_in_home;
@@ -218,6 +216,18 @@ public:
             ss << def.type_to_string(key) << " expected, got ";
             ss << value;
             throw std::runtime_error(ss.str());
+        }
+    }
+
+    void run_setter(const std::string& key)
+    {
+        if (storage.find(key) == storage.end())
+        {
+            return;
+        }
+        if (setters.find(key) != setters.end())
+        {
+            setters[key](storage.at(key));
         }
     }
 

--- a/src/config_def.cpp
+++ b/src/config_def.cpp
@@ -1,7 +1,7 @@
 #include "config_def.hpp"
 #include "filesystem.hpp"
 #include "optional.hpp"
-#include "thirdparty/microhcl/hcl.hpp"
+#include "hcl.hpp"
 #include <fstream>
 #include <iostream>
 #include <map>

--- a/src/config_def.hpp
+++ b/src/config_def.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include "spec.hpp"
-#include "thirdparty/microhcl/hcl.hpp"
+#include "hcl.hpp"
 
 namespace elona
 {

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -10,7 +10,7 @@
 #include "map.hpp"
 #include "mef.hpp"
 #include "random.hpp"
-#include "thirdparty/microhcl/hcl.hpp"
+#include "hcl.hpp"
 #include "variables.hpp"
 
 

--- a/src/hcl.hpp
+++ b/src/hcl.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+#define MICROHCL_MAP_TYPE tsl::ordered_map
+#define MICROHCL_MAP_ACCESSOR &it.value()
+#include "thirdparty/ordered_map/ordered_map.h"
+#include "thirdparty/microhcl/hcl.hpp"

--- a/src/i18n.cpp
+++ b/src/i18n.cpp
@@ -1,4 +1,4 @@
-#include "thirdparty/microhcl/hcl.hpp"
+#include "hcl.hpp"
 #include "thirdparty/microhil/hil.hpp"
 
 #include <fstream>

--- a/src/i18n.hpp
+++ b/src/i18n.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "thirdparty/microhcl/hcl.hpp"
 #include "thirdparty/microhil/hil.hpp"
 #include "thirdparty/sol2/sol.hpp"
 
@@ -10,6 +9,7 @@
 #include "cat.hpp"
 #include "character.hpp"
 #include "filesystem.hpp"
+#include "hcl.hpp"
 #include "item.hpp"
 #include "log.hpp"
 #include "lua_env/lua_api.hpp"

--- a/src/set_option.cpp
+++ b/src/set_option.cpp
@@ -568,28 +568,6 @@ set_option_begin:
     {
         if (reset_page)
         {
-            if (config::instance().zkey == 0)
-            {
-                key_quick = u8"z"s;
-                key_zap = u8"Z"s;
-            }
-            else
-            {
-                key_zap = u8"z"s;
-                key_quick = u8"Z"s;
-            }
-
-            if (config::instance().xkey == 0)
-            {
-                key_quickinv = u8"x"s;
-                key_inventory = u8"X"s;
-            }
-            else
-            {
-                key_inventory = u8"x"s;
-                key_quickinv = u8"X"s;
-            }
-
             cs_bk = -1;
             pagemax = (listmax - 1) / pagesize;
 

--- a/src/set_option.cpp
+++ b/src/set_option.cpp
@@ -281,6 +281,7 @@ typedef std::vector<std::unique_ptr<config_menu>> config_screen;
 
 // Functions for adding items to the config screen.
 
+template <class M>
 static void add_config_menu(const spec_key& key,
                             const i18n_key& menu_name_key,
                             const config_def& def,
@@ -290,7 +291,7 @@ static void add_config_menu(const spec_key& key,
     auto children = def.get_children(key);
     int w = width;
     int h = 165 + (19 * children.size());
-    ret.emplace_back(std::make_unique<config_menu>(i18n::s.get(menu_name_key), w, h));
+    ret.emplace_back(std::make_unique<M>(i18n::s.get(menu_name_key), w, h));
 }
 
 
@@ -401,7 +402,7 @@ void visit_toplevel(config& conf, config_screen& ret)
     i18n_key menu_name_key = locale_key + ".name";
 
     // Add the top level menu.
-    add_config_menu(key, menu_name_key, conf.get_def(), 370, ret);
+    add_config_menu<config_menu>(key, menu_name_key, conf.get_def(), 370, ret);
 
     // Add the names of top-level config menu sections if they are visible.
     for (const auto& section_name : conf.get_def().get_children(key))
@@ -437,7 +438,7 @@ void visit_section(config& conf, const spec_key& current_key, config_screen& ret
     }
 
     // Add the submenu.
-    add_config_menu(key, menu_name_key, conf.get_def(), 440, ret);
+    add_config_menu<config_menu_submenu>(key, menu_name_key, conf.get_def(), 440, ret);
 
     // Visit child config items of this section.
     for (const auto& child : conf.get_def().get_children(key))

--- a/src/spec.cpp
+++ b/src/spec.cpp
@@ -1,7 +1,7 @@
 #include "config_def.hpp"
 #include "filesystem.hpp"
 #include "optional.hpp"
-#include "thirdparty/microhcl/hcl.hpp"
+#include "hcl.hpp"
 #include <fstream>
 #include <iostream>
 #include <map>

--- a/src/spec.hpp
+++ b/src/spec.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "thirdparty/microhcl/hcl.hpp"
+#include "hcl.hpp"
 #include "filesystem.hpp"
 #include "optional.hpp"
 #include <cassert>

--- a/src/spec.hpp
+++ b/src/spec.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include <boost/variant.hpp>
 #include <boost/variant/get.hpp>
+#include "thirdparty/ordered_map/ordered_map.h"
 
 using namespace std::literals::string_literals;
 
@@ -134,7 +135,7 @@ static const constexpr char* unknown_enum_variant = "__unknown__";
 class object
 {
 public:
-    typedef std::map<std::string, item>::const_iterator const_iterator;
+    typedef tsl::ordered_map<std::string, item>::const_iterator const_iterator;
 
     object(std::string name_) : name(name_) {}
     ~object() = default;
@@ -336,7 +337,7 @@ private:
     enum_def visit_enum(const std::string&, const hcl::Object&, const std::string&, const std::string&);
 
     std::string name;
-    std::map<std::string, item> items;
+    tsl::ordered_map<std::string, item> items;
 };
 }
 }

--- a/src/tests/spec.cpp
+++ b/src/tests/spec.cpp
@@ -1,6 +1,7 @@
 #include "../thirdparty/catch2/catch.hpp"
 
 #include "../spec.hpp"
+#include <iostream>
 
 using namespace std::literals::string_literals;
 using namespace elona;
@@ -381,20 +382,23 @@ TEST_CASE("Test get_children", "[Spec: Definition]")
 {
     test_spec def = load(R"(
 test def {
-    foo = {
+    foo {
         type = "section"
         options = {
             bar = false
             baz = "quux"
+            hoge = "fuga"
+            piyo = true
         }
     }
-    hoge = "piyo"
 }
 )");
     auto children = def.get_children("core.test.foo");
-    REQUIRE(children.size() == 2);
-    REQUIRE(children.at(0) == "baz");
-    REQUIRE(children.at(1) == "bar");
+    REQUIRE(children.size() == 4);
+    REQUIRE(children.at(0) == "bar");
+    REQUIRE(children.at(1) == "baz");
+    REQUIRE(children.at(2) == "hoge");
+    REQUIRE(children.at(3) == "piyo");
 
     REQUIRE_THROWS(def.get_children("core.test.hoge"));
 }

--- a/src/thirdparty/microhcl/hcl.hpp
+++ b/src/thirdparty/microhcl/hcl.hpp
@@ -11,23 +11,25 @@
 #include <iterator>
 #include <sstream>
 #include <string>
-#ifdef MICROHCL_USE_MAP
-#include <map>
-#else
+#include <vector>
+
+#ifndef MICROHCL_MAP_TYPE
 #include <unordered_map>
 #endif
-#include <vector>
 
 namespace hcl {
 
 class Value;
 typedef std::vector<Value> List;
 
-#ifdef MICROHCL_USE_MAP
-typedef std::map<std::string, Value> Object;
-#else
-typedef std::unordered_map<std::string, Value> Object;
+#ifndef MICROHCL_MAP_TYPE
+#define MICROHCL_MAP_TYPE std::unordered_map
 #endif
+#ifndef MICROHCL_MAP_ACCESSOR
+#define MICROHCL_MAP_ACCESSOR &it->second
+#endif
+
+typedef MICROHCL_MAP_TYPE<std::string, Value> Object;
 
 namespace internal {
 template<typename T> struct call_traits_value {
@@ -1866,7 +1868,7 @@ inline Value* Value::findChild(const std::string& key)
     if (it == object_->end())
         return nullptr;
 
-    return &it->second;
+    return MICROHCL_MAP_ACCESSOR;
 }
 
 inline const Value* Value::findChild(const std::string& key) const
@@ -1878,7 +1880,7 @@ inline const Value* Value::findChild(const std::string& key) const
     if (it == object_->end())
         return nullptr;
 
-    return &it->second;
+    return MICROHCL_MAP_ACCESSOR;
 }
 
 // ----------------------------------------------------------------------

--- a/src/thirdparty/ordered_map/LICENSE
+++ b/src/thirdparty/ordered_map/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Tessil
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/thirdparty/ordered_map/ordered_hash.h
+++ b/src/thirdparty/ordered_map/ordered_hash.h
@@ -1,0 +1,1340 @@
+/**
+ * MIT License
+ * 
+ * Copyright (c) 2017 Tessil
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef TSL_ORDERED_HASH_H
+#define TSL_ORDERED_HASH_H
+
+
+#include <algorithm>
+#include <cassert>
+#include <climits>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <functional>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <stdexcept>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+
+/**
+ * Macros for compatibility with GCC 4.8
+ */
+#ifndef TSL_NO_CONTAINER_ERASE_CONST_ITERATOR
+    #if (defined(__GNUC__) && (__GNUC__ == 4) && (__GNUC_MINOR__ < 9))
+    #define TSL_NO_CONTAINER_ERASE_CONST_ITERATOR
+    #endif
+#endif
+
+#ifndef TSL_NO_CONTAINER_EMPLACE_CONST_ITERATOR
+    #if (defined(__GNUC__) && (__GNUC__ == 4) && (__GNUC_MINOR__ < 9))
+    #define TSL_NO_CONTAINER_EMPLACE_CONST_ITERATOR
+    #endif
+#endif
+
+
+/**
+ * Only activate tsl_assert if TSL_DEBUG is defined. 
+ * This way we avoid the performance hit when NDEBUG is not defined with assert as tsl_assert is used a lot
+ * (people usually compile with "-O3" and not "-O3 -DNDEBUG").
+ */
+#ifndef tsl_assert
+    #ifdef TSL_DEBUG
+    #define tsl_assert(expr) assert(expr)
+    #else
+    #define tsl_assert(expr) (static_cast<void>(0))
+    #endif
+#endif
+
+
+/**
+ * If exceptions are enabled, throw the exception passed in parameter, otherwise std::terminate.
+ */
+#ifndef TSL_THROW_OR_TERMINATE
+    #if (defined(__cpp_exceptions) || defined(__EXCEPTIONS) || (defined (_MSC_VER) && defined (_CPPUNWIND))) && !defined(TSL_NO_EXCEPTIONS)
+    #define TSL_THROW_OR_TERMINATE(ex) throw ex
+    #else
+    #define TSL_THROW_OR_TERMINATE(ex) std::terminate()
+    #endif
+#endif
+
+namespace tsl {
+
+namespace detail_ordered_hash {
+    
+template<typename T>
+struct make_void {
+    using type = void;
+};
+
+template<typename T, typename = void>
+struct has_is_transparent: std::false_type {
+};
+
+template<typename T>
+struct has_is_transparent<T, typename make_void<typename T::is_transparent>::type>: std::true_type {
+};
+
+
+template<typename T, typename = void>
+struct is_vector: std::false_type {
+};
+
+template<typename T>
+struct is_vector<T, typename std::enable_if<
+                        std::is_same<T, std::vector<typename T::value_type, typename T::allocator_type>>::value
+                    >::type>: std::true_type {
+};
+
+
+/**
+ * Each bucket entry stores a 32-bits index which is the index in m_values corresponding to the bucket's value 
+ * and a 32 bits hash (truncated if the original was 64-bits) corresponding to the hash of the value.
+ * 
+ * The 32-bit index limits the size of the map to 2^32 - 1 elements (-1 due to a reserved value used to mark a
+ * bucket as empty).
+ */
+class bucket_entry {
+public:
+    using index_type = std::uint_least32_t;
+    using truncated_hash_type = std::uint_least32_t;
+    
+    
+    bucket_entry() noexcept: m_index(EMPTY_MARKER_INDEX), m_hash(0) {
+    }
+    
+    bool empty() const noexcept {
+        return m_index == EMPTY_MARKER_INDEX;
+    }
+    
+    void clear() noexcept {
+        m_index = EMPTY_MARKER_INDEX;
+    }
+    
+    index_type index() const noexcept {
+        tsl_assert(!empty());
+        return m_index;
+    }
+    
+    index_type& index_ref() noexcept {
+        tsl_assert(!empty());
+        return m_index;
+    }
+    
+    void set_index(index_type index) noexcept {
+        tsl_assert(index <= max_size());
+        
+        m_index = index;
+    }
+    
+    truncated_hash_type truncated_hash() const noexcept {
+        tsl_assert(!empty());
+        return m_hash;
+    }
+    
+    truncated_hash_type& truncated_hash_ref() noexcept {
+        tsl_assert(!empty());
+        return m_hash;
+    }
+    
+    void set_hash(std::size_t hash) noexcept {
+        m_hash = truncate_hash(hash);
+    }
+    
+    
+    
+    static truncated_hash_type truncate_hash(std::size_t hash) noexcept {
+        return truncated_hash_type(hash);
+    }
+    
+    static std::size_t max_size() noexcept {
+        return std::numeric_limits<index_type>::max() - NB_RESERVED_INDEXES;
+    }
+    
+private:
+    static const index_type EMPTY_MARKER_INDEX = std::numeric_limits<index_type>::max();
+    static const std::size_t NB_RESERVED_INDEXES = 1;
+    
+    index_type m_index;
+    truncated_hash_type m_hash;
+};
+
+
+
+/**
+ * Internal common class used by ordered_map and ordered_set.
+ * 
+ * ValueType is what will be stored by ordered_hash (usually std::pair<Key, T> for map and Key for set).
+ * 
+ * KeySelect should be a FunctionObject which takes a ValueType in parameter and return a reference to the key.
+ * 
+ * ValueSelect should be a FunctionObject which takes a ValueType in parameter and return a reference to the value. 
+ * ValueSelect should be void if there is no value (in set for example).
+ * 
+ * ValueTypeContainer is the container which will be used to store ValueType values. 
+ * Usually a std::deque<ValueType, Allocator> or std::vector<ValueType, Allocator>.
+ * 
+ * 
+ * 
+ * The orderd_hash structure is a hash table which preserves the order of insertion of the elements.
+ * To do so, it stores the values in the ValueTypeContainer (m_values) using emplace_back at each
+ * insertion of a new element. Another structure (m_buckets of type std::vector<bucket_entry>) will 
+ * serve as buckets array for the hash table part. Each bucket stores an index which corresponds to 
+ * the index in m_values where the bucket's value is and the (truncated) hash of this value. An index
+ * is used instead of a pointer to the value to reduce the size of each bucket entry.
+ * 
+ * To resolve collisions in the buckets array, the structures use robin hood linear probing with 
+ * backward shift deletion.
+ */
+template<class ValueType,
+         class KeySelect,
+         class ValueSelect,
+         class Hash,
+         class KeyEqual,
+         class Allocator,
+         class ValueTypeContainer>
+class ordered_hash: private Hash, private KeyEqual {
+private:
+    template<typename U>
+    using has_mapped_type = typename std::integral_constant<bool, !std::is_same<U, void>::value>;
+    
+    static_assert(std::is_same<typename ValueTypeContainer::value_type, ValueType>::value, 
+                  "ValueTypeContainer::value_type != ValueType. "
+                  "Check that the ValueTypeContainer has 'Key' as type for a set or 'std::pair<Key, T>' as type for a map.");
+    
+    static_assert(std::is_same<typename ValueTypeContainer::allocator_type, Allocator>::value, 
+                  "ValueTypeContainer::allocator_type != Allocator. "
+                  "Check that the allocator for ValueTypeContainer is the same as Allocator.");
+    
+    static_assert(std::is_same<typename Allocator::value_type, ValueType>::value, 
+                  "Allocator::value_type != ValueType. "
+                  "Check that the allocator has 'Key' as type for a set or 'std::pair<Key, T>' as type for a map.");
+    
+    
+public:
+    template<bool IsConst>
+    class ordered_iterator;
+    
+    using key_type = typename KeySelect::key_type;
+    using value_type = ValueType;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using hasher = Hash;
+    using key_equal = KeyEqual;
+    using allocator_type = Allocator;
+    using reference = value_type&;
+    using const_reference = const value_type&;
+    using pointer = value_type*;
+    using const_pointer = const value_type*;
+    using iterator = ordered_iterator<false>;
+    using const_iterator = ordered_iterator<true>;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+    
+    using values_container_type = ValueTypeContainer;
+    
+public:
+    template<bool IsConst>
+    class ordered_iterator {
+        friend class ordered_hash;
+        
+    private:
+        using iterator = typename std::conditional<IsConst, 
+                                                    typename values_container_type::const_iterator, 
+                                                    typename values_container_type::iterator>::type;
+    
+        
+        ordered_iterator(iterator it) noexcept: m_iterator(it) {
+        }
+        
+    public:
+        using iterator_category = std::random_access_iterator_tag;
+        using value_type = const typename ordered_hash::value_type;
+        using difference_type = typename iterator::difference_type;
+        using reference = value_type&;
+        using pointer = value_type*;
+        
+        
+        ordered_iterator() noexcept {
+        }
+        
+        ordered_iterator(const ordered_iterator<false>& other) noexcept: m_iterator(other.m_iterator) {
+        }
+
+        const typename ordered_hash::key_type& key() const {
+            return KeySelect()(*m_iterator);
+        }
+
+        template<class U = ValueSelect, typename std::enable_if<has_mapped_type<U>::value && IsConst>::type* = nullptr>
+        const typename U::value_type& value() const {
+            return U()(*m_iterator);
+        }
+
+        template<class U = ValueSelect, typename std::enable_if<has_mapped_type<U>::value && !IsConst>::type* = nullptr>
+        typename U::value_type& value() {
+            return U()(*m_iterator);
+        }
+        
+        reference operator*() const { return *m_iterator; }
+        pointer operator->() const { return m_iterator.operator->(); }
+        
+        ordered_iterator& operator++() { ++m_iterator; return *this; }
+        ordered_iterator& operator--() { --m_iterator; return *this; }
+        
+        ordered_iterator operator++(int) { ordered_iterator tmp(*this); ++(*this); return tmp; }
+        ordered_iterator operator--(int) { ordered_iterator tmp(*this); --(*this); return tmp; }
+        
+        reference operator[](difference_type n) const { return m_iterator[n]; }
+        
+        ordered_iterator& operator+=(difference_type n) { m_iterator += n; return *this; }
+        ordered_iterator& operator-=(difference_type n) { m_iterator -= n; return *this; }
+        
+        ordered_iterator operator+(difference_type n) { ordered_iterator tmp(*this); tmp += n; return tmp; }
+        ordered_iterator operator-(difference_type n) { ordered_iterator tmp(*this); tmp -= n; return tmp; }
+        
+        friend bool operator==(const ordered_iterator& lhs, const ordered_iterator& rhs) { 
+            return lhs.m_iterator == rhs.m_iterator; 
+        }
+        
+        friend bool operator!=(const ordered_iterator& lhs, const ordered_iterator& rhs) { 
+            return lhs.m_iterator != rhs.m_iterator; 
+        }
+        
+        friend bool operator<(const ordered_iterator& lhs, const ordered_iterator& rhs) { 
+            return lhs.m_iterator < rhs.m_iterator; 
+        }
+        
+        friend bool operator>(const ordered_iterator& lhs, const ordered_iterator& rhs) { 
+            return lhs.m_iterator > rhs.m_iterator; 
+        }
+        
+        friend bool operator<=(const ordered_iterator& lhs, const ordered_iterator& rhs) { 
+            return lhs.m_iterator <= rhs.m_iterator; 
+        }
+        
+        friend bool operator>=(const ordered_iterator& lhs, const ordered_iterator& rhs) { 
+            return lhs.m_iterator >= rhs.m_iterator; 
+        }
+
+        friend ordered_iterator operator+(difference_type n, const ordered_iterator& it) { 
+            return n + it.m_iterator;
+        }
+
+        friend difference_type operator-(const ordered_iterator& lhs, const ordered_iterator& rhs) { 
+            return lhs.m_iterator - rhs.m_iterator; 
+        }
+
+    private:
+        iterator m_iterator;
+    };
+    
+    
+private:
+    using buckets_container_allocator = typename 
+                            std::allocator_traits<allocator_type>::template rebind_alloc<bucket_entry>; 
+                            
+    using buckets_container_type = std::vector<bucket_entry, buckets_container_allocator>;
+    
+    
+    using truncated_hash_type = typename bucket_entry::truncated_hash_type;
+    using index_type = typename bucket_entry::index_type;
+    
+public:
+    ordered_hash(size_type bucket_count, 
+                 const Hash& hash,
+                 const KeyEqual& equal,
+                 const Allocator& alloc,
+                 float max_load_factor): Hash(hash), KeyEqual(equal), m_buckets(alloc), 
+                                         m_values(alloc), m_grow_on_next_insert(false)
+    {
+        bucket_count = round_up_to_power_of_two(bucket_count);
+        if(bucket_count > max_bucket_count()) {
+            TSL_THROW_OR_TERMINATE(std::length_error("The map exceeds its maxmimum size."));
+        }
+        tsl_assert(bucket_count > 0);
+        
+        m_buckets.resize(bucket_count);
+        m_mask = bucket_count - 1; 
+        
+        this->max_load_factor(max_load_factor);
+    }
+    
+    allocator_type get_allocator() const {
+        return m_values.get_allocator();
+    }
+    
+    
+    /*
+     * Iterators
+     */
+    iterator begin() noexcept {
+        return iterator(m_values.begin());
+    }
+    
+    const_iterator begin() const noexcept {
+        return cbegin();
+    }
+    
+    const_iterator cbegin() const noexcept {
+        return const_iterator(m_values.cbegin());
+    }
+    
+    iterator end() noexcept {
+        return iterator(m_values.end());
+    }
+    
+    const_iterator end() const noexcept {
+        return cend();
+    }
+    
+    const_iterator cend() const noexcept {
+        return const_iterator(m_values.cend());
+    }  
+    
+    
+    reverse_iterator rbegin() noexcept {
+        return reverse_iterator(m_values.end());
+    }
+    
+    const_reverse_iterator rbegin() const noexcept {
+        return rcbegin();
+    }
+    
+    const_reverse_iterator rcbegin() const noexcept {
+        return const_reverse_iterator(m_values.cend());
+    }
+    
+    reverse_iterator rend() noexcept {
+        return reverse_iterator(m_values.begin());
+    }
+    
+    const_reverse_iterator rend() const noexcept {
+        return rcend();
+    }
+    
+    const_reverse_iterator rcend() const noexcept {
+        return const_reverse_iterator(m_values.cbegin());
+    }  
+    
+    
+    /*
+     * Capacity
+     */
+    bool empty() const noexcept {
+        return m_values.empty();
+    }
+    
+    size_type size() const noexcept {
+        return m_values.size();
+    }
+    
+    size_type max_size() const noexcept {
+        return std::min(bucket_entry::max_size(), m_values.max_size());
+    }
+    
+
+    /*
+     * Modifiers
+     */
+    void clear() noexcept {
+        for(auto& bucket: m_buckets) {
+            bucket.clear();
+        }
+        
+        m_values.clear();
+        m_grow_on_next_insert = false;
+    }
+    
+    template<typename P>
+    std::pair<iterator, bool> insert(P&& value) {
+        return insert_impl(KeySelect()(value), std::forward<P>(value));
+    }
+    
+    template<typename P>
+    iterator insert(const_iterator hint, P&& value) { 
+        if(hint != cend() && compare_keys(KeySelect()(*hint), KeySelect()(value))) { 
+            return mutable_iterator(hint); 
+        }
+        
+        return insert(std::forward<P>(value)).first; 
+    }
+    
+    template<class InputIt>
+    void insert(InputIt first, InputIt last) {
+        if(std::is_base_of<std::forward_iterator_tag, 
+                           typename std::iterator_traits<InputIt>::iterator_category>::value) 
+        {
+            const auto nb_elements_insert = std::distance(first, last);
+            const size_type nb_free_buckets = m_load_threshold - size();
+            tsl_assert(m_load_threshold >= size());
+            
+            if(nb_elements_insert > 0 && nb_free_buckets < size_type(nb_elements_insert)) {
+                reserve(size() + size_type(nb_elements_insert));
+            }
+        }
+        
+        for(; first != last; ++first) {
+            insert(*first);
+        }
+    }
+    
+    
+    
+    template<class K, class M>
+    std::pair<iterator, bool> insert_or_assign(K&& key, M&& value) {
+        auto it = try_emplace(std::forward<K>(key), std::forward<M>(value));
+        if(!it.second) {
+            it.first.value() = std::forward<M>(value);
+        }
+        
+        return it;
+    }
+    
+    template<class K, class M>
+    iterator insert_or_assign(const_iterator hint, K&& key, M&& obj) {
+        if(hint != cend() && compare_keys(KeySelect()(*hint), key)) { 
+            auto it = mutable_iterator(hint); 
+            it.value() = std::forward<M>(obj);
+            
+            return it;
+        }
+        
+        return insert_or_assign(std::forward<K>(key), std::forward<M>(obj)).first;
+    }
+    
+    
+    
+    template<class... Args>
+    std::pair<iterator, bool> emplace(Args&&... args) {
+        return insert(value_type(std::forward<Args>(args)...));
+    }
+    
+    template<class... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args) { 
+        return insert(hint, value_type(std::forward<Args>(args)...));
+    }
+    
+    
+    
+    template<class K, class... Args>
+    std::pair<iterator, bool> try_emplace(K&& key, Args&&... value_args) {
+        return insert_impl(key, std::piecewise_construct, 
+                                std::forward_as_tuple(std::forward<K>(key)), 
+                                std::forward_as_tuple(std::forward<Args>(value_args)...));     
+    }
+    
+    template<class K, class... Args>
+    iterator try_emplace(const_iterator hint, K&& key, Args&&... args) {
+        if(hint != cend() && compare_keys(KeySelect()(*hint), key)) { 
+            return mutable_iterator(hint); 
+        }
+        
+        return try_emplace(std::forward<K>(key), std::forward<Args>(args)...).first;
+    }
+    
+    
+    
+    /**
+     * Here to avoid `template<class K> size_type erase(const K& key)` being used when
+     * we use a iterator instead of a const_iterator.
+     */
+    iterator erase(iterator pos) {
+        return erase(const_iterator(pos));
+    }
+    
+    iterator erase(const_iterator pos) {
+        tsl_assert(pos != cend());
+        
+        const std::size_t index_erase = iterator_to_index(pos);
+        
+        auto it_bucket = find_key(pos.key(), hash_key(pos.key()));
+        tsl_assert(it_bucket != m_buckets.end());
+        
+        erase_value_from_bucket(it_bucket);
+        
+        /*
+         * One element was removed from m_values, due to the left shift the next element 
+         * is now at the position of the previous element (or end if none).
+         */
+        return begin() + index_erase;
+    }
+
+    iterator erase(const_iterator first, const_iterator last) {
+        if(first == last) {
+            return mutable_iterator(first);
+        }
+        
+        tsl_assert(std::distance(first, last) > 0);
+        const std::size_t start_index = iterator_to_index(first);
+        const std::size_t nb_values = std::size_t(std::distance(first, last));
+        const std::size_t end_index = start_index + nb_values;
+        
+        // Delete all values
+#ifdef TSL_NO_CONTAINER_ERASE_CONST_ITERATOR     
+        auto next_it = m_values.erase(mutable_iterator(first).m_iterator, mutable_iterator(last).m_iterator);   
+#else
+        auto next_it = m_values.erase(first.m_iterator, last.m_iterator);
+#endif
+        
+        /*
+         * Mark the buckets corresponding to the values as empty and do a backward shift.
+         * 
+         * Also, the erase operation on m_values has shifted all the values on the right of last.m_iterator.
+         * Adapt the indexes for these values.
+         */
+        std::size_t ibucket = 0;
+        while(ibucket < m_buckets.size()) {
+            if(m_buckets[ibucket].empty()) {
+                ibucket++;
+            }
+            else if(m_buckets[ibucket].index() >= start_index && m_buckets[ibucket].index() < end_index) {
+                m_buckets[ibucket].clear();
+                backward_shift(ibucket);
+                // Don't increment ibucket, backward_shift may have replaced current bucket.
+            }
+            else if(m_buckets[ibucket].index() >= end_index) {
+                m_buckets[ibucket].set_index(index_type(m_buckets[ibucket].index() - nb_values));
+                ibucket++;
+            }
+            else {
+                ibucket++;
+            }
+        }
+        
+        return iterator(next_it);
+    }
+    
+
+    template<class K>
+    size_type erase(const K& key) {
+        return erase(key, hash_key(key));
+    }
+    
+    template<class K>
+    size_type erase(const K& key, std::size_t hash) {
+        return erase_impl(key, hash);
+    }
+    
+    void swap(ordered_hash& other) {
+        using std::swap;
+        
+        swap(static_cast<Hash&>(*this), static_cast<Hash&>(other));
+        swap(static_cast<KeyEqual&>(*this), static_cast<KeyEqual&>(other));
+        swap(m_buckets, other.m_buckets);
+        swap(m_mask, other.m_mask);
+        swap(m_values, other.m_values);
+        swap(m_grow_on_next_insert, other.m_grow_on_next_insert);
+        swap(m_max_load_factor, other.m_max_load_factor);
+        swap(m_load_threshold, other.m_load_threshold);
+    }
+    
+        
+    
+
+    /*
+     * Lookup
+     */    
+    template<class K, class U = ValueSelect, typename std::enable_if<has_mapped_type<U>::value>::type* = nullptr>
+    typename U::value_type& at(const K& key) {
+        return at(key, hash_key(key));
+    }
+    
+    template<class K, class U = ValueSelect, typename std::enable_if<has_mapped_type<U>::value>::type* = nullptr>
+    typename U::value_type& at(const K& key, std::size_t hash) {
+        return const_cast<typename U::value_type&>(static_cast<const ordered_hash*>(this)->at(key, hash));
+    }
+    
+    template<class K, class U = ValueSelect, typename std::enable_if<has_mapped_type<U>::value>::type* = nullptr>
+    const typename U::value_type& at(const K& key) const {
+        return at(key, hash_key(key));
+    }
+    
+    template<class K, class U = ValueSelect, typename std::enable_if<has_mapped_type<U>::value>::type* = nullptr>
+    const typename U::value_type& at(const K& key, std::size_t hash) const {
+        auto it = find(key, hash);
+        if(it != end()) {
+            return it.value();
+        }
+        else {
+            TSL_THROW_OR_TERMINATE(std::out_of_range("Couldn't find the key."));
+        }
+    }
+    
+    
+    template<class K, class U = ValueSelect, typename std::enable_if<has_mapped_type<U>::value>::type* = nullptr>
+    typename U::value_type& operator[](K&& key) {
+        return try_emplace(std::forward<K>(key)).first.value();
+    }
+    
+    
+    template<class K>
+    size_type count(const K& key) const {
+        return count(key, hash_key(key));
+    }
+    
+    template<class K>
+    size_type count(const K& key, std::size_t hash) const {
+        if(find(key, hash) == cend()) {
+            return 0;
+        }
+        else {
+            return 1;
+        }
+    }
+    
+    template<class K>
+    iterator find(const K& key) {
+        return find(key, hash_key(key));
+    }
+    
+    template<class K>
+    iterator find(const K& key, std::size_t hash) {
+        auto it_bucket = find_key(key, hash);
+        return (it_bucket != m_buckets.end())?iterator(m_values.begin() + it_bucket->index()):end();
+    }
+    
+    template<class K>
+    const_iterator find(const K& key) const {
+        return find(key, hash_key(key));
+    }
+    
+    template<class K>
+    const_iterator find(const K& key, std::size_t hash) const {
+        auto it_bucket = find_key(key, hash);
+        return (it_bucket != m_buckets.cend())?const_iterator(m_values.begin() + it_bucket->index()):end();
+    }
+    
+    
+    template<class K>
+    std::pair<iterator, iterator> equal_range(const K& key) {
+        return equal_range(key, hash_key(key));
+    }
+    
+    template<class K>
+    std::pair<iterator, iterator> equal_range(const K& key, std::size_t hash) {
+        iterator it = find(key, hash);
+        return std::make_pair(it, (it == end())?it:std::next(it));
+    }
+    
+    template<class K>
+    std::pair<const_iterator, const_iterator> equal_range(const K& key) const {
+        return equal_range(key, hash_key(key));
+    }
+    
+    template<class K>
+    std::pair<const_iterator, const_iterator> equal_range(const K& key, std::size_t hash) const {
+        const_iterator it = find(key, hash);
+        return std::make_pair(it, (it == cend())?it:std::next(it));
+    }    
+    
+    
+    /*
+     * Bucket interface 
+     */
+    size_type bucket_count() const {
+        return m_buckets.size(); 
+    }
+    
+    size_type max_bucket_count() const {
+        return m_buckets.max_size();
+    }    
+    
+    /*
+     *  Hash policy 
+     */
+    float load_factor() const {
+        return float(size())/float(bucket_count());
+    }
+    
+    float max_load_factor() const {
+        return m_max_load_factor;
+    }
+    
+    void max_load_factor(float ml) {
+        m_max_load_factor = std::max(0.1f, std::min(ml, 0.95f));
+        m_load_threshold = size_type(float(bucket_count())*m_max_load_factor);
+    }
+    
+    void rehash(size_type count) {
+        count = std::max(count, size_type(std::ceil(float(size())/max_load_factor())));
+        rehash_impl(count);
+    }
+    
+    void reserve(size_type count) {
+        reserve_space_for_values(count);
+        
+        count = size_type(std::ceil(float(count)/max_load_factor()));
+        rehash(count);
+    }
+    
+    
+    /*
+     * Observers
+     */
+    hasher hash_function() const {
+        return static_cast<const Hash&>(*this);
+    }
+    
+    key_equal key_eq() const {
+        return static_cast<const KeyEqual&>(*this);
+    }
+
+    
+    /*
+     * Other
+     */
+    iterator mutable_iterator(const_iterator pos) {
+        return iterator(m_values.begin() + iterator_to_index(pos));
+    }
+    
+    iterator nth(size_type index) {
+        return iterator(m_values.begin() + index);
+    }
+    
+    const_iterator nth(size_type index) const {
+        return const_iterator(m_values.cbegin() + index);
+    }
+    
+    const_reference front() const {
+        return m_values.front();
+    }
+    
+    const_reference back() const {
+        return m_values.back();
+    }
+    
+    const values_container_type& values_container() const noexcept {
+        return m_values;
+    }
+    
+    template<class U = values_container_type, typename std::enable_if<is_vector<U>::value>::type* = nullptr>    
+    const typename values_container_type::value_type* data() const noexcept {
+        return m_values.data();
+    }
+    
+    template<class U = values_container_type, typename std::enable_if<is_vector<U>::value>::type* = nullptr>    
+    size_type capacity() const noexcept {
+        return m_values.capacity();
+    }
+    
+    void shrink_to_fit() {
+        m_values.shrink_to_fit();
+    }
+    
+    
+    template<typename P>
+    std::pair<iterator, bool> insert_at_position(const_iterator pos, P&& value) {
+        return insert_at_position_impl(pos.m_iterator, KeySelect()(value), std::forward<P>(value));
+    }
+    
+    template<class... Args>
+    std::pair<iterator, bool> emplace_at_position(const_iterator pos, Args&&... args) {
+        return insert_at_position(pos, value_type(std::forward<Args>(args)...));
+    }
+    
+    template<class K, class... Args>
+    std::pair<iterator, bool> try_emplace_at_position(const_iterator pos, K&& key, Args&&... value_args) {
+        return insert_at_position_impl(pos.m_iterator, key, 
+                                       std::piecewise_construct, 
+                                       std::forward_as_tuple(std::forward<K>(key)), 
+                                       std::forward_as_tuple(std::forward<Args>(value_args)...));
+    }
+    
+
+    void pop_back() {
+        tsl_assert(!empty());
+        erase(std::prev(end()));
+    }
+    
+    
+    /**
+     * Here to avoid `template<class K> size_type unordered_erase(const K& key)` being used when
+     * we use a iterator instead of a const_iterator.
+     */    
+    iterator unordered_erase(iterator pos) {
+        return unordered_erase(const_iterator(pos));
+    }
+    
+    iterator unordered_erase(const_iterator pos) {
+        const std::size_t index_erase = iterator_to_index(pos);
+        unordered_erase(pos.key());
+        
+        /*
+         * One element was deleted, index_erase now points to the next element as the elements after
+         * the deleted value were shifted to the left in m_values (will be end() if we deleted the last element).
+         */
+        return begin() + index_erase;
+    }
+    
+    template<class K>
+    size_type unordered_erase(const K& key) {
+        return unordered_erase(key, hash_key(key));
+    }
+    
+    template<class K>
+    size_type unordered_erase(const K& key, std::size_t hash) {
+        auto it_bucket_key = find_key(key, hash);
+        if(it_bucket_key == m_buckets.end()) {
+            return 0;
+        }
+        
+        /**
+         * If we are not erasing the last element in m_values, we swap 
+         * the element we are erasing with the last element. We then would 
+         * just have to do a pop_back() in m_values.
+         */
+        if(!compare_keys(key, KeySelect()(back()))) {
+            auto it_bucket_last_elem = find_key(KeySelect()(back()), hash_key(KeySelect()(back())));
+            tsl_assert(it_bucket_last_elem != m_buckets.end());
+            tsl_assert(it_bucket_last_elem->index() == m_values.size() - 1);
+            
+            using std::swap;
+            swap(m_values[it_bucket_key->index()], m_values[it_bucket_last_elem->index()]);
+            swap(it_bucket_key->index_ref(), it_bucket_last_elem->index_ref());
+        }
+        
+        erase_value_from_bucket(it_bucket_key);
+        
+        return 1;
+    }
+    
+    friend bool operator==(const ordered_hash& lhs, const ordered_hash& rhs) {
+        return lhs.m_values == rhs.m_values;
+    }
+    
+    friend bool operator!=(const ordered_hash& lhs, const ordered_hash& rhs) {
+        return lhs.m_values != rhs.m_values;
+    }
+    
+    friend bool operator<(const ordered_hash& lhs, const ordered_hash& rhs) {
+        return lhs.m_values < rhs.m_values;
+    }
+    
+    friend bool operator<=(const ordered_hash& lhs, const ordered_hash& rhs) {
+        return lhs.m_values <= rhs.m_values;
+    }
+    
+    friend bool operator>(const ordered_hash& lhs, const ordered_hash& rhs) {
+        return lhs.m_values > rhs.m_values;
+    }
+    
+    friend bool operator>=(const ordered_hash& lhs, const ordered_hash& rhs) {
+        return lhs.m_values >= rhs.m_values;
+    }
+    
+    
+private:
+    template<class K>
+    std::size_t hash_key(const K& key) const {
+        return Hash::operator()(key);
+    }
+    
+    template<class K1, class K2>
+    bool compare_keys(const K1& key1, const K2& key2) const {
+        return KeyEqual::operator()(key1, key2);
+    }
+    
+    template<class K>
+    typename buckets_container_type::iterator find_key(const K& key, std::size_t hash) {
+        auto it = static_cast<const ordered_hash*>(this)->find_key(key, hash);
+        return m_buckets.begin() + std::distance(m_buckets.cbegin(), it);
+    }
+    
+    /**
+     * Return bucket which has the key 'key' or m_buckets.end() if none.
+     * 
+     * From the bucket_for_hash, search for the value until we either find an empty bucket
+     * or a bucket which has a value with a distance from its ideal bucket longer
+     * than the probe length for the value we are looking for.
+     */
+    template<class K>
+    typename buckets_container_type::const_iterator find_key(const K& key, std::size_t hash) const {
+        for(std::size_t ibucket = bucket_for_hash(hash), dist_from_ideal_bucket = 0; ; 
+            ibucket = next_bucket(ibucket), dist_from_ideal_bucket++) 
+        {
+            if(m_buckets[ibucket].empty()) {
+                return m_buckets.end();
+            }
+            else if(m_buckets[ibucket].truncated_hash() == bucket_entry::truncate_hash(hash) && 
+                    compare_keys(key, KeySelect()(m_values[m_buckets[ibucket].index()]))) 
+            {
+                return m_buckets.begin() + ibucket;
+            }
+            else if(dist_from_ideal_bucket > distance_from_ideal_bucket(ibucket)) {
+                return m_buckets.end();
+            }
+        }
+    }
+    
+    void rehash_impl(size_type bucket_count) {
+        bucket_count = round_up_to_power_of_two(bucket_count);
+        tsl_assert(bucket_count > 0);
+        
+        if(bucket_count == this->bucket_count()) {
+            return;
+        }
+        
+        if(bucket_count > max_bucket_count()) {
+            TSL_THROW_OR_TERMINATE(std::length_error("The map exceeds its maxmimum size."));
+        }
+        
+        
+        buckets_container_type old_buckets(bucket_count);
+        m_buckets.swap(old_buckets);
+        // Everything should be noexcept from here.
+        
+        m_mask = bucket_count - 1;
+        this->max_load_factor(m_max_load_factor);
+        m_grow_on_next_insert = false;
+        
+        
+        
+        for(const bucket_entry& old_bucket: old_buckets) {
+            if(old_bucket.empty()) {
+                continue;
+            }
+            
+            truncated_hash_type insert_hash = old_bucket.truncated_hash();
+            index_type insert_index = old_bucket.index();
+            
+            for(std::size_t ibucket = bucket_for_hash(insert_hash), dist_from_ideal_bucket = 0; ; 
+                ibucket = next_bucket(ibucket), dist_from_ideal_bucket++) 
+            {
+                if(m_buckets[ibucket].empty()) {
+                    m_buckets[ibucket].set_index(insert_index);
+                    m_buckets[ibucket].set_hash(insert_hash);
+                    break;
+                }
+                
+                const std::size_t distance = distance_from_ideal_bucket(ibucket);
+                if(dist_from_ideal_bucket > distance) {
+                    std::swap(insert_index, m_buckets[ibucket].index_ref());
+                    std::swap(insert_hash, m_buckets[ibucket].truncated_hash_ref());
+                    dist_from_ideal_bucket = distance;
+                }
+            }
+        }
+    }
+    
+    template<class T = values_container_type, typename std::enable_if<is_vector<T>::value>::type* = nullptr>
+    void reserve_space_for_values(size_type count) {
+        m_values.reserve(count);
+    }
+    
+    template<class T = values_container_type, typename std::enable_if<!is_vector<T>::value>::type* = nullptr>
+    void reserve_space_for_values(size_type /*count*/) {
+    }
+    
+    /**
+     * Swap the empty bucket with the values on its right until we cross another empty bucket
+     * or if the other bucket has a distance_from_ideal_bucket == 0.
+     */
+    void backward_shift(std::size_t empty_ibucket) noexcept {
+        tsl_assert(m_buckets[empty_ibucket].empty());
+        
+        std::size_t previous_ibucket = empty_ibucket;
+        for(std::size_t current_ibucket = next_bucket(previous_ibucket); 
+            !m_buckets[current_ibucket].empty() && distance_from_ideal_bucket(current_ibucket) > 0;
+            previous_ibucket = current_ibucket, current_ibucket = next_bucket(current_ibucket)) 
+        {
+            std::swap(m_buckets[current_ibucket], m_buckets[previous_ibucket]);
+        }
+    }
+    
+    void erase_value_from_bucket(typename buckets_container_type::iterator it_bucket) {
+        tsl_assert(it_bucket != m_buckets.end() && !it_bucket->empty());
+        
+        m_values.erase(m_values.begin() + it_bucket->index());
+        
+        /*
+         * m_values.erase shifted all the values on the right of the erased value, 
+         * shift the indexes by 1 in the buckets array for these values.
+         */
+        if(it_bucket->index() != m_values.size()) {
+            shift_indexes_in_buckets(it_bucket->index(), short(1));
+        }        
+        
+        // Mark the bucket as empty and do a backward shift of the values on the right
+        it_bucket->clear();
+        backward_shift(std::size_t(std::distance(m_buckets.begin(), it_bucket)));
+    }
+    
+    /**
+     * Go through each value from [from_ivalue, m_values.size()) in m_values and for each
+     * bucket corresponding to the value, shift the indexes to the left by delta.
+     */
+    void shift_indexes_in_buckets(index_type from_ivalue, short delta) noexcept  {
+        static_assert(std::is_unsigned<index_type>::value && sizeof(index_type) >= sizeof(short), 
+                      "index_type should be unsigned and sizeof(index_type) >= sizeof(short)");
+        
+        for(std::size_t ivalue = from_ivalue; ivalue < m_values.size(); ivalue++) {
+            std::size_t ibucket = bucket_for_hash(hash_key(KeySelect()(m_values[ivalue])));
+            
+            // Modulo arithmetic, we should be alright for index_type(ivalue + delta). TODO further checks
+            while(m_buckets[ibucket].index() != index_type(ivalue + delta)) {
+                ibucket = next_bucket(ibucket);
+            }
+            
+            m_buckets[ibucket].set_index(index_type(m_buckets[ibucket].index() - delta));
+        }
+    }
+    
+    template<class K>
+    size_type erase_impl(const K& key, std::size_t hash) {
+        auto it_bucket = find_key(key, hash);
+        if(it_bucket != m_buckets.end()) {
+            erase_value_from_bucket(it_bucket);
+            
+            return 1;
+        }
+        else {
+            return 0;
+        }
+    }
+    
+    /**
+     * Insert the element at the end.
+     */
+    template<class K, class... Args>
+    std::pair<iterator, bool> insert_impl(const K& key, Args&&... value_type_args) {
+        const std::size_t hash = hash_key(key);
+        
+        std::size_t ibucket = bucket_for_hash(hash); 
+        std::size_t dist_from_ideal_bucket = 0;
+        
+        while(!m_buckets[ibucket].empty() && dist_from_ideal_bucket <= distance_from_ideal_bucket(ibucket)) {
+            if(m_buckets[ibucket].truncated_hash() == bucket_entry::truncate_hash(hash) && 
+               compare_keys(key, KeySelect()(m_values[m_buckets[ibucket].index()]))) 
+            {
+                return std::make_pair(begin() + m_buckets[ibucket].index(), false);
+            }
+            
+            ibucket = next_bucket(ibucket);
+            dist_from_ideal_bucket++;
+        }
+        
+        if(size() >= max_size()) {
+            TSL_THROW_OR_TERMINATE(std::length_error("We reached the maximum size for the hash table."));
+        }
+        
+        
+        if(grow_on_high_load()) {
+            ibucket = bucket_for_hash(hash);
+            dist_from_ideal_bucket = 0;
+        }
+        
+                
+        m_values.emplace_back(std::forward<Args>(value_type_args)...);
+        insert_index(ibucket, dist_from_ideal_bucket, 
+                     index_type(m_values.size() - 1), bucket_entry::truncate_hash(hash));
+        
+        
+        return std::make_pair(std::prev(end()), true);
+    }
+    
+    /**
+     * Insert the element before insert_position.
+     */
+    template<class K, class... Args>
+    std::pair<iterator, bool> insert_at_position_impl(typename values_container_type::const_iterator insert_position,
+                                                      const K& key, Args&&... value_type_args) 
+    {
+        const std::size_t hash = hash_key(key);
+        
+        std::size_t ibucket = bucket_for_hash(hash); 
+        std::size_t dist_from_ideal_bucket = 0;
+        
+        while(!m_buckets[ibucket].empty() && dist_from_ideal_bucket <= distance_from_ideal_bucket(ibucket)) {
+            if(m_buckets[ibucket].truncated_hash() == bucket_entry::truncate_hash(hash) && 
+               compare_keys(key, KeySelect()(m_values[m_buckets[ibucket].index()]))) 
+            {
+                return std::make_pair(begin() + m_buckets[ibucket].index(), false);
+            }
+            
+            ibucket = next_bucket(ibucket);
+            dist_from_ideal_bucket++;
+        }
+        
+        if(size() >= max_size()) {
+            TSL_THROW_OR_TERMINATE(std::length_error("We reached the maximum size for the hash table."));
+        }
+        
+        
+        if(grow_on_high_load()) {
+            ibucket = bucket_for_hash(hash);
+            dist_from_ideal_bucket = 0;
+        }
+        
+        
+        const index_type index_insert_position = index_type(std::distance(m_values.cbegin(), insert_position));
+        
+#ifdef TSL_NO_CONTAINER_EMPLACE_CONST_ITERATOR
+        m_values.emplace(m_values.begin() + std::distance(m_values.cbegin(), insert_position), std::forward<Args>(value_type_args)...);
+#else        
+        m_values.emplace(insert_position, std::forward<Args>(value_type_args)...);
+#endif        
+
+        insert_index(ibucket, dist_from_ideal_bucket, 
+                     index_insert_position, bucket_entry::truncate_hash(hash));
+        
+        /*
+         * The insertion didn't happend at the end of the m_values container, 
+         * we need to shift the indexes in m_buckets.
+         */
+        if(index_insert_position != m_values.size() - 1) {
+            shift_indexes_in_buckets(index_insert_position + 1, short(-1));
+        }
+        
+        return std::make_pair(iterator(m_values.begin() + index_insert_position), true);
+    }
+    
+    void insert_index(std::size_t ibucket, std::size_t dist_from_ideal_bucket, 
+                      index_type index_insert, truncated_hash_type hash_insert) noexcept
+    {
+        while(!m_buckets[ibucket].empty()) {
+            const std::size_t distance = distance_from_ideal_bucket(ibucket);
+            if(dist_from_ideal_bucket > distance) {
+                std::swap(index_insert, m_buckets[ibucket].index_ref());
+                std::swap(hash_insert, m_buckets[ibucket].truncated_hash_ref());
+                
+                dist_from_ideal_bucket = distance;
+            }
+
+            
+            ibucket = next_bucket(ibucket);
+            dist_from_ideal_bucket++;
+            
+            
+            if(dist_from_ideal_bucket > REHASH_ON_HIGH_NB_PROBES__NPROBES && !m_grow_on_next_insert &&
+               load_factor() >= REHASH_ON_HIGH_NB_PROBES__MIN_LOAD_FACTOR)
+            {
+                // We don't want to grow the map now as we need this method to be noexcept.
+                // Do it on next insert.
+                m_grow_on_next_insert = true;
+            }
+        }
+        
+        
+        m_buckets[ibucket].set_index(index_insert);
+        m_buckets[ibucket].set_hash(hash_insert); 
+    }
+    
+    std::size_t distance_from_ideal_bucket(std::size_t ibucket) const noexcept {
+        const std::size_t ideal_bucket = bucket_for_hash(m_buckets[ibucket].truncated_hash());
+        
+        if(ibucket >= ideal_bucket) {
+            return ibucket - ideal_bucket;
+        }
+        // If the bucket is smaller than the ideal bucket for the value, there was a wrapping at the end of the 
+        // bucket array due to the modulo.
+        else {
+            return (bucket_count() + ibucket) - ideal_bucket;
+        }
+    }
+    
+    std::size_t next_bucket(std::size_t index) const noexcept {
+        tsl_assert(index < m_buckets.size());
+        
+        index++;
+        return (index < m_buckets.size())?index:0;
+    }
+    
+    std::size_t bucket_for_hash(std::size_t hash) const noexcept {
+        return hash & m_mask;
+    }    
+    
+    std::size_t iterator_to_index(const_iterator it) const noexcept {
+        const auto dist = std::distance(cbegin(), it);
+        tsl_assert(dist >= 0);
+        
+        return std::size_t(dist);
+    }
+    
+    /**
+     * Return true if the map has been rehashed.
+     */
+    bool grow_on_high_load() {
+        if(m_grow_on_next_insert || size() >= m_load_threshold) {
+            rehash_impl(bucket_count() * 2);
+            m_grow_on_next_insert = false;
+            
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
+    
+    static std::size_t round_up_to_power_of_two(std::size_t value) {
+        if(is_power_of_two(value)) {
+            return value;
+        }
+        
+        if(value == 0) {
+            return 1;
+        }
+        
+        --value;
+        for(std::size_t i = 1; i < sizeof(std::size_t) * CHAR_BIT; i *= 2) {
+            value |= value >> i;
+        }
+        
+        return value + 1;
+    }
+    
+    static constexpr bool is_power_of_two(std::size_t value) {
+        return value != 0 && (value & (value - 1)) == 0;
+    }
+
+    
+public:
+    static const size_type DEFAULT_INIT_BUCKETS_SIZE = 16;
+    static constexpr float DEFAULT_MAX_LOAD_FACTOR = 0.75f;
+
+private:    
+    static const size_type REHASH_ON_HIGH_NB_PROBES__NPROBES = 128;
+    static constexpr float REHASH_ON_HIGH_NB_PROBES__MIN_LOAD_FACTOR = 0.15f;
+    
+private:
+    buckets_container_type m_buckets;
+    size_type m_mask;
+    
+    values_container_type m_values;
+    
+    bool m_grow_on_next_insert;
+    float m_max_load_factor;
+    size_type m_load_threshold;
+};
+
+
+} // end namespace detail_ordered_hash
+
+} // end namespace tsl
+
+#endif

--- a/src/thirdparty/ordered_map/ordered_map.h
+++ b/src/thirdparty/ordered_map/ordered_map.h
@@ -1,0 +1,787 @@
+/**
+ * MIT License
+ * 
+ * Copyright (c) 2017 Tessil
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef TSL_ORDERED_MAP_H
+#define TSL_ORDERED_MAP_H
+
+
+#include <cstddef>
+#include <deque>
+#include <functional>
+#include <initializer_list>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+#include "ordered_hash.h"
+
+
+namespace tsl {
+
+
+/**
+ * Implementation of an hash map using open adressing with robin hood with backshift delete to resolve collisions.
+ * 
+ * The particularity of this hash map is that it remembers the order in which the elements were added and
+ * provide a way to access the structure which stores these values through the 'values_container()' method. 
+ * The used container is defined by ValueTypeContainer, by default a std::deque is used (grows faster) but
+ * a std::vector may be used. In this case the map provides a 'data()' method which give a direct access 
+ * to the memory used to store the values (which can be usefull to communicate with C API's).
+ * 
+ * The Key and T must be copy constructible and/or move constructible. To use `unordered_erase` they both
+ * must be swappable.
+ * 
+ * The behaviour of the hash map is undefinded if the destructor of Key or T throws an exception.
+ * 
+ * Iterators invalidation:
+ *  - clear, operator=, reserve, rehash: always invalidate the iterators (also invalidate end()).
+ *  - insert, emplace, emplace_hint, operator[]: when a std::vector is used as ValueTypeContainer 
+ *                                               and if size() < capacity(), only end(). 
+ *                                               Otherwise all the iterators are invalidated if an insert occurs.
+ *  - erase, unordered_erase: when a std::vector is used as ValueTypeContainer invalidate the iterator of 
+ *                            the erased element and all the ones after the erased element (including end()). 
+ *                            Otherwise all the iterators are invalidated if an erase occurs.
+ */
+template<class Key, 
+         class T, 
+         class Hash = std::hash<Key>,
+         class KeyEqual = std::equal_to<Key>,
+         class Allocator = std::allocator<std::pair<Key, T>>,
+         class ValueTypeContainer = std::deque<std::pair<Key, T>, Allocator>>
+class ordered_map {
+private:
+    template<typename U>
+    using has_is_transparent = tsl::detail_ordered_hash::has_is_transparent<U>;
+    
+    class KeySelect {
+    public:
+        using key_type = Key;
+        
+        const key_type& operator()(const std::pair<Key, T>& key_value) const noexcept {
+            return key_value.first;
+        }
+        
+        key_type& operator()(std::pair<Key, T>& key_value) noexcept {
+            return key_value.first;
+        }
+    };  
+    
+    class ValueSelect {
+    public:
+        using value_type = T;
+        
+        const value_type& operator()(const std::pair<Key, T>& key_value) const noexcept {
+            return key_value.second;
+        }
+        
+        value_type& operator()(std::pair<Key, T>& key_value) noexcept {
+            return key_value.second;
+        }
+    };
+    
+    using ht = detail_ordered_hash::ordered_hash<std::pair<Key, T>, KeySelect, ValueSelect,
+                                                 Hash, KeyEqual, Allocator, ValueTypeContainer>;
+    
+public:
+    using key_type = typename ht::key_type;
+    using mapped_type = T;
+    using value_type = typename ht::value_type;
+    using size_type = typename ht::size_type;
+    using difference_type = typename ht::difference_type;
+    using hasher = typename ht::hasher;
+    using key_equal = typename ht::key_equal;
+    using allocator_type = typename ht::allocator_type;
+    using reference = typename ht::reference;
+    using const_reference = typename ht::const_reference;
+    using pointer = typename ht::pointer;
+    using const_pointer = typename ht::const_pointer;
+    using iterator = typename ht::iterator;
+    using const_iterator = typename ht::const_iterator;
+    using reverse_iterator = typename ht::reverse_iterator;
+    using const_reverse_iterator = typename ht::const_reverse_iterator;
+    
+    using values_container_type = typename ht::values_container_type;
+    
+    
+    /*
+     * Constructors
+     */
+    ordered_map(): ordered_map(ht::DEFAULT_INIT_BUCKETS_SIZE) {
+    }
+    
+    explicit ordered_map(size_type bucket_count, 
+                         const Hash& hash = Hash(),
+                         const KeyEqual& equal = KeyEqual(),
+                         const Allocator& alloc = Allocator()): 
+                     m_ht(bucket_count, hash, equal, alloc, ht::DEFAULT_MAX_LOAD_FACTOR)
+    {
+    }
+    
+    ordered_map(size_type bucket_count,
+                const Allocator& alloc): ordered_map(bucket_count, Hash(), KeyEqual(), alloc)
+    {
+    }
+    
+    ordered_map(size_type bucket_count,
+                const Hash& hash,
+                const Allocator& alloc): ordered_map(bucket_count, hash, KeyEqual(), alloc)
+    {
+    }
+    
+    explicit ordered_map(const Allocator& alloc): ordered_map(ht::DEFAULT_INIT_BUCKETS_SIZE, alloc) {
+    }
+    
+    template<class InputIt>
+    ordered_map(InputIt first, InputIt last,
+                size_type bucket_count = ht::DEFAULT_INIT_BUCKETS_SIZE,
+                const Hash& hash = Hash(),
+                const KeyEqual& equal = KeyEqual(),
+                const Allocator& alloc = Allocator()): ordered_map(bucket_count, hash, equal, alloc)
+    {
+        insert(first, last);
+    }
+    
+    template<class InputIt>
+    ordered_map(InputIt first, InputIt last,
+                size_type bucket_count,
+                const Allocator& alloc): ordered_map(first, last, bucket_count, Hash(), KeyEqual(), alloc)
+    {
+    }
+    
+    template<class InputIt>
+    ordered_map(InputIt first, InputIt last,
+                size_type bucket_count,
+                const Hash& hash,
+                const Allocator& alloc): ordered_map(first, last, bucket_count, hash, KeyEqual(), alloc)
+    {
+    }
+
+    ordered_map(std::initializer_list<value_type> init,
+                size_type bucket_count = ht::DEFAULT_INIT_BUCKETS_SIZE,
+                const Hash& hash = Hash(),
+                const KeyEqual& equal = KeyEqual(),
+                const Allocator& alloc = Allocator()): 
+            ordered_map(init.begin(), init.end(), bucket_count, hash, equal, alloc)
+    {
+    }
+
+    ordered_map(std::initializer_list<value_type> init,
+                size_type bucket_count,
+                const Allocator& alloc): 
+            ordered_map(init.begin(), init.end(), bucket_count, Hash(), KeyEqual(), alloc)
+    {
+    }
+
+    ordered_map(std::initializer_list<value_type> init,
+                size_type bucket_count,
+                const Hash& hash,
+                const Allocator& alloc): 
+            ordered_map(init.begin(), init.end(), bucket_count, hash, KeyEqual(), alloc)
+    {
+    }
+
+    
+    ordered_map& operator=(std::initializer_list<value_type> ilist) {
+        m_ht.clear();
+        
+        m_ht.reserve(ilist.size());
+        m_ht.insert(ilist.begin(), ilist.end());
+        
+        return *this;
+    }
+    
+    allocator_type get_allocator() const { return m_ht.get_allocator(); }
+    
+
+    
+    /*
+     * Iterators
+     */
+    iterator begin() noexcept { return m_ht.begin(); }
+    const_iterator begin() const noexcept { return m_ht.begin(); }
+    const_iterator cbegin() const noexcept { return m_ht.cbegin(); }
+    
+    iterator end() noexcept { return m_ht.end(); }
+    const_iterator end() const noexcept { return m_ht.end(); }
+    const_iterator cend() const noexcept { return m_ht.cend(); }
+    
+    reverse_iterator rbegin() noexcept { return m_ht.rbegin(); }
+    const_reverse_iterator rbegin() const noexcept { return m_ht.rbegin(); }
+    const_reverse_iterator rcbegin() const noexcept { return m_ht.rcbegin(); }
+    
+    reverse_iterator rend() noexcept { return m_ht.rend(); }
+    const_reverse_iterator rend() const noexcept { return m_ht.rend(); }
+    const_reverse_iterator rcend() const noexcept { return m_ht.rcend(); }
+    
+    
+    /*
+     * Capacity
+     */
+    bool empty() const noexcept { return m_ht.empty(); }
+    size_type size() const noexcept { return m_ht.size(); }
+    size_type max_size() const noexcept { return m_ht.max_size(); }
+    
+    /*
+     * Modifiers
+     */
+    void clear() noexcept { m_ht.clear(); }
+    
+    
+    
+    std::pair<iterator, bool> insert(const value_type& value) { return m_ht.insert(value); }
+        
+    template<class P, typename std::enable_if<std::is_constructible<value_type, P&&>::value>::type* = nullptr>
+    std::pair<iterator, bool> insert(P&& value) { return m_ht.emplace(std::forward<P>(value)); }
+    
+    std::pair<iterator, bool> insert(value_type&& value) { return m_ht.insert(std::move(value)); }
+    
+    
+    iterator insert(const_iterator hint, const value_type& value) {
+        return m_ht.insert(hint, value);
+    }
+        
+    template<class P, typename std::enable_if<std::is_constructible<value_type, P&&>::value>::type* = nullptr>
+    iterator insert(const_iterator hint, P&& value) {
+        return m_ht.emplace_hint(hint, std::forward<P>(value));
+    }
+    
+    iterator insert(const_iterator hint, value_type&& value) { 
+        return m_ht.insert(hint, std::move(value));
+    }
+    
+    
+    template<class InputIt>
+    void insert(InputIt first, InputIt last) { m_ht.insert(first, last); }
+    void insert(std::initializer_list<value_type> ilist) { m_ht.insert(ilist.begin(), ilist.end()); }
+
+    
+    
+    
+    template<class M>
+    std::pair<iterator, bool> insert_or_assign(const key_type& k, M&& obj) { 
+        return m_ht.insert_or_assign(k, std::forward<M>(obj)); 
+    }
+
+    template<class M>
+    std::pair<iterator, bool> insert_or_assign(key_type&& k, M&& obj) { 
+        return m_ht.insert_or_assign(std::move(k), std::forward<M>(obj)); 
+    }
+    
+    
+    template<class M>
+    iterator insert_or_assign(const_iterator hint, const key_type& k, M&& obj) {
+        return m_ht.insert_or_assign(hint, k, std::forward<M>(obj));
+    }
+    
+    template<class M>
+    iterator insert_or_assign(const_iterator hint, key_type&& k, M&& obj) {
+        return m_ht.insert_or_assign(hint, std::move(k), std::forward<M>(obj));
+    }
+    
+    /**
+     * Due to the way elements are stored, emplace will need to move or copy the key-value once.
+     * The method is equivalent to insert(value_type(std::forward<Args>(args)...));
+     * 
+     * Mainly here for compatibility with the std::unordered_map interface.
+     */
+    template<class... Args>
+    std::pair<iterator, bool> emplace(Args&&... args) { return m_ht.emplace(std::forward<Args>(args)...); }
+    
+    /**
+     * Due to the way elements are stored, emplace_hint will need to move or copy the key-value once.
+     * The method is equivalent to insert(hint, value_type(std::forward<Args>(args)...));
+     * 
+     * Mainly here for compatibility with the std::unordered_map interface.
+     */
+    template <class... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args) {
+        return m_ht.emplace_hint(hint, std::forward<Args>(args)...);
+    }
+    
+    
+    
+    
+    template<class... Args>
+    std::pair<iterator, bool> try_emplace(const key_type& k, Args&&... args) { 
+        return m_ht.try_emplace(k, std::forward<Args>(args)...);
+    }
+    
+    template<class... Args>
+    std::pair<iterator, bool> try_emplace(key_type&& k, Args&&... args) {
+        return m_ht.try_emplace(std::move(k), std::forward<Args>(args)...);
+    }
+    
+    template<class... Args>
+    iterator try_emplace(const_iterator hint, const key_type& k, Args&&... args) {
+        return m_ht.try_emplace(hint, k, std::forward<Args>(args)...);
+    }
+    
+    template<class... Args>
+    iterator try_emplace(const_iterator hint, key_type&& k, Args&&... args) {
+        return m_ht.try_emplace(hint, std::move(k), std::forward<Args>(args)...);
+    }
+    
+    
+    
+
+    /**
+     * When erasing an element, the insert order will be preserved and no holes will be present in the container
+     * returned by 'values_container()'. 
+     * 
+     * The method is in O(n), if the order is not important 'unordered_erase(...)' method is faster with an O(1)
+     * average complexity.
+     */
+    iterator erase(iterator pos) { return m_ht.erase(pos); }
+    
+    /**
+     * @copydoc erase(iterator pos)
+     */
+    iterator erase(const_iterator pos) { return m_ht.erase(pos); }
+    
+    /**
+     * @copydoc erase(iterator pos)
+     */    
+    iterator erase(const_iterator first, const_iterator last) { return m_ht.erase(first, last); }
+    
+    /**
+     * @copydoc erase(iterator pos)
+     */    
+    size_type erase(const key_type& key) { return m_ht.erase(key); }
+    
+    /**
+     * @copydoc erase(iterator pos)
+     * 
+     * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same
+     * as hash_function()(key). Usefull to speed-up the lookup to the value if you already have the hash.
+     */    
+    size_type erase(const key_type& key, std::size_t precalculated_hash) { 
+        return m_ht.erase(key, precalculated_hash); 
+    }
+    
+    /**
+     * @copydoc erase(iterator pos)
+     * 
+     * This overload only participates in the overload resolution if the typedef KeyEqual::is_transparent exists. 
+     * If so, K must be hashable and comparable to Key.
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr> 
+    size_type erase(const K& key) { return m_ht.erase(key); }
+    
+    /**
+     * @copydoc erase(const key_type& key, std::size_t precalculated_hash)
+     * 
+     * This overload only participates in the overload resolution if the typedef KeyEqual::is_transparent exists. 
+     * If so, K must be hashable and comparable to Key.
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr> 
+    size_type erase(const K& key, std::size_t precalculated_hash) { 
+        return m_ht.erase(key, precalculated_hash); 
+    }
+    
+    
+    
+    void swap(ordered_map& other) { other.m_ht.swap(m_ht); }
+    
+    /*
+     * Lookup
+     */
+    T& at(const Key& key) { return m_ht.at(key); }
+    
+    /**
+     * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same
+     * as hash_function()(key). Usefull to speed-up the lookup if you already have the hash.
+     */
+    T& at(const Key& key, std::size_t precalculated_hash) { return m_ht.at(key, precalculated_hash); }
+    
+    
+    const T& at(const Key& key) const { return m_ht.at(key); }
+    
+    /**
+     * @copydoc at(const Key& key, std::size_t precalculated_hash)
+     */
+    const T& at(const Key& key, std::size_t precalculated_hash) const { return m_ht.at(key, precalculated_hash); }
+    
+    
+    /**
+     * This overload only participates in the overload resolution if the typedef KeyEqual::is_transparent exists. 
+     * If so, K must be hashable and comparable to Key.
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr> 
+    T& at(const K& key) { return m_ht.at(key); }
+    
+    /**
+     * @copydoc at(const K& key)
+     * 
+     * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same
+     * as hash_function()(key). Usefull to speed-up the lookup if you already have the hash.
+     */    
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr> 
+    T& at(const K& key, std::size_t precalculated_hash) { return m_ht.at(key, precalculated_hash); }
+    
+    /**
+     * @copydoc at(const K& key)
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>     
+    const T& at(const K& key) const { return m_ht.at(key); }
+    
+    /**
+     * @copydoc at(const K& key, std::size_t precalculated_hash)
+     */    
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr> 
+    const T& at(const K& key, std::size_t precalculated_hash) const { return m_ht.at(key, precalculated_hash); }
+    
+    
+    
+    T& operator[](const Key& key) { return m_ht[key]; }    
+    T& operator[](Key&& key) { return m_ht[std::move(key)]; }
+    
+    
+    
+    size_type count(const Key& key) const { return m_ht.count(key); }
+    
+    /**
+     * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same
+     * as hash_function()(key). Usefull to speed-up the lookup if you already have the hash.
+     */
+    size_type count(const Key& key, std::size_t precalculated_hash) const { 
+        return m_ht.count(key, precalculated_hash); 
+    }
+    
+    /**
+     * This overload only participates in the overload resolution if the typedef KeyEqual::is_transparent exists. 
+     * If so, K must be hashable and comparable to Key.
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>     
+    size_type count(const K& key) const { return m_ht.count(key); }
+    
+    /**
+     * @copydoc count(const K& key) const
+     * 
+     * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same
+     * as hash_function()(key). Usefull to speed-up the lookup if you already have the hash.
+     */     
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr> 
+    size_type count(const K& key, std::size_t precalculated_hash) const { 
+        return m_ht.count(key, precalculated_hash);
+    }
+    
+    
+    
+    iterator find(const Key& key) { return m_ht.find(key); }
+    
+    /**
+     * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same
+     * as hash_function()(key). Usefull to speed-up the lookup if you already have the hash.
+     */
+    iterator find(const Key& key, std::size_t precalculated_hash) { return m_ht.find(key, precalculated_hash); }
+    
+    const_iterator find(const Key& key) const { return m_ht.find(key); }
+    
+    /**
+     * @copydoc find(const Key& key, std::size_t precalculated_hash)
+     */
+    const_iterator find(const Key& key, std::size_t precalculated_hash) const { 
+        return m_ht.find(key, precalculated_hash);
+    }
+    
+    /**
+     * This overload only participates in the overload resolution if the typedef KeyEqual::is_transparent exists. 
+     * If so, K must be hashable and comparable to Key.
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr> 
+    iterator find(const K& key) { return m_ht.find(key); }
+    
+    /**
+     * @copydoc find(const K& key)
+     * 
+     * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same
+     * as hash_function()(key). Usefull to speed-up the lookup if you already have the hash.
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr> 
+    iterator find(const K& key, std::size_t precalculated_hash) { return m_ht.find(key, precalculated_hash); }
+    
+    /**
+     * @copydoc find(const K& key)
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr> 
+    const_iterator find(const K& key) const { return m_ht.find(key); }
+    
+    /**
+     * @copydoc find(const K& key)
+     * 
+     * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same
+     * as hash_function()(key). Usefull to speed-up the lookup if you already have the hash.
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr> 
+    const_iterator find(const K& key, std::size_t precalculated_hash) const { 
+        return m_ht.find(key, precalculated_hash); 
+    }
+    
+    
+    
+    std::pair<iterator, iterator> equal_range(const Key& key) { return m_ht.equal_range(key); }
+    
+    /**
+     * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same
+     * as hash_function()(key). Usefull to speed-up the lookup if you already have the hash.
+     */
+    std::pair<iterator, iterator> equal_range(const Key& key, std::size_t precalculated_hash) { 
+        return m_ht.equal_range(key, precalculated_hash); 
+    }
+    
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const { return m_ht.equal_range(key); }
+    
+    /**
+     * @copydoc equal_range(const Key& key, std::size_t precalculated_hash)
+     */
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key, std::size_t precalculated_hash) const { 
+        return m_ht.equal_range(key, precalculated_hash); 
+    }
+
+    /**
+     * This overload only participates in the overload resolution if the typedef KeyEqual::is_transparent exists. 
+     * If so, K must be hashable and comparable to Key.
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>     
+    std::pair<iterator, iterator> equal_range(const K& key) { return m_ht.equal_range(key); }
+    
+    /**
+     * @copydoc equal_range(const K& key)
+     * 
+     * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same
+     * as hash_function()(key). Usefull to speed-up the lookup if you already have the hash.
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr> 
+    std::pair<iterator, iterator> equal_range(const K& key, std::size_t precalculated_hash) { 
+        return m_ht.equal_range(key, precalculated_hash); 
+    }
+    
+    /**
+     * @copydoc equal_range(const K& key)
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>     
+    std::pair<const_iterator, const_iterator> equal_range(const K& key) const { return m_ht.equal_range(key); }
+    
+    /**
+     * @copydoc equal_range(const K& key, std::size_t precalculated_hash)
+     */    
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr> 
+    std::pair<const_iterator, const_iterator> equal_range(const K& key, std::size_t precalculated_hash) const { 
+        return m_ht.equal_range(key, precalculated_hash); 
+    }
+    
+    
+    
+    /*
+     * Bucket interface 
+     */
+    size_type bucket_count() const { return m_ht.bucket_count(); }
+    size_type max_bucket_count() const { return m_ht.max_bucket_count(); }
+    
+    
+    /*
+     * Hash policy 
+     */
+    float load_factor() const { return m_ht.load_factor(); }
+    float max_load_factor() const { return m_ht.max_load_factor(); }
+    void max_load_factor(float ml) { m_ht.max_load_factor(ml); }
+    
+    void rehash(size_type count) { m_ht.rehash(count); }
+    void reserve(size_type count) { m_ht.reserve(count); }
+    
+    
+    /*
+     * Observers
+     */
+    hasher hash_function() const { return m_ht.hash_function(); }
+    key_equal key_eq() const { return m_ht.key_eq(); }
+    
+    
+    
+    /*
+     * Other
+     */
+    
+    /**
+     * Convert a const_iterator to an iterator.
+     */
+    iterator mutable_iterator(const_iterator pos) {
+        return m_ht.mutable_iterator(pos);
+    }
+    
+    /**
+     * Requires index <= size().
+     * 
+     * Return an iterator to the element at index. Return end() if index == size().
+     */
+    iterator nth(size_type index) { return m_ht.nth(index); }
+    
+    /**
+     * @copydoc nth(size_type index)
+     */
+    const_iterator nth(size_type index) const { return m_ht.nth(index); }
+    
+    
+    /**
+     * Return const_reference to the first element. Requires the container to not be empty.
+     */
+    const_reference front() const { return m_ht.front(); }
+    
+    /**
+     * Return const_reference to the last element. Requires the container to not be empty.
+     */
+    const_reference back() const { return m_ht.back(); }
+    
+    
+    /**
+     * Only available if ValueTypeContainer is a std::vector. Same as calling 'values_container().data()'.
+     */
+    template<class U = values_container_type, typename std::enable_if<tsl::detail_ordered_hash::is_vector<U>::value>::type* = nullptr>    
+    const typename values_container_type::value_type* data() const noexcept { return m_ht.data(); }
+        
+    /**
+     * Return the container in which the values are stored. The values are in the same order as the insertion order
+     * and are contiguous in the structure, no holes (size() == values_container().size()).
+     */
+    const values_container_type& values_container() const noexcept { return m_ht.values_container(); }
+
+    template<class U = values_container_type, typename std::enable_if<tsl::detail_ordered_hash::is_vector<U>::value>::type* = nullptr>    
+    size_type capacity() const noexcept { return m_ht.capacity(); }
+    
+    void shrink_to_fit() { m_ht.shrink_to_fit(); }
+    
+    
+    
+    /**
+     * Insert the value before pos shifting all the elements on the right of pos (including pos) one position 
+     * to the right.
+     * 
+     * Amortized linear time-complexity in the distance between pos and end().
+     */
+    std::pair<iterator, bool> insert_at_position(const_iterator pos, const value_type& value) { 
+        return m_ht.insert_at_position(pos, value); 
+    }
+    
+    /**
+     * @copydoc insert_at_position(const_iterator pos, const value_type& value)
+     */
+    std::pair<iterator, bool> insert_at_position(const_iterator pos, value_type&& value) { 
+        return m_ht.insert_at_position(pos, std::move(value)); 
+    }
+    
+    /**
+     * @copydoc insert_at_position(const_iterator pos, const value_type& value)
+     * 
+     * Same as insert_at_position(pos, value_type(std::forward<Args>(args)...), mainly
+     * here for coherence.
+     */
+    template<class... Args>
+    std::pair<iterator, bool> emplace_at_position(const_iterator pos, Args&&... args) {
+        return m_ht.emplace_at_position(pos, std::forward<Args>(args)...); 
+    }
+       
+    /**
+     * @copydoc insert_at_position(const_iterator pos, const value_type& value)
+     */       
+    template<class... Args>
+    std::pair<iterator, bool> try_emplace_at_position(const_iterator pos, const key_type& k, Args&&... args) { 
+        return m_ht.try_emplace_at_position(pos, k, std::forward<Args>(args)...);
+    }
+    
+    /**
+     * @copydoc insert_at_position(const_iterator pos, const value_type& value)
+     */    
+    template<class... Args>
+    std::pair<iterator, bool> try_emplace_at_position(const_iterator pos, key_type&& k, Args&&... args) {
+        return m_ht.try_emplace_at_position(pos, std::move(k), std::forward<Args>(args)...);
+    }
+    
+    
+    
+    void pop_back() { m_ht.pop_back(); }
+    
+    /**
+     * Faster erase operation with an O(1) average complexity but it doesn't preserve the insertion order.
+     * 
+     * If an erasure occurs, the last element of the map will take the place of the erased element.
+     */
+    iterator unordered_erase(iterator pos) { return m_ht.unordered_erase(pos); }
+    
+    /**
+     * @copydoc unordered_erase(iterator pos)
+     */
+    iterator unordered_erase(const_iterator pos) { return m_ht.unordered_erase(pos); }
+    
+    /**
+     * @copydoc unordered_erase(iterator pos)
+     */    
+    size_type unordered_erase(const key_type& key) { return m_ht.unordered_erase(key); }
+    
+    /**
+     * @copydoc unordered_erase(iterator pos)
+     * 
+     * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same
+     * as hash_function()(key). Usefull to speed-up the lookup if you already have the hash.
+     */    
+    size_type unordered_erase(const key_type& key, std::size_t precalculated_hash) { 
+        return m_ht.unordered_erase(key, precalculated_hash); 
+    }
+    
+    /**
+     * @copydoc unordered_erase(iterator pos)
+     * 
+     * This overload only participates in the overload resolution if the typedef KeyEqual::is_transparent exists. 
+     * If so, K must be hashable and comparable to Key.
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr> 
+    size_type unordered_erase(const K& key) { return m_ht.unordered_erase(key); }
+    
+    /**
+     * @copydoc unordered_erase(const K& key)
+     * 
+     * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same
+     * as hash_function()(key). Usefull to speed-up the lookup if you already have the hash.
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr> 
+    size_type unordered_erase(const K& key, std::size_t precalculated_hash) { 
+        return m_ht.unordered_erase(key, precalculated_hash); 
+    }
+    
+    
+    
+    friend bool operator==(const ordered_map& lhs, const ordered_map& rhs) { return lhs.m_ht == rhs.m_ht; }
+    friend bool operator!=(const ordered_map& lhs, const ordered_map& rhs) { return lhs.m_ht != rhs.m_ht; }
+    friend bool operator<(const ordered_map& lhs, const ordered_map& rhs) { return lhs.m_ht < rhs.m_ht; }
+    friend bool operator<=(const ordered_map& lhs, const ordered_map& rhs) { return lhs.m_ht <= rhs.m_ht; }
+    friend bool operator>(const ordered_map& lhs, const ordered_map& rhs) { return lhs.m_ht > rhs.m_ht; }
+    friend bool operator>=(const ordered_map& lhs, const ordered_map& rhs) { return lhs.m_ht >= rhs.m_ht; }
+    
+    friend void swap(ordered_map& lhs, ordered_map& rhs) { lhs.swap(rhs); }
+
+private:
+    ht m_ht;
+};
+
+} // end namespace tsl
+
+#endif

--- a/src/thirdparty/ordered_map/ordered_set.h
+++ b/src/thirdparty/ordered_map/ordered_set.h
@@ -1,0 +1,642 @@
+/**
+ * MIT License
+ * 
+ * Copyright (c) 2017 Tessil
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef TSL_ORDERED_SET_H
+#define TSL_ORDERED_SET_H
+
+
+#include <cstddef>
+#include <deque>
+#include <functional>
+#include <initializer_list>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+#include "ordered_hash.h"
+
+
+namespace tsl {
+
+
+/**
+ * Implementation of an hash set using open adressing with robin hood with backshift delete to resolve collisions.
+ * 
+ * The particularity of this hash set is that it remembers the order in which the elements were added and
+ * provide a way to access the structure which stores these values through the 'values_container()' method. 
+ * The used container is defined by ValueTypeContainer, by default a std::deque is used (grows faster) but
+ * a std::vector may be used. In this case the set provides a 'data()' method which give a direct access 
+ * to the memory used to store the values (which can be usefull to communicate with C API's).
+ * 
+ * The Key must be copy constructible and/or move constructible. To use `unordered_erase` it also must be swappable.
+ * 
+ * The behaviour of the hash set is undefinded if the destructor of Key throws an exception.
+ * 
+ * Iterators invalidation:
+ *  - clear, operator=, reserve, rehash: always invalidate the iterators (also invalidate end()).
+ *  - insert, emplace, emplace_hint, operator[]: when a std::vector is used as ValueTypeContainer 
+ *                                               and if size() < capacity(), only end(). 
+ *                                               Otherwise all the iterators are invalidated if an insert occurs.
+ *  - erase, unordered_erase: when a std::vector is used as ValueTypeContainer invalidate the iterator of 
+ *                            the erased element and all the ones after the erased element (including end()). 
+ *                            Otherwise all the iterators are invalidated if an erase occurs.
+ */
+template<class Key, 
+         class Hash = std::hash<Key>,
+         class KeyEqual = std::equal_to<Key>,
+         class Allocator = std::allocator<Key>,
+         class ValueTypeContainer = std::deque<Key, Allocator>>
+class ordered_set {
+private:
+    template<typename U>
+    using has_is_transparent = tsl::detail_ordered_hash::has_is_transparent<U>;
+    
+    class KeySelect {
+    public:
+        using key_type = Key;
+        
+        const key_type& operator()(const Key& key) const noexcept {
+            return key;
+        }
+        
+        key_type& operator()(Key& key) noexcept {
+            return key;
+        }
+    };
+    
+    using ht = detail_ordered_hash::ordered_hash<Key, KeySelect, void,
+                                                 Hash, KeyEqual, Allocator, ValueTypeContainer>;
+            
+public:
+    using key_type = typename ht::key_type;
+    using value_type = typename ht::value_type;
+    using size_type = typename ht::size_type;
+    using difference_type = typename ht::difference_type;
+    using hasher = typename ht::hasher;
+    using key_equal = typename ht::key_equal;
+    using allocator_type = typename ht::allocator_type;
+    using reference = typename ht::reference;
+    using const_reference = typename ht::const_reference;
+    using pointer = typename ht::pointer;
+    using const_pointer = typename ht::const_pointer;
+    using iterator = typename ht::iterator;
+    using const_iterator = typename ht::const_iterator;
+    using reverse_iterator = typename ht::reverse_iterator;
+    using const_reverse_iterator = typename ht::const_reverse_iterator;
+    
+    using values_container_type = typename ht::values_container_type;
+
+    
+    /*
+     * Constructors
+     */
+    ordered_set(): ordered_set(ht::DEFAULT_INIT_BUCKETS_SIZE) {
+    }
+    
+    explicit ordered_set(size_type bucket_count, 
+                         const Hash& hash = Hash(),
+                         const KeyEqual& equal = KeyEqual(),
+                         const Allocator& alloc = Allocator()): 
+                        m_ht(bucket_count, hash, equal, alloc, ht::DEFAULT_MAX_LOAD_FACTOR)
+    {
+    }
+    
+    ordered_set(size_type bucket_count,
+                const Allocator& alloc): ordered_set(bucket_count, Hash(), KeyEqual(), alloc)
+    {
+    }
+    
+    ordered_set(size_type bucket_count,
+                const Hash& hash,
+                const Allocator& alloc): ordered_set(bucket_count, hash, KeyEqual(), alloc)
+    {
+    }
+    
+    explicit ordered_set(const Allocator& alloc): ordered_set(ht::DEFAULT_INIT_BUCKETS_SIZE, alloc) {
+    }
+    
+    template<class InputIt>
+    ordered_set(InputIt first, InputIt last,
+                size_type bucket_count = ht::DEFAULT_INIT_BUCKETS_SIZE,
+                const Hash& hash = Hash(),
+                const KeyEqual& equal = KeyEqual(),
+                const Allocator& alloc = Allocator()): ordered_set(bucket_count, hash, equal, alloc)
+    {
+        insert(first, last);
+    }
+    
+    template<class InputIt>
+    ordered_set(InputIt first, InputIt last,
+                size_type bucket_count,
+                const Allocator& alloc): ordered_set(first, last, bucket_count, Hash(), KeyEqual(), alloc)
+    {
+    }
+    
+    template<class InputIt>
+    ordered_set(InputIt first, InputIt last,
+                size_type bucket_count,
+                const Hash& hash,
+                const Allocator& alloc): ordered_set(first, last, bucket_count, hash, KeyEqual(), alloc)
+    {
+    }
+
+    ordered_set(std::initializer_list<value_type> init,
+                size_type bucket_count = ht::DEFAULT_INIT_BUCKETS_SIZE,
+                const Hash& hash = Hash(),
+                const KeyEqual& equal = KeyEqual(),
+                const Allocator& alloc = Allocator()): 
+            ordered_set(init.begin(), init.end(), bucket_count, hash, equal, alloc)
+    {
+    }
+
+    ordered_set(std::initializer_list<value_type> init,
+                size_type bucket_count,
+                const Allocator& alloc): 
+            ordered_set(init.begin(), init.end(), bucket_count, Hash(), KeyEqual(), alloc)
+    {
+    }
+
+    ordered_set(std::initializer_list<value_type> init,
+                size_type bucket_count,
+                const Hash& hash,
+                const Allocator& alloc): 
+            ordered_set(init.begin(), init.end(), bucket_count, hash, KeyEqual(), alloc)
+    {
+    }
+
+    
+    ordered_set& operator=(std::initializer_list<value_type> ilist) {
+        m_ht.clear();
+        
+        m_ht.reserve(ilist.size());
+        m_ht.insert(ilist.begin(), ilist.end());
+        
+        return *this;
+    }
+    
+    allocator_type get_allocator() const { return m_ht.get_allocator(); }
+    
+    
+    /*
+     * Iterators
+     */
+    iterator begin() noexcept { return m_ht.begin(); }
+    const_iterator begin() const noexcept { return m_ht.begin(); }
+    const_iterator cbegin() const noexcept { return m_ht.cbegin(); }
+    
+    iterator end() noexcept { return m_ht.end(); }
+    const_iterator end() const noexcept { return m_ht.end(); }
+    const_iterator cend() const noexcept { return m_ht.cend(); }
+    
+    reverse_iterator rbegin() noexcept { return m_ht.rbegin(); }
+    const_reverse_iterator rbegin() const noexcept { return m_ht.rbegin(); }
+    const_reverse_iterator rcbegin() const noexcept { return m_ht.rcbegin(); }
+    
+    reverse_iterator rend() noexcept { return m_ht.rend(); }
+    const_reverse_iterator rend() const noexcept { return m_ht.rend(); }
+    const_reverse_iterator rcend() const noexcept { return m_ht.rcend(); }
+    
+    
+    /*
+     * Capacity
+     */
+    bool empty() const noexcept { return m_ht.empty(); }
+    size_type size() const noexcept { return m_ht.size(); }
+    size_type max_size() const noexcept { return m_ht.max_size(); }
+    
+    /*
+     * Modifiers
+     */
+    void clear() noexcept { m_ht.clear(); }
+    
+    
+    
+    std::pair<iterator, bool> insert(const value_type& value) { return m_ht.insert(value); }
+    std::pair<iterator, bool> insert(value_type&& value) { return m_ht.insert(std::move(value)); }
+    
+    iterator insert(const_iterator hint, const value_type& value) {
+        return m_ht.insert(hint, value); 
+    }
+    
+    iterator insert(const_iterator hint, value_type&& value) { 
+        return m_ht.insert(hint, std::move(value)); 
+    }
+    
+    template<class InputIt>
+    void insert(InputIt first, InputIt last) { m_ht.insert(first, last); }
+    void insert(std::initializer_list<value_type> ilist) { m_ht.insert(ilist.begin(), ilist.end()); }
+
+    
+    
+    /**
+     * Due to the way elements are stored, emplace will need to move or copy the key-value once.
+     * The method is equivalent to insert(value_type(std::forward<Args>(args)...));
+     * 
+     * Mainly here for compatibility with the std::unordered_map interface.
+     */
+    template<class... Args>
+    std::pair<iterator, bool> emplace(Args&&... args) { return m_ht.emplace(std::forward<Args>(args)...); }
+    
+    /**
+     * Due to the way elements are stored, emplace_hint will need to move or copy the key-value once.
+     * The method is equivalent to insert(hint, value_type(std::forward<Args>(args)...));
+     * 
+     * Mainly here for compatibility with the std::unordered_map interface.
+     */
+    template<class... Args>
+    iterator emplace_hint(const_iterator hint, Args&&... args) {
+        return m_ht.emplace_hint(hint, std::forward<Args>(args)...); 
+    }
+
+    /**
+     * When erasing an element, the insert order will be preserved and no holes will be present in the container
+     * returned by 'values_container()'. 
+     * 
+     * The method is in O(n), if the order is not important 'unordered_erase(...)' method is faster with an O(1)
+     * average complexity.
+     */    
+    iterator erase(iterator pos) { return m_ht.erase(pos); }
+    
+    /**
+     * @copydoc erase(iterator pos)
+     */    
+    iterator erase(const_iterator pos) { return m_ht.erase(pos); }
+    
+    /**
+     * @copydoc erase(iterator pos)
+     */    
+    iterator erase(const_iterator first, const_iterator last) { return m_ht.erase(first, last); }
+    
+    /**
+     * @copydoc erase(iterator pos)
+     */    
+    size_type erase(const key_type& key) { return m_ht.erase(key); }
+    
+    /**
+     * @copydoc erase(iterator pos)
+     * 
+     * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same
+     * as hash_function()(key). Usefull to speed-up the lookup to the value if you already have the hash.
+     */    
+    size_type erase(const key_type& key, std::size_t precalculated_hash) { 
+        return m_ht.erase(key, precalculated_hash); 
+    }
+    
+    /**
+     * @copydoc erase(iterator pos)
+     * 
+     * This overload only participates in the overload resolution if the typedef KeyEqual::is_transparent exists. 
+     * If so, K must be hashable and comparable to Key.
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr> 
+    size_type erase(const K& key) { return m_ht.erase(key); }
+    
+    /**
+     * @copydoc erase(const key_type& key, std::size_t precalculated_hash)
+     * 
+     * This overload only participates in the overload resolution if the typedef KeyEqual::is_transparent exists. 
+     * If so, K must be hashable and comparable to Key.
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr> 
+    size_type erase(const K& key, std::size_t precalculated_hash) { 
+        return m_ht.erase(key, precalculated_hash); 
+    }
+    
+    
+    
+    void swap(ordered_set& other) { other.m_ht.swap(m_ht); }
+    
+    /*
+     * Lookup
+     */
+    size_type count(const Key& key) const { return m_ht.count(key); }
+    
+    /**
+     * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same
+     * as hash_function()(key). Usefull to speed-up the lookup if you already have the hash.
+     */
+    size_type count(const Key& key, std::size_t precalculated_hash) const { 
+        return m_ht.count(key, precalculated_hash); 
+    }
+    
+    /**
+     * This overload only participates in the overload resolution if the typedef KeyEqual::is_transparent exists. 
+     * If so, K must be hashable and comparable to Key.
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+    size_type count(const K& key) const { return m_ht.count(key); }
+    
+    /**
+     * @copydoc count(const K& key) const
+     * 
+     * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same
+     * as hash_function()(key). Usefull to speed-up the lookup if you already have the hash.
+     */     
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr> 
+    size_type count(const K& key, std::size_t precalculated_hash) const { 
+        return m_ht.count(key, precalculated_hash);
+    }
+    
+    
+    
+    
+    iterator find(const Key& key) { return m_ht.find(key); }
+    
+    /**
+     * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same
+     * as hash_function()(key). Usefull to speed-up the lookup if you already have the hash.
+     */
+    iterator find(const Key& key, std::size_t precalculated_hash) { return m_ht.find(key, precalculated_hash); }
+    
+    const_iterator find(const Key& key) const { return m_ht.find(key); }
+    
+    /**
+     * @copydoc find(const Key& key, std::size_t precalculated_hash)
+     */
+    const_iterator find(const Key& key, std::size_t precalculated_hash) const { 
+        return m_ht.find(key, precalculated_hash);
+    }
+    
+    /**
+     * This overload only participates in the overload resolution if the typedef KeyEqual::is_transparent exists. 
+     * If so, K must be hashable and comparable to Key.
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+    iterator find(const K& key) { return m_ht.find(key); }
+    
+    /**
+     * @copydoc find(const K& key)
+     * 
+     * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same
+     * as hash_function()(key). Usefull to speed-up the lookup if you already have the hash.
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr> 
+    iterator find(const K& key, std::size_t precalculated_hash) { return m_ht.find(key, precalculated_hash); }
+    
+    /**
+     * @copydoc find(const K& key)
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>
+    const_iterator find(const K& key) const { return m_ht.find(key); }
+    
+    /**
+     * @copydoc find(const K& key)
+     * 
+     * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same
+     * as hash_function()(key). Usefull to speed-up the lookup if you already have the hash.
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr> 
+    const_iterator find(const K& key, std::size_t precalculated_hash) const { 
+        return m_ht.find(key, precalculated_hash); 
+    }
+    
+    
+    
+    std::pair<iterator, iterator> equal_range(const Key& key) { return m_ht.equal_range(key); }
+    
+    /**
+     * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same
+     * as hash_function()(key). Usefull to speed-up the lookup if you already have the hash.
+     */
+    std::pair<iterator, iterator> equal_range(const Key& key, std::size_t precalculated_hash) { 
+        return m_ht.equal_range(key, precalculated_hash); 
+    }
+    
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key) const { return m_ht.equal_range(key); }
+    
+    /**
+     * @copydoc equal_range(const Key& key, std::size_t precalculated_hash)
+     */
+    std::pair<const_iterator, const_iterator> equal_range(const Key& key, std::size_t precalculated_hash) const { 
+        return m_ht.equal_range(key, precalculated_hash); 
+    }
+    
+    /**
+     * This overload only participates in the overload resolution if the typedef KeyEqual::is_transparent exists. 
+     * If so, K must be hashable and comparable to Key.
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>     
+    std::pair<iterator, iterator> equal_range(const K& key) { return m_ht.equal_range(key); }
+    
+    /**
+     * @copydoc equal_range(const K& key)
+     * 
+     * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same
+     * as hash_function()(key). Usefull to speed-up the lookup if you already have the hash.
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr> 
+    std::pair<iterator, iterator> equal_range(const K& key, std::size_t precalculated_hash) { 
+        return m_ht.equal_range(key, precalculated_hash); 
+    }
+    
+    /**
+     * @copydoc equal_range(const K& key)
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr>     
+    std::pair<const_iterator, const_iterator> equal_range(const K& key) const { return m_ht.equal_range(key); }
+    
+    /**
+     * @copydoc equal_range(const K& key, std::size_t precalculated_hash)
+     */    
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr> 
+    std::pair<const_iterator, const_iterator> equal_range(const K& key, std::size_t precalculated_hash) const { 
+        return m_ht.equal_range(key, precalculated_hash); 
+    }
+    
+
+    /*
+     * Bucket interface 
+     */
+    size_type bucket_count() const { return m_ht.bucket_count(); }
+    size_type max_bucket_count() const { return m_ht.max_bucket_count(); }
+    
+    
+    /*
+     *  Hash policy 
+     */
+    float load_factor() const { return m_ht.load_factor(); }
+    float max_load_factor() const { return m_ht.max_load_factor(); }
+    void max_load_factor(float ml) { m_ht.max_load_factor(ml); }
+    
+    void rehash(size_type count) { m_ht.rehash(count); }
+    void reserve(size_type count) { m_ht.reserve(count); }
+    
+    
+    /*
+     * Observers
+     */
+    hasher hash_function() const { return m_ht.hash_function(); }
+    key_equal key_eq() const { return m_ht.key_eq(); }
+    
+    
+    /*
+     * Other
+     */
+    
+    /**
+     * Convert a const_iterator to an iterator.
+     */
+    iterator mutable_iterator(const_iterator pos) {
+        return m_ht.mutable_iterator(pos);
+    }
+    
+    /**
+     * Requires index <= size().
+     * 
+     * Return an iterator to the element at index. Return end() if index == size().
+     */
+    iterator nth(size_type index) { return m_ht.nth(index); }
+    
+    /**
+     * @copydoc nth(size_type index)
+     */
+    const_iterator nth(size_type index) const { return m_ht.nth(index); }
+    
+    
+    /**
+     * Return const_reference to the first element. Requires the container to not be empty.
+     */
+    const_reference front() const { return m_ht.front(); }
+    
+    /**
+     * Return const_reference to the last element. Requires the container to not be empty.
+     */
+    const_reference back() const { return m_ht.back(); }
+    
+    
+    /**
+     * Only available if ValueTypeContainer is a std::vector. Same as calling 'values_container().data()'.
+     */ 
+    template<class U = values_container_type, typename std::enable_if<tsl::detail_ordered_hash::is_vector<U>::value>::type* = nullptr>    
+    const typename values_container_type::value_type* data() const noexcept { return m_ht.data(); }
+    
+    /**
+     * Return the container in which the values are stored. The values are in the same order as the insertion order
+     * and are contiguous in the structure, no holes (size() == values_container().size()).
+     */        
+    const values_container_type& values_container() const noexcept { return m_ht.values_container(); }
+
+    template<class U = values_container_type, typename std::enable_if<tsl::detail_ordered_hash::is_vector<U>::value>::type* = nullptr>    
+    size_type capacity() const noexcept { return m_ht.capacity(); }
+    
+    void shrink_to_fit() { m_ht.shrink_to_fit(); }
+    
+    
+    
+    /**
+     * Insert the value before pos shifting all the elements on the right of pos (including pos) one position 
+     * to the right.
+     * 
+     * Amortized linear time-complexity in the distance between pos and end().
+     */
+    std::pair<iterator, bool> insert_at_position(const_iterator pos, const value_type& value) { 
+        return m_ht.insert_at_position(pos, value); 
+    }
+    
+    /**
+     * @copydoc insert_at_position(const_iterator pos, const value_type& value)
+     */
+    std::pair<iterator, bool> insert_at_position(const_iterator pos, value_type&& value) { 
+        return m_ht.insert_at_position(pos, std::move(value)); 
+    }
+    
+    /**
+     * @copydoc insert_at_position(const_iterator pos, const value_type& value)
+     * 
+     * Same as insert_at_position(pos, value_type(std::forward<Args>(args)...), mainly
+     * here for coherence.
+     */
+    template<class... Args>
+    std::pair<iterator, bool> emplace_at_position(const_iterator pos, Args&&... args) {
+        return m_ht.emplace_at_position(pos, std::forward<Args>(args)...); 
+    }
+    
+    
+    
+    void pop_back() { m_ht.pop_back(); }
+    
+    /**
+     * Faster erase operation with an O(1) average complexity but it doesn't preserve the insertion order.
+     * 
+     * If an erasure occurs, the last element of the map will take the place of the erased element.
+     */    
+    iterator unordered_erase(iterator pos) { return m_ht.unordered_erase(pos); }
+    
+    /**
+     * @copydoc unordered_erase(iterator pos)
+     */    
+    iterator unordered_erase(const_iterator pos) { return m_ht.unordered_erase(pos); }
+    
+    /**
+     * @copydoc unordered_erase(iterator pos)
+     */    
+    size_type unordered_erase(const key_type& key) { return m_ht.unordered_erase(key); }
+    
+    /**
+     * @copydoc unordered_erase(iterator pos)
+     * 
+     * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same
+     * as hash_function()(key). Usefull to speed-up the lookup if you already have the hash.
+     */    
+    size_type unordered_erase(const key_type& key, std::size_t precalculated_hash) { 
+        return m_ht.unordered_erase(key, precalculated_hash); 
+    }
+    
+    /**
+     * @copydoc unordered_erase(iterator pos)
+     * 
+     * This overload only participates in the overload resolution if the typedef KeyEqual::is_transparent exists. 
+     * If so, K must be hashable and comparable to Key.
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr> 
+    size_type unordered_erase(const K& key) { return m_ht.unordered_erase(key); }
+    
+    /**
+     * @copydoc unordered_erase(const K& key)
+     * 
+     * Use the hash value 'precalculated_hash' instead of hashing the key. The hash value should be the same
+     * as hash_function()(key). Usefull to speed-up the lookup if you already have the hash.
+     */
+    template<class K, class KE = KeyEqual, typename std::enable_if<has_is_transparent<KE>::value>::type* = nullptr> 
+    size_type unordered_erase(const K& key, std::size_t precalculated_hash) { 
+        return m_ht.unordered_erase(key, precalculated_hash); 
+    }
+    
+    
+    
+    friend bool operator==(const ordered_set& lhs, const ordered_set& rhs) { return lhs.m_ht == rhs.m_ht; }
+    friend bool operator!=(const ordered_set& lhs, const ordered_set& rhs) { return lhs.m_ht != rhs.m_ht; }
+    friend bool operator<(const ordered_set& lhs, const ordered_set& rhs) { return lhs.m_ht < rhs.m_ht; }
+    friend bool operator<=(const ordered_set& lhs, const ordered_set& rhs) { return lhs.m_ht <= rhs.m_ht; }
+    friend bool operator>(const ordered_set& lhs, const ordered_set& rhs) { return lhs.m_ht > rhs.m_ht; }
+    friend bool operator>=(const ordered_set& lhs, const ordered_set& rhs) { return lhs.m_ht >= rhs.m_ht; }
+    
+    friend void swap(ordered_set& lhs, ordered_set& rhs) { lhs.swap(rhs); }
+    
+private:
+    ht m_ht;    
+};
+
+} // end namespace tsl
+
+#endif

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1987,66 +1987,66 @@ void display_window2(
 
 
 void display_window(
-    int prm_668,
-    int prm_669,
-    int prm_670,
-    int prm_671,
+    int window_x,
+    int window_y,
+    int window_width,
+    int window_height,
     int prm_672,
     int prm_673)
 {
     if (windowshadow == 1)
     {
-        window(prm_668 + 4, prm_669 + 4, prm_670, prm_671 - prm_671 % 8, true);
+        window(window_x + 4, window_y + 4, window_width, window_height - window_height % 8, true);
         windowshadow = 0;
     }
-    window(prm_668, prm_669, prm_670, prm_671 - prm_671 % 8);
+    window(window_x, window_y, window_width, window_height - window_height % 8);
     if (s != ""s)
     {
         window2(
-            prm_668 + 34,
-            prm_669 - 4,
-            45 * prm_670 / 100 + clamp(int(strlen_u(s) * 8 - 120), 0, 200),
+            window_x + 34,
+            window_y - 4,
+            45 * window_width / 100 + clamp(int(strlen_u(s) * 8 - 120), 0, 200),
             32,
             1,
             1);
     }
     gmode(2);
-    draw("tip_icon", prm_668 + 30 + prm_672, prm_669 + prm_671 - 47 - prm_671 % 8);
+    draw("tip_icon", window_x + 30 + prm_672, window_y + window_height - 47 - window_height % 8);
     line(
-        prm_668 + 50 + prm_672,
-        prm_669 + prm_671 - 48 - prm_671 % 8,
-        prm_668 + prm_670 - 40,
-        prm_669 + prm_671 - 48 - prm_671 % 8,
+        window_x + 50 + prm_672,
+        window_y + window_height - 48 - window_height % 8,
+        window_x + window_width - 40,
+        window_y + window_height - 48 - window_height % 8,
         {194, 170, 146});
     line(
-        prm_668 + 50 + prm_672,
-        prm_669 + prm_671 - 49 - prm_671 % 8,
-        prm_668 + prm_670 - 40,
-        prm_669 + prm_671 - 49 - prm_671 % 8,
+        window_x + 50 + prm_672,
+        window_y + window_height - 49 - window_height % 8,
+        window_x + window_width - 40,
+        window_y + window_height - 49 - window_height % 8,
         {234, 220, 188});
     font(15 + en - en * 2);
     bmes(
         s,
-        prm_668 + 45 * prm_670 / 200 + 34 - strlen_u(s) * 4
-            + clamp(int(s(0).size() * 8 - 120), 0, 200) / 2,
-        prm_669 + 4 + vfix,
+        window_x + 45 * window_width / 200 + 34 - strlen_u(s) * 4
+            + clamp(int(strlen_u(s) * 8 - 120), 0, 200) / 2,
+        window_y + 4 + vfix,
         {255, 255, 255},
         {20, 10, 0});
     font(12 + sizefix - en * 2);
-    pos(prm_668 + 58 + prm_672, prm_669 + prm_671 - 43 - prm_671 % 8);
+    pos(window_x + 58 + prm_672, window_y + window_height - 43 - window_height % 8);
     mes(s(1));
     if (pagesize != 0)
     {
         s = u8"Page."s + (page + 1) + u8"/"s + (pagemax + 1);
         font(12 + sizefix - en * 2, snail::font_t::style_t::bold);
-        pos(prm_668 + prm_670 - strlen_u(s) * 7 - 40 - prm_673,
-            prm_669 + prm_671 - 65 - prm_671 % 8);
+        pos(window_x + window_width - strlen_u(s) * 7 - 40 - prm_673,
+            window_y + window_height - 65 - window_height % 8);
         mes(s);
     }
-    wx = prm_668;
-    wy = prm_669;
-    ww = prm_670;
-    wh = prm_671;
+    wx = window_x;
+    wy = window_y;
+    ww = window_width;
+    wh = window_height;
 }
 
 


### PR DESCRIPTION
# Related Issues

Close #673.

# Summary
Adds `tsl::ordered_map` as a new dependency and edits `hcl.hpp` to use it instead. Now the declared order inside any HCL object will be the same as the order of iteration of `hcl::Object`.

# TODO
- [x] Verify config menu order is the same as vanilla.
- [x] Verify order of config options in saved `config.hcl`.