### PR TITLE
Do not bundle into .app on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,7 +279,7 @@ else()
     add_executable(${PROJECT_NAME} ${BENCH_SOURCES})
     target_link_libraries(${PROJECT_NAME} hayai_main ${LIB_TIMING})
   else()
-    add_executable(${PROJECT_NAME} WIN32 MACOSX_BUNDLE ${CORE_SOURCES} src/main.cpp)
+    add_executable(${PROJECT_NAME} WIN32 ${CORE_SOURCES} src/main.cpp)
   endif()
 
   if(WIN32)


### PR DESCRIPTION

# Summary

On macOS, the executable and resource files are bundled into `Elona_foobar.app`. However, during the process, the executable `Elona_foobar` lacks debug information such as symbol table. It prevents me from debugging by using interactive debugger like GDB or LLDB.

Now that the all build results are placed in `./bin` directly.

