### PR TITLE
Fix eating effect

### DIFF
--- a/doc/api/classes/LuaCharacter.luadoc
+++ b/doc/api/classes/LuaCharacter.luadoc
@@ -102,3 +102,9 @@ function gain_skill(id, initial_level, initial_stock) end
 -- @tparam num id the skill/spell ID
 -- @tparam num amount the amount of experience
 function gain_skill_exp(id, amount) end
+
+--- Modify a character's resistance. Since the effect is permanent,
+--- once your resistance is modified, it will not be reset on refreshing.
+-- @tparam num element the corresponding element
+-- @tparam num delta the amount of increase/decrease
+function modify_resistance(element, delta) end

--- a/runtime/data/lua/enums.lua
+++ b/runtime/data/lua/enums.lua
@@ -28,6 +28,23 @@ Enums.StatusAilment = {
    Sick = 12,
 }
 
+Enums.Element = {
+   Fire = 50,
+   Cold = 51,
+   Lightning = 52,
+   Darkness = 53,
+   Mind = 54,
+   Poison = 55,
+   Nether = 56,
+   Sound = 57,
+   Nerve = 58,
+   Chaos = 59,
+   Magic = 60,
+   Cut = 61,
+   Ether = 62,
+   Acid = 63,
+}
+
 Enums.TileKind = {
    Normal = 0,
    Wall = 1,

--- a/runtime/mods/core/exports/eating_effect.lua
+++ b/runtime/mods/core/exports/eating_effect.lua
@@ -26,13 +26,13 @@ end
 
 function eating_effect.iron(eater)
    eat_message(eater, "iron", Enums.Color.Purple)
-   eater:apply_status_ailment(Enums.StatusAilment.Dimmed, 200)
+   eater:apply_ailment(Enums.StatusAilment.Dimmed, 200)
 end
 
 function eating_effect.deformed_eye(eater)
    eat_message(eater, "deformed_eye", Enums.Color.Purple)
    eater:gain_sanity(-25)
-   eater:apply_status_ailment(Enums.StatusAilment.Insane, 500)
+   eater:apply_ailment(Enums.StatusAilment.Insane, 500)
 end
 
 function eating_effect.horse(eater)
@@ -70,7 +70,7 @@ function eating_effect.insanity(eater)
    eat_message(eater, "insanity", Enums.Color.Purple)
    eater:modify_resistance(Enums.Element.Mind, 50)
    eater:gain_sanity(-500)
-   eater:apply_status_ailment(Enums.StatusAilment.Insane, 1000)
+   eater:apply_ailment(Enums.StatusAilment.Insane, 1000)
 end
 
 function eating_effect.putit(eater)
@@ -87,7 +87,7 @@ end
 local function eating_effect_poisonous(gain_resist)
    return function(eater)
       eat_message(eater, "poisonous", Enums.Color.Purple)
-      eater:apply_status_ailment(Enums.StatusAilment.Poisoned, 100)
+      eater:apply_ailment(Enums.StatusAilment.Poisoned, 100)
       if gain_resist then
          mod_resist_chance(eater, Enums.Element.Poison, 6)
       end
@@ -120,7 +120,7 @@ end
 
 function eating_effect.grudge(eater)
    eat_message(eater, "grudge", Enums.Color.Purple)
-   eater:apply_status_ailment(Enums.StatusAilment.Confused, 200)
+   eater:apply_ailment(Enums.StatusAilment.Confused, 200)
 end
 
 function eating_effect.calm(eater)
@@ -145,7 +145,7 @@ end
 
 function eating_effect.lightning(eater)
    eat_message(eater, "lightning", Enums.Color.Purple)
-   eater:apply_status_ailment(Enums.StatusAilment.Paralyzed, 300)
+   eater:apply_ailment(Enums.StatusAilment.Paralyzed, 300)
 end
 
 function eating_effect.cat(eater)
@@ -230,7 +230,7 @@ end
 
 function eating_effect.chaos_cloud(eater)
    eat_message(eater, "chaos_cloud", Enums.Color.Purple)
-   eater:apply_status_ailment(Enums.StatusAilment.Confused, 300)
+   eater:apply_ailment(Enums.StatusAilment.Confused, 300)
    mod_resist_chance(eater, Enums.Element.Chaos, 5)
 end
 

--- a/src/lua_env/api_manager.cpp
+++ b/src/lua_env/api_manager.cpp
@@ -1234,6 +1234,7 @@ void gain_skill(character&, int, int);
 void gain_skill_stock(character&, int, int, int);
 void gain_skill_exp(character&, int, int);
 void modify_trait(character&, int, int);
+void modify_resistance(character&, int, int);
 } // namespace LuaCharacter
 
 void LuaCharacter::damage_hp(character& self, int amount)
@@ -1316,6 +1317,15 @@ void LuaCharacter::gain_skill_exp(character& self, int skill, int amount)
     elona::skillmod(skill, self.index, amount);
 }
 
+
+
+void LuaCharacter::modify_resistance(character& self, int element, int delta)
+{
+    elona::resistmod(self.index, element, delta);
+}
+
+
+
 /***
  * Set up usertype tables in Sol so we can call methods with them.
  */
@@ -1348,6 +1358,8 @@ void init_usertypes(lua_env& lua)
             &LuaCharacter::gain_skill, &LuaCharacter::gain_skill_stock),
         "gain_skill_exp",
         &LuaCharacter::gain_skill_exp,
+        "modify_resistance",
+        &LuaCharacter::modify_resistance,
         "hp",
         sol::readonly(&character::hp),
         "max_hp",

--- a/src/tests/lua/classes/LuaCharacter.lua
+++ b/src/tests/lua/classes/LuaCharacter.lua
@@ -51,4 +51,18 @@ lrun("test LuaCharacter:gain_skill_exp", function()
         lequal(Skill.level(10, putit), 14)
 end)
 
+lrun("test LuaCharacter:modify_resistance", function()
+        Testing.start_in_debug_map()
+
+        local putit = Chara.create(0, 0, 3)
+        lequal(Skill.level(Enums.Element.Fire, putit), 100)
+        lequal(Skill.level(Enums.Element.Cold, putit), 100)
+
+        putit:modify_resistance(Enums.Element.Fire, 50)
+        putit:modify_resistance(Enums.Element.Cold, -50)
+
+        lequal(Skill.level(Enums.Element.Fire, putit), 150)
+        lequal(Skill.level(Enums.Element.Cold, putit), 50)
+end)
+
 assert(lresults())


### PR DESCRIPTION
# Summary

- Fix wrong function name in Lua.
  - `apply_status_ailment` -> `apply_ailment`. The former doesn't exist.
- Implement missing Lua function, `modify_resistance()`.

# TODO
- [x] Created a binding in `lua_api.cpp` inside the appropriate namespace.
- [x] Set the binding on the correct table in `lua::init()`.
- [x] Updated `.luacheckrc` with the new table value.
- [x] Added LDoc documentation in `doc/api`.
- [x] Added tests inside `tests/lua_api.cpp`.
