### PR TITLE
Add Lua object reference changes from serialization change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,6 +281,7 @@ else()
       src/tests/lua_registry_item.cpp
       src/tests/lua_serialization.cpp
       src/tests/elonacore.cpp
+      src/tests/item.cpp
       src/tests/i18n.cpp
       src/tests/i18n_builtins.cpp
       src/tests/i18n_regressions.cpp

--- a/runtime/data/lua/handle.lua
+++ b/runtime/data/lua/handle.lua
@@ -1,44 +1,43 @@
 --- Lua-side storage for safe references to C++ objects.
 --
--- Whenever a new object is initialized, a corresponding handle will
--- be created here to track the object's lifetime in an isolated Lua
--- environment managed by a C++ handle manager. If the object is no
--- longer valid for use (a character died, or an item was destroyed),
--- the C++ side will set the Lua side's handle to be invalid. An
--- error will be thrown on trying to access or write to anything on
--- an invalid handle. Since objects are identified by simple integer
--- ids, this also allows for relatively simple serialization of such
--- references to C++ objects from Lua, allowing us to save the state
--- of any mods that are in use along with the base save data.
---
--- This mechanism is a solution for the problem of what happens when a
--- user assigns a C++ object reference to a deeply nested Lua table,
--- then that reference goes invalid on the C++ side. Originally an
--- approach was attempted where the C++ storage mechanism bound to Lua
--- attempted to detect invalid references when they were accessed.
--- This didn't work, because it didn't solve the problem of what
--- happens when the reference is assigned to a nested Lua table which
--- is referenced in the C++ storage. The C++ code would have to
--- iterate every possible nested table value to check for any invalid
--- references. This solution is more lightweight and robust since a
--- simple flag can be set on a handle and all references to it will be
--- updated automatically.
+-- Whenever a new character or item is initialized, a corresponding
+-- handle will be created here to track the object's lifetime in an
+-- isolated Lua environment managed by a C++ handle manager. If the
+-- object is no longer valid for use (a character died, or an item was
+-- destroyed), the C++ side will set the Lua side's handle to be
+-- invalid. An error will be thrown on trying to access or write to
+-- anything on an invalid handle. Since objects are identified by
+-- UUIDs, it is possible to serialize references to C++ objects
+-- relatively easily, allowing for serializing the state of any mods
+-- that are in use along with the base save data. The usage of UUIDs
+-- also allows checking equality and validity of objects, even long
+-- after the C++ object the handle references has been removed.
 --
 -- Borrowed from https://eliasdaler.github.io/game-object-references/
 
 local Handle = {}
 
--- Stores a map of handle -> C++ object reference. These should not be
+-- Stores a map of handle.__uuid -> C++ object reference. These should not be
 -- directly accessable outside this chunk.
+-- Indexed by [class_name][uuid].
 local refs = {}
 
 -- Stores a map of integer ID -> handle.
+-- Indexed by [class_name][id].
 -- NOTE: If integer indices as IDs are completely removed, then this
 -- may have to be indexed by another value.
 local handles_by_index = {}
 
-local function print_handle_error(key)
-   if _IS_TEST then return end
+-- Cache for function closures resolved when indexing a handle.
+-- Creating a new closure for every method lookup is expensive.
+-- Indexed by [class_name][method_name].
+local memoized_funcs = {}
+
+
+local function print_handle_error(handle, key)
+   if _IS_TEST then
+      return
+   end
 
    if Elona.core and Elona.core.GUI then
       Elona.core.GUI.txt_color(3)
@@ -49,69 +48,79 @@ local function print_handle_error(key)
       Elona.core.GUI.txt("This means the character/item got removed. ")
       Elona.core.GUI.txt_color(0)
    end
-   print("Error: handle is not valid!")
+
+   if handle then
+      print("Error: handle is not valid! " .. handle.__kind .. ":" .. handle.__index)
+   else
+      print("Error: handle is not valid! " .. tostring(handle))
+   end
    print(debug.traceback())
 end
 
--- Cache for function closures resolved when indexing a handle.
--- Creating a new closure for every method lookup is expensive.
--- Indexed by [class_name][method_name].
-local memoizedFuncs = {}
-
 
 function Handle.is_valid(handle)
-   return handle ~= nil and refs[handle.kind][handle.uuid] ~= nil
+   return handle ~= nil and refs[handle.__kind][handle.__uuid] ~= nil
 end
 
 
-local function generate_metatable(prefix)
+--- Create a metatable to be set on all handle tables of a given kind
+--- ("LuaCharacter", "LuaItem") which will check for validity on
+--- variable/method access.
+local function generate_metatable(kind)
    -- The userdata table is bound by sol2 as a global.
-   local userdata_table = _ENV[prefix]
+   local userdata_table = _ENV[kind]
 
    local mt = {}
-   memoizedFuncs[prefix] = {}
+   memoized_funcs[kind] = {}
    mt.__index = function(handle, key)
+      if key == "is_valid" then
+         -- workaround to avoid serializing is_valid function, since
+         -- serpent will refuse to load it safely
+         return Handle.is_valid
+      end
+
       if not Handle.is_valid(handle)then
