### PR TITLE
Fix keys not working after using house board

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -998,6 +998,7 @@ void wait_key_released()
         result = stick(stick_key::mouse_left | stick_key::mouse_right);
         if (result == 0)
         {
+            await(config::instance().wait1);
             key_check();
             if (key(0).empty())
             {


### PR DESCRIPTION

# Summary

Fix keys not working after using house board.

# How to reproduce

1. Use[t] house board.
2. Press ESC and select any tile.
3. Exit house design mode.
4. Press two cursor keys at the same frame.

# Solution

Add missing `await()`.
