### PR TITLE
Delete static_cast<int> for StickKey

### DIFF
--- a/src/elona.hpp
+++ b/src/elona.hpp
@@ -528,8 +528,6 @@ void pos(int x, int y = 0);
 void redraw();
 
 
-int stick(int allow_repeat_keys = 0);
-
 
 size_t strlen_u(const std::string& str);
 

--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -136,9 +136,8 @@ void select_house_board_tile()
         gmode(2);
         redraw();
         await(Config::instance().wait1);
-        int a{};
-        a = stick();
-        if (a == static_cast<int>(StickKey::mouse_left))
+        const auto input = stick();
+        if (input == StickKey::mouse_left)
         {
             p = mousex / 24 + mousey / 24 * 33;
             if (p >= listmax)
@@ -151,7 +150,7 @@ void select_house_board_tile()
             house_board_update_screen();
             return;
         }
-        if (a == static_cast<int>(StickKey::mouse_right))
+        if (input == StickKey::mouse_right)
         {
             house_board_update_screen();
             return;
@@ -8260,14 +8259,13 @@ int target_position()
                 wait_key_released();
                 continue;
             }
-            int a{};
-            a = stick(
-                static_cast<int>(StickKey::mouse_left | StickKey::mouse_right));
-            if (a == static_cast<int>(StickKey::mouse_left))
+            const auto input =
+                stick(StickKey::mouse_left | StickKey::mouse_right);
+            if (input == StickKey::mouse_left)
             {
                 key = key_enter;
             }
