### PR TITLE
Implement per-mod require and loaded chunk cache

### DIFF
--- a/src/lua_env/loaded_chunk_cache.hpp
+++ b/src/lua_env/loaded_chunk_cache.hpp
@@ -1,0 +1,84 @@
+#pragma once
+#include <unordered_map>
+#include "../filesystem.hpp"
+#include "../thirdparty/sol2/sol.hpp"
+
+namespace elona
+{
+namespace lua
+{
+
+
+/**
+ * Acts as Lua's package.loaded and require, but local to a single Lua
+ * environment.
+ *
+ * This is needed since package.loaded is normally global to the entire Lua
+ * state.
+ */
+class loaded_chunk_cache
+{
+public:
+    loaded_chunk_cache(const fs::path& base_path_)
+        : base_path(base_path_)
+    {
+        assert(fs::exists(base_path));
+    }
+
+public:
+    sol::object
+    require(const std::string& name, sol::environment env, sol::state& state)
+    {
+        auto it = chunk_cache.find(name);
+        if (it != chunk_cache.end())
+            return it->second;
+
+        const fs::path full_path = base_path / (name + ".lua");
+        if (!file_contained_in_dir(full_path))
+            return sol::lua_nil;
+
+        sol::object result = state.script_file(full_path.string(), env);
+
+        if (result != sol::lua_nil)
+            chunk_cache[name] = result;
+
+        return result;
+    }
+
+private:
+    bool file_contained_in_dir(fs::path file)
+    {
+        // Modifies filename, so copy is needed.
+        if (!file.has_filename())
+        {
+            return false;
+        }
+        file.remove_filename();
+
+        if (!fs::exists(file))
+        {
+            return false;
+        }
+
+        // Strip "." and ".."
+        file = fs::canonical(file);
+        fs::path dir = fs::canonical(base_path);
+
+        std::size_t dir_len = std::distance(dir.begin(), dir.end());
+        std::size_t file_len = std::distance(file.begin(), file.end());
+
+        if (dir_len > file_len)
+        {
+            return false;
+        }
+
+        bool dir_is_prefix = std::equal(dir.begin(), dir.end(), file.begin());
+        return dir_is_prefix;
+    }
+
+    fs::path base_path;
+    std::unordered_map<std::string, sol::object> chunk_cache;
+};
+
+} // namespace lua
+} // namespace elona

--- a/src/lua_env/mod_manager.cpp
+++ b/src/lua_env/mod_manager.cpp
@@ -319,16 +319,15 @@ void mod_manager::setup_mod_globals(mod_info& mod, sol::table& table)
 
     // Add a custom version of "require" for use within mods. (Not
     // added for scripts/console environment)
-    if (mod.path)
+    if (mod.chunk_cache)
     {
         auto state = lua_->get_state();
-        fs::path mod_path = *mod.path;
-        table["require"] = [state, mod_path](
-                               const std::string& path,
+        auto& chunk_cache = *mod.chunk_cache;
+        table["require"] = [state, &chunk_cache](
+                               const std::string& name,
                                sol::this_environment this_env) {
             sol::environment env = this_env;
-            const fs::path full_path = mod_path / (path + ".lua");
-            return state->script_file(full_path.string(), env);
+            return chunk_cache.require(name, env, *state);
         };
     }
 }

--- a/src/lua_env/mod_manager.hpp
+++ b/src/lua_env/mod_manager.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include "../filesystem.hpp"
 #include "../optional.hpp"
+#include "loaded_chunk_cache.hpp"
 #include "lua_env.hpp"
 
 namespace elona
@@ -35,6 +36,11 @@ struct mod_info
 
         store_local = state->create_table();
         store_global = state->create_table();
+
+        if (path)
+        {
+            chunk_cache = loaded_chunk_cache{*path};
+        }
     }
     mod_info(const mod_info&) = delete;
     mod_info& operator=(const mod_info&) = delete;
@@ -42,6 +48,7 @@ struct mod_info
 
     std::string name;
     optional<fs::path> path;
+    optional<loaded_chunk_cache> chunk_cache;
     sol::environment env;
     sol::table store_local;
     sol::table store_global;

--- a/src/tests/data/mods/test_require_chunks/data/script.lua
+++ b/src/tests/data/mods/test_require_chunks/data/script.lua
@@ -1,0 +1,14 @@
+local val = 0
+
+local function value()
+   return val
+end
+
+local function increment_locally()
+   val = val + 1
+end
+
+return {
+   value = value,
+   increment_locally = increment_locally
+}


### PR DESCRIPTION
# Related Issues

Close #731.

# Summary
- Implement a special version of `require` for use in mods.
  + Mods can load other Lua files, and the results of the load will be cached.
  + Mods cannot load files outside the mod's directory.