-         print_handle_error(key)
+         print_handle_error(handle, key)
          error("Error: handle is not valid!", 2)
       end
 
       -- Try to get a property out of the C++ reference.
-      local ref = refs[prefix][handle.uuid][key]
+      local val = refs[kind][handle.__uuid][key]
 
-      if ref ~= nil then
-         if type(ref) ~= "function" then
-            return ref
+      if val ~= nil then
+         -- If the found property is a plain value, return it.
+         if type(val) ~= "function" then
+            return val
          end
       end
 
       -- If that fails, try calling a function by the name given.
-      local f = memoizedFuncs[prefix][key]
+      local f = memoized_funcs[kind][key]
       if not f then
          -- Look up the function on the usertype table generated by
          -- sol2.
-         f = function(h, ...) return userdata_table[key](refs[prefix][h.uuid], ...) end
+         f = function(h, ...) return userdata_table[key](refs[kind][h.__uuid], ...) end
 
          -- Cache it so we don't incur the overhead of creating a
          -- closure on every lookup.
-         memoizedFuncs[prefix][key] = f
+         memoized_funcs[kind][key] = f
       end
       return f
    end
    mt.__newindex = function(handle, key, value)
       if not Handle.is_valid(handle) then
-         print_handle_error(key)
+         print_handle_error(handle, key)
          error("Error: handle is not valid!", 2)
       end
 
-      refs[prefix][handle.uuid][key] = value
+      refs[kind][handle.__uuid][key] = value
    end
    mt.__eq = function(lhs, rhs)
-      return lhs.kind == rhs.kind and lhs.uuid == rhs.uuid
+      return lhs.__kind == rhs.__kind and lhs.__uuid == rhs.__uuid
    end
 
-   refs[prefix] = {}
-   handles_by_index[prefix] = {}
+   refs[kind] = {}
+   handles_by_index[kind] = {}
 
    return mt
 end
@@ -124,18 +133,28 @@ metatables.LuaItem = generate_metatable("LuaItem")
 --- userdata reference.
 function Handle.get_ref(handle, kind)
    if not Handle.is_valid(handle) then
-      print_handle_error()
+      print_handle_error(handle)
       error("Error: handle is not valid!", 2)
       return nil
    end
 
-   if not handle.kind == kind then
+   if not handle.__kind == kind then
       print(debug.traceback())
-      error("Error: handle is of wrong type: wanted " .. kind .. ", got " .. handle.kind)
+      error("Error: handle is of wrong type: wanted " .. kind .. ", got " .. handle.__kind)
       return nil
    end
 
-   return refs[kind][handle.uuid]
+   return refs[kind][handle.__uuid]
+end
+
+function Handle.set_ref(handle, ref)
+   refs[handle.__kind][handle.__uuid] = ref
+end
+
+--- Gets a metatable for the lua type specified ("LuaItem",
+--- "LuaCharacter")
+function Handle.get_metatable(kind)
+   return metatables[kind]
 end
 
 --- Given a C++ userdata reference and kind, retrieves the handle that
@@ -143,36 +162,44 @@ end
 function Handle.get_handle(cpp_ref, kind)
    local handle = handles_by_index[kind][cpp_ref.index]
 
-   if handle and not handle.kind == kind then
+   if handle and handle.__kind ~= kind then
       print(debug.traceback())
-      error("Error: handle is of wrong type: wanted " .. kind .. ", got " .. handle.kind)
+      error("Error: handle is of wrong type: wanted " .. kind .. ", got " .. handle.__kind)
       return nil
    end
 
    return handle
 end
 
+--- Creates a new handle by using a C++ reference's integer index. The
+--- handle's index must not be occupied by another handle, to prevent
+--- overwrites.
 function Handle.create_handle(cpp_ref, kind, uuid)
-   -- TEMP until serialization feature is added
-   -- if handles_by_index[kind][cpp_ref.index] ~= nil then
-   --    error("Handle already exists: " .. kind .. ":" .. cpp_ref.index, 2)
-   --    return nil
-   -- end
+   if handles_by_index[kind][cpp_ref.index] ~= nil then
+      print(handles_by_index[kind][cpp_ref.index].__uuid)
+      error("Handle already exists: " .. kind .. ":" .. cpp_ref.index, 2)
+      return nil
+   end
+
+   --print("CREATE " .. cpp_ref.index .. " " .. uuid)
 
    local handle = {
-      uuid = uuid,
-      kind = kind,
-      is_valid = function(self) return Handle.is_valid(self) end
+      __uuid = uuid,
+      __kind = kind,
+      __index = cpp_ref.index,
+      __handle = true
    }
 
-   setmetatable(handle, metatables[handle.kind])
-   refs[handle.kind][handle.uuid] = cpp_ref
-   handles_by_index[handle.kind][cpp_ref.index] = handle
+   setmetatable(handle, metatables[handle.__kind])
+   refs[handle.__kind][handle.__uuid] = cpp_ref
+   handles_by_index[handle.__kind][cpp_ref.index] = handle
 
    return handle
 end
 
 
+--- Removes an existing handle by using a C++ reference's integer
+--- index. It is acceptable if the handle doesn't already exist.
 function Handle.remove_handle(cpp_ref, kind)
    local handle = handles_by_index[kind][cpp_ref.index]
 
