### PR TITLE
Fix wrong condition checking if all mods have been scanned

### DIFF
--- a/src/lua_env/lua_env.cpp
+++ b/src/lua_env/lua_env.cpp
@@ -240,7 +240,7 @@ void lua_env::scan_all_mods(const fs::path& mods_dir)
 
 void lua_env::load_core_mod()
 {
-    if (stage != mod_loading_stage_t::scan_finished)
+    if (stage == mod_loading_stage_t::not_started)
     {
         throw std::runtime_error("Mods haven't been scanned yet!");
     }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #680.

@Ruin0x11 
I haven't read all of your changes well, so could you review the fix is proper or not?

```cpp
enum class mod_loading_stage_t : unsigned
{
    not_started,
    scan_finished,
    core_mod_loaded,
    all_mods_loaded,
};
```

I guess `core_mod_loaded` and `all_mods_loaded` imply `scan_finished`.
