### PR TITLE
Fix item_fire() and item_cold()

### DIFF
--- a/src/dmgheal.cpp
+++ b/src/dmgheal.cpp
@@ -584,7 +584,7 @@ int damage_hp(
         }
         if (element == 51)
         {
-            item_cold(victim.index, -1);
+            item_cold(victim.index);
         }
         if (victim.sleep != 0)
         {

--- a/src/dmgheal.cpp
+++ b/src/dmgheal.cpp
@@ -580,7 +580,7 @@ int damage_hp(
         }
         if ((element == 50 || damage_source == -9) && victim.wet == 0)
         {
-            item_fire(victim.index, -1);
+            item_fire(victim.index);
         }
         if (element == 51)
         {

--- a/src/dmgheal.cpp
+++ b/src/dmgheal.cpp
@@ -574,7 +574,7 @@ int damage_hp(
             {
                 if (victim.index == 0 || rnd(3) == 0)
                 {
-                    item_acid(victim.index, -1);
+                    item_acid(victim);
                 }
             }
         }

--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -14663,7 +14663,7 @@ label_22191_internal:
                         {
                             if (rnd(5) == 0)
                             {
-                                item_acid(cc, cw);
+                                item_acid(cdata[cc], cw);
                             }
                         }
                     }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1647,7 +1647,6 @@ bool item_fire(int owner, int ci)
                 if (blanket == -1)
                 {
                     blanket = cnt;
-                    item_separate(blanket);
                 }
                 continue;
             }
