### PR TITLE
Add option to run script over existing save data

### DIFF
--- a/runtime/config.hcl
+++ b/runtime/config.hcl
@@ -177,6 +177,10 @@ config {
             # Provide a script's name, like "my_script.lua" for "data/script/my_script.lua".
             startup_script = ""
 
+            # Set to true to run startup scripts in a loaded save.
+            # This may be dangerous, so back up your save data first.
+            run_script_in_save = false
+
             # Show damage popups.
             damage_popup = true
         }

--- a/runtime/mods/core/config/config_def.hcl
+++ b/runtime/mods/core/config/config_def.hcl
@@ -342,6 +342,11 @@ config def {
                 default = ""
                 visible = false
             }
+
+            run_script_in_save = {
+                default = false
+                visible = false
+            }
         }
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -181,7 +181,10 @@ void start_elona()
         main_loop();
         return;
     }
-    else if (config::instance().startup_script != ""s)
+    else if (
+        config::instance().startup_script != ""s
+        && !config::instance().get<bool>(
+               "core.config.foobar.run_script_in_save"))
     {
         mode = 6;
         initialize_game();
@@ -1239,6 +1242,7 @@ void initialize_testbed()
 void initialize_game()
 {
     bool script_loaded = false;
+    bool will_load_script = false;
     autopick::instance().load(playerid);
 
     mtilefilecur = -1;
@@ -1270,12 +1274,7 @@ void initialize_game()
         playerid = u8"sav_testbed"s;
         initialize_debug_globals();
         initialize_testbed();
-        if (config::instance().startup_script != ""s)
-        {
-            lua::lua->get_mod_manager().run_startup_script(
-                config::instance().startup_script);
-            script_loaded = true;
-        }
+        will_load_script = true;
         mode = 2;
     }
     if (mode == 2)
@@ -1287,7 +1286,21 @@ void initialize_game()
     if (mode == 3)
     {
         load_save_data();
+
+        if (config::instance().get<bool>(
+                "core.config.foobar.run_script_in_save"))
+        {
+            will_load_script = true;
+        }
     }
+
+    if (will_load_script && config::instance().startup_script != ""s)
+    {
+        lua::lua->get_mod_manager().run_startup_script(
+            config::instance().startup_script);
+        script_loaded = true;
+    }
+
     init_fovlist();
     initialize_map();
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #573.


# Summary
Add a config option, `run_script_in_save`, that will load startup scripts when a save is loaded, instead of creating a blank map and loading it.