### PR TITLE
Fix crash when you drop item

### DIFF
--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -12717,7 +12717,7 @@ int drop_item()
     itemturn(ci);
     int stat = item_stack(-1, ci);
     const auto tibk = ti; // TODO: refactor
-    if (stat == 0 || dropval == 0)
+    if (stat == 0)
     {
         ti = inv_getfreeid(-1);
         if (ti == -1)


### PR DESCRIPTION

# Summary

Fix crash when you drop an item and the item is stacked.

# How to reproduce

1. Start new game.
2. Drop one crim ale.
3. Drop another crim ale.
4. Assertion fails.