### PR TITLE
Fix the current map name being displayed as the left map name

### DIFF
--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -5337,7 +5337,8 @@ turn_result_t exit_map()
         else
         {
             msgtemp += i18n::s.get(
-                "core.locale.action.exit_map.left", mapname(gdata_current_map));
+                "core.locale.action.exit_map.left",
+                mapname(gdata_previous_map));
         }
         if (gdata_cargo_weight > gdata_current_cart_limit)
         {


### PR DESCRIPTION
# Summary

Fix departure message.

# Bug details

1. Start a new game.
2. Leave your home.

> You left North Tyris.

The current map name(`North Tyris`) was displayed as the left map name(`Your Home`).