### PR TITLE
Fix incorrect forward declaration in ui/ (again)

### DIFF
--- a/src/ui/ui_menu_ctrl_ally.hpp
+++ b/src/ui/ui_menu_ctrl_ally.hpp
@@ -3,7 +3,7 @@
 
 namespace elona
 {
-class character;
+struct character;
 enum class ctrl_ally_operation;
 
 namespace ui


### PR DESCRIPTION
# Summary
Not sure why, but the change in https://github.com/Ruin0x11/ElonaFoobar/commit/2b10dfb45be2f03681711b16a0b24531a10eb01c became undone in `ui_menu_ctrl_ally.hpp`.