@@ -1744,6 +1743,7 @@ bool item_fire(int owner, int ci)
 
         if (blanket != -1)
         {
+            item_separate(blanket);
             if (is_in_fov(cdata[owner]))
             {
                 txt(lang(
@@ -1881,7 +1881,6 @@ bool item_cold(int owner, int ci)
                 if (blanket == -1)
                 {
                     blanket = cnt;
-                    item_separate(blanket);
                 }
                 continue;
             }
@@ -1928,6 +1927,7 @@ bool item_cold(int owner, int ci)
         }
         if (blanket != -1)
         {
+            item_separate(blanket);
             if (is_in_fov(cdata[owner]))
             {
                 txt(lang(

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1561,65 +1561,60 @@ void item_dump_desc(const item& i)
     pagemax = (listmax - 1) / pagesize;
 }
 
-void item_acid(int prm_838, int prm_839)
+
+
+void item_acid(const character& owner, int ci)
 {
-    int body_at_m138 = 0;
-    if (prm_839 != -1)
+    if (ci == -1)
     {
-        ci_at_m138 = prm_839;
-    }
-    else
-    {
-        ci_at_m138 = -1;
-        for (int i = 0; i < 30; ++i)
+        for (const auto& body_part : owner.body_parts)
         {
-            body_at_m138 = cdata[prm_838].body_parts[i] / 10000;
-            if (body_at_m138 == 0)
+            if (body_part / 10000 == 0)
             {
                 break;
             }
-            p_at_m138 = cdata[prm_838].body_parts[i] % 10000 - 1;
-            if (p_at_m138 == -1)
+            int i = body_part % 10000 - 1;
+            if (i == -1)
             {
                 continue;
             }
-            if (rnd(clamp(30, 1, 30)) == 0)
+            if (inv[i].enhancement >= -3)
             {
-                if (inv[p_at_m138].enhancement > -4)
+                if (rnd(30) == 0)
                 {
-                    ci_at_m138 = p_at_m138;
+                    ci = p;
                     break;
                 }
             }
         }
+        if (ci == -1)
+        {
+            return;
+        }
     }
-    if (ci_at_m138 == -1)
+
+    if (the_item_db[inv[ci].id]->category >= 50000)
     {
         return;
     }
-    if (the_item_db[inv[ci_at_m138].id]->category >= 50000)
-    {
-        return;
-    }
-    if (ibit(1, ci_at_m138) == 0)
+
+    if (ibit(1, ci) == 0)
     {
         txtef(8);
         txt(lang(
-            name(prm_838) + u8"の"s + itemname(ci_at_m138)
-                + u8"は酸で傷ついた。"s,
-            name(prm_838) + your(prm_838) + u8" "s + itemname(ci_at_m138, 0, 1)
+            name(owner.index) + u8"の"s + itemname(ci) + u8"は酸で傷ついた。"s,
+            name(owner.index) + your(owner.index) + u8" "s + itemname(ci, 0, 1)
                 + u8" is damaged by acid."s));
-        --inv[ci_at_m138].enhancement;
+        --inv[ci].enhancement;
     }
     else
     {
         txt(lang(
-            name(prm_838) + u8"の"s + itemname(ci_at_m138)
+            name(owner.index) + u8"の"s + itemname(ci)
                 + u8"は酸では傷つかない。"s,
-            name(prm_838) + your(prm_838) + u8" "s + itemname(ci_at_m138, 0, 1)
+            name(owner.index) + your(owner.index) + u8" "s + itemname(ci, 0, 1)
                 + u8" is immune to acid."s));
     }
-    return;
 }
 
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1914,15 +1914,6 @@ bool item_cold(int owner, int ci)
         }
 
         int a_ = the_item_db[inv[ci_].id]->category;
-        std::string s_;
-        if (owner == -1)
-        {
-            s_ = "";
-        }
-        else
-        {
-            s_ = name(owner) + lang(u8"の"s, your(owner));
-        }
         if (a_ == 72000 || a_ == 59000 || a_ == 68000)
         {
             continue;
@@ -1942,31 +1933,53 @@ bool item_cold(int owner, int ci)
         {
             if (inv[blanket].number() > 0)
             {
-                txt(lang(
-                    itemname(blanket, 1) + u8"が"s + name(owner)
-                        + u8"の持ち物を冷気から守った。"s,
-                    itemname(blanket, 1) + u8" protects "s + name(owner)
-                        + your(owner) + u8" stuff from cold."s));
+                if (is_in_fov(cdata[owner]))
+                {
+                    txt(lang(
+                        itemname(blanket, 1) + u8"が"s + name(owner)
+                            + u8"の持ち物を冷気から守った。"s,
+                        itemname(blanket, 1) + u8" protects "s + name(owner)
+                            + your(owner) + u8" stuff from cold."s));
+                }
                 if (inv[blanket].count > 0)
                 {
                     --inv[blanket].count;
                 }
                 else if (rnd(20) == 0)
                 {
-                    txt(lang(
-                        itemname(blanket, 1) + u8"は粉々に砕けた。"s,
-                        itemname(blanket, 1) + u8" is broken to pieces."s));
                     inv[blanket].modify_number(-1);
+                    if (is_in_fov(cdata[owner]))
+                    {
+                        txt(lang(
+                            itemname(blanket, 1) + u8"は粉々に砕けた。"s,
+                            itemname(blanket, 1) + u8" is broken to pieces."s));
+                    }
                     break;
                 }
                 continue;
             }
         }
         int p_ = rnd(inv[ci_].number()) / 2 + 1;
-        txtef(8);
-        txt(lang(
-            s_ + itemname(ci_, p_) + u8"は粉々に砕けた。"s,
-            s_ + itemname(ci_, p_) + u8" break"s + _s2(p_) + u8" to pieces."s));
+        if (owner != -1)
+        {
+            if (is_in_fov(cdata[owner]))
+            {
+                txtef(8);
+                txt(lang(
+                    name(owner) + u8"の"s + itemname(ci_, p_)
+                        + u8"は粉々に砕けた。"s,
+                    name(owner) + your(owner) + u8" "s + itemname(ci_, p_, 1)
+                        + u8" break"s + _s2(p_) + u8" to pieces."s));
+            }
+        }
+        else if (is_in_fov(inv[ci_].position))
+        {
+            txtef(8);
+            txt(lang(
+                u8"地面の"s + itemname(ci_, p_) + u8"は粉々に砕けた。"s,
+                itemname(ci_, p_) + u8" on the ground break"s + _s2(p_)
+                    + u8" to pieces."s));
+        }
         inv[ci_].modify_number(-p_);
         broken = true;
     }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1766,8 +1766,8 @@ bool item_fire(int owner, int ci)
                         txt(lang(
                             itemname(blanket, 1) + u8"は灰と化した。"s,
                             itemname(blanket, 1) + u8" turns to dust."s));
-                        break;
                     }
+                    break;
                 }
                 continue;
             }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1977,34 +1977,30 @@ bool item_cold(int owner, int ci)
 
 
 
-void mapitem_cold(int prm_846, int prm_847)
+void mapitem_cold(int x, int y)
 {
-    if (map(prm_846, prm_847, 4) == 0)
+    if (map(x, y, 4) == 0)
     {
         return;
     }
-    ci_at_m138 = -1;
+    int ci = -1;
     for (const auto& cnt : items(-1))
     {
         if (inv[cnt].number() == 0)
         {
             continue;
         }
-        if (inv[cnt].position.x == prm_846)
+        if (inv[cnt].position == position_t{x, y})
         {
-            if (inv[cnt].position.y == prm_847)
-            {
-                ci_at_m138 = cnt;
-                break;
-            }
+            ci = cnt;
+            break;
         }
     }
-    if (ci_at_m138 != -1)
+    if (ci != -1)
     {
-        item_cold(-1, ci_at_m138);
-        cell_refresh(prm_846, prm_847);
+        item_cold(-1, ci);
+        cell_refresh(x, y);
     }
-    return;
 }
 
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1744,33 +1744,30 @@ bool item_fire(int owner, int ci)
 
         if (blanket != -1)
         {
-            if (inv[blanket].number() > 0)
+            if (is_in_fov(cdata[owner]))
             {
+                txt(lang(
+                    itemname(blanket, 1) + u8"が"s + name(owner)
+                        + u8"の持ち物を炎から守った。"s,
+                    itemname(blanket, 1) + u8" protects "s + name(owner)
+                        + your(owner) + u8" stuff from fire."s));
+            }
+            if (inv[blanket].count > 0)
+            {
+                --inv[blanket].count;
+            }
+            else if (rnd(20) == 0)
+            {
+                inv[blanket].modify_number(-1);
                 if (is_in_fov(cdata[owner]))
                 {
                     txt(lang(
-                        itemname(blanket, 1) + u8"が"s + name(owner)
-                            + u8"の持ち物を炎から守った。"s,
-                        itemname(blanket, 1) + u8" protects "s + name(owner)
-                            + your(owner) + u8" stuff from fire."s));
+                        itemname(blanket, 1) + u8"は灰と化した。"s,
+                        itemname(blanket, 1) + u8" turns to dust."s));
                 }
-                if (inv[blanket].count > 0)
-                {
-                    --inv[blanket].count;
-                }
-                else if (rnd(20) == 0)
-                {
-                    inv[blanket].modify_number(-1);
-                    if (is_in_fov(cdata[owner]))
-                    {
-                        txt(lang(
-                            itemname(blanket, 1) + u8"は灰と化した。"s,
-                            itemname(blanket, 1) + u8" turns to dust."s));
-                    }
-                    break;
-                }
-                continue;
+                break;
             }