-            if (a == static_cast<int>(StickKey::mouse_right))
+            if (input == StickKey::mouse_right)
             {
                 if (chipm(0, map(tlocx, tlocy, 0)) == 2
                     || chipm(0, map(tlocx, tlocy, 0)) == 1)
@@ -10133,9 +10131,8 @@ TurnResult do_debug_console()
     while (1)
     {
         await(Config::instance().wait1);
-        int a{};
-        a = stick();
-        if (a == static_cast<int>(StickKey::escape))
+        const auto input = stick();
+        if (input == StickKey::escape)
         {
             return do_exit_debug_console();
         }
@@ -15266,9 +15263,8 @@ void do_play_scene()
     }
     scidx += s(0).size();
 label_2681:
-    int a{};
-    a = stick(static_cast<int>(StickKey::escape));
-    if (a == static_cast<int>(StickKey::escape))
+    const auto input = stick(StickKey::escape);
+    if (input == StickKey::escape)
     {
         scene_cut = 1;
     }
@@ -15463,8 +15459,8 @@ label_2684_internal:
     for (int cnt = 1; cnt < 16; ++cnt)
     {
         await(30);
-        a = stick(static_cast<int>(StickKey::escape));
-        if (a == static_cast<int>(StickKey::escape))
+        const auto input = stick(StickKey::escape);
+        if (input == StickKey::escape)
         {
             scene_cut = 1;
         }

--- a/src/enums.hpp
+++ b/src/enums.hpp
@@ -10,6 +10,7 @@ namespace elona
 
 enum class StickKey
 {
+    none = 0,
     left = 1 << 0,
     up = 1 << 1,
     right = 1 << 2,

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -510,11 +510,11 @@ void key_check(KeyWaitDelay delay_type)
     mousel = 0;
     key_tab = 0;
     key_escape = 0;
-    int p_at_m19 = stick(static_cast<int>(
-        StickKey::left | StickKey::up | StickKey::right | StickKey::down));
-    if (p_at_m19 != 0)
+    auto input =
+        stick(StickKey::left | StickKey::up | StickKey::right | StickKey::down);
+    if (input != StickKey::none)
     {
-        if (p_at_m19 == static_cast<int>(StickKey::escape))
+        if (input == StickKey::escape)
         {
             if (keywait == 0)
             {
@@ -522,7 +522,7 @@ void key_check(KeyWaitDelay delay_type)
                 key_escape = 1;
             }
         }
-        if (p_at_m19 == static_cast<int>(StickKey::tab))
+        if (input == StickKey::tab)
         {
             key_tab = 1;
             key = key_next;
@@ -532,58 +532,58 @@ void key_check(KeyWaitDelay delay_type)
     {
         if (getkey(snail::Key::home))
         {
-            p_at_m19 = static_cast<int>(StickKey::up | StickKey::left);
+            input = StickKey::up | StickKey::left;
         }
         else if (getkey(snail::Key::pageup))
         {
-            p_at_m19 = static_cast<int>(StickKey::up | StickKey::right);
+            input = StickKey::up | StickKey::right;
         }
         else if (getkey(snail::Key::end))
         {
-            p_at_m19 = static_cast<int>(StickKey::down | StickKey::left);
+            input = StickKey::down | StickKey::left;
         }
         else if (getkey(snail::Key::pagedown))
         {
-            p_at_m19 = static_cast<int>(StickKey::down | StickKey::right);
+            input = StickKey::down | StickKey::right;
         }
 
         // Handle the case of the current key matching the movement
         // keybindings set in the user's config.
         else if (key == key_west)
         {
-            p_at_m19 = static_cast<int>(StickKey::left);
+            input = StickKey::left;
         }
         else if (key == key_north)
         {
-            p_at_m19 = static_cast<int>(StickKey::up);
+            input = StickKey::up;
         }
         else if (key == key_east)
         {
-            p_at_m19 = static_cast<int>(StickKey::right);
+            input = StickKey::right;
         }
         else if (key == key_south)
         {
-            p_at_m19 = static_cast<int>(StickKey::down);
+            input = StickKey::down;
         }
         else if (key == key_northwest)
         {
-            p_at_m19 = static_cast<int>(StickKey::up | StickKey::left);
+            input = StickKey::up | StickKey::left;
         }
         else if (key == key_northeast)
         {
-            p_at_m19 = static_cast<int>(StickKey::up | StickKey::right);
+            input = StickKey::up | StickKey::right;
         }
         else if (key == key_southwest)
         {
-            p_at_m19 = static_cast<int>(StickKey::down | StickKey::left);
+            input = StickKey::down | StickKey::left;
         }
         else if (key == key_southeast)
         {
-            p_at_m19 = static_cast<int>(StickKey::down | StickKey::right);
+            input = StickKey::down | StickKey::right;
         }
         else if (key == key_wait)
         {
-            p_at_m19 = 0;
+            input = StickKey::none;
             delay_keypress = true;
         }
     }
@@ -637,19 +637,19 @@ void key_check(KeyWaitDelay delay_type)
         DIGETJOYSTATE(j_at_m19, 0);
         if (HMMBITCHECK(j_at_m19, 0))
         {
-            p_at_m19 += 2;
+            input |= StickKey::up;
         }
         if (HMMBITCHECK(j_at_m19, 1))
         {
-            p_at_m19 += 8;
+            input |= StickKey::down;
         }
         if (HMMBITCHECK(j_at_m19, 2))
         {
-            p_at_m19 += 1;
+            input |= StickKey::left;
         }
         if (HMMBITCHECK(j_at_m19, 3))
         {
-            p_at_m19 += 4;
+            input |= StickKey::right;
         }
         int a_at_m19 = 0;
         for (int cnt = 0; cnt < 12; ++cnt)
@@ -664,7 +664,7 @@ void key_check(KeyWaitDelay delay_type)
                 if (jkey(cnt) == key_cancel)
                 {
                     key_shift = 1;
-                    if (p_at_m19 != 0)
+                    if (input != StickKey::none)
                     {
                         keybd_wait = 100000;
                     }
@@ -721,7 +721,7 @@ void key_check(KeyWaitDelay delay_type)
     }
     if (quickkeywait)
     {
-        if (p_at_m19 != 0)
+        if (input != StickKey::none)
         {
             return;
         }
@@ -737,7 +737,7 @@ void key_check(KeyWaitDelay delay_type)
             keybd_wait = 1000;
         }
     }
-    if (p_at_m19 == static_cast<int>(StickKey::left))
+    if (input == StickKey::left)
     {
         if (key_alt == 0)
         {
@@ -745,7 +745,7 @@ void key_check(KeyWaitDelay delay_type)
             delay_keypress = true;
         }
     }
-    if (p_at_m19 == static_cast<int>(StickKey::up))
+    if (input == StickKey::up)
     {
         if (key_alt == 0)
         {
@@ -753,7 +753,7 @@ void key_check(KeyWaitDelay delay_type)
             delay_keypress = true;
         }
     }
-    if (p_at_m19 == static_cast<int>(StickKey::right))
+    if (input == StickKey::right)
     {
         if (key_alt == 0)
         {
@@ -761,7 +761,7 @@ void key_check(KeyWaitDelay delay_type)
             delay_keypress = true;
         }
     }
-    if (p_at_m19 == static_cast<int>(StickKey::down))
+    if (input == StickKey::down)
     {
         if (key_alt == 0)
         {
@@ -769,22 +769,22 @@ void key_check(KeyWaitDelay delay_type)
             delay_keypress = true;
         }
     }
-    if (p_at_m19 == static_cast<int>(StickKey::up | StickKey::left))
+    if (input == (StickKey::up | StickKey::left))
     {
         key = key_northwest;
         delay_keypress = true;
     }
-    if (p_at_m19 == static_cast<int>(StickKey::up | StickKey::right))
+    if (input == (StickKey::up | StickKey::right))
     {
         key = key_northeast;
         delay_keypress = true;
     }
-    if (p_at_m19 == static_cast<int>(StickKey::down | StickKey::left))
+    if (input == (StickKey::down | StickKey::left))
     {
         key = key_southwest;
         delay_keypress = true;
     }
-    if (p_at_m19 == static_cast<int>(StickKey::down | StickKey::right))
+    if (input == (StickKey::down | StickKey::right))
     {
         key = key_southeast;
         delay_keypress = true;
@@ -881,7 +881,7 @@ void key_check(KeyWaitDelay delay_type)
                     }
                 }
             }
-            else if (p_at_m19 == 0)
+            else if (input == StickKey::none)
             {
                 if (keybd_wait < 20)
                 {
@@ -994,10 +994,8 @@ void wait_key_released()
     while (1)
     {
         await(Config::instance().wait1);
-        int result{};
-        result = stick(
-            static_cast<int>(StickKey::mouse_left | StickKey::mouse_right));
-        if (result == 0)
+        const auto input = stick(StickKey::mouse_left | StickKey::mouse_right);
+        if (input == StickKey::none)
         {
             await(Config::instance().wait1);
             key_check();

--- a/src/input.hpp
+++ b/src/input.hpp
@@ -32,6 +32,8 @@ bool input_text_dialog(
     bool is_cancelable = true,
     bool limit_length = true);
 
+StickKey stick(StickKey allow_repeat_keys = StickKey::none);
+
 void key_check(KeyWaitDelay = KeyWaitDelay::always);
 void wait_key_released();
 void wait_key_pressed(bool only_enter_or_cancel = false);

--- a/src/talk.cpp
+++ b/src/talk.cpp
@@ -604,9 +604,8 @@ int talk_window_query()
         await(Config::instance().wait1);
         key_check();
         cursor_check();
-        int a{};
-        a = stick(static_cast<int>(StickKey::escape));
-        if (a == static_cast<int>(StickKey::escape))
+        const auto input = stick(StickKey::escape);
+        if (input == StickKey::escape)
         {
             if (scenemode)
             {

--- a/src/tcg.cpp
+++ b/src/tcg.cpp
@@ -105,7 +105,6 @@ elona_vector1<int> cflist_at_tcg;
 elona_vector1<std::string> cfname_at_tcg;
 int page_at_tcg = 0;
 int dlistmax_at_tcg = 0;
-int a_at_tcg = 0;
 int chaincontinue_at_tcg = 0;
 int emax_at_tcg = 0;
 
@@ -2744,7 +2743,6 @@ void tcg_prompt_action()
         tcgdraw();
         cursor_at_tcg = 1;
         await(15);
-        a_at_tcg = stick();
         key_check();
         if (key == key_east)
         {
@@ -3275,8 +3273,8 @@ void tcg_proc_ai()
         if (init)
         {
             spellused_at_tcg = 0;
-            a_at_tcg = stick();
-            if (a_at_tcg)
+            const auto input = stick();
+            if (input != StickKey::none)
             {
                 cpdata_at_tcg(4, 0) = 0;
             }


### PR DESCRIPTION
# Summary

In #843, all `enum`s were converted to `enum class`es. They lacked implicit conversion between integer, so I added `static_cast<int>` if needed. However, some of them can be deleted by refactoring. This pull requests deletes `static_cast<int>` for `enum class StickKey`.