### PR TITLE
Fix random event's title being empty

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,10 +119,10 @@ set(CORE_SOURCES
   src/message.cpp
   src/network.cpp
   src/proc_event.cpp
-  src/proc_random_event.cpp
   src/quest.cpp
   src/race.cpp
   src/random.cpp
+  src/random_event.cpp
   src/set_item_info.cpp
   src/set_option.cpp
   src/shop.cpp

--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -11218,16 +11218,14 @@ void label_2151()
         }
         if (tc != -1)
         {
-            s = i18n::s.get("core.locale.activity.sleep.new_gene.title");
-            buff = i18n::s.get(
-                "core.locale.activity.sleep.new_gene.text", cdata[tc]);
-            listmax = 0;
-            list(0, listmax) = 1;
-            listn(0, listmax) = i18n::s.get_enum(
-                "core.locale.activity.sleep.new_gene.choices", 0);
-            ++listmax;
             cdata[tc].has_made_gene() = false;
-            show_random_event_window(u8"bg_re14");
+            show_random_event_window(
+                i18n::s.get("core.locale.activity.sleep.new_gene.title"),
+                i18n::s.get(
+                    "core.locale.activity.sleep.new_gene.text", cdata[tc]),
+                {i18n::s.get_enum(
+                    "core.locale.activity.sleep.new_gene.choices", 0)},
+                u8"bg_re14");
             save_gene();
         }
     }

--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -49,6 +49,7 @@
 #include "quest.hpp"
 #include "race.hpp"
 #include "random.hpp"
+#include "random_event.hpp"
 #include "shop.hpp"
 #include "status_ailment.hpp"
 #include "trait.hpp"
@@ -3727,13 +3728,6 @@ void initialize_set_of_random_generation()
     fsetplantunknown(2) = 54000;
     fsetplantunknown(3) = 64000;
     fsetplantunknown(4) = 77000;
-    fsetremain(0) = 25000;
-    fsetremain(1) = 57000;
-    fsetremain(2) = 57000;
-    fsetremain(3) = 77000;
-    fsetremain(4) = 53000;
-    fsetremain(5) = 52000;
-    fsetremain(6) = 57000;
     fsetbarrel(0) = 25000;
     fsetbarrel(1) = 57000;
     fsetbarrel(2) = 53000;

--- a/src/proc_event.cpp
+++ b/src/proc_event.cpp
@@ -16,6 +16,7 @@
 #include "mef.hpp"
 #include "quest.hpp"
 #include "random.hpp"
+#include "random_event.hpp"
 #include "ui.hpp"
 #include "variables.hpp"
 

--- a/src/proc_event.cpp
+++ b/src/proc_event.cpp
@@ -134,17 +134,18 @@ void proc_event()
         break;
     case 12:
         update_screen();