+            continue;
         }
 
         int p_ = rnd(inv[ci_].number()) / 2 + 1;
@@ -1931,33 +1928,30 @@ bool item_cold(int owner, int ci)
         }
         if (blanket != -1)
         {
-            if (inv[blanket].number() > 0)
+            if (is_in_fov(cdata[owner]))
             {
+                txt(lang(
+                    itemname(blanket, 1) + u8"が"s + name(owner)
+                        + u8"の持ち物を冷気から守った。"s,
+                    itemname(blanket, 1) + u8" protects "s + name(owner)
+                        + your(owner) + u8" stuff from cold."s));
+            }
+            if (inv[blanket].count > 0)
+            {
+                --inv[blanket].count;
+            }
+            else if (rnd(20) == 0)
+            {
+                inv[blanket].modify_number(-1);
                 if (is_in_fov(cdata[owner]))
                 {
                     txt(lang(
-                        itemname(blanket, 1) + u8"が"s + name(owner)
-                            + u8"の持ち物を冷気から守った。"s,
-                        itemname(blanket, 1) + u8" protects "s + name(owner)
-                            + your(owner) + u8" stuff from cold."s));
+                        itemname(blanket, 1) + u8"は粉々に砕けた。"s,
+                        itemname(blanket, 1) + u8" is broken to pieces."s));
                 }
