### PR TITLE
Fix cursed food not being removed

### DIFF
--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -860,7 +860,11 @@ void continuous_action_eating()
 
 void continuous_action_eating_finish()
 {
+    // `ci` may be overwritten in apply_general_eating_effect() call. E.g.,
+    // vomit is created.
+    const auto ci_save = ci;
     apply_general_eating_effect(ci);
+    ci = ci_save;
     if (cc == 0)
     {
         item_identify(inv[ci], identification_state_t::partly_identified);


### PR DESCRIPTION

<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #788.


# Summary

The global variable `ci` was overwritten after `apply_general_eating_effect()` if the character vomited. Saves the previous `ci`(which represents the food) and then restore it.