### PR TITLE
Add a option to toggle PCC graphic scale(shrinked/full-scale)

### DIFF
--- a/runtime/locale/en/config.hcl
+++ b/runtime/locale/en/config.hcl
@@ -517,6 +517,14 @@ Run a script in the data/script/ folder at startup.
 Provide a script's name, like 'my_script.lua' for 'data/script/my_script.lua'.
 DOC
                 }
+
+                pcc_graphic_scale = {
+                    name = "PCC Graphic"
+                    variants {
+                        shrinked = "Shrinked"
+                        fullscale = "Full-scale"
+                    }
+                }
             }
 
             android {

--- a/runtime/locale/jp/config.hcl
+++ b/runtime/locale/jp/config.hcl
@@ -370,6 +370,14 @@
                 }
                 startup_script {
                 }
+
+                pcc_graphic_scale = {
+                    name = "PCC表示"
+                    variants {
+                        shrinked = "縮小(通常)"
+                        fullscale = "原寸"
+                    }
+                }
             }
 
             android {

--- a/runtime/mods/core/config/config_def.hcl
+++ b/runtime/mods/core/config/config_def.hcl
@@ -347,6 +347,12 @@ config def {
                 default = false
                 visible = false
             }
+
+            pcc_graphic_scale = {
+                type = "enum"
+                default = "shrinked"
+                variants = ["shrinked", "fullscale"]
+            }
         }
     }
 

--- a/src/cell_draw.cpp
+++ b/src/cell_draw.cpp
@@ -19,6 +19,17 @@ namespace
 
 
 
+int pcc_size(int shrinked, int fullscale)
+{
+    assert(shrinked < fullscale);
+
+    const auto is_fullscale =
+        config::instance().pcc_graphic_scale == "fullscale";
+    return is_fullscale ? fullscale : shrinked;
+}
+
+
+
 template <typename T>
 struct loop_xy
 {
@@ -563,12 +574,26 @@ void draw_character_sprite_in_water(
     // Upper body
     pos(x + 24, y + 16);
     gmode(2);
-    gcopy_c(texture_id, frame, direction * 48, 32, 28, 24, 24);
+    gcopy_c(
+        texture_id,
+        frame,
+        direction * 48,
+        32,
+        28,
+        pcc_size(24, 32),
+        pcc_size(24, 28));
 
     // Lower body
-    pos(x + 24, y + 36);
+    pos(x + 24, y + pcc_size(36, 40));
     gmode(4, 146);
-    gcopy_c(texture_id, frame, direction * 48 + 28, 32, 20, 24, 16);
+    gcopy_c(
+        texture_id,
+        frame,
+        direction * 48 + 28,
+        32,
+        20,
+        pcc_size(24, 32),
+        pcc_size(16, 20));
 }
 
 
@@ -590,7 +615,14 @@ void draw_character_sprite(
     // Character sprite
     pos(x + 24, y + dy + 8);
     gmode(2);
-    gcopy_c(texture_id, frame, direction * 48, 32, 48, 24, 40);
+    gcopy_c(
+        texture_id,
+        frame,
+        direction * 48,
+        32,
+        48,
+        pcc_size(24, 32),
+        pcc_size(40, 48));
 }
 
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -326,6 +326,10 @@ void load_config(const fs::path& hcl_file)
         std::string,
         config::instance().startup_script);
     CONFIG_OPTION(
+        "foobar.pcc_graphic_scale"s,
+        std::string,
+        config::instance().pcc_graphic_scale);
+    CONFIG_OPTION(
         "game.attack_neutral_npcs"s,
         bool,
         config::instance().attack_neutral_npcs);

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -78,6 +78,7 @@ public:
     bool netwish;
     bool noadebug;
     bool objectshadow;
+    std::string pcc_graphic_scale;
     int restock_interval;
     bool runscroll;
     int runwait;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #823 


# Summary

New option:

```
PCC Graphic
    Shrinked(Normal)        default
    Full-scale
```

# Screenshot

![image](https://user-images.githubusercontent.com/36858341/44616990-e297e900-a895-11e8-98ba-ec7179c84346.png)

Left: shrinked
Right: full-scale