-                if (inv[blanket].count > 0)
-                {
-                    --inv[blanket].count;
-                }
-                else if (rnd(20) == 0)
-                {
-                    inv[blanket].modify_number(-1);
-                    if (is_in_fov(cdata[owner]))
-                    {
-                        txt(lang(
-                            itemname(blanket, 1) + u8"は粉々に砕けた。"s,
-                            itemname(blanket, 1) + u8" is broken to pieces."s));
-                    }
-                    break;
-                }
-                continue;
+                break;
             }
+            continue;
         }
         int p_ = rnd(inv[ci_].number()) / 2 + 1;
         if (owner != -1)

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1823,126 +1823,6 @@ bool item_fire(int owner, int ci)
 
 
 
-int item_cold(int prm_844, int prm_845)
-{
-    std::string s_at_m138;
-    max_at_m138 = 0;
-    ti_at_m138 = -1;
-    if (prm_845 != -1)
-    {
-        list_at_m138(0) = prm_845;
-        ++max_at_m138;
-    }
-    if (prm_844 != -1)
-    {
-        if (sdata(51, prm_844) / 50 >= 6 || cdata[prm_844].quality >= 4)
-        {
-            return 0;
-        }
-        for (const auto& cnt : items(prm_844))
-        {
-            if (inv[cnt].number() == 0)
-            {
-                continue;
-            }
-            if (inv[cnt].id == 568)
-            {
-                if (ti_at_m138 == -1)
-                {
-                    ti_at_m138 = cnt;
-                    item_separate(ti_at_m138);
-                }
-                continue;
-            }
-            if (prm_845 == -1)
-            {
-                list_at_m138(max_at_m138) = cnt;
-                ++max_at_m138;
-            }
-        }
-    }
-    if (max_at_m138 == 0)
-    {
-        return 0;
-    }
-    f_at_m138 = 0;
-    for (int cnt = 0; cnt < 2; ++cnt)
-    {
-        ci_at_m138 = list_at_m138(rnd(max_at_m138));
-        if (inv[ci_at_m138].number() <= 0)
-        {
-            continue;
-        }
-        rowact_item(ci_at_m138);
-        if (ibit(5, ci_at_m138) == 0)
-        {
-            a_at_m138 = the_item_db[inv[ci_at_m138].id]->category;
-            if (prm_844 == -1)
-            {
-                s_at_m138 = "";
-            }
-            else
-            {
-                s_at_m138 = name(prm_844) + lang(u8"の"s, your(prm_844));
-            }
-            if (a_at_m138 == 72000 || a_at_m138 == 59000 || a_at_m138 == 68000)
-            {
-                continue;
-            }
-            if (inv[ci_at_m138].quality >= 4 || inv[ci_at_m138].body_part != 0)
-            {
-                continue;
-            }
-            if (a_at_m138 != 52000)
-            {
-                if (rnd(30))
-                {
-                    continue;
-                }
-            }
-            if (ti_at_m138 != -1)
-            {
-                if (inv[ti_at_m138].number() > 0)
-                {
-                    txt(lang(
-                        itemname(ti_at_m138, 1) + u8"が"s + name(prm_844)
-                            + u8"の持ち物を冷気から守った。"s,
-                        itemname(ti_at_m138, 1) + u8" protects "s
-                            + name(prm_844) + your(prm_844)
-                            + u8" stuff from cold."s));
-                    if (inv[ti_at_m138].count > 0)
-                    {
-                        --inv[ti_at_m138].count;
-                    }
-                    else if (rnd(20) == 0)
-                    {
-                        txt(lang(
-                            itemname(ti_at_m138, 1) + u8"は粉々に砕けた。"s,
-                            itemname(ti_at_m138, 1)
-                                + u8" is broken to pieces."s));
-                        inv[ti_at_m138].modify_number(-1);
-                        break;
-                    }
-                    continue;
-                }
-            }
-            p_at_m138 = rnd(inv[ci_at_m138].number()) / 2 + 1;
-            txtef(8);
-            txt(lang(
-                s_at_m138 + itemname(ci_at_m138, p_at_m138)
-                    + u8"は粉々に砕けた。"s,
-                s_at_m138 + itemname(ci_at_m138, p_at_m138) + u8" break"s
-                    + _s2(p_at_m138) + u8" to pieces."s));
-            inv[ci_at_m138].modify_number(-p_at_m138);
-            f_at_m138 = 1;
-        }
-    }
-    refresh_burden_state();
-    return f_at_m138;
-}
-
-
-
 void mapitem_fire(int x, int y)
 {
     if (map(x, y, 4) == 0)
@@ -1975,6 +1855,124 @@ void mapitem_fire(int x, int y)
         }
         cell_refresh(x, y);
     }
