### PR TITLE
Externalize music as definition files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ set(CORE_SOURCES
   src/ctrl_file.cpp
   src/ctrl_inventory.cpp
   src/crafting.cpp
+  src/db_music.cpp
   src/db_sound.cpp
   src/debug.cpp
   src/dmgheal.cpp

--- a/runtime/data/scene1.hsp
+++ b/runtime/data/scene1.hsp
@@ -1,7 +1,7 @@
 ;#####################################
 {0}
 {pic}	"bg3"
-{mc}	"mcIntro"
+{mc}	"core.music.mcIntro"
 {txt}
 今はもう忘れ去られた昔
 イルヴァの地に十の文明の残骸が埋もれ
@@ -48,7 +48,7 @@
 
 {1}
 {actor_1}	"ザナンの皇子『サイモア』,54"
-{mc}	"mcTown1"
+{mc}	"core.music.mcTown1"
 
 {pic}	"bg1"
 
@@ -64,7 +64,7 @@
 供の腕に弱々しくもたれた白子の皇子の言葉に
 皆が耳を傾けていた。
 
-{mc}	"mcUnrest2"
+{mc}	"core.music.mcUnrest2"
 {chat_1}
 …そして深い悲しみが 私を襲う。ザナンが新王国との戦に敗れ、指導者を失った大陸が二大国間の戦火の舞台となり、幾多の歳月が過ぎよう。今は亡きクレイン皇子のあとを継ぎ和平に模索しても、二国の対立の溝はうまらず、未だ緊張の糸は張り詰められたままだ。
 
@@ -94,7 +94,7 @@
 {actor_1}	"ザナンの紅血『ロイター』,49"
 {actor_2}	"兵士,18"
 {actor_3}	"????,50"
-{mc}	"mcTown1"
+{mc}	"core.music.mcTown1"
 {pic}	"bg2"
 {txt}
 同刻 - ヴェルニースの酒場 -
@@ -136,7 +136,7 @@
 誰のために言ったと思っている？ザナンの白き鷹、それがお前の目の前にいる男だ。…しばし二人だけにさせてもらう。
 
 {fade}
-{mc}	"mcMemory"
+{mc}	"core.music.mcMemory"
 {fadein}
 
 {chat_1}
@@ -184,7 +184,7 @@
 {actor_2}	"青い髪の『ヴァリウス』,48"
 {actor_3}	"兵士,18"
 
-{mc}	"xp_shrine2.mid"
+{mc}	"core.music.mcUnrest2"
 
 {pic}	"bg6"
 {txt}
@@ -229,7 +229,7 @@
 {actor_3}	"青い髪の『ヴァリウス』,48"
 {actor_4}	"ザナンの皇子サイモア,54"
 
-{mc}	"xp_field7.mid"
+{mc}	"core.music.mcTown4"
 {pic}	"bg5"
 
 {txt}
@@ -275,7 +275,7 @@
 陛下…わかりました。しかし明日また参ります。陛下の決断が最後の希望です。
 
 {fade}
-{mc} "soraochi.mid"
+{mc} "core.music.mcSoraochi"
 {fadein}
 
 
@@ -323,7 +323,7 @@
 {actor_3}	"????,120"
 {actor_4}	"白き鷹『ヴェセル』,50"
 
-{mc}	"PSML515.mid"
+{mc}	"core.music.mcPsml515"
 {pic}	"bg2"
 
 {txt}
@@ -405,7 +405,7 @@
 {actor_5}	"セビリスの部下,18"
 {actor_6}	"青い髪の『ヴァリウス』,48"
 
-{mc}	"PSML060.mid"
+{mc}	"core.music.mcLonely"
 {pic}	"bg5"
 
 {txt}
@@ -477,7 +477,7 @@
 {actor_2}	"青い髪の『ヴァリウス』,48"
 {actor_3}	"風を聴く者『ラーネイレ』,112"
 
-{mc}	"xp_shrine2.mid"
+{mc}	"core.music.mcUnrest2"
 
 {pic}	"bg6"
 
@@ -502,7 +502,7 @@
 {chat_3}
 …
 
-{mc}	"PSML035.mid"
+{mc}	"core.music.mcPsml035"
 {wait}
 
 {chat_1}
@@ -531,7 +531,7 @@
 {actor_5}	"セビリスの部下,18"
 {actor_6}	"青い髪の『ヴァリウス』,48"
 
-{mc}	"PSML060.mid"
+{mc}	"core.music.mcLonely"
 {pic}	"bg2"
 
 {txt}
@@ -566,7 +566,7 @@
 {actor_2}	"青い髪の『ヴァリウス』,48"
 {actor_3}	"風を聴く者『ラーネイレ』,112"
 
-{mc}	"PSML035.mid"
+{mc}	"core.music.mcPsml035"
 {pic}	"bg6"
 
 {txt}
@@ -625,7 +625,7 @@
 
 
 {pic}	"bg6"
-{mc}	"xp_field7.mid"
+{mc}	"core.music.mcTown4"
 
 {txt}
 - パルミア城 一室 -
@@ -654,7 +654,7 @@
 
 {wait}
 {se}	"door1.wav"
-{mc}	"pinch2.mid"
+{mc}	"core.music.mcPinch2"
 
 {chat_5}
 いたぞ！暗殺者だ！
@@ -690,7 +690,7 @@
 {actor_3}	"異形の森の使者『ロミアス』,57"
 {actor_4}	"白き鷹『ヴェセル』,50"
 
-{mc}	"PSML060.mid"
+{mc}	"core.music.mcLonely"
 {pic}	"bg9"
 
 {txt}
@@ -729,7 +729,7 @@
 {actor_3}	"異形の森の使者『ロミアス』,57"
 {actor_4}	"白き鷹『ヴェセル』,50"
 
-{mc}	"PSML515.mid"
+{mc}	"core.music.mcPsml515"
 {pic}	"bg4"
 
 {txt}
@@ -759,7 +759,7 @@
 {actor_2}	"ラーネイレ,112"
 
 {pic}	"bg7"
-{mc}	"memory2.mid"
+{mc}	"core.music.mcMemory2"
 
 {txt}
 - 野営地 -
@@ -811,7 +811,7 @@
 {actor_2}	"ラーネイレ,112"
 
 {pic}	"bg7"
-{mc}	"memory2.mid"
+{mc}	"core.music.mcMemory2"
 
 {chat_1}
 アルティハイトに来る以前、私はアテランという士官学校にいた。アテランは少数の優れた者が才能を磨くための施設だった。彼らにとっては力こそが全てだ。他人は全て敵であり、自らを押し上げるための道具に過ぎない。弱者を踏み台にすることに、何の躊躇いもない連中だ。…そして、私もそんな人間の一人だった。私は知らずに、あるいは知っていても何の抵抗もなく、多くの人を傷つけていた。高慢で冷酷な男だった。
@@ -838,7 +838,7 @@
 {actor_1}	"ヴェセル,50"
 {actor_2}	"ラーネイレ,112"
 
-{mc}	"mcMemory"
+{mc}	"core.music.mcMemory"
 {pic}	"bg7"
 
 {chat_1}
@@ -872,7 +872,7 @@
 {actor_4}	"白き鷹『ヴェセル』,50"
 {actor_5}	"青い髪の『ヴァリウス』,48"
 
-{mc}	"xp_shrine2.mid"
+{mc}	"core.music.mcUnrest2"
 {pic}	"bg10"
 
 {chat_3}
@@ -893,7 +893,7 @@
 {chat_5}
 信じるかどうかは、あなた次第。無駄な画策のために貴重な時間を削るつもりはありません。私は、同じエレアの血を分かつ者として、あなた方の置かれた境遇に同情さえしています。
 
-{mc}	"AnoSora.mid"
+{mc}	"core.music.mcAnoSora"
 {wait}
 
 {chat_5}
@@ -927,7 +927,7 @@
 {actor_4}	"白き鷹『ヴェセル』,50"
 {actor_5}	"青い髪の『ヴァリウス』,48"
 
-{mc}	"AnoSora.mid"
+{mc}	"core.music.mcAnoSora"
 {pic}	"bg10"
 
 {chat_5}
@@ -961,7 +961,7 @@
 {actor_3}	"異形の森の使者『ロミアス』,57"
 {actor_4}	"白き鷹『ヴェセル』,50"
 
-{mc}	"PSML060.mid"
+{mc}	"core.music.mcLonely"
 {pic}	"bg9"
 
 {chat_4}
@@ -996,7 +996,7 @@
 {actor_4}	"ダルフィの霧『セビリス』,59"
 {actor_5}	"異形の森の使者『ロミアス』,57"
 
-{mc}	"PSML060.mid"
+{mc}	"core.music.mcLonely"
 {pic}	"bg7"
 
 {chat_5}
@@ -1013,7 +1013,7 @@
 
 {fade}
 {pic}	"bg5"
-{mc} "soraochi.mid"
+{mc} "core.music.mcSoraochi"
 {fadein}
 
 {txt}
@@ -1037,7 +1037,7 @@
 {actor_3}	"異形の森の使者『ロミアス』,57"
 {actor_4}	"白き鷹『ヴェセル』,50"
 
-{mc}	"climax.mid"
+{mc}	"core.music.mcBoss2"
 {pic}	"bg11"
 
 {chat_3}
@@ -1068,7 +1068,7 @@
 {actor_4}	"白き鷹『ヴェセル』,50"
 {actor_5}	"青い髪の『ヴァリウス』,48"
 
-{mc}	"climax.mid"
+{mc}	"core.music.mcBoss2"
 {pic}	"bg11"
 
 {chat_5}
@@ -1117,7 +1117,7 @@
 
 {100}
 {pic}	"bg12"
-{mc}	"xp_epilogue1.mid"
+{mc}	"core.music.mcEpilogue"
 
 {txt}
 - エピローグ -

--- a/runtime/data/scene2.hsp
+++ b/runtime/data/scene2.hsp
@@ -1,7 +1,7 @@
 ;#####################################
 {0}
 {pic}	"bg3"
-{mc}	"mcIntro"
+{mc}	"core.music.mcIntro"
 {txt}
 Ages ago, in the times when the scars
 of Rehm-Ido still marred the land of Irva,

--- a/runtime/mods/core/data/music.hcl
+++ b/runtime/mods/core/data/music.hcl
@@ -1,0 +1,289 @@
+music mcReset {
+    file = "gm_on.mid"
+    id = 50
+    predefined = true
+}
+
+music mcTown1 {
+    file = "pop01.mid"
+    id = 51
+    predefined = true
+}
+
+music mcTown2 {
+    file = "morning_breeze.mid"
+    id = 52
+    predefined = true
+}
+
+music mcTown3 {
+    file = "happymarch.mid"
+    id = 53
+    predefined = true
+}
+
+music mcTown4 {
+    file = "xp_field7.mid"
+    id = 54
+    predefined = true
+}
+
+music mcDungeon1 {
+    file = "pop03.mid"
+    id = 55
+    predefined = true
+}
+
+music mcDungeon2 {
+    file = "PSML522.MID"
+    id = 56
+    predefined = true
+}
+
+music mcDungeon3 {
+    file = "PSML514.MID"
+    id = 57
+    predefined = true
+}
+
+music mcDungeon4 {
+    file = "PSML507.MID"
+    id = 58
+    predefined = true
+}
+
+music mcDungeon5 {
+    file = "fantasy04.mid"
+    id = 59
+    predefined = true
+}
+
+music mcDungeon6 {
+    file = "fantasy03.mid"
+    id = 60
+    predefined = true
+}
+
+music mcPuti {
+    file = "dwarf.mid"
+    id = 61
+    predefined = true
+}
+
+music mcBoss {
+    file = "battle1.mid"
+    id = 62
+    predefined = true
+}
+
+music mcBoss2 {
+    file = "climax.mid"
+    id = 63
+    predefined = true
+}
+
+music mcVictory {
+    file = "orc05.mid"
+    id = 64
+    predefined = true
+}
+
+music mcOpening {
+    file = "orc01.mid"
+    id = 65
+    predefined = true
+}
+
+music mcLastBoss {
+    file = "orc03.mid"
+    id = 66
+    predefined = true
+}
+
+music mcHome {
+    file = "PSML516.MID"
+    id = 67
+    predefined = true
+}
+
+music mcLonely {
+    file = "PSML060.MID"
+    id = 68
+    predefined = true
+}
+
+music mcChaos {
+    file = "fantasy01.MID"
+    id = 69
+    predefined = true
+}
+
+music mcMarch1 {
+    file = "orc06.MID"
+    id = 70
+    predefined = true
+}
+
+music mcMarch2 {
+    file = "orc02.MID"
+    id = 71
+    predefined = true
+}
+
+music mcMarch3 {
+    file = "orc04.mid"
+    id = 72
+    predefined = true
+}
+
+music mcArena {
+    file = "victory.mid"
+    id = 73
+    predefined = true
+}
+
+music mcFanfare {
+    file = "fanfare.mid"
+    id = 74
+    predefined = true
+}
+
+music mcVillage1 {
+    file = "cobalt.mid"
+    id = 75
+    predefined = true
+}
+
+music mcBattle1 {
+    file = "battle3.mid"
+    id = 76
+    predefined = true
+}
+
+music mcCasino {
+    file = "town2l.mid"
+    id = 77
+    predefined = true
+}
+
+music mcCoda {
+    file = "epi1coda.mid"
+    id = 78
+    predefined = true
+}
+
+music mcRuin {
+    file = "ruins1.mid"
+    id = 79
+    predefined = true
+}
+
+music mcWedding {
+    file = "PSML052.mid"
+    id = 80
+    predefined = true
+}
+
+music mcPetArena {
+    file = "main2.mid"
+    id = 81
+    predefined = true
+}
+
+music mcUnrest {
+    file = "PSML514.MID"
+    id = 82
+    predefined = true
+}
+
+music mcTown5 {
+    file = "PSML047.MID"
+    id = 83
+    predefined = true
+}
+
+music mcUnrest2 {
+    file = "xp_shrine2.mid"
+    id = 84
+    predefined = true
+}
+
+music mcTown6 {
+    file = "morning_breeze.mid"
+    id = 85
+    predefined = true
+}
+
+music mcField1 {
+    file = "orc04.mid"
+    id = 86
+    predefined = true
+}
+
+music mcField2 {
+    file = "xp_field2.mid"
+    id = 87
+    predefined = true
+}
+
+music mcField3 {
+    file = "xp_field4.mid"
+    id = 88
+    predefined = true
+}
+
+music mcMemory {
+    file = "memory.mid"
+    id = 89
+    predefined = true
+}
+
+music mcIntro {
+    file = "field1_d.mid"
+    id = 90
+    predefined = true
+}
+
+### These songs are only played during cutscenes.
+
+music mcSoraochi {
+    file = "soraochi.mid"
+    id = 91
+    predefined = true
+}
+
+music mcPsml515 {
+    file = "PSML515.mid"
+    id = 92
+    predefined = true
+}
+
+music mcPsml035 {
+    file = "PSML035.mid"
+    id = 93
+    predefined = true
+}
+
+music mcPinch2 {
+    file = "pinch2.mid"
+    id = 94
+    predefined = true
+}
+
+music mcMemory2 {
+    file = "memory2.mid"
+    id = 95
+    predefined = true
+}
+
+music mcAnoSora {
+    file = "AnoSora.mid"
+    id = 96
+    predefined = true
+}
+
+music mcEpilogue {
+    file = "xp_epilogue1.mid"
+    id = 97
+    predefined = true
+}

--- a/runtime/mods/core/data/music.hcl
+++ b/runtime/mods/core/data/music.hcl
@@ -113,19 +113,19 @@ music mcLonely {
 }
 
 music mcChaos {
-    file = "fantasy01.MID"
+    file = "fantasy01.mid"
     id = 69
     predefined = true
 }
 
 music mcMarch1 {
-    file = "orc06.MID"
+    file = "orc06.mid"
     id = 70
     predefined = true
 }
 
 music mcMarch2 {
-    file = "orc02.MID"
+    file = "orc02.mid"
     id = 71
     predefined = true
 }
@@ -179,7 +179,7 @@ music mcRuin {
 }
 
 music mcWedding {
-    file = "PSML052.mid"
+    file = "PSML052.MID"
     id = 80
     predefined = true
 }
@@ -253,13 +253,13 @@ music mcSoraochi {
 }
 
 music mcPsml515 {
-    file = "PSML515.mid"
+    file = "PSML515.MID"
     id = 92
     predefined = true
 }
 
 music mcPsml035 {
-    file = "PSML035.mid"
+    file = "PSML035.MID"
     id = 93
     predefined = true
 }

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -29,7 +29,142 @@ constexpr int temporary_channels_size = 6;
 std::vector<int> soundlist;
 
 int envwprev{};
-int musicprev{};
+shared_id musicprev{};
+
+
+shared_id get_default_music()
+{
+    optional<std::string> music_id = none;
+
+    if (adata(0, gdata_current_map) == mdata_t::map_type_t::field)
+    {
+        return musicprev;
+    }
+    if (adata(0, gdata_current_map) == mdata_t::map_type_t::town)
+    {
+        music_id = "core.music.mcTown1"s;
+    }
+    if (adata(0, gdata_current_map) == mdata_t::map_type_t::player_owned)
+    {
+        music_id = "core.music.mcHome"s;
+    }
+    if (mdata_map_bgm != 0)
+    {
+        music_id = **the_music_db.get_id_from_legacy(mdata_map_bgm);
+    }
+    if (adata(0, gdata_current_map) >= mdata_t::map_type_t::dungeon)
+    {
+        static const std::vector<std::string> choices =
+            {"core.music.mcDungeon1",
+             "core.music.mcDungeon2",
+             "core.music.mcDungeon3",
+             "core.music.mcDungeon4",
+             "core.music.mcDungeon5",
+             "core.music.mcDungeon6"};
+        music_id = choices[gdata_hour % 6];
+    }
+    if (adata(16, gdata_current_map) == mdata_t::map_id_t::random_dungeon
+        || adata(16, gdata_current_map) == mdata_t::map_id_t::the_void)
+    {
+        if (gdata_current_dungeon_level == adata(10, gdata_current_map))
+        {
+            if (adata(20, gdata_current_map) != -1)
+            {
+                music_id = "core.music.mcBoss"s;
+            }
+        }
+    }
+    if (gdata_current_map == mdata_t::map_id_t::quest)
+    {
+        if (gdata_executing_immediate_quest_type == 1001)
+        {
+            music_id = "core.music.mcBattle1"s;
+        }
+        if (gdata_executing_immediate_quest_type == 1006)
+        {
+            music_id = "core.music.mcVillage1"s;
+        }
+        if (gdata_executing_immediate_quest_type == 1009)
+        {
+            music_id = "core.music.mcCasino"s;
+        }
+        if (gdata_executing_immediate_quest_type == 1008)
+        {
+            music_id = "core.music.mcBoss"s;
+        }
+        if (gdata_executing_immediate_quest_type == 1010)
+        {
+            music_id = "core.music.mcArena";
+        }
+    }
+    if (gdata_current_map == mdata_t::map_id_t::arena)
+    {
+        music_id = "core.music.mcArena"s;
+    }
+    if (gdata_current_map == mdata_t::map_id_t::larna)
+    {
+        music_id = "core.music.mcVillage1"s;
+    }
+    if (gdata_current_map == mdata_t::map_id_t::port_kapul)
+    {
+        music_id = "core.music.mcTown2"s;
+    }
+    if (gdata_current_map == mdata_t::map_id_t::lumiest)
+    {
+        music_id = "core.music.mcTown2"s;
+    }
+    if (gdata_current_map == mdata_t::map_id_t::yowyn)
+    {
+        music_id = "core.music.mcVillage1"s;
+    }
+    if (gdata_current_map == mdata_t::map_id_t::derphy)
+    {
+        music_id = "core.music.mcTown3"s;
+    }
+    if (gdata_current_map == mdata_t::map_id_t::palmia)
+    {
+        music_id = "core.music.mcTown4"s;
+    }
+    if (gdata_current_map == mdata_t::map_id_t::cyber_dome)
+    {
+        music_id = "core.music.mcTown5"s;
+    }
+    if (gdata_current_map == mdata_t::map_id_t::noyel)
+    {
+        music_id = "core.music.mcTown6"s;
+    }
+
+    if (!music_id || adata(0, gdata_current_map) == mdata_t::map_type_t::world_map)
+    {
+        static const std::vector<std::string> choices =
+            {"core.music.mcField1",
+             "core.music.mcField2",
+             "core.music.mcField3"};
+        music_id = choices[gdata_day % 3];
+    }
+
+    return shared_id(*music_id);
+}
+
+void play_music_inner(const shared_id& music_id, int musicloop)
+{
+    if (musicprev != music_id)
+    {
+        musicprev = music_id;
+        stop_music();
+        auto music = the_music_db[music_id];
+        assert(music);
+        if (!fs::exists(music->file))
+        {
+            return;
+        }
+
+        // Since we're using SDL mixer, this should load any file
+        // format that mixer was compiled to support.
+        DMLOADFNAME(music->file, 0);
+        DMPLAY(musicloop, 0);
+    }
+}
 
 } // namespace
 
