### PR TITLE
Fix case of Lua reference relocation during "change" mode

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2273,7 +2273,10 @@ void chara_relocate(
     character::copy(source, destination);
     source.clear();
 
-    // Relocate the corresponding Lua reference.
+    // Relocate the corresponding Lua reference, if it exists. It may
+    // not always exist, since if the mode is "change" the
+    // source's state will be empty. If the source's state is empty, the
+    // destination slot will instead be set to empty as well.
     lua::lua->get_handle_manager().relocate_handle<character>(source, slot);
 
     for (int cnt = 0; cnt < 10; ++cnt)
@@ -2290,7 +2293,10 @@ void chara_relocate(
 
     if (mode == chara_relocate_mode::change)
     {
+        // A new Lua handle is created here. The handles at both slots should
+        // have been cleared by now.
         destination.set_state(character::state_t::alive);
+
         destination.position = position;
         destination.initial_position = initial_position;
         destination.relationship = relationship;

--- a/src/tests/lua_handles.cpp
+++ b/src/tests/lua_handles.cpp
@@ -379,6 +379,30 @@ TEST_CASE("Test relocation of character handle", "[Lua: Handles]")
     REQUIRE(handle["__uuid"].get<std::string>() == uuid);
 }
 
+TEST_CASE(
+    "Test relocation of character handle caused by in-place change",
+    "[Lua: Handles]")
+{
+    start_in_debug_map();
+    auto& handle_mgr = elona::lua::lua->get_handle_manager();
+    REQUIRE(chara_create(-1, PUTIT_PROTO_ID, 4, 8));
+    character& chara = elona::cdata[elona::rc];
+    auto handle = handle_mgr.get_handle(chara);
+
+    int first_index = elona::rc;
+    std::string uuid = handle["__uuid"];
+    REQUIRE(handle["__index"].get<int>() == first_index);
+
+    int tc = elona::rc;
+    flt(20, 2);
+    REQUIRE(chara_create(56, 0, -3, 0));
+    chara_relocate(cdata.tmp(), tc, chara_relocate_mode::change);
+
+    REQUIRE(handle_mgr.handle_is_valid(handle) == true);
+    REQUIRE(handle["__index"].get<int>() == elona::rc);
+    REQUIRE(handle["__uuid"].get<std::string>() == uuid);
+}
+
 TEST_CASE("Test copying of character handles", "[Lua: Handles]")
 {
     start_in_debug_map();


### PR DESCRIPTION
# Related Issues

Close #773.


# Summary
Adds more checks to handle in-place character relocation caused by change creature magic and related.

The issue was mainly that a temporary character with an empty state was being copied over a valid character, but the corresponding Lua reference was not updated to reflect this.

## Test script
```lua
local Event = Elona.require("Event")
local Chara = Elona.require("Chara")
local Item = Elona.require("Item")
local Map = Elona.require("Map")

local function setup()
   for i=0,25 do
      Chara.create(Map.random_pos(), "core.master_yeek")
   end
   Item.create(25, 25, "core.rod_of_change_creature", 5)
end

Event.register(Event.EventKind.ScriptLoaded, setup)
```