### PR TITLE
Fix random item color like potions

### DIFF
--- a/src/calc.cpp
+++ b/src/calc.cpp
@@ -1567,8 +1567,7 @@ int generate_color(color_index_t index, int id)
         // The choice can't be completely random - it has to be the
         // same as all other items of this type. So, base it off the
         // random seed of the current save data.
-        int p = (id % gdata_random_seed) % 6;
-        color = _randcolor(p);
+        color = _randcolor((id + gdata_random_seed) % 6);
     }
     if (index == color_index_t::random_any)
     {


### PR DESCRIPTION
# Summary

Fix up #745.
Random item colors are different from the previous ones.