### PR TITLE
Fix text color at material spot

### DIFF
--- a/runtime/locale/jp/activity.hcl
+++ b/runtime/locale/jp/activity.hcl
@@ -202,9 +202,9 @@ locale {
 
             get_verb {
                 dig_up = "掘り当てた"
-                fish_up = "釣り上げた。"
-                harvest = "採取した。"
-                find = "見つけた。"
+                fish_up = "釣り上げた"
+                harvest = "採取した"
+                find = "見つけた"
                 get = "入手した"
             }
 

--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -2052,44 +2052,47 @@ int search_material_spot()
     return 0;
 }
 
+
+
 void matgetmain(int material_id, int amount, int spot_type)
 {
-    std::string message;
-    std::string verb = "?";
     if (amount == 0)
     {
         amount = 1;
     }
     mat(material_id) += amount;
     snd(21);
-    if (spot_type == 1)
+
+    std::string verb;
+    switch (spot_type)
     {
-        verb = i18n::s.get("core.locale.activity.material.get_verb.dig_up");
-    }
-    if (spot_type == 2)
-    {
-        verb = i18n::s.get("core.locale.activity.material.get_verb.fish_up");
-    }
-    if (spot_type == 3)
-    {
-        verb = i18n::s.get("core.locale.activity.material.get_verb.harvest");
-    }
-    if (spot_type == 5)
-    {
-        verb = i18n::s.get("core.locale.activity.material.get_verb.find");
-    }
-    if (spot_type == 0)
-    {
+    case 0:
         verb = i18n::s.get("core.locale.activity.material.get_verb.get");
+        break;
+    case 1:
+        verb = i18n::s.get("core.locale.activity.material.get_verb.dig_up");
+        break;
+    case 2:
+        verb = i18n::s.get("core.locale.activity.material.get_verb.fish_up");
+        break;
+    case 3:
+        verb = i18n::s.get("core.locale.activity.material.get_verb.harvest");
+        break;
+    case 5:
+        verb = i18n::s.get("core.locale.activity.material.get_verb.find");
+        break;
+    default:
+        verb = i18n::s.get("core.locale.activity.material.get_verb.get");
+        break;
     }
-    txt(i18n::s.get(
-        "core.locale.activity.material.get",
-        verb,
-        amount,
-        matname(material_id)));
+
     txtef(4);
-    txt(message + u8"("s + mat(material_id) + u8") "s);
-    return;
+    txt(i18n::s.get(
+            "core.locale.activity.material.get",
+            verb,
+            amount,
+            matname(material_id))
+        + u8"("s + mat(material_id) + u8") "s);
 }
 
 


### PR DESCRIPTION
# Summary

Remove unnecessary period in JP.

> BEFORE:
> マテリアル: 電気を1個採取した。。(1)
> AFTER:
> マテリアル: 電気を1個採取した。(1)


Fix text color at material spot.

BEFORE:

![image](https://user-images.githubusercontent.com/36858341/43681996-e1a94b0c-989f-11e8-94a6-bee0a9e5af80.png)


AFTER:
![image](https://user-images.githubusercontent.com/36858341/43681989-b38a2e30-989f-11e8-9c6c-d3567d44fcdb.png)