+}
+
+
+
+bool item_cold(int owner, int ci)
+{
+    int blanket = -1;
+    std::vector<int> list;
+    if (ci != -1)
+    {
+        list.push_back(ci);
+    }
+    if (owner != -1)
+    {
+        if (sdata(51, owner) / 50 >= 6 || cdata[owner].quality >= 4)
+        {
+            return false;
+        }
+        for (const auto& cnt : items(owner))
+        {
+            if (inv[cnt].number() == 0)
+            {
+                continue;
+            }
+            if (inv[cnt].id == 568)
+            {
+                if (blanket == -1)
+                {
+                    blanket = cnt;
+                    item_separate(blanket);
+                }
+                continue;
+            }
+            if (ci == -1)
+            {
+                list.push_back(cnt);
+            }
+        }
+    }
+    if (list.empty())
+    {
+        return false;
+    }
+
+    bool broken{};
+    for (int cnt = 0; cnt < 2; ++cnt)
+    {
+        int ci_ = choice(list);
+        if (inv[ci_].number() <= 0)
+        {
+            continue;
+        }
+        rowact_item(ci_);
+        if (ibit(5, ci_))
+        {
+            continue;
+        }
+
+        int a_ = the_item_db[inv[ci_].id]->category;
+        std::string s_;
+        if (owner == -1)
+        {
+            s_ = "";
+        }
+        else
+        {
+            s_ = name(owner) + lang(u8"の"s, your(owner));
+        }
+        if (a_ == 72000 || a_ == 59000 || a_ == 68000)
+        {
+            continue;
+        }
+        if (inv[ci_].quality >= 4 || inv[ci_].body_part != 0)
+        {
+            continue;
+        }
+        if (a_ != 52000)
+        {
+            if (rnd(30))
+            {
+                continue;
+            }
+        }
+        if (blanket != -1)
+        {
+            if (inv[blanket].number() > 0)
+            {
+                txt(lang(
+                    itemname(blanket, 1) + u8"が"s + name(owner)
+                        + u8"の持ち物を冷気から守った。"s,
+                    itemname(blanket, 1) + u8" protects "s + name(owner)
+                        + your(owner) + u8" stuff from cold."s));
+                if (inv[blanket].count > 0)
+                {
+                    --inv[blanket].count;
+                }
+                else if (rnd(20) == 0)
+                {
+                    txt(lang(
+                        itemname(blanket, 1) + u8"は粉々に砕けた。"s,
+                        itemname(blanket, 1) + u8" is broken to pieces."s));
+                    inv[blanket].modify_number(-1);
+                    break;
+                }
+                continue;
+            }
+        }
+        int p_ = rnd(inv[ci_].number()) / 2 + 1;
+        txtef(8);
+        txt(lang(
+            s_ + itemname(ci_, p_) + u8"は粉々に砕けた。"s,
+            s_ + itemname(ci_, p_) + u8" break"s + _s2(p_) + u8" to pieces."s));
+        inv[ci_].modify_number(-p_);
+        broken = true;
+    }
+
+    refresh_burden_state();
+    return broken;
 }
 
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1941,42 +1941,43 @@ int item_cold(int prm_844, int prm_845)
     return f_at_m138;
 }
 
