### PR TITLE
Fix overlap between hp bar and skill tracker

### DIFF
--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -291,7 +291,21 @@ void show_hp_bar(show_hp_bar_side side, int inf_clocky)
         {
             const auto name = cdatan(0, i);
             const int x = 16 + (windoww - strlen_u(name) * 7 - 16) * right;
-            const int y = inf_clocky + 200 - 180 * right + cnt * 32;
+            int y = inf_clocky + (right ? 20 : 136) + cnt * 32;
+
+            // If they are shown left side, move them below the skill
+            // trackers.
+            if (!right)
+            {
+                for (int i = 0; i < 10; ++i)
+                {
+                    if (gdata(750 + i) % 10000 != 0)
+                    {
+                        y += 16;
+                    }
+                }
+            }
+
             bmes(
                 name,
                 x,

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -588,14 +588,14 @@ void render_skill_trackers()
             strutil::take_by_width(
                 i18n::_(u8"ability", std::to_string(skill), u8"name"), 6),
             16,
-            inf_clocky + 125 + y * 16);
+            inf_clocky + 107 + y * 16);
         bmes(
             ""s + sdata.get(skill, chara).original_level + u8"."s
                 + std::to_string(
                       1000 + sdata.get(skill, chara).experience % 1000)
                       .substr(1),
             66,
-            inf_clocky + 125 + y * 16);
+            inf_clocky + 107 + y * 16);
         if (elona::config::instance().allow_enhanced_skill)
         {
             elona::snail::color col{255, 130, 130};
@@ -615,7 +615,7 @@ void render_skill_trackers()
             bmes(
                 ""s + sdata.get(skill, chara).potential + u8"%"s,
                 112,
-                inf_clocky + 125 + y * 16,
+                inf_clocky + 107 + y * 16,
                 col);
         }
 

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -598,27 +598,18 @@ void render_skill_trackers()
             inf_clocky + 125 + y * 16);
         if (elona::config::instance().allow_enhanced_skill)
         {
-            elona::snail::color col(0, 0, 0, 255);
+            elona::snail::color col{255, 130, 130};
+
             if (sdata.get(skill, chara).potential
                 > elona::config::instance().enhanced_skill_upperbound)
             {
-                col.g = 255;
-                col.r = 130;
-                col.b = 130;
+                col = {130, 255, 130};
             }
             else if (
                 sdata.get(skill, chara).potential
                 > elona::config::instance().enhanced_skill_lowerbound)
             {
-                col.g = 255;
-                col.r = 255;
-                col.b = 130;
-            }
-            else
-            {
-                col.g = 130;
-                col.r = 255;
-                col.b = 130;
+                col = {255, 255, 130};
             }
 
             bmes(


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #833 


# Summary

- Adjust Y position of skill trackers.
- Move pets' HP bars below the skill trackers.

# Screenshot

![image](https://user-images.githubusercontent.com/36858341/44844851-e73e1200-ac86-11e8-871a-7e90dfebca32.png)