-        s = i18n::s.get("core.locale.event.popup.reunion_with_pet.title");
-        buff = i18n::s.get("core.locale.event.popup.reunion_with_pet.text");
-        listmax = 4;
-        for (int cnt = 0; cnt < listmax; cnt++)
         {
-            list(0, cnt) = cnt;
-            listn(0, cnt) = i18n::s.get_enum(
-                "core.locale.event.popup.reunion_with_pet.choices", cnt);
-        }
-        {
-            int result = show_random_event_window(u8"bg_re13");
+            std::vector<std::string> choices;
+            for (int i = 0; i < 4; ++i)
+            {
+                choices.push_back(i18n::s.get_enum(
+                    "core.locale.event.popup.reunion_with_pet.choices", i));
+            }
+            int result = show_random_event_window(
+                i18n::s.get("core.locale.event.popup.reunion_with_pet.title"),
+                i18n::s.get("core.locale.event.popup.reunion_with_pet.text"),
+                choices,
+                u8"bg_re13");
             p = 3;
             if (result == 0)
             {
@@ -171,17 +172,11 @@ void proc_event()
         break;
     case 13:
         play_music("core.mcWedding");
-        s = i18n::s.get("core.locale.event.popup.marriage.title");
-        buff =
-            i18n::s.get("core.locale.event.popup.marriage.text", cdata[marry]);
-        listmax = 1;
-        for (int cnt = 0; cnt < listmax; cnt++)
-        {
-            list(0, cnt) = cnt;
-            listn(0, cnt) = i18n::s.get_enum(
-                "core.locale.event.popup.marriage.choices", cnt);
-        }
-        show_random_event_window(u8"bg_re14");
+        show_random_event_window(
+            i18n::s.get("core.locale.event.popup.marriage.title"),
+            i18n::s.get("core.locale.event.popup.marriage.text", cdata[marry]),
+            {i18n::s.get_enum("core.locale.event.popup.marriage.choices", 0)},
+            u8"bg_re14");
         for (int i = 0; i < 5; ++i)
         {
             flt(calcobjlv(cdata[marry].level + 5), calcfixlv(3));

--- a/src/proc_random_event.cpp
+++ b/src/proc_random_event.cpp
@@ -229,8 +229,6 @@ void run_random_event(int id, int luck_threshold)
         }
     }
 
-    s = i18n::s.get_enum_property("core.locale.event.popup", "title", id);
-    buff = i18n::s.get_enum_property("core.locale.event.popup", "text", id);
     std::string event_bg;
 
     switch (id)
@@ -447,6 +445,8 @@ void run_random_event(int id, int luck_threshold)
         break;
     }
 
+    s = i18n::s.get_enum_property("core.locale.event.popup", "title", id);
+    buff = i18n::s.get_enum_property("core.locale.event.popup", "text", id);
     for (int cnt = 0; cnt < listmax; cnt++)
     {
         list(0, cnt) = cnt;

--- a/src/random_event.hpp
+++ b/src/random_event.hpp
@@ -1,0 +1,17 @@
+#include <string>
+#include <vector>
+
+
+
+namespace elona
+{
+
+
+
+void proc_random_event();
+
+int show_random_event_window(const std::string& file);
+
+
+
+} // namespace elona

--- a/src/random_event.hpp
+++ b/src/random_event.hpp
@@ -10,7 +10,22 @@ namespace elona
 
 void proc_random_event();
 
-int show_random_event_window(const std::string& file);
+/**
+ * Show random event window. If config::instance().skiprandevents is enabled and
+ * choices has only one choice, doesn't show a window and returns -1
+ * immediately.
+ * @param[in] title
+ * @param[in] text
+ * @param[in] choices The list of choices whose size is not 0.
+ * @param[in] background_filename
+ * @return The index of the selected choice in choices. If the event is
+ * skipped, returns -1.
+ */
+int show_random_event_window(
+    const std::string& title,
+    const std::string& text,
+    const std::vector<std::string> choices,
+    const std::string& file);
 
 
 

--- a/src/variables.hpp
+++ b/src/variables.hpp
@@ -172,9 +172,6 @@ ELONA_EXTERN(bool player_queried_for_input);
 // network.cpp
 ELONA_EXTERN(elona_vector1<std::string> netbuf);
 
-// proc_random_event.cpp
-ELONA_EXTERN(elona_vector1<int> fsetremain);
-
 // activity.cpp
 ELONA_EXTERN(elona_vector1<int> fsetperform);
 
@@ -739,8 +736,6 @@ int place_random_nefias();
 int get_card_info();
 int label_1835();
 int label_1845();
-int proc_random_event();
-int show_random_event_window(const std::string&);
 int label_1898();
 int label_1931();
 int label_1932();


### PR DESCRIPTION

# Summary

## Before

![image](https://user-images.githubusercontent.com/36858341/43680929-eca3aaf8-9880-11e8-8884-8a993b660528.png)

## After

![image](https://user-images.githubusercontent.com/36858341/43680930-f0f89f64-9880-11e8-89dc-70ae5a813fb1.png)

## Cause

The title was stored in the global variable `s`, but it might be overwritten during an event process.