@@ -180,10 +207,42 @@ function Handle.remove_handle(cpp_ref, kind)
       return
    end
 
-   assert(handle.kind == kind)
+   --print("REMOVE " .. cpp_ref.index .. " " .. handle.__uuid)
 
-   refs[handle.kind][handle.uuid] = nil
-   handles_by_index[handle.kind][cpp_ref.index] = nil
+   assert(handle.__kind == kind)
+
+   refs[handle.__kind][handle.__uuid] = nil
+   handles_by_index[handle.__kind][cpp_ref.index] = nil
+end
+
+
+--- Moves a handle from one integer index to another and updates its
+--- __index field with the new value. The handle must be valid and the
+--- target index must not be occupied already.
+function Handle.relocate_handle(cpp_ref, new_index, kind)
+   print("RELOCATE " .. cpp_ref.index .. " "  .. new_index)
+   local handle = handles_by_index[kind][cpp_ref.index]
+   assert(Handle.is_valid(handle))
+   -- assert(not Handle.is_valid(handles_by_index[kind][new_index]))
+
+   handle.__index = new_index
+   handles_by_index[kind][new_index] = handle
+   handles_by_index[kind][cpp_ref.index] = nil
+end
+
+--- Exchanges the positions of two handles and updates their __index
+--- fields with the new values. Both handles must be valid.
+function Handle.swap_handles(cpp_ref_a, cpp_ref_b, kind)
+   print("SWAP " .. cpp_ref_a.index .. " "  .. cpp_ref_b.index)
+   local handle_a = handles_by_index[kind][cpp_ref_a.index]
+   local handle_b = handles_by_index[kind][cpp_ref_b.index]
+   assert(Handle.is_valid(handle_a))
+   assert(Handle.is_valid(handle_b))
+
+   handle_b.__index = cpp_ref_a.index
+   handle_a.__index = cpp_ref_b.index
+   handles_by_index[kind][cpp_ref_a.index] = handle_b
+   handles_by_index[kind][cpp_ref_b.index] = handle_a
 end
 
 
@@ -201,13 +260,63 @@ function Handle.assert_invalid(cpp_ref, kind)
 end
 
 
+-- Functions for deserialization. The steps are as follows.
+-- 1. Deserialize mod data that contains the table of handles.
+-- 2. Clear out existing handles/references in "handles_by_index" and
+--    "refs" using "get_handle_range" and "clear_handle_range".
+-- 3. Place handles into the "handles_by_index" table using
+--    "merge_handles".
+-- 4. In C++, for each object loaded, add its reference to the "refs"
+--    table using by looking up a newly inserted handle using the C++
+--    object's integer index in "handles_by_index".
+--    (handle_manager::resolve_handle)
+
+function Handle.get_handle_range(kind, index_start, index_end)
+   local ret = {}
+   print("RANGE " .. index_start .. " " .. index_end)
+   for index, handle in Handle.iter(kind, index_start, index_end) do
+      ret[index] = handle
+   end
+   return ret
+end
+
+function Handle.clear_handle_range(kind, index_start, index_end)
+   print("CLEARRANGE " .. index_start .. " " .. index_end)
+   for index=index_start, index_end do
+      local handle = handles_by_index[kind][index]
+      if handle ~= nil then
+         refs[kind][handle.__uuid] = nil
+         handles_by_index[kind][index] = nil
+      end
+   end
+end
+
+function Handle.merge_handles(kind, handles_)
+   for index, handle in pairs(handles_) do
+
+      -- Lua tables index from 1, but the underlying C++ arrays index
+      -- from 0. The handles_by_index table is serialized as-is with
+      -- the 0th index potentially occupied, but serpent seems to
+      -- shift the index by 1 when deserializing.
+      local adjusted_index = index - 1
+
+      if handle ~= nil then
+         if handles_by_index[kind][adjusted_index] ~= nil then
+            error("Attempt to overwrite handle " .. kind .. ":" .. adjusted_index, 2)
+         end
+         handles_by_index[kind][adjusted_index] = handle
+      end
+   end
+end
+
+
 function Handle.clear()
-   for k, _ in pairs(refs) do
-      refs[k] = {}
+   for kind, _ in pairs(refs) do
+      refs[kind] = {}
    end
 
-   for k, _ in pairs(handles_by_index) do
-      handles_by_index[k] = {}
+   for kind, _ in pairs(handles_by_index) do
+      handles_by_index[kind] = {}
    end
 end
 
@@ -215,6 +324,7 @@ end
 local function iter(a, i)
    local v = a.handles[i]
    while not (v and Handle.is_valid(v)) do
+      -- Skip over indices that point to invalid handles.
       if i >= a.to then
          return nil
       end
@@ -225,26 +335,22 @@ local function iter(a, i)
    return i, v
 end
 
+function Handle.iter(kind, from, to)
+   if from > to then
+      return nil
+   end
+   return iter, {handles=handles_by_index[kind], to=to}, from
+end
 
 -- These functions exist in the separate handle environment because I
 -- couldn't quite figure out how to make a valid custom C++/Lua
 -- iterator with Sol that returns Lua table references as values.
 
 -- Chara.iter(from, to)