@@ -136,7 +271,7 @@ void initialize_sound_file()
 std::pair<short, unsigned char> sound_calculate_position(int listener_x, int listener_y, int source_x, int source_y)
 {
     // Larger means it takes more distance for sounds to become quiet.
-    const constexpr double distance_factor = 8.0;
+    const constexpr double distance_factor = 7.0;
 
     double x = static_cast<double>(source_x - listener_x);
     double y = static_cast<double>(source_y - listener_y);
@@ -240,7 +375,19 @@ void snd_inner(const sound_data& sound, short angle, unsigned char dist, bool lo
 
 
 
-void play_music(int music_id)
+void stop_music()
+{
+    mmstop();
+    if (config::instance().music == "direct_music")
+    {
+        DMSTOP();
+        DMLOADFNAME(filesystem::dir::sound() / u8"gm_on.mid", 0);
+        DMPLAY(1, 0);
+    }
+}
+
+
+void sound_play_environmental()
 {
     int env{};
 
@@ -307,112 +454,28 @@ void play_music(int music_id)
     {
         DSSTOP(16);
     }
-    if (envonly == 1)
-    {
-        envonly = 0;
-        return;
-    }
+}
+
+void play_music(const char* music_id)
+{
+    shared_id id = shared_id(std::string(music_id));
+    play_music(id);
+}
+
+void play_music(optional<shared_id> music_id)
+{
+    sound_play_environmental();
+
     if (config::instance().music == "none")
     {
         return;
     }
-    if (music_id == 0)
+
+    if (!music_id)
     {
-        if (adata(0, gdata_current_map) == mdata_t::map_type_t::field)
-        {
-            music_id = musicprev;
-        }
-        if (adata(0, gdata_current_map) == mdata_t::map_type_t::town)
-        {
-            music_id = 51;
-        }
-        if (adata(0, gdata_current_map) == mdata_t::map_type_t::player_owned)
-        {
-            music_id = 67;
-        }
-        if (mdata_map_bgm != 0)
-        {
-            music_id = mdata_map_bgm;
-        }
-        if (adata(0, gdata_current_map) >= mdata_t::map_type_t::dungeon)
-        {
-            music_id = 55 + gdata_hour % 6;
-        }
-        if (adata(16, gdata_current_map) == mdata_t::map_id_t::random_dungeon
-            || adata(16, gdata_current_map) == mdata_t::map_id_t::the_void)
-        {
-            if (gdata_current_dungeon_level == adata(10, gdata_current_map))
-            {
-                if (adata(20, gdata_current_map) != -1)
-                {
-                    music_id = 62;
-                }
-            }
-        }
-        if (gdata_current_map == mdata_t::map_id_t::quest)
-        {
-            if (gdata_executing_immediate_quest_type == 1001)
-            {
-                music_id = 76;
-            }
-            if (gdata_executing_immediate_quest_type == 1006)
-            {
-                music_id = 75;
-            }
-            if (gdata_executing_immediate_quest_type == 1009)
-            {
-                music_id = 77;
-            }
-            if (gdata_executing_immediate_quest_type == 1008)
-            {
-                music_id = 62;
-            }
-            if (gdata_executing_immediate_quest_type == 1010)
-            {
-                music_id = 73;
-            }
-        }
-        if (gdata_current_map == mdata_t::map_id_t::arena)
-        {
-            music_id = 73;
-        }
-        if (gdata_current_map == mdata_t::map_id_t::larna)
-        {
-            music_id = 75;
-        }
-        if (gdata_current_map == mdata_t::map_id_t::port_kapul)
-        {
-            music_id = 52;
-        }
-        if (gdata_current_map == mdata_t::map_id_t::lumiest)
-        {
-            music_id = 52;
-        }
-        if (gdata_current_map == mdata_t::map_id_t::yowyn)
-        {
-            music_id = 75;
-        }
-        if (gdata_current_map == mdata_t::map_id_t::derphy)
-        {
-            music_id = 53;
-        }
-        if (gdata_current_map == mdata_t::map_id_t::palmia)
-        {
-            music_id = 54;
-        }
-        if (gdata_current_map == mdata_t::map_id_t::cyber_dome)
-        {
-            music_id = 83;
-        }
-        if (gdata_current_map == mdata_t::map_id_t::noyel)
-        {
-            music_id = 85;
-        }
+        music_id = get_default_music();
     }
-    if (music_id == 0 || adata(0, gdata_current_map) == mdata_t::map_type_t::world_map)
-    {
-        music_id = 86 + gdata_day % 3;
-    }
+
     if (musicloop == 1)
     {
         musicloop = 0;
@@ -421,43 +484,9 @@ void play_music(int music_id)
     {
         musicloop = 65535;
     }
-    if (musicprev != music_id || music_id == 91)
-    {
-        musicprev = music_id;
-        mmstop();
-        if (config::instance().music == "direct_music")
-        {
-            DMSTOP();
-            DMLOADFNAME(filesystem::dir::sound() / u8"gm_on.mid", 0);
-            DMPLAY(1, 0);
-        }
-        if (music_id != -1)
-        {
-            auto music_dir = filesystem::dir::user() / u8"music";
-            if (!fs::exists(music_dir / musicfile(music_id)))
-            {
-                music_dir = filesystem::dir::sound();
-                if (!fs::exists(music_dir / musicfile(music_id)))
-                {
-                    return;
-                }
-            }
 
-            const auto is_mp3 =
-                strutil::contains(musicfile(music_id), u8".mp3");
+    play_music_inner(*music_id, musicloop);
 
-            if (config::instance().music == "mci" || is_mp3)
-            {
-                mmload(music_dir / musicfile(music_id), 0, musicloop == 65535);
-                mmplay(0);
-            }
-            else
-            {
-                DMLOADFNAME(music_dir / musicfile(music_id), 0);
-                DMPLAY(musicloop, 0);
-            }
-        }
-    }
     musicloop = 0;
 }
 

--- a/src/audio.hpp
+++ b/src/audio.hpp
@@ -12,6 +12,15 @@
 namespace elona
 {
 
+namespace detail
+{
+
+void snd_inner(const sound_data& sound,
+               short angle = 0, unsigned char dist = 0,
+               bool loop = false, bool allow_duplicate = true);
+
+} // namespace
+
 int DSINIT();
 void DSLOADFNAME(const fs::path& filepath, int id);
 void DSPLAY(int, bool);
@@ -36,18 +45,14 @@ void snd_at(I sound_id, const position_t& p, bool loop = false, bool allow_dupli
     unsigned char dist;
     std::tie (angle, dist) = sound_calculate_position(p);
 
-    snd_inner(**the_sound_db[sound_id], angle, dist, loop, allow_duplicate);
+    detail::snd_inner(**the_sound_db[sound_id], angle, dist, loop, allow_duplicate);
 }
 
 template <typename I>
 void snd(I sound_id, bool loop = false, bool allow_duplicate = true)
 {
-    snd_inner(**the_sound_db[sound_id], 0, 0, loop, allow_duplicate);
+    detail::snd_inner(**the_sound_db[sound_id], 0, 0, loop, allow_duplicate);
 }
-
-void snd_inner(const sound_data& sound,
-               short angle = 0, unsigned char dist = 0,
-               bool loop = false, bool allow_duplicate = true);
 
 void sound_play_environmental();
 void stop_music();

--- a/src/audio.hpp
+++ b/src/audio.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
-#include "filesystem.hpp"
+#include "db_music.hpp"
 #include "db_sound.hpp"
+#include "filesystem.hpp"
+#include "optional.hpp"
 #include "position.hpp"
+#include "shared_id.hpp"
 
 
 
@@ -45,7 +48,12 @@ void snd(I sound_id, bool loop = false, bool allow_duplicate = true)
 void snd_inner(const sound_data& sound,
                short angle = 0, unsigned char dist = 0,
                bool loop = false, bool allow_duplicate = true);
-void play_music(int music_id = 0);
+
+void sound_play_environmental();
+void stop_music();
+
+void play_music(optional<shared_id> music_id = none);
+void play_music(const char* music_id);
 
 
 } // namespace elona

--- a/src/casino.cpp
+++ b/src/casino.cpp
@@ -44,13 +44,13 @@ void casino_dealer()
     if (atxid == 1)
     {
         txt(i18n::s.get("core.locale.casino.talk_to_dealer"));
-        play_music(77);
+        play_music("core.music.mcCasino");
         casino_wrapper();
         return;
     }
     if (atxid == 4)
     {
-        play_music(77);
+        play_music("core.music.mcCasino");
         casino_wrapper();
         return;
     }

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -1957,12 +1957,19 @@ turn_result_t do_use_command()
     {
         txt(i18n::s.get("core.locale.action.use.music_disc.play", inv[ci]));
         auto music = inv[ci].param1 + 50 + 1;
-        if (music > 90)
+        if (music > 97)
         {
-            music = 90;
+            music = 97;
         }
         mdata_map_bgm = music;
-        play_music(music);
+
+        auto music_id = *the_music_db.get_id_from_legacy(music);
+        assert(music_id);
+        if (!music_id)
+        {
+            goto label_2229_internal;
+        }
+        play_music(*music_id);
     }
         goto label_2229_internal;
     case 10:
@@ -2139,8 +2146,7 @@ turn_result_t do_use_command()
         }
         txt(i18n::s.get("core.locale.action.use.statue.lulwy.normal"));
         txt(i18n::s.get("core.locale.action.weather.changes"));
-        envonly = 1;
-        play_music();
+        sound_play_environmental();
         goto label_2229_internal;
     case 28:
         if (mdata_map_type == mdata_t::map_type_t::world_map)

--- a/src/db_music.cpp
+++ b/src/db_music.cpp
@@ -1,0 +1,42 @@
+#include "db_music.hpp"
+
+namespace elona
+{
+
+music_db the_music_db;
+
+music_data music_db::convert(const std::string& id_,
+                             const sol::table& data,
+                             lua::lua_env& lua)
+{
+    ELONA_LION_DB_FIELD(_mod,                       std::string, "");
+    ELONA_LION_DB_FIELD(id,                         int, -1);
+    ELONA_LION_DB_FIELD(file,                       std::string, "");
+    ELONA_LION_DB_FIELD(predefined,                 bool, false);
+
+    assert(id != -1); // TODO
+
+    fs::path music_dir;
+    if (predefined)
+    {
+        music_dir = filesystem::dir::sound();
+    }
+    else
+    {
+        assert(music_dir != ""); // TODO
+        music_dir = filesystem::dir::for_mod(_mod);
+    }
+
+    const fs::path music_file = music_dir / filesystem::u8path(file);
+    if (!fs::exists(music_file))
+    {
+        throw std::runtime_error(id_ + ": Music file doesn't exist: " + music_file.string());
+    }
+
+    return music_data{
+        id,
+        music_file
+    };
+}
+
+}

--- a/src/db_music.hpp
+++ b/src/db_music.hpp
@@ -1,0 +1,46 @@
+#pragma once
+#include "filesystem.hpp"
+#include "lion.hpp"
+
+namespace elona
+{
+
+
+struct music_data
+{
+    int id;
+    fs::path file;
+};
+
+
+class music_db;
+
+
+namespace lion
+{
+
+template <>
+struct lion_db_traits<music_db>
+{
+    using data_type = music_data;
+    using legacy_id_type = int;
+    static constexpr const char* datatype_name = u8"music";
+};
+
+} // namespace cat
+
+
+
+class music_db : public lion::lion_db<music_db>
+{
+public:
+    music_db() = default;
+
+    music_data convert(const std::string&, const sol::table&, lua::lua_env&);
+};
+
+
+extern music_db the_music_db;
+
+
+} // namespace elona

--- a/src/dmgheal.cpp
+++ b/src/dmgheal.cpp
@@ -126,11 +126,11 @@ int dmghp(int victim_id, int amount, int damage_source, int element, int element
     {
         if (critical)
         {
-            snd(3);
+            snd_at(3, victim.position);
         }
         else
         {
-            snd(2);
+            snd_at(2, victim.position);
         }
     }
     if (victim.wet > 0)

--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -1057,7 +1057,7 @@ void fltn(const std::string& prm_447)
 
 int discsetmc()
 {
-    return rnd(40);
+    return rnd(47);
 }
 
 
@@ -11069,7 +11069,7 @@ void label_2151()
     }
     label_2150();
     musicloop = 1;
-    play_music(78);
+    play_music("core.music.mcCoda");
     msg_halt();
     for (int cnt = 0; cnt < 20; ++cnt)
     {
@@ -15813,32 +15813,8 @@ label_2682_internal:
     }
     if (s == u8"{mc}"s)
     {
-        auto music = -1;
-        if (s(1) == u8"mcUnrest2"s)
-        {
-            music = 84;
-        }
-        if (s(1) == u8"mcTown1"s)
-        {
-            music = 51;
-        }
-        if (s(1) == u8"mcMemory"s)
-        {
-            music = 89;
-        }
-        if (s(1) == u8"mcIntro"s)
-        {
-            music = 90;
-        }
-        if (music == -1)
-        {
-            musicfile(91) = s(1);
-            play_music(91);
-        }
-        else
-        {
-            play_music(music);
-        }
+        shared_id music_id(s(1));
+        play_music(music_id);
         goto label_2682_internal;
     }
     if (s == u8"{se}"s)
@@ -15973,8 +15949,7 @@ void weather_changes_by_location()
         if (gdata_pc_x_in_world_map < 65 && gdata_pc_y_in_world_map > 10)
         {
             gdata_weather = 3;
-            envonly = 1;
-            play_music();
+            sound_play_environmental();
             gdata_hours_until_weather_changes += 3;
             txt(i18n::s.get("core.locale.action.weather.changes"));
         }
@@ -15984,8 +15959,7 @@ void weather_changes_by_location()
         if (gdata_pc_x_in_world_map > 65 || gdata_pc_y_in_world_map < 10)
         {
             gdata_weather = 2;
-            envonly = 1;
-            play_music();
+            sound_play_environmental();
             gdata_hours_until_weather_changes += 3;
             txt(i18n::s.get("core.locale.action.weather.changes"));
         }
@@ -16178,8 +16152,7 @@ void weather_changes()
         }
         if (p != gdata_weather)
         {
-            envonly = 1;
-            play_music();
+            sound_play_environmental();
         }
     }
     label_1746();
