### PR TITLE
Reset _was_released_immediately flag when the key is released

### DIFF
--- a/src/snail/input.hpp
+++ b/src/snail/input.hpp
@@ -42,6 +42,7 @@ struct button : public lib::noncopyable
     {
         _is_pressed = false;
         _repeat = -1;
+        _was_released_immediately = false;
     }
 
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #797 


# Summary

The cause is that `_was_released_immediately` flag was not reset even if the key was released.