-function Handle.iter_charas(from, to)
-   if from > to then
-      return nil
-   end
-   return iter, {handles=handles_by_index.LuaCharacter, to=to}, from
-end
+Handle.iter_charas = function(from, to) return Handle.iter("LuaCharacter", from, to) end
 
 -- Item.iter(from, to)
-function Handle.iter_items(from, to)
-   if from > to then
-      return nil
-   end
-   return iter, {handles=handles_by_index.LuaItem, to=to}, from
-end
+Handle.iter_items = function(from, to) return Handle.iter("LuaItem", from, to) end
 
 
 return Handle

--- a/runtime/data/lua/handle.lua
+++ b/runtime/data/lua/handle.lua
@@ -220,7 +220,6 @@ end
 --- __index field with the new value. The handle must be valid and the
 --- target index must not be occupied already.
 function Handle.relocate_handle(cpp_ref, new_index, kind)
-   print("RELOCATE " .. cpp_ref.index .. " "  .. new_index)
    local handle = handles_by_index[kind][cpp_ref.index]
    assert(Handle.is_valid(handle))
    -- assert(not Handle.is_valid(handles_by_index[kind][new_index]))
@@ -233,7 +232,6 @@ end
 --- Exchanges the positions of two handles and updates their __index
 --- fields with the new values. Both handles must be valid.
 function Handle.swap_handles(cpp_ref_a, cpp_ref_b, kind)
-   print("SWAP " .. cpp_ref_a.index .. " "  .. cpp_ref_b.index)
    local handle_a = handles_by_index[kind][cpp_ref_a.index]
    local handle_b = handles_by_index[kind][cpp_ref_b.index]
    assert(Handle.is_valid(handle_a))
@@ -273,7 +271,6 @@ end
 
 function Handle.get_handle_range(kind, index_start, index_end)
    local ret = {}
-   print("RANGE " .. index_start .. " " .. index_end)
    for index, handle in Handle.iter(kind, index_start, index_end) do
       ret[index] = handle
    end
@@ -281,7 +278,6 @@ function Handle.get_handle_range(kind, index_start, index_end)
 end
 
 function Handle.clear_handle_range(kind, index_start, index_end)
-   print("CLEARRANGE " .. index_start .. " " .. index_end)
    for index=index_start, index_end do
       local handle = handles_by_index[kind][index]
       if handle ~= nil then

--- a/src/building.cpp
+++ b/src/building.cpp
@@ -581,7 +581,6 @@ void prompt_hiring()
             cdata.player().gold -= calchirecost(tc) * 20;
             await(config::instance().animewait * 10);
             cdata[tc].set_state(character::state_t::alive);
-            lua::lua->get_handle_manager().create_chara_handle(cdata[tc]);
             txtef(2);
             txt(i18n::s.get(
                 "core.locale.building.home.hire.you_hire", cdata[tc]));

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2255,8 +2255,8 @@ void chara_relocate(
     source.item_which_will_be_used = 0;
     source.is_livestock() = false;
 
-    // TODO handle transferring through Lua robustly
-    // lua::lua->remove_chara_handle_run_callbacks(source);
+    lua::lua->get_handle_manager().relocate_handle<character>(
+        source, tc_at_m125);
 
     // Copy from `source` to `destination` and clear `source`
     sdata.copy(slot, source.index);

--- a/src/character.hpp
+++ b/src/character.hpp
@@ -363,7 +363,15 @@ struct character
         return "LuaCharacter";
     }
 
-    character::state_t state()
+    bool is_dead()
+    {
+        return state_ == character::state_t::empty
+            || state_ == character::state_t::pet_dead
+            || state_ == character::state_t::villager_dead
+            || state_ == character::state_t::adventurer_dead;
+    }
+
+    character::state_t state() const
     {
         return state_;
     }
@@ -647,11 +655,13 @@ void chara_refresh(int);
 /**
  * Copy `source` character to a new slot.
  * @param source The character copied from.
- * @return true if `source` was successfully copied; otherwise, false.
+ * @return the character slot copied to if `source` was successfully copied;
+ * otherwise, -1.
  */
-bool chara_copy(const character& source);
+int chara_copy(const character& source);
 
 void chara_delete(int = 0);
+void chara_remove(character&);
 void chara_vanquish(int = 0);
 void chara_killed(character&);
 int chara_find(int id);

--- a/src/character_making.cpp
+++ b/src/character_making.cpp
@@ -955,8 +955,6 @@ main_menu_result_t character_making_final_phase()
     }
     mode = 5;
     cdata.player().index = 0;
-    lua::lua->get_handle_manager().create_chara_handle_run_callbacks(
-        cdata.player());
     return main_menu_result_t::initialize_game;
 }
 

