### PR TITLE
Add 7 more tracked skills and potential tinted according to value.

### DIFF
--- a/runtime/locale/en/config.hcl
+++ b/runtime/locale/en/config.hcl
@@ -399,6 +399,9 @@ DOC
                         right = "Show right side"
                     }
                 }
+                allow_enhanced_skill_tracking {
+                    name = "Allow enhanced skill tracking"
+                }
                 leash_icon {
                     name = "Leash icon"
                     yes_no = core.locale.config.common.yes_no.show_dont_show

--- a/runtime/locale/jp/config.hcl
+++ b/runtime/locale/jp/config.hcl
@@ -1,4 +1,4 @@
-locale {
+﻿locale {
     config {
         common {
             menu = "項目"
@@ -341,7 +341,7 @@ locale {
                     }
                 }
                 allow_enhanced_skill_tracking {
-                    name = "強化されたスキル追跡を許可する"
+                    name = "スキルトラック拡張"
                 }
                 leash_icon {
                     name = "紐のアイコン表示"

--- a/runtime/locale/jp/config.hcl
+++ b/runtime/locale/jp/config.hcl
@@ -340,6 +340,9 @@ locale {
                         right = "右側に表示"
                     }
                 }
+                allow_enhanced_skill_tracking {
+                    name = "強化されたスキル追跡を許可する"
+                }
                 leash_icon {
                     name = "紐のアイコン表示"
                 }

--- a/runtime/mods/core/config/config_def.hcl
+++ b/runtime/mods/core/config/config_def.hcl
@@ -311,7 +311,17 @@ config def {
                 default = "right"
                 variants = ["hide", "left", "right"]
             }
-
+            allow_enhanced_skill_tracking =true
+            enhanced_skill_tracking_lowerbound = {
+                default = 50
+                min = 0
+                max = 390
+            }
+            enhanced_skill_tracking_upperbound = {
+                default = 100
+                min = 10
+                max = 400
+            }
             leash_icon = true
             autopick = true
             autosave = false

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -310,6 +310,18 @@ void load_config(const fs::path& hcl_file)
     CONFIG_OPTION(
         "foobar.max_damage_popup"s, int, config::instance().max_damage_popup);
     CONFIG_OPTION(
+        "foobar.allow_enhanced_skill_tracking"s,
+        bool,
+        config::instance().allow_enhanced_skill);
+    CONFIG_OPTION(
+        "foobar.enhanced_skill_tracking_lowerbound"s,
+        int,
+        config::instance().enhanced_skill_lowerbound);
+    CONFIG_OPTION(
+        "foobar.enhanced_skill_tracking_upperbound"s,
+        int,
+        config::instance().enhanced_skill_upperbound);
+    CONFIG_OPTION(
         "foobar.startup_script"s,
         std::string,
         config::instance().startup_script);

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -67,6 +67,9 @@ public:
     std::string language;
     bool leash_icon;
     int max_damage_popup;
+    bool allow_enhanced_skill;
+    int enhanced_skill_lowerbound;
+    int enhanced_skill_upperbound;
     bool msgaddtime;
     int msgtrans;
     std::string music;

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -38,6 +38,10 @@
 #include "ui/ui_menu_scene.hpp"
 #include "ui/ui_menu_spell_writer.hpp"
 
+/*
+        gdata(750 - 760) => tracked skills (ctrl +f for [TRACKING])
+*/
+
 namespace elona
 {
 
@@ -2288,7 +2292,11 @@ label_2035_internal:
                     s = i18n::s.get(
                         "core.locale.ui.chara_sheet.skill.resist", cnven(s));
                 }
-                for (int cnt = 0; cnt < 3; ++cnt)
+                // [TRACKING] Shows the star in the (c) menu
+                for (int cnt = 0;
+                     cnt < (elona::config::instance().allow_enhanced_skill ? 10
+                                                                           : 3);
+                     ++cnt)
                 {
                     if (gdata(750 + cnt) == cc * 10000 + i)
                     {
@@ -2396,6 +2404,7 @@ label_2035_internal:
     }
     else if (csctrl != 1)
     {
+        // [TRACKING] Stores which skill id is to be tracked
         if (key == key_mode2)
         {
             for (int cnt = 0, cnt_end = (keyrange); cnt < cnt_end; ++cnt)
@@ -2406,7 +2415,11 @@ label_2035_internal:
             if (i != -1)
             {
                 p = 750;
-                for (int cnt = 750; cnt < 753; ++cnt)
+                for (int cnt = 0;
+                     cnt < (elona::config::instance().allow_enhanced_skill
+                                ? 750 + 10
+                                : 750 + 3);
+                     ++cnt)
                 {
                     if (gdata(cnt) % 10000 == 0)
                     {
@@ -2560,7 +2573,7 @@ label_2035_internal:
         }
     }
     goto label_2035_internal;
-}
+} // namespace elona
 
 menu_result menu_equipment()
 {

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -571,7 +571,7 @@ void render_clock()
 void render_skill_trackers()
 {
     int y{};
-    for (int i = 0; i < 3; ++i)
+    for (int i = 0; i < 10; ++i)
     {
         const auto skill = gdata(750 + i) % 10000;
         if (skill == 0)
@@ -588,14 +588,46 @@ void render_skill_trackers()
             strutil::take_by_width(
                 i18n::_(u8"ability", std::to_string(skill), u8"name"), 6),
             16,
-            inf_clocky + 155 - y * 16);
+            inf_clocky + 125 + y * 16);
         bmes(
             ""s + sdata.get(skill, chara).original_level + u8"."s
                 + std::to_string(
                       1000 + sdata.get(skill, chara).experience % 1000)
                       .substr(1),
             66,
-            inf_clocky + 155 - y * 16);
+            inf_clocky + 125 + y * 16);
+        if (elona::config::instance().allow_enhanced_skill)
+        {
+            elona::snail::color col(0, 0, 0, 255);
+            if (sdata.get(skill, chara).potential
+                > elona::config::instance().enhanced_skill_upperbound)
+            {
+                col.g = 255;
+                col.r = 130;
+                col.b = 130;
+            }
+            else if (
+                sdata.get(skill, chara).potential
+                > elona::config::instance().enhanced_skill_lowerbound)
+            {
+                col.g = 255;
+                col.r = 255;
+                col.b = 130;
+            }
+            else
+            {
+                col.g = 130;
+                col.r = 255;
+                col.b = 130;
+            }
+
+            bmes(
+                ""s + sdata.get(skill, chara).potential + u8"%"s,
+                112,
+                inf_clocky + 125 + y * 16,
+                col);
+        }
+
         ++y;
     }
 }


### PR DESCRIPTION
# Summary

Allow player to track up to 10 skills and shows corresponding potential slightly tinted in green if > 100, in yellow if >50 or in red if <=50.