@@ -16417,7 +16390,7 @@ void conquer_lesimas()
 {
     std::string wincomment;
     snd(51);
-    play_music(-1);
+    stop_music();
     txt(lang(
         u8"信じられない！あなたはネフィアの迷宮「レシマス」を制覇した！"s,
         u8"Unbelievable! You conquered Lesimas!"s));
@@ -16438,7 +16411,7 @@ void conquer_lesimas()
         txt(u8"「お前がここに辿り着くことは」台座から、何かの声が聞こえる。"s);
         flt();
         chara_create(-1, 23, cdata[0].position.x, cdata[0].position.y);
-        play_music(69);
+        play_music("core.music.mcChaos");
         msg_halt();
         msg_clear();
         txt(u8"「決まっていたことなのだ…遅かれ早かれな」"s);
@@ -16470,7 +16443,7 @@ void conquer_lesimas()
         msg_halt();
     }
     mode = 0;
-    play_music(71);
+    play_music("core.music.mcMarch2");
     label_1442();
     gsel(4);
     pos(0, 0);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -384,9 +384,11 @@ void initialize_lion_db()
 
     auto chara_table = initialize_single_lion_db("chara", data_path / "chara.hcl");
     auto sound_table = initialize_single_lion_db("sound", data_path / "sound.hcl");