--- a/src/dmgheal.cpp
+++ b/src/dmgheal.cpp
@@ -640,7 +640,7 @@ int damage_hp(
                 {
                     if (mdata_map_type != mdata_t::map_type_t::world_map)
                     {
-                        if (chara_copy(victim))
+                        if (chara_copy(victim) != -1)
                         {
                             txt(i18n::s.get(
                                 "core.locale.damage.splits", victim));
@@ -661,7 +661,7 @@ int damage_hp(
                     {
                         if (mdata_map_type != mdata_t::map_type_t::world_map)
                         {
-                            if (chara_copy(victim))
+                            if (chara_copy(victim) != -1)
                             {
                                 txt(i18n::s.get(
                                     "core.locale.damage.splits", victim));
@@ -1189,7 +1189,6 @@ int damage_hp(
         }
 
         end_dmghp(victim);
-        chara_killed(victim);
 
         return 0;
     }

--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -3079,12 +3079,10 @@ void label_15380()
     cdata[rc].mp = cdata[rc].max_mp / 3;
     cdata[rc].sp = cdata[rc].max_sp / 3;
     cdata[rc].insanity = 0;
-    cdata[rc].set_state(character::state_t::alive);
     cdata[rc].current_map = 0;
     cdata[rc].relationship = cdata[rc].original_relationship;
     cdata[rc].nutrition = 8000;
-    lua::lua->get_handle_manager().create_chara_handle(
-        cdata[rc]); // TODO add separate Lua event for revival
+    cdata[rc].set_state(character::state_t::alive);
     return;
 }
 
@@ -5381,8 +5379,6 @@ turn_result_t exit_map()
             if (cdata[cnt].state() == character::state_t::pet_in_other_map)
             {
                 cdata[cnt].set_state(character::state_t::alive);
-                lua::lua->get_handle_manager().create_chara_handle(
-                    cdata[cnt]); // TODO add separate Lua event for revival
             }
             continue;
         }

--- a/src/initialize_map.cpp
+++ b/src/initialize_map.cpp
@@ -72,8 +72,6 @@ label_17401:
                 if (cdata[cnt].state() == character::state_t::pet_moving_to_map)
                 {
                     cdata[cnt].set_state(character::state_t::alive);
-                    lua::lua->get_handle_manager().create_chara_handle(
-                        cdata[cnt]);
                 }
             }
         }
@@ -2771,7 +2769,6 @@ label_1742_internal:
         }
         rc = cnt;
         cdata[rc].set_state(character::state_t::alive);
-        lua::lua->get_handle_manager().create_chara_handle(cdata[rc]);
         if (cdata[cnt].is_contracting() == 1)
         {
             cxinit = cdata.player().position.x;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -453,13 +453,17 @@ void item_copy(int a, int b)
     if (a < 0 || b < 0)
         return;
 
-    bool created_new = inv[b].number() == 0;
+    bool was_empty = inv[b].number() == 0;
 
     item::copy(inv[a], inv[b]);
 
-    if (created_new)
+    if (was_empty && inv[b].number() != 0)
     {
         lua::lua->get_handle_manager().create_item_handle_run_callbacks(inv[b]);
+    }
+    else if (!was_empty && inv[b].number() == 0)
+    {
+        inv[b].remove();
     }
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -77,6 +77,10 @@ bool item::almost_equals(const item& other, bool ignore_position)
 inventory::inventory()
     : storage(5480)
 {
+    for (size_t i = 0; i < storage.size(); ++i)
+    {
+        storage[i].index = static_cast<int>(i);
+    }
 }
 
 int ibit(size_t type, int ci)

--- a/src/lua_env/handle_manager.cpp
+++ b/src/lua_env/handle_manager.cpp
@@ -39,7 +39,7 @@ void handle_manager::bind(lua_env& lua)
     Item.set("iter", handle_env["Handle"]["iter_items"]);
 }
 
-void handle_manager::create_chara_handle(character& chara)
+void handle_manager::create_chara_handle(const character& chara)
 {
     if (chara.state() == character::state_t::empty)
     {
@@ -49,7 +49,7 @@ void handle_manager::create_chara_handle(character& chara)
     create_handle(chara);
 }
 
-void handle_manager::create_item_handle(item& item)
+void handle_manager::create_item_handle(const item& item)
 {
     if (item.number() == 0)
     {
@@ -59,26 +59,19 @@ void handle_manager::create_item_handle(item& item)
     create_handle(item);
 }
 
-void handle_manager::remove_chara_handle(character& chara)
+void handle_manager::remove_chara_handle(const character& chara)
 {
-    if (chara.state() == character::state_t::empty)
-    {
-        return;
-    }
-
-    // TODO should chara.state() == character::state_t::empty mean the handle is
-    // invalid? Some characters can die and respawn again.
     remove_handle(chara);
 }
 
-void handle_manager::remove_item_handle(item& item)
+void handle_manager::remove_item_handle(const item& item)
 {
     remove_handle(item);
 }
 
 
 // Handlers for brand-new instances of characters/objects being created
-void handle_manager::create_chara_handle_run_callbacks(character& chara)
+void handle_manager::create_chara_handle_run_callbacks(const character& chara)
 {
     assert(chara.state() != character::state_t::empty);
     create_chara_handle(chara);
@@ -89,7 +82,7 @@ void handle_manager::create_chara_handle_run_callbacks(character& chara)
         handle);
 }
 
-void handle_manager::create_item_handle_run_callbacks(item& item)
+void handle_manager::create_item_handle_run_callbacks(const item& item)
 {
     assert(item.number() != 0);
     create_item_handle(item);
@@ -102,7 +95,7 @@ void handle_manager::create_item_handle_run_callbacks(item& item)
 
 // Handlers for invalidation of characters/items (character death, item count is
 // 0)
-void handle_manager::remove_chara_handle_run_callbacks(character& chara)
+void handle_manager::remove_chara_handle_run_callbacks(const character& chara)
 {
     auto handle = get_handle(chara);
     if (handle == sol::lua_nil)
@@ -115,7 +108,7 @@ void handle_manager::remove_chara_handle_run_callbacks(character& chara)
     remove_chara_handle(chara);
 }
 
-void handle_manager::remove_item_handle_run_callbacks(item& item)
+void handle_manager::remove_item_handle_run_callbacks(const item& item)
 {
     auto handle = get_handle(item);
     if (handle == sol::lua_nil)

--- a/src/lua_env/handle_manager.cpp
+++ b/src/lua_env/handle_manager.cpp
@@ -105,6 +105,11 @@ void handle_manager::create_item_handle_run_callbacks(item& item)
 void handle_manager::remove_chara_handle_run_callbacks(character& chara)
 {
     auto handle = get_handle(chara);
+    if (handle == sol::lua_nil)
+    {
+        return;
+    }
+
     lua->get_event_manager().run_callbacks<event_kind_t::character_removed>(
         handle);
     remove_chara_handle(chara);
@@ -113,6 +118,11 @@ void handle_manager::remove_chara_handle_run_callbacks(character& chara)
 void handle_manager::remove_item_handle_run_callbacks(item& item)
 {
     auto handle = get_handle(item);
+    if (handle == sol::lua_nil)
+    {
+        return;
+    }
+
     lua->get_event_manager().run_callbacks<event_kind_t::item_removed>(handle);
     remove_item_handle(item);
 }

--- a/src/lua_env/handle_manager.hpp
+++ b/src/lua_env/handle_manager.hpp
@@ -45,8 +45,8 @@ public:
      * If the handle already exists, handle_set is instead checked for
      * validity.
      */
-    void create_chara_handle(character& chara);
-    void create_item_handle(item& item);
+    void create_chara_handle(const character& chara);
+    void create_item_handle(const item& item);
 
     /***
      * Removes an existing handle in the isolated handle environment.
@@ -54,8 +54,8 @@ public:
      * If the handle doesn't exist in this manager's handle list, handle_set
      * is checked that the handle is invalid.
      */
-    void remove_chara_handle(character& chara);
-    void remove_item_handle(item& item);
+    void remove_chara_handle(const character& chara);
+    void remove_item_handle(const item& item);
 
 
     /***
@@ -63,10 +63,10 @@ public:
      * creation/removal event callbacks using the event manager
      * instance.
      */
-    void create_chara_handle_run_callbacks(character&);
-    void create_item_handle_run_callbacks(item&);
-    void remove_chara_handle_run_callbacks(character&);
-    void remove_item_handle_run_callbacks(item&);
+    void create_chara_handle_run_callbacks(const character&);
+    void create_item_handle_run_callbacks(const item&);
+    void remove_chara_handle_run_callbacks(const character&);
+    void remove_item_handle_run_callbacks(const item&);
 
 
     /***

--- a/src/lua_env/handle_manager.hpp
+++ b/src/lua_env/handle_manager.hpp
@@ -24,10 +24,15 @@ class lua_env;
  * forgetting to check they're still valid.
  *
  * The handles are represented as Lua tables stored in an isolated Lua
- * environment. The handle manager acts as the interface for providing
- * references to the handles to other Lua environments.
+ * environment. Each handle acts as a reference to an object whose
+ * memory is managed by C++. The C++ reference is not stored on the
+ * handle; it acts as a unique identifier for that object instance,
+ * but to gain access to the C++ reference the handle manager must be
+ * used, where it will check for validity. The handle manager also
+ * acts as the interface for providing handles to other Lua
+ * environments.
  *
- * See mods/core/handle.lua for more information.
+ * See data/lua/handle.lua for more information.
  */
 class handle_manager : public lib::noncopyable
 {
@@ -79,7 +84,7 @@ public:
     template <typename T>
     bool handle_is(sol::table handle)
     {
-        return handle["kind"] == T::lua_type();
+        return handle["__kind"] == T::lua_type();
     }
 
     bool handle_is_valid(sol::table handle)
@@ -102,15 +107,57 @@ public:
 
         // NOTE: currently indexes by the object's integer ID, but
         // this may be phased out in the future.
-        sol::optional<sol::table> handle =
+        sol::object handle =
             handle_env["Handle"]["get_handle"](obj, T::lua_type());
-
-        if (!handle)
+        if (!handle.is<sol::table>())
         {
             return sol::lua_nil;
         }
-        return *handle;
+        return handle;
     }
+
+
+    sol::table
+    get_handle_range(const std::string& kind, int index_start, int index_end)
+    {
+        return handle_env["Handle"]["get_handle_range"](
+            kind, index_start, index_end);
+    }
+
+    void
+    clear_handle_range(const std::string& kind, int index_start, int index_end)
+    {
+        handle_env["Handle"]["clear_handle_range"](
+            kind, index_start, index_end);
+    }
+
+    void merge_handles(const std::string& kind, sol::table handles)
+    {
+        handle_env["Handle"]["merge_handles"](kind, handles);
+    }
+
+    template <typename T>
+    void relocate_handle(const T& obj, int new_index)
+    {
+        handle_env["Handle"]["relocate_handle"](obj, new_index, T::lua_type());
+    }
+
+    template <typename T>
+    void swap_handles(const T& obj_a, const T& obj_b)
+    {
+        handle_env["Handle"]["swap_handles"](obj_a, obj_b, T::lua_type());
+    }
+
+    template <typename T>
+    void resolve_handle(T& obj)
+    {
+        auto handle = get_handle<T>(obj);
+        if (handle != sol::lua_nil)
+        {
+            handle_env["Handle"]["set_ref"](handle, obj);
+        }
+    }
+
 
     void clear_all_handles();
 

--- a/src/lua_env/lua_api/lua_api_chara.cpp
+++ b/src/lua_env/lua_api/lua_api_chara.cpp
@@ -8,15 +8,13 @@ namespace lua
 
 bool Chara::is_alive(lua_character_handle handle)
 {
-    try
-    {
-        auto& chara = lua::lua->get_handle_manager().get_ref<character>(handle);
-        return chara.state() == character::state_t::alive;
-    }
-    catch (...)
+    if (!lua::lua->get_handle_manager().handle_is_valid(handle))
     {
         return false;
     }
+
+    auto& chara = lua::lua->get_handle_manager().get_ref<character>(handle);
+    return chara.state() == character::state_t::alive;
 }
 
 bool Chara::is_player(lua_character_handle handle)

--- a/src/tests/item.cpp
+++ b/src/tests/item.cpp
@@ -1,0 +1,22 @@
+#include "../thirdparty/catch2/catch.hpp"
+
+#include "../item.hpp"
+#include "../itemgen.hpp"
+#include "../testing.hpp"
+#include "../variables.hpp"
+#include "tests.hpp"
+
+TEST_CASE("Test that index of copied item is set", "[C++: Item]")
+{
+    testing::start_in_debug_map();
+    int amount = 1;
+
+    REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, amount));
+    item& i = elona::inv[elona::ci];
+
+    int ti = elona::inv_getfreeid(-1);
+    elona::item::copy(i, elona::inv[ti]);
+
+    REQUIRE(elona::inv[elona::ci].index == elona::ci);
+    REQUIRE(elona::inv[ti].index == ti);
+}

--- a/src/tests/lua_handles.cpp
+++ b/src/tests/lua_handles.cpp
@@ -350,7 +350,7 @@ TEST_CASE(
 
     REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, 1));
     elona::cc = 0;
-    elona::in = inv[ci].number();
+    elona::in = inv[elona::ci].number();
 
     REQUIRE(handle_mgr.get_handle(inv[elona::ci]) != sol::lua_nil);
     REQUIRE(pick_up_item() == 1);

--- a/src/tests/lua_handles.cpp
+++ b/src/tests/lua_handles.cpp
@@ -356,3 +356,173 @@ TEST_CASE(
     REQUIRE(pick_up_item() == 1);
     REQUIRE(handle_mgr.get_handle(inv[elona::ti]) != sol::lua_nil);
 }
+
+TEST_CASE("Test relocation of character handle", "[Lua: Handles]")
+{
+    auto& handle_mgr = elona::lua::lua->get_handle_manager();
+
+    REQUIRE(chara_create(-1, PUTIT_PROTO_ID, 4, 8));
+    character& chara = elona::cdata[elona::rc];
+    auto handle = handle_mgr.get_handle(chara);
+
+    int first_index = elona::rc;
+    std::string uuid = handle["__uuid"];
+    REQUIRE(handle["__index"].get<int>() == first_index);
+
+    new_ally_joins();
+
+    REQUIRE(handle_mgr.handle_is_valid(handle) == true);
+    REQUIRE(elona::rc != first_index);
+    REQUIRE(handle["__index"].get<int>() == elona::rc);
+    REQUIRE(handle["__uuid"].get<std::string>() == uuid);
+}
+
+TEST_CASE("Test removal of character causing handle removal", "[Lua: Handles]")
+{
+    auto& handle_mgr = elona::lua::lua->get_handle_manager();
+
+    REQUIRE(chara_create(-1, PUTIT_PROTO_ID, 4, 8));
+    character& chara = elona::cdata[elona::rc];
+    auto handle = handle_mgr.get_handle(chara);
+
+    chara_delete(chara.index);
+
+    REQUIRE(handle_mgr.handle_is_valid(handle) == false);
+}
+
+TEST_CASE(
+    "Test setting of item amount causing handle deletion",
+    "[Lua: Handles]")
+{
+    auto& handle_mgr = elona::lua::lua->get_handle_manager();
+    int amount = 2;
+
+    REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, amount));
+    item& i = elona::inv[elona::ci];
+    auto handle = handle_mgr.get_handle(i);
+
+    REQUIRE(handle_mgr.handle_is_valid(handle) == true);
+
+    // Amount becomes 1.
+    i.set_number(1);
+    REQUIRE(handle_mgr.handle_is_valid(handle) == true);
+
+    // Amount becomes 0.
+    i.set_number(-5);
+    REQUIRE(handle_mgr.handle_is_valid(handle) == false);
+
+    // Amount becomes 1 again. Item counts as recreated.
+    i.set_number(1);
+    REQUIRE(handle_mgr.handle_is_valid(handle) == false);
+
+    // The handle has been replaced, so retrieve it again.
+    handle = handle_mgr.get_handle(i);
+    REQUIRE(handle_mgr.handle_is_valid(handle) == true);
+}
+
+TEST_CASE(
+    "Test modifying of item amount causing handle deletion",
+    "[Lua: Handles]")
+{
+    auto& handle_mgr = elona::lua::lua->get_handle_manager();
+    int amount = 2;
+
+    REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, amount));
+    item& i = elona::inv[elona::ci];
+    auto handle = handle_mgr.get_handle(i);
+
+    REQUIRE(handle_mgr.handle_is_valid(handle) == true);
+
+    // Amount becomes 1.
+    i.modify_number(-1);
+    REQUIRE(handle_mgr.handle_is_valid(handle) == true);
+
+    // Amount becomes 0.
+    i.modify_number(-5);
+    REQUIRE(handle_mgr.handle_is_valid(handle) == false);
+
+    // Amount becomes 1 again. Item counts as recreated.
+    i.modify_number(1);
+    REQUIRE(handle_mgr.handle_is_valid(handle) == false);
+
+    // The handle has been replaced, so retrieve it again.
+    handle = handle_mgr.get_handle(i);
+    REQUIRE(handle_mgr.handle_is_valid(handle) == true);
+}
+
+TEST_CASE("Test separation of item handles", "[Lua: Handles]")
+{
+    auto& handle_mgr = elona::lua::lua->get_handle_manager();
+    int amount = 3;
+
+    REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, amount));
+    item& i = elona::inv[elona::ci];
+    sol::table handle = handle_mgr.get_handle(i);
+
+    elona::item_separate(elona::ci);
+    item& item_sep = elona::inv[elona::ci];
+    sol::table handle_sep = handle_mgr.get_handle(item_sep);
+
+    REQUIRE(handle_mgr.handle_is_valid(handle) == true);
+    REQUIRE(handle_mgr.handle_is_valid(handle_sep) == true);
+
+    elona::item_separate(elona::ci);
+    REQUIRE(handle_mgr.handle_is_valid(handle) == true);
+    REQUIRE(handle_mgr.handle_is_valid(handle_sep) == true);
+}
+
+TEST_CASE("Test copying of item handles", "[Lua: Handles]")
+{
+    auto& handle_mgr = elona::lua::lua->get_handle_manager();
+    int amount = 1;
+
+    REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, amount));
+    item& i = elona::inv[elona::ci];
+    sol::table handle = handle_mgr.get_handle(i);
+
+    int ti = elona::inv_getfreeid(-1);
+    REQUIRE(handle_mgr.get_handle(elona::inv[ti]) == sol::lua_nil);
+
+    elona::item::copy(elona::ci, ti);
+    item& copy = elona::inv[ti];
+    sol::table handle_copy = handle_mgr.get_handle(copy);
+
+    REQUIRE(handle_mgr.handle_is_valid(handle) == true);
+    REQUIRE(handle_mgr.handle_is_valid(handle_copy) == true);
+
+    // Copying will create a handle with a unique UUID if no item
+    // existed before at the new index.
+    REQUIRE(
+        handle["__uuid"].get<std::string>()
+        != handle_copy["__uuid"].get<std::string>());
+
+    // Assert that copying to an existing item will not try to
+    // overwrite the existing handle.
+    REQUIRE_NOTHROW(elona::item_copy(elona::ci, ti));
+}
+
+TEST_CASE("Test swapping of item handles", "[Lua: Handles]")
+{
+    auto& handle_mgr = elona::lua::lua->get_handle_manager();
+
+    REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, 1));
+    item& item_a = elona::inv[elona::ci];
+    sol::table handle_a = handle_mgr.get_handle(item_a);
+
+    REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 9, 1));
+    item& item_b = elona::inv[elona::ci];
+    sol::table handle_b = handle_mgr.get_handle(item_b);
+
+    std::string uuid_a = handle_a["__uuid"];
+    std::string uuid_b = handle_b["__uuid"];
+
+    elona::item_exchange(item_a.index, item_b.index);
+
+    // Handle indices should reflect the swapped item indices.
+    REQUIRE(handle_a["__index"].get<int>() == item_b.index);
+    REQUIRE(handle_b["__index"].get<int>() == item_a.index);
+
+    // UUIDs should still be the same as before.
+    REQUIRE(handle_a["__uuid"].get<std::string>() == uuid_a);
+    REQUIRE(handle_b["__uuid"].get<std::string>() == uuid_b);
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #749.


# Summary
Adds the missing changes for Lua handle management from #710. This should prevent assertions related to Lua object handles.