### PR TITLE
Add 'make format' command for Windows

### DIFF
--- a/.github/CODE_STYLE.md
+++ b/.github/CODE_STYLE.md
@@ -3,6 +3,7 @@ The following is ideal; not all of these are being regarded at the moment.
 
 ## C++
 
+- C++ formatting style is handled by the use of `clang-format`. It's best to set up `clang-format` to be run after saving a `.cpp`/`.hpp` file in your editor. If it can't be done, you'll have to remember to use `make format`/`nmake -f Makefile.win format` after finishing your changes. Continuous integration is set up so code with inconsistent formatting will fail the build.
 - C++ source files use `.cpp`, header files use `.hpp`.
 - Try to keep source files below 5,000SLoC. This makes a high-level overview of pieces of related functionality easier to parse.
 - Break up large methods as much as possible, especially things like long `switch` statements.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,24 +10,24 @@ Create a new issue from [here](https://github.com/ElonaFoobar/ElonaFoobar/issues
 # Pull request
 
 1. Create a new issue.
-1. Fork this repository and clone the forked one.
-1. Set up `upstream` branch. `git remote add upstream https:://github.com/YOUR_ACCOUNT/ElonaFoobar`.
-1. Update local `develop`. `git checkout develop && git pull upstream develop`.
-1. Create your working branch from `develop`. Naming conventions are as follows:
+2. Fork this repository and clone the forked one.
+3. Set up `upstream` branch. `git remote add upstream https:://github.com/YOUR_ACCOUNT/ElonaFoobar`.
+4. Update local `develop`. `git checkout develop && git pull upstream develop`.
+5. Create your working branch from `develop`. Naming conventions are as follows:
   * Prepend `feature/` to the short summary of your changes. For example,
     - `feature/import-XXX-from-omake`
-1. Work and commit your changes. Small commits are prefered.
-1. Update local `develop` again.
-1. Rebase. `git checkout YOUR_WORKING_BRANCH && git rebase develop`.
-1. Push to your remote branch. `git push origin YOUR_WORKING_BRANCH`.
-1. Create a new pull request.
-1. Your pull request is reviewed and fix problems if needed.
-1. Your pull request is merged.
+6. Work and commit your changes. Small commits are prefered.
+7. Run `make format` or `nmake -f Makefile.win format` to format your changed source code.
+  * **Note:** If your changed source code is not formatted consistently, continuous integration will not pass.
+8. Update local `develop` again.
+9. Rebase. `git checkout YOUR_WORKING_BRANCH && git rebase develop`.
+10. Push to your remote branch. `git push origin YOUR_WORKING_BRANCH`.
+11. Create a new pull request.
+12. Your pull request is reviewed and fix problems if needed.
+13. Your pull request is merged.
 
 
 If your changes are big or you need help, you can send a pull request with prefix `[WIP]`. Pull requests marked as "work in progress" are not merged.
-
-In all commits, the C++ source code should be formatted by `clang-format`.
 
 ## Lua API features
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -49,6 +49,10 @@ $(BENCH_RUNNER):
 clean: FORCE
 	-rd /q /s $(BIN_DIR)
 
+format: FORCE
+        powershell -Command "Get-ChildItem src -Include *.cpp,*.hpp -Recurs | Where {$$_.FullName -notlike '*\src\thirdparty\*'} | Foreach {clang-format -i $$_.FullName; Write-Host $$_.Name}"
+        git diff
+
 FORCE:
 
 


### PR DESCRIPTION
# Summary
Developers with access to Windows only will currently not be able to run `make format`, so the automated build will not pass if any formatting differences are found. This adds the `make format` command to `Makefile.win`.