+    auto music_table = initialize_single_lion_db("music", data_path / "music.hcl");
 
     the_character_db.initialize(chara_table);
     the_sound_db.initialize(sound_table);
+    the_music_db.initialize(music_table);
 }
 
 void initialize_config(const fs::path& config_file)

--- a/src/lion.hpp
+++ b/src/lion.hpp
@@ -100,6 +100,7 @@ public:
     void clear()
     {
         storage.clear();
+        by_legacy_id.clear();
     }
 
     void initialize(sol::table table)
@@ -116,6 +117,12 @@ public:
 
             data_type converted = static_cast<T&>(*this).convert(id, data, lua);
             id_type the_id(prefix + "." + id);
+
+            auto it = by_legacy_id.find(converted.id);
+            if (it != by_legacy_id.end())
+            {
+                throw std::runtime_error(the_id.get() + ": Legacy id already exists: " + converted.id + " -> " + it->second.get());
+            }
 
             by_legacy_id.emplace(converted.id, the_id);
             storage.emplace(the_id, converted);

--- a/src/lion.hpp
+++ b/src/lion.hpp
@@ -11,6 +11,8 @@
 #include "thirdparty/ordered_map/ordered_map.h"
 #include "thirdparty/sol2/sol.hpp"
 
+using namespace std::literals::string_literals;
+
 namespace elona
 {
 
@@ -121,7 +123,7 @@ public:
             auto it = by_legacy_id.find(converted.id);
             if (it != by_legacy_id.end())
             {
-                throw std::runtime_error(the_id.get() + ": Legacy id already exists: " + converted.id + " -> " + it->second.get());
+                throw std::runtime_error(the_id.get() + ": Legacy id already exists: "s + std::to_string(converted.id) + " -> "s + it->second.get());
             }
 
             by_legacy_id.emplace(converted.id, the_id);

--- a/src/lion.hpp
+++ b/src/lion.hpp
@@ -122,6 +122,14 @@ public:
         }
     }
 