-void mapitem_fire(int prm_842, int prm_843)
+
+
+void mapitem_fire(int x, int y)
 {
-    if (map(prm_842, prm_843, 4) == 0)
+    if (map(x, y, 4) == 0)
     {
         return;
     }
-    ci_at_m138 = -1;
+
+    int ci = -1;
     for (const auto& cnt : items(-1))
     {
         if (inv[cnt].number() == 0)
         {
             continue;
         }
-        if (inv[cnt].position.x == prm_842)
+        if (inv[cnt].position == position_t{x, y})
         {
-            if (inv[cnt].position.y == prm_843)
-            {
-                ci_at_m138 = cnt;
-                break;
-            }
+            ci = cnt;
+            break;
         }
     }
-    if (ci_at_m138 != -1)
+    if (ci != -1)
     {
-        int stat = item_fire(-1, ci_at_m138);
-        if (stat == 1)
+        const auto burned = item_fire(-1, ci);
+        if (burned)
         {
-            if (map(prm_842, prm_843, 8) == 0)
+            if (map(x, y, 8) == 0)
             {
-                mef_add(prm_842, prm_843, 5, 24, rnd(10) + 5, 100, cc);
+                mef_add(x, y, 5, 24, rnd(10) + 5, 100, cc);
             }
         }
-        cell_refresh(prm_842, prm_843);
+        cell_refresh(x, y);
     }
-    return;
 }
+
+
 
 void mapitem_cold(int prm_846, int prm_847)
 {

--- a/src/item.hpp
+++ b/src/item.hpp
@@ -215,10 +215,10 @@ int item_separate(int);
 int item_stack(int = 0, int = 0, int = 0);
 void item_dump_desc(const item&);
 
-int item_cold(int = 0, int = 0);
 bool item_fire(int owner, int ci = -1);
+void mapitem_fire(int x, int y);
+int item_cold(int = 0, int = 0);
 void mapitem_cold(int = 0, int = 0);
-void mapitem_fire(int = 0, int = 0);
 
 // TODO unsure how these are separate from item
 int inv_find(int = 0, int = 0);

--- a/src/item.hpp
+++ b/src/item.hpp
@@ -184,6 +184,9 @@ private:
 extern inventory inv;
 
 
+struct character;
+
+
 
 int ibit(size_t type, int ci);
 void ibitmod(size_t type, int ci, int on);
@@ -199,7 +202,7 @@ void itemname_additional_info();
 void item_checkknown(int = 0);
 int inv_compress(int);
 void item_copy(int = 0, int = 0);
-void item_acid(int = 0, int = 0);
+void item_acid(const character& owner, int ci = -1);
 void item_delete(int);
 void item_exchange(int = 0, int = 0);
 void item_modify_num(item&, int);

--- a/src/item.hpp
+++ b/src/item.hpp
@@ -217,7 +217,7 @@ void item_dump_desc(const item&);
 
 bool item_fire(int owner, int ci = -1);
 void mapitem_fire(int x, int y);
-int item_cold(int = 0, int = 0);
+bool item_cold(int owner, int ci = -1);
 void mapitem_cold(int = 0, int = 0);
 
 // TODO unsure how these are separate from item

--- a/src/item.hpp
+++ b/src/item.hpp
@@ -216,7 +216,7 @@ int item_stack(int = 0, int = 0, int = 0);
 void item_dump_desc(const item&);
 
 int item_cold(int = 0, int = 0);
-int item_fire(int = 0, int = 0);
+bool item_fire(int owner, int ci = -1);
 void mapitem_cold(int = 0, int = 0);
 void mapitem_fire(int = 0, int = 0);
 

--- a/src/item.hpp
+++ b/src/item.hpp
@@ -218,7 +218,7 @@ void item_dump_desc(const item&);
 bool item_fire(int owner, int ci = -1);
 void mapitem_fire(int x, int y);
 bool item_cold(int owner, int ci = -1);
-void mapitem_cold(int = 0, int = 0);
+void mapitem_cold(int x, int y);
 
 // TODO unsure how these are separate from item
 int inv_find(int = 0, int = 0);


### PR DESCRIPTION
# Related Issues

Close #837 


# Summary

- Refactor related functions.
- Fix item_cold()'s message.
  - Check whether PC can see the character/the position.
  - Add "on the ground" to the messages if the destroyed item is placed on the ground.
- Change fireproof blanket's behavior. Now that it does not rely on PC's vision.
- Separate blanket immediately before they work.
  - Previously, blankets were separated even if all of your stuffs are fire/coldproof.