### PR TITLE
Add missing functions needed by exports/eating_effect.lua

### DIFF
--- a/doc/api/classes/LuaCharacter.luadoc
+++ b/doc/api/classes/LuaCharacter.luadoc
@@ -1,4 +1,4 @@
---- Represents a character.
+--- Represents this character.
 -- @classmod LuaCharacter
 
 --- [R] The index of this character in the global characters array.
@@ -68,9 +68,9 @@ function apply_ailment(ailment, power) end
 -- @treturn bool true if the character was recruited successfully
 function recruit_as_ally() end
 
---- Sets a flag on a character. <b>Note</b>: Currently, all flags up
+--- Sets a flag on this character. <b>Note</b>: Currently, all flags up
 --- to <code>IsQuickTempered</code> are "intrinsic" and are always
---- reset when a character is refreshed each turn. To change these
+--- reset when this character is refreshed each turn. To change these
 --- flags, you must call this function inside a handler for
 --- <code>Event.EventKind.CharaRefreshed</code>, or the flag will be
 --- reset later.
@@ -84,27 +84,49 @@ function recruit_as_ally() end
 --   chara:set_flag(Enums.CharaFlag.IsInvisible, true) -- intrinsic, reset on refresh
 -- end
 --
--- -- force this flag to be overridden after a character is refreshed.
+-- -- force this flag to be overridden after this character is refreshed.
 -- Event.register(Event.EventKind.CharaRefreshed, make_invisible)
 -- Event.register(Event.EventKind.CharaCreated, make_invisible)
 
 function set_flag(flag, value) end
 
---- Makes a character gain a new skill or spell. This only has an
+--- Makes this character gain a new skill or spell. This only has an
 --- effect if the character does not already know the skill/spell.
 -- @tparam num id the skill/spell ID
 -- @tparam num initial_level the intial skill/spell level
 -- @tparam[opt] num initial_stock the initial spell stock for spells
 function gain_skill(id, initial_level, initial_stock) end
 
---- Makes a character gain experience in a skill or spell. This only
+--- Makes this character gain experience in a skill or spell. This only
 --- has an effect if the character already knows the skill/spell.
 -- @tparam num id the skill/spell ID
 -- @tparam num amount the amount of experience
 function gain_skill_exp(id, amount) end
 
---- Modify a character's resistance. Since the effect is permanent,
---- once your resistance is modified, it will not be reset on refreshing.
+--- Modifies this character's resistance. Since the effect is
+--- permanent, once your resistance is modified, it will not be reset
+--- on refreshing.
 -- @tparam num element the corresponding element
--- @tparam num delta the amount of increase/decrease
+-- @tparam num delta the amount of increase/decrease (can be negative)
 function modify_resistance(element, delta) end
+
+--- Modifies this character's sanity.
+-- @tparam num delta the amount of increase/decrease (can be negative)
+function modify_sanity(delta) end
+
+--- Modifies this character's karma. Currently only has an effect if
+--- the character is the player.
+-- @tparam num delta the amount of increase/decrease (can be negative)
+function modify_karma(delta) end
+
+--- Modifies this character's ether corruption. Currently only has an
+--- effect if the character is the player.
+-- @tparam num delta the amount of increase/decrease (can be negative)
+function modify_corruption(delta) end
+
+--- Makes this character pregnant. Only has an effect if the character
+--- is not already pregnant.
+function make_pregnant() end
+
+--- Applies the effects of eating rotten food to this character.
+function eat_rotten_food() end

--- a/doc/api/math.luadoc
+++ b/doc/api/math.luadoc
@@ -1,0 +1,23 @@
+--- Math utility functions.
+--  @usage local Math = Elona.require("Math")
+
+module "Math"
+
+--- Retrieves the maximum of two numbers.
+-- @tparam num a
+-- @tparam num b
+-- @treturn num the maximum of a and b
+function max(a, b) end
+
+--- Retrieves the minimum of two numbers.
+-- @tparam num a
+-- @tparam num b
+-- @treturn num the minimum of a and b
+function min(a, b) end
+
+--- Clamps a number between two numbers.
+-- @tparam num n
+-- @tparam num min
+-- @tparam num max
+-- @treturn num a number between min and max
+function clamp(n, min, max) end

--- a/runtime/data/lua/init.lua
+++ b/runtime/data/lua/init.lua
@@ -5,6 +5,7 @@ Elona.core.Debug.inspect = require "inspect"
 Elona.core.Enums = require "enums"
 Elona.core.HCL = require "hclua"
 Elona.core.Iter = require "iter"
+Elona.core.Math = require "math_ext"
 Elona.core.ReadOnly = require "readonly"
 Elona.core.table = require "table"
 

--- a/runtime/data/lua/math_ext.lua
+++ b/runtime/data/lua/math_ext.lua
@@ -1,0 +1,12 @@
+local math = require "math"
+
+local Math = {}
+
+Math.min = math.min
+Math.max = math.max
+
+function Math.clamp(n, min, max)
+  return Math.min(Math.max(n, min), max)
+end
+
+return Math

--- a/runtime/mods/core/exports/eating_effect.lua
+++ b/runtime/mods/core/exports/eating_effect.lua
@@ -31,7 +31,7 @@ end
 
 function eating_effect.deformed_eye(eater)
    eat_message(eater, "deformed_eye", Enums.Color.Purple)
-   eater:gain_sanity(-25)
+   eater:modify_sanity(-25)
    eater:apply_ailment(Enums.StatusAilment.Insane, 500)
 end
 
