### PR TITLE
Fix overlap of generated card image

### DIFF
--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -309,7 +309,7 @@ optional_ref<extent> prepare_item_image(int id, int color, int character_image)
     {
         item_rect = draw_get_rect_item(id);
         gsel(1);
-        boxf(0, 960, item_rect->width, item_rect->height);
+        boxf(0, 960, inf_tiles, inf_tiles * 2);
 
         const auto character_id = character_image % 1000;
         const auto character_color = character_image / 1000;


### PR DESCRIPTION
# Related Issues

Close #784.


# Summary
The assembled card image was copied to `(0, 960+48)` in the work buffer, but if the character image was only 48 pixels tall, the space at `(0, 1008)` would not be cleared as the clearing started from `(0, 960)` and the cleared region was only as tall as the character.