### PR TITLE
Fix save directory

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -815,7 +815,7 @@ int run()
     initialize_config_preload(config_file);
     initialize_screen();
 
-    filesystem::dir::set_base_save_directory(fs::path("save"));
+    filesystem::dir::set_base_save_directory(filesystem::path("save"));
 
     initialize_config(config_file);
     init_assets();


### PR DESCRIPTION

# Summary

Change `boost::filesystem::path("save")` to `filesystem::path("save")`.
The former returns relative path from current directory, while the latter returns absolute path based on the executable path.