@@ -42,7 +42,7 @@ end
 
 function eating_effect.holy_one(eater)
    eat_message(eater, "holy_one", Enums.Color.Green)
-   eater:gain_sanity(-50)
+   eater:modify_sanity(-50)
    mod_resist_chance(eater, Enums.Element.Mind, 5)
 end
 
@@ -69,7 +69,7 @@ end
 function eating_effect.insanity(eater)
    eat_message(eater, "insanity", Enums.Color.Purple)
    eater:modify_resistance(Enums.Element.Mind, 50)
-   eater:gain_sanity(-500)
+   eater:modify_sanity(-500)
    eater:apply_ailment(Enums.StatusAilment.Insane, 1000)
 end
 
@@ -125,7 +125,7 @@ end
 
 function eating_effect.calm(eater)
    eat_message(eater, "calm", Enums.Color.Green)
-   eater:gain_sanity(20)
+   eater:modify_sanity(20)
 end
 
 function eating_effect.fire_crab(eater)
@@ -139,7 +139,7 @@ end
 
 function eating_effect.yith(eater)
    eat_message(eater, "insanity", Enums.Color.Purple)
-   eater:gain_sanity(-50)
+   eater:modify_sanity(-50)
    mod_resist_chance(eater, Enums.Element.Mind, 5)
 end
 

--- a/src/lua_env/lua_class/lua_class_character.cpp
+++ b/src/lua_env/lua_class/lua_class_character.cpp
@@ -1,8 +1,10 @@
 #include "lua_class_character.hpp"
 #include "../../ability.hpp"
 #include "../../character.hpp"
+#include "../../character_status.hpp"
 #include "../../dmgheal.hpp"
 #include "../../element.hpp"
+#include "../../food.hpp"
 
 namespace elona
 {
@@ -94,6 +96,58 @@ void LuaCharacter::modify_resistance(character& self, int element, int delta)
     elona::resistmod(self.index, element, delta);
 }
 
+void LuaCharacter::modify_sanity(character& self, int delta)
+{
+    if (delta < 0)
+    {
+        elona::damage_insanity(self, (-delta));
+    }
+    else
+    {
+        elona::heal_insanity(self, delta);
+    }
+}
+
+void LuaCharacter::modify_karma(character& self, int delta)
+{
+    if (self.index != 0)
+    {
+        return;
+    }
+
+    elona::modify_karma(self, delta);
+}
+
+void LuaCharacter::modify_corruption(character& self, int delta)
+{
+    if (self.index != 0)
+    {
+        return;
+    }
+
+    elona::modify_ether_disease_stage(delta);
+}
+
+void LuaCharacter::make_pregnant(character& self)
+{
+    int tc_bk = self.index;
+    elona::tc = self.index;
+
+    elona::get_pregnant();
+
+    elona::tc = tc_bk;
+}
+
+void LuaCharacter::eat_rotten_food(character& self)
+{
+    int cc_bk = self.index;
+    elona::cc = self.index;
+
+    elona::eat_rotten_food();
+
+    elona::cc = cc_bk;
+}
+
 void LuaCharacter::bind(sol::state& lua)
 {
     sol::usertype<character> LuaCharacter(
@@ -118,6 +172,16 @@ void LuaCharacter::bind(sol::state& lua)
         &LuaCharacter::gain_skill_exp,
         "modify_resistance",
         &LuaCharacter::modify_resistance,
+        "modify_sanity",
+        &LuaCharacter::modify_sanity,
+        "modify_karma",
+        &LuaCharacter::modify_karma,
+        "modify_corruption",
+        &LuaCharacter::modify_corruption,
+        "make_pregnant",
+        &LuaCharacter::make_pregnant,
+        "eat_rotten_food",
+        &LuaCharacter::eat_rotten_food,
 
         "hp",
         sol::readonly(&character::hp),

--- a/src/lua_env/lua_class/lua_class_character.hpp
+++ b/src/lua_env/lua_class/lua_class_character.hpp
@@ -28,6 +28,16 @@ void modify_trait(character&, int, int);
 
 void modify_resistance(character&, int, int);
 
+void modify_sanity(character&, int);
+
+void modify_karma(character&, int);
+
+void modify_corruption(character&, int);
+
+void make_pregnant(character&);
+
+void eat_rotten_food(character&);
+
 
 void bind(sol::state&);
 } // namespace LuaCharacter

--- a/src/tests/lua/exports/eating_effect.lua
+++ b/src/tests/lua/exports/eating_effect.lua
@@ -1,0 +1,11 @@
+require "tests/lua/support/minctest"
+
+local Chara = Elona.require("Chara")
+local Exports = Elona.require("core", "Exports")
+
+for name, func in pairs(Exports.eating_effect) do
+   lrun("test " .. name, function()
+           Testing.start_in_debug_map()
+           lok(pcall(function() func(Chara.player()) end), "")
+   end)
+end

--- a/src/tests/lua_api.cpp
+++ b/src/tests/lua_api.cpp
@@ -90,3 +90,9 @@ TEST_CASE("Core API: LuaCharacter", "[Lua: API]")
 {
     lua_testcase("classes/LuaCharacter.lua");
 }
+
+
+TEST_CASE("Exports: eating_effect", "[Lua: Exports]")
+{
+    lua_testcase("exports/eating_effect.lua");
+}


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #775. Close #759.


# Summary
- Adds missing functions used by `mods/core/exports/eating_effect.lua`.
- Adds sanity check test for `exports/eating_effect.lua`.