+    optional_ref<id_type> get_id_from_legacy(const legacy_id_type& legacy_id) const
+    {
+        const auto itr = by_legacy_id.find(legacy_id);
+        if (itr == std::end(by_legacy_id))
+            return none;
+        else
+            return itr->second;
+    }
 
     optional_ref<data_type> operator[](const id_type& id) const
     {
@@ -141,11 +149,10 @@ public:
 
     optional_ref<data_type> operator[](const legacy_id_type& legacy_id) const
     {
-        const auto itr = by_legacy_id.find(legacy_id);
-        if (itr == std::end(by_legacy_id))
-            return none;
+        if (const auto id = get_id_from_legacy(legacy_id))
+            return (*this)[**id];
         else
-            return (*this)[itr->second];
+            return none;
     }
 
 

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -20,7 +20,7 @@ main_menu_result_t main_title_menu()
 {
     mode = 10;
     lomiaseaster = 0;
-    play_music(65);
+    play_music("core.music.mcOpening");
     cs = 0;
     cs_bk = -1;
     keyrange = 6;

--- a/src/proc_event.cpp
+++ b/src/proc_event.cpp
@@ -169,7 +169,7 @@ void proc_event()
         new_ally_joins();
         break;
     case 13:
-        play_music(80);
+        play_music("core.music.mcWedding");
         s = i18n::s.get("core.locale.event.popup.marriage.title");
         buff = i18n::s.get("core.locale.event.popup.marriage.text", cdata[marry]);
         listmax = 1;
@@ -239,7 +239,7 @@ void proc_event()
         txt(i18n::s.get("core.locale.event.guarded_by_lord", mapname(gdata_current_map), cdata[tc]));
         break;
     case 5:
-        play_music(64);
+        play_music("core.music.mcVictory");
         snd(51);
         flt(0, calcfixlv());
         flttypemajor = 54000;
@@ -816,8 +816,7 @@ void proc_event()
         if (mdata_map_type == mdata_t::map_type_t::world_map)
             break;
         gdata_weather = 1;
-        envonly = 1;
-        play_music();
+        sound_play_environmental();
         txt(i18n::s.get("core.locale.event.ragnarok"));
         msg_halt();
         ragnarok_animation().play();

--- a/src/quest.cpp
+++ b/src/quest.cpp
@@ -1180,7 +1180,7 @@ void quest_team_victorious()
 void quest_all_targets_killed()
 {
     musicloop = 1;
-    play_music(74);
+    play_music("core.music.mcFanfare");
     gdata(73) = 3;
     if (gdata_executing_immediate_quest_type == 1)
     {

--- a/src/snail/detail/sdl_impl.cpp
+++ b/src/snail/detail/sdl_impl.cpp
@@ -107,7 +107,7 @@ sdl_mixer::sdl_mixer()
     }
 
     enforce_mixer(
-        ::Mix_OpenAudio(MIX_DEFAULT_FREQUENCY, MIX_DEFAULT_FORMAT, 2, 2048));
+        ::Mix_OpenAudio(44100, MIX_DEFAULT_FORMAT, 2, 2048));
 }
 
 

--- a/src/testing.cpp
+++ b/src/testing.cpp
@@ -1,6 +1,8 @@
 #include "testing.hpp"
 #include <sstream>
 #include "config.hpp"
+#include "db_music.hpp"
+#include "db_sound.hpp"
 #include "draw.hpp"
 #include "gdata.hpp"
 #include "i18n.hpp"
@@ -89,6 +91,8 @@ void load_translations(const std::string& hcl)
 void clear_lion_db()
 {
     the_character_db.clear();
+    the_sound_db.clear();
+    the_music_db.clear();
 }
 
 void configure_lua()

--- a/src/variables.hpp
+++ b/src/variables.hpp
@@ -471,7 +471,6 @@ ELONA_EXTERN(int encounterlv);
 ELONA_EXTERN(int encounterref);
 ELONA_EXTERN(int enemylv);
 ELONA_EXTERN(int enemyteam);
-ELONA_EXTERN(int envonly);
 ELONA_EXTERN(int eqmultiweapon);
 ELONA_EXTERN(int eqtwohand);
 ELONA_EXTERN(int equip);


### PR DESCRIPTION
# Related Issues

#604.


# Summary
- Move music definitions to an external file, `music.hcl`.
- Allow playing back any music format that `SDL_Mixer` supports.
- Increase the resolution of audio playback to 44100 Hz.
- Update `scene1.hsp` and `scene2.hsp` to use the data ID format.
- Add definitions of 7 extra songs that are only played during cutscenes.
- Allow music discs to spawn with cutscene-only music.