### PR TITLE
Define enum class Quality

### DIFF
--- a/src/access_character_info.cpp
+++ b/src/access_character_info.cpp
@@ -104,7 +104,7 @@ int access_character_info()
         eqweapon1 = data->eqweapon1;
         if (data->fixlv == 6)
         {
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         cspecialeq = data->cspecialeq;
         cdata[rc].damage_reaction_info = data->damage_reaction_info;

--- a/src/access_item_db.cpp
+++ b/src/access_item_db.cpp
@@ -102,7 +102,7 @@ int access_item_db(int dbmode)
             fixeditemenc(4) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 790:
@@ -172,7 +172,7 @@ int access_item_db(int dbmode)
             ibitmod(5, ci, 1);
             ibitmod(7, ci, 1);
             inv[ci].param3 = 240;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 776:
@@ -182,7 +182,7 @@ int access_item_db(int dbmode)
             ibitmod(5, ci, 1);
             ibitmod(7, ci, 1);
             inv[ci].param3 = 240;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 775:
@@ -202,7 +202,7 @@ int access_item_db(int dbmode)
     case 771:
         if (dbmode == 3)
         {
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         if (dbmode == 15)
         {
@@ -237,7 +237,7 @@ int access_item_db(int dbmode)
             inv[ci].function = 17;
             ibitmod(5, ci, 1);
             inv[ci].param1 = 200;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 760:
@@ -246,7 +246,7 @@ int access_item_db(int dbmode)
             inv[ci].function = 49;
             ibitmod(5, ci, 1);
             inv[ci].param1 = rnd(20000) + 1;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 759:
@@ -264,7 +264,7 @@ int access_item_db(int dbmode)
             fixeditemenc(2) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 757:
@@ -283,7 +283,7 @@ int access_item_db(int dbmode)
             fixeditemenc(10) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 756:
@@ -373,7 +373,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             ibitmod(5, ci, 1);
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         if (dbmode == 13)
         {
@@ -396,7 +396,7 @@ int access_item_db(int dbmode)
             fixeditemenc(8) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 740:
@@ -411,7 +411,7 @@ int access_item_db(int dbmode)
             fixeditemenc(6) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 739:
@@ -433,7 +433,7 @@ int access_item_db(int dbmode)
             fixeditemenc(12) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 738:
@@ -521,7 +521,7 @@ int access_item_db(int dbmode)
             fixeditemenc(6) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 727:
@@ -535,7 +535,7 @@ int access_item_db(int dbmode)
             fixeditemenc(4) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 726:
@@ -551,7 +551,7 @@ int access_item_db(int dbmode)
             fixeditemenc(6) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 725:
@@ -567,7 +567,7 @@ int access_item_db(int dbmode)
             fixeditemenc(6) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 724:
@@ -586,7 +586,7 @@ int access_item_db(int dbmode)
             fixeditemenc(4) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 722:
@@ -599,7 +599,7 @@ int access_item_db(int dbmode)
             fixeditemenc(4) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 721:
@@ -609,7 +609,7 @@ int access_item_db(int dbmode)
             ibitmod(5, ci, 1);
             ibitmod(7, ci, 1);
             inv[ci].param3 = 480;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 720:
@@ -631,7 +631,7 @@ int access_item_db(int dbmode)
             fixeditemenc(6) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 718:
@@ -651,7 +651,7 @@ int access_item_db(int dbmode)
             fixeditemenc(10) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 717:
@@ -666,7 +666,7 @@ int access_item_db(int dbmode)
             inv[ci].skill = 111;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 715:
@@ -751,7 +751,7 @@ int access_item_db(int dbmode)
             inv[ci].function = 17;
             ibitmod(5, ci, 1);
             inv[ci].param1 = 180;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 706:
@@ -775,7 +775,7 @@ int access_item_db(int dbmode)
             fixeditemenc(6) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 704:
@@ -798,7 +798,7 @@ int access_item_db(int dbmode)
         {
             ibitmod(5, ci, 1);
             inv[ci].param2 = 4;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 701:
@@ -867,7 +867,7 @@ int access_item_db(int dbmode)
             fixeditemenc(2) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 693:
@@ -933,7 +933,7 @@ int access_item_db(int dbmode)
             ibitmod(5, ci, 1);
             ibitmod(7, ci, 1);
             inv[ci].param3 = 720;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 685:
@@ -958,7 +958,7 @@ int access_item_db(int dbmode)
             inv[ci].param1 = 1132;
             inv[ci].param2 = 100;
             inv[ci].param3 = 24;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 682:
@@ -968,7 +968,7 @@ int access_item_db(int dbmode)
             ibitmod(5, ci, 1);
             ibitmod(7, ci, 1);
             inv[ci].param3 = 72;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 681:
@@ -980,7 +980,7 @@ int access_item_db(int dbmode)
             inv[ci].param1 = 404;
             inv[ci].param2 = 400;
             inv[ci].param3 = 8;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 680:
@@ -992,7 +992,7 @@ int access_item_db(int dbmode)
             inv[ci].param1 = 446;
             inv[ci].param2 = 300;
             inv[ci].param3 = 12;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 679:
@@ -1012,7 +1012,7 @@ int access_item_db(int dbmode)
             fixeditemenc(10) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 678:
@@ -1032,7 +1032,7 @@ int access_item_db(int dbmode)
             fixeditemenc(10) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 677:
@@ -1052,7 +1052,7 @@ int access_item_db(int dbmode)
             fixeditemenc(10) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 676:
@@ -1076,7 +1076,7 @@ int access_item_db(int dbmode)
             fixeditemenc(14) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 675:
@@ -1100,7 +1100,7 @@ int access_item_db(int dbmode)
             fixeditemenc(14) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 674:
@@ -1118,7 +1118,7 @@ int access_item_db(int dbmode)
             fixeditemenc(8) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 673:
@@ -1136,7 +1136,7 @@ int access_item_db(int dbmode)
             fixeditemenc(8) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 672:
@@ -1144,7 +1144,7 @@ int access_item_db(int dbmode)
         {
             inv[ci].function = 29;
             ibitmod(5, ci, 1);
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 671:
@@ -1152,7 +1152,7 @@ int access_item_db(int dbmode)
         {
             inv[ci].function = 28;
             ibitmod(5, ci, 1);
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 670:
@@ -1192,7 +1192,7 @@ int access_item_db(int dbmode)
             ibitmod(5, ci, 1);
             ibitmod(7, ci, 1);
             inv[ci].param3 = 120;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 665:
@@ -1202,7 +1202,7 @@ int access_item_db(int dbmode)
             ibitmod(5, ci, 1);
             ibitmod(7, ci, 1);
             inv[ci].param3 = 240;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 664:
@@ -1217,7 +1217,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             ibitmod(5, ci, 1);
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 662:
@@ -1225,7 +1225,7 @@ int access_item_db(int dbmode)
         {
             ibitmod(5, ci, 1);
             inv[ci].param2 = 7;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 661:
@@ -1242,7 +1242,7 @@ int access_item_db(int dbmode)
             fixeditemenc(8) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 660:
@@ -1264,7 +1264,7 @@ int access_item_db(int dbmode)
         {
             ibitmod(5, ci, 1);
             inv[ci].param2 = 7;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 654:
@@ -1296,7 +1296,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             ibitmod(5, ci, 1);
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 640:
@@ -1310,7 +1310,7 @@ int access_item_db(int dbmode)
         {
             ibitmod(5, ci, 1);
             inv[ci].param2 = 7;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 638:
@@ -1326,7 +1326,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             ibitmod(5, ci, 1);
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 635:
@@ -1405,7 +1405,7 @@ int access_item_db(int dbmode)
             fixeditemenc(12) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 626:
@@ -2026,7 +2026,7 @@ int access_item_db(int dbmode)
             fixeditemenc(10) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 513:
@@ -3019,7 +3019,7 @@ int access_item_db(int dbmode)
             fixeditemenc(12) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 359:
@@ -3037,7 +3037,7 @@ int access_item_db(int dbmode)
             fixeditemenc(8) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 358:
@@ -3059,7 +3059,7 @@ int access_item_db(int dbmode)
             fixeditemenc(12) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 357:
@@ -3084,7 +3084,7 @@ int access_item_db(int dbmode)
             fixeditemenc(16) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 356:
@@ -3106,7 +3106,7 @@ int access_item_db(int dbmode)
             fixeditemenc(12) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 355:
@@ -3129,7 +3129,7 @@ int access_item_db(int dbmode)
             fixeditemenc(14) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 354:
@@ -3949,7 +3949,7 @@ int access_item_db(int dbmode)
             fixeditemenc(12) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 206:
@@ -3967,7 +3967,7 @@ int access_item_db(int dbmode)
             fixeditemenc(8) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 205:
@@ -4517,7 +4517,7 @@ int access_item_db(int dbmode)
             fixeditemenc(2) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 72:
@@ -4584,7 +4584,7 @@ int access_item_db(int dbmode)
             fixeditemenc(12) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 63:
@@ -4604,7 +4604,7 @@ int access_item_db(int dbmode)
             fixeditemenc(10) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 62:
@@ -4660,7 +4660,7 @@ int access_item_db(int dbmode)
             fixeditemenc(8) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 56:
@@ -4678,7 +4678,7 @@ int access_item_db(int dbmode)
             fixeditemenc(8) = 0;
             ibitmod(5, ci, 1);
             inv[ci].difficulty_of_identification = 500;
-            fixlv = 6;
+            fixlv = Quality::special;
         }
         break;
     case 44:

--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -476,14 +476,17 @@ void continuous_action_perform()
                                         flt(calcobjlv(
                                                 cdata[cc].quality_of_performance
                                                 / 8),
-                                            calcfixlv(3 + (rnd(4) == 0)));
+                                            calcfixlv(
+                                                (rnd(4) == 0)
+                                                    ? Quality::miracle
+                                                    : Quality::great));
                                     }
                                     else
                                     {
                                         flt(calcobjlv(
                                                 cdata[cc].quality_of_performance
                                                 / 10),
-                                            calcfixlv(3));
+                                            calcfixlv(Quality::good));
                                     }
                                     flttypemajor = choice(fsetperform);
                                     dbid = 0;
@@ -1735,10 +1738,10 @@ void spot_digging()
                                  ++cnt)
                             {
                                 flt(calcobjlv(cdata.player().level + 10),
-                                    calcfixlv(3));
+                                    calcfixlv(Quality::good));
                                 if (cnt == 0)
                                 {
-                                    fixlv = 5;
+                                    fixlv = Quality::godly;
                                 }
                                 flttypemajor = choice(fsetchest);
                                 itemcreate(
@@ -1881,7 +1884,8 @@ void spot_mining_or_wall()
                 }
                 else if (rtval == -1)
                 {
-                    flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(3));
+                    flt(calcobjlv(gdata_current_dungeon_level),
+                        calcfixlv(Quality::good));
                     flttypemajor = 77000;
                     itemcreate(-1, 0, digx, digy, 0);
                 }

--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -1125,11 +1125,11 @@ void continuous_action_others()
             {
                 i = i * 15 / 10;
             }
-            if (inv[ci].quality == 3)
+            if (inv[ci].quality == Quality::great)
             {
                 i = i * 8 / 10;
             }
-            if (inv[ci].quality >= 4)
+            if (inv[ci].quality >= Quality::miracle)
             {
                 i = i * 5 / 10;
             }

--- a/src/adventurer.cpp
+++ b/src/adventurer.cpp
@@ -30,7 +30,7 @@ void create_all_adventurers()
 
 void create_adventurer()
 {
-    flt(0, 4);
+    flt(0, Quality::miracle);
     initlv = rnd(60 + cdata.player().level) + 1;
     p(0) = 75;
     p(1) = 41;
@@ -339,7 +339,7 @@ int adventurer_discover_equipment()
     {
         return 0;
     }
-    flt(cdata[rc].level, 4);
+    flt(cdata[rc].level, Quality::miracle);
     if (rnd(3) == 0)
     {
         flttypemajor = choice(fsetwear);

--- a/src/adventurer.cpp
+++ b/src/adventurer.cpp
@@ -354,7 +354,7 @@ int adventurer_discover_equipment()
         return 0;
     }
     inv[ci].identification_state = IdentifyState::completely_identified;
-    if (inv[ci].quality >= 4)
+    if (inv[ci].quality >= Quality::miracle)
     {
         if (the_item_db[inv[ci].id]->category < 50000)
         {

--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -198,7 +198,7 @@ TurnResult ai_proc_basic()
             efid = act;
             if (cdata[cc].mp < cdata[cc].max_mp / 7)
             {
-                if (rnd(3) || cc < 16 || cdata[cc].quality >= 4
+                if (rnd(3) || cc < 16 || cdata[cc].quality >= Quality::miracle
                     || cdata[cc].cures_mp_frequently())
                 {
                     cdata[cc].mp += cdata[cc].level / 4 + 5;
@@ -409,7 +409,8 @@ TurnResult proc_npc_movement_event(bool retreat)
             return ai_proc_basic();
         }
         else if (
-            (cdata[cc].quality > 3 && cdata[cc].level > cdata[tc].level)
+            (cdata[cc].quality > Quality::great
+             && cdata[cc].level > cdata[tc].level)
             || cdata[tc].is_hung_on_sand_bag())
         {
             if (cdata[cc].enemy_id != tc)
@@ -440,7 +441,7 @@ TurnResult proc_npc_movement_event(bool retreat)
     }
     if (cc >= 16)
     {
-        if (cdata[cc].quality > 3)
+        if (cdata[cc].quality > Quality::great)
         {
             if (cdata[cc].relationship <= -2)
             {

--- a/src/buff.cpp
+++ b/src/buff.cpp
@@ -161,7 +161,7 @@ void buff_add(
         {
             resists = false;
         }
-        if (cc.quality > 3)
+        if (cc.quality > Quality::great)
         {
             if (rnd(4))
             {
@@ -172,7 +172,7 @@ void buff_add(
                 turns = turns / 5 + 1;
             }
         }
-        if (cc.quality >= 4 && id == 16)
+        if (cc.quality >= Quality::miracle && id == 16)
         {
             resists = true;
         }

--- a/src/building.cpp
+++ b/src/building.cpp
@@ -974,7 +974,7 @@ void show_shop_log()
         {
             continue;
         }
-        if (inv[cnt].quality >= 6)
+        if (inv[cnt].quality >= Quality::special)
         {
             continue;
         }
@@ -1025,7 +1025,7 @@ void show_shop_log()
         if (rnd(4) == 0)
         {
             list(0, listmax) = the_item_db[inv[ci].id]->level;
-            list(1, listmax) = inv[ci].quality;
+            list(1, listmax) = static_cast<int>(inv[ci].quality);
             listn(0, listmax) = std::to_string(category);
             listn(1, listmax) = std::to_string(val0);
             ++listmax;

--- a/src/building.cpp
+++ b/src/building.cpp
@@ -1086,7 +1086,7 @@ void show_shop_log()
         int cnt2 = cnt;
         for (int cnt = 0; cnt < 4; ++cnt)
         {
-            flt(list(0, cnt2), list(1, cnt2));
+            flt(list(0, cnt2), static_cast<Quality>(list(1, cnt2)));
             flttypemajor = elona::stoi(listn(0, cnt2));
             nostack = 1;
             int stat = itemcreate(-1, 0, -1, -1, 0);
@@ -1201,11 +1201,11 @@ void update_shop()
 void calc_collection_value(bool val0)
 {
     rc = 56;
-    fixlv = 2;
+    fixlv = Quality::good;
     dbmode = 3;
     access_character_info();
     ++dblist(val0 ? 1 : 0, cdata.tmp().id);
-    if (fixlv == 6)
+    if (fixlv == Quality::special)
     {
         rtval = 70 + cdata.tmp().level;
     }
@@ -1453,7 +1453,7 @@ void update_ranch()
                 goto label_1734_internal;
             }
         }
-        flt(calcobjlv(cdata[worker].level), 1);
+        flt(calcobjlv(cdata[worker].level), Quality::bad);
         if (rnd(2))
         {
             dbid = cdata[worker].id;
@@ -1496,7 +1496,7 @@ void update_ranch()
             {
                 continue;
             }
-            flt(calcobjlv(cnt.level), 2);
+            flt(calcobjlv(cnt.level), Quality::good);
             p = rnd(5);
             f = 0;
             if (rnd(egg + 1) > 2)

--- a/src/calc.cpp
+++ b/src/calc.cpp
@@ -265,9 +265,10 @@ int calcobjlv(int base)
 
 
 
-int calcfixlv(int base)
+Quality calcfixlv(Quality base_quality)
 {
-    int ret = base == 0 ? 2 : base;
+    int ret = static_cast<int>(
+        base_quality == Quality::none ? Quality::good : base_quality);
     for (int i = 1; i < 4; ++i)
     {
         int p = rnd(30 + i * 5);
@@ -283,7 +284,8 @@ int calcfixlv(int base)
         }
         break;
     }
-    return clamp(ret, 1, 5);
+    return static_cast<Quality>(clamp(
+        ret, static_cast<int>(Quality::bad), static_cast<int>(Quality::godly)));
 }
 
 
@@ -1537,7 +1539,7 @@ void calcpartyscore2()
         {
             continue;
         }
-        if (cnt.impression >= 53 && cnt.quality >= 4)
+        if (cnt.impression >= 53 && cnt.quality >= Quality::miracle)
         {
             score += 20 + cnt.level / 2;
             txt(i18n::s.get("core.locale.quest.party.is_satisfied", cnt));

--- a/src/calc.hpp
+++ b/src/calc.hpp
@@ -23,7 +23,7 @@ struct SkillDamage
 };
 optional<SkillDamage> calc_skill_damage(int, int, int);
 int calcobjlv(int = 0);
-int calcfixlv(int = 0);
+Quality calcfixlv(Quality base_quality = Quality::none);
 int calcfame(int = 0, int = 0);
 int decfame(int = 0, int = 0);
 int calcshopreform();

--- a/src/casino.cpp
+++ b/src/casino.cpp
@@ -1201,27 +1201,27 @@ bool casino_blackjack()
             "core.locale.casino.blackjack.game.total_wins", winrow));
         for (int cnt = 0; cnt < 1; ++cnt)
         {
-            i = 2;
+            Quality quality = Quality::good;
             if (winrow > 2)
             {
-                i = 3;
+                quality = Quality::great;
             }
             if (winrow > 7)
             {
                 if (stake >= 5)
                 {
-                    i = 4;
+                    quality = Quality::miracle;
                 }
             }
             if (winrow > 15)
             {
                 if (stake >= 20)
                 {
-                    i = 5;
+                    quality = Quality::godly;
                 }
             }
             flt(calcobjlv(rnd(stake + winrow * 2) + winrow * 3 / 2 + stake / 2),
-                i);
+                quality);
             flttypemajor = choice(fsetwear);
             itemcreate(-1, 0, -1, -1, 0);
             if (inv[ci].number() == 0)

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -55,14 +55,14 @@ int chara_create_internal()
     {
         if (fltselect == 0 && filtermax == 0 && fltnrace(0).empty())
         {
-            if (fixlv == 3)
+            if (fixlv == Quality::great)
             {
                 if (rnd(20) == 0)
                 {
                     fltselect = 2;
                 }
             }
-            if (fixlv == 4)
+            if (fixlv == Quality::miracle)
             {
                 if (rnd(10) == 0)
                 {
@@ -74,9 +74,9 @@ int chara_create_internal()
         get_random_npc_id();
         if (dbid == 0)
         {
-            if (fltselect == 2 || fixlv == 6)
+            if (fltselect == 2 || fixlv == Quality::special)
             {
-                fixlv = 4;
+                fixlv = Quality::miracle;
             }
             flt(objlv + 10, fixlv);
             dbmode = 1;
@@ -99,9 +99,9 @@ int chara_create_internal()
         if (rnd(5))
         {
             objlv *= 2;
-            if (fixlv >= 4)
+            if (fixlv >= Quality::miracle)
             {
-                fixlv = 3;
+                fixlv = Quality::great;
             }
             cmshade = 1;
             flt(objlv, fixlv);
@@ -131,7 +131,7 @@ int chara_create_internal()
         cdatan(0, rc) = i18n::s.get("core.locale.chara.job.shade");
         cdata[rc].image = 280;
     }
-    cdata[rc].quality = fixlv;
+    cdata[rc].quality = static_cast<Quality>(fixlv);
     cdata[rc].index = rc;
     initialize_character();
 
@@ -838,14 +838,14 @@ void chara_set_generation_filter()
     dbid = 0;
     if (gdata_current_map == mdata_t::MapId::cyber_dome)
     {
-        flt(calcobjlv(10), calcfixlv(2));
+        flt(calcobjlv(10), calcfixlv(Quality::bad));
         fltn(u8"sf"s);
         return;
     }
     if (mdata_map_type == mdata_t::MapType::town
         || mdata_map_type == mdata_t::MapType::guild)
     {
-        flt(calcobjlv(10), calcfixlv(2));
+        flt(calcobjlv(10), calcfixlv(Quality::bad));
         fltselect = 5;
         if (gdata_current_dungeon_level == 1)
         {
@@ -928,7 +928,7 @@ void chara_set_generation_filter()
     }
     if (gdata_current_map == mdata_t::MapId::lesimas)
     {
-        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(2));
+        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(Quality::bad));
         if (gdata_current_dungeon_level < 4)
         {
             if (objlv > 5)
@@ -940,29 +940,30 @@ void chara_set_generation_filter()
     }
     if (gdata_current_map == mdata_t::MapId::the_void)
     {
-        flt(calcobjlv(gdata_current_dungeon_level % 50 + 5), calcfixlv(2));
+        flt(calcobjlv(gdata_current_dungeon_level % 50 + 5),
+            calcfixlv(Quality::bad));
         return;
     }
     if (gdata_current_map == mdata_t::MapId::dragons_nest)
     {
-        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(2));
+        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(Quality::bad));
         return;
     }
     if (gdata_current_map == mdata_t::MapId::crypt_of_the_damned)
     {
-        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(2));
+        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(Quality::bad));
         fltn(u8"undead"s);
         return;
     }
     if (gdata_current_map == mdata_t::MapId::tower_of_fire)
     {
-        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(2));
+        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(Quality::bad));
         fltn(u8"fire"s);
         return;
     }
     if (gdata_current_map == mdata_t::MapId::ancient_castle)
     {
-        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(2));
+        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(Quality::bad));
         if (rnd(2) == 0)
         {
             fltn(u8"man"s);
@@ -971,14 +972,14 @@ void chara_set_generation_filter()
     }
     if (gdata_current_map == mdata_t::MapId::pyramid)
     {
-        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(2));
+        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(Quality::bad));
         flttypemajor = 13;
         return;
     }
     if (gdata_current_map == mdata_t::MapId::lumiest_graveyard
         || gdata_current_map == mdata_t::MapId::truce_ground)
     {
-        flt(calcobjlv(20), calcfixlv(2));
+        flt(calcobjlv(20), calcfixlv(Quality::bad));
         fltselect = 4;
         return;
     }
@@ -987,7 +988,7 @@ void chara_set_generation_filter()
         if (gdata_executing_immediate_quest_type >= 1000)
         {
             flt(calcobjlv(qdata(5, gdata_executing_immediate_quest) + 1),
-                calcfixlv(2));
+                calcfixlv(Quality::bad));
         }
         if (gdata_executing_immediate_quest_type == 1006)
         {
@@ -998,7 +999,7 @@ void chara_set_generation_filter()
     }
     if (adata(16, gdata_current_map) == mdata_t::MapId::yeeks_nest)
     {
-        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(2));
+        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(Quality::bad));
         if (rnd(2))
         {
             fltn(u8"yeek"s);
@@ -1007,7 +1008,7 @@ void chara_set_generation_filter()
     }
     if (adata(16, gdata_current_map) == mdata_t::MapId::minotaurs_nest)
     {
-        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(2));
+        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(Quality::bad));
         if (rnd(2))
         {
             fltn(u8"mino"s);
@@ -1016,13 +1017,13 @@ void chara_set_generation_filter()
     }
     if (mdata_map_type >= static_cast<int>(mdata_t::MapType::dungeon))
     {
-        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(2));
+        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(Quality::bad));
         return;
     }
     if (adata(16, gdata_current_map) == mdata_t::MapId::museum
         || adata(16, gdata_current_map) == mdata_t::MapId::shop)
     {
-        flt(calcobjlv(100), calcfixlv(2));
+        flt(calcobjlv(100), calcfixlv(Quality::bad));
         if (rnd(1))
         {
             fltselect = 5;
@@ -1033,7 +1034,7 @@ void chara_set_generation_filter()
         }
         return;
     }
-    flt(calcobjlv(cdata.player().level), calcfixlv(2));
+    flt(calcobjlv(cdata.player().level), calcfixlv(Quality::bad));
     return;
 }
 
@@ -1502,7 +1503,7 @@ void chara_refresh(int cc)
     {
         if (cdata[cc].attr_adjs[cnt] != 0)
         {
-            if (cdata[cc].quality >= 4)
+            if (cdata[cc].quality >= Quality::miracle)
             {
                 if (cdata[cc].attr_adjs[cnt]
                     < sdata.get(10 + cnt, cc).original_level / 5)
@@ -1581,11 +1582,11 @@ void chara_refresh(int cc)
             + (cdata[cc].pv + cdata[cc].level / 2
                + cdata[cc].pv_correction_value / 25)
                 * cdata[cc].pv_correction_value / 100;
-        if (cdata[cc].quality == 3)
+        if (cdata[cc].quality == Quality::great)
         {
             cdata[cc].max_hp = cdata[cc].max_hp * 3 / 2;
         }
-        if (cdata[cc].quality >= 4)
+        if (cdata[cc].quality >= Quality::miracle)
         {
             cdata[cc].max_hp = cdata[cc].max_hp * 5;
         }
@@ -2244,13 +2245,13 @@ bool belong_to_same_team(const Character& c1, const Character& c2)
 
 void chara_add_quality_parens()
 {
-    if (fixlv == 4)
+    if (fixlv == Quality::miracle)
     {
         cdatan(0, rc) = i18n::_(u8"ui", u8"bracket_left") + cdatan(0, rc)
             + i18n::_(u8"ui", u8"bracket_right");
         cdata[rc].level = cdata[rc].level * 10 / 8;
     }
-    else if (fixlv == 5)
+    else if (fixlv == Quality::godly)
     {
         cdatan(0, rc) =
             i18n::s.get("core.locale.chara.name_with_title", cdata[rc]);

--- a/src/character.hpp
+++ b/src/character.hpp
@@ -90,7 +90,7 @@ struct Character
     int birth_year = 0;
     int nutrition = 0;
     int can_talk = 0;
-    int quality = 0;
+    Quality quality = Quality::none;
     int turn = 0;
     int id = 0;
     int vision_distance = 0;

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -644,7 +644,8 @@ TurnResult do_throw_command()
             if (inv[ci].id == 685)
             {
                 if (tc < ELONA_MAX_PARTY_CHARACTERS
-                    || cdata[tc].character_role != 0 || cdata[tc].quality == 6
+                    || cdata[tc].character_role != 0
+                    || cdata[tc].quality == Quality::special
                     || cdata[tc].is_lord_of_dungeon() == 1)
                 {
                     txt(

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -375,21 +375,21 @@ optional<const CraftingRecipe&> crafting_find_recipe(int matid_)
     return it->second;
 }
 
-static int _determine_crafted_fixlv(const CraftingRecipe& recipe)
+static Quality _determine_crafted_fixlv(const CraftingRecipe& recipe)
 {
-    int fixlv_ = 2;
+    Quality ret = Quality::good;
     if (rnd(200 + recipe.required_skill_level * 2)
         < sdata(recipe.skill_used, 0) + 20)
     {
-        fixlv_ = 4;
+        ret = Quality::miracle;
     }
     if (rnd(100 + recipe.required_skill_level * 2)
         < sdata(recipe.skill_used, 0) + 20)
     {
-        fixlv_ = 3;
+        ret = Quality::great;
     }
 
-    return fixlv_;
+    return ret;
 }
 
 static void _craft_item(int matid, const CraftingRecipe& recipe)

--- a/src/ctrl_inventory.cpp
+++ b/src/ctrl_inventory.cpp
@@ -279,7 +279,7 @@ label_20591:
                 {
                     continue;
                 }
-                if (inv[cnt].quality == 6)
+                if (inv[cnt].quality == Quality::special)
                 {
                     continue;
                 }
@@ -425,7 +425,8 @@ label_20591:
                 }
                 if (invctrl(1) == 7)
                 {
-                    if (inv[cnt].quality >= 4 || reftype >= 50000)
+                    if (inv[cnt].quality >= Quality::miracle
+                        || reftype >= 50000)
                     {
                         continue;
                     }

--- a/src/dmgheal.cpp
+++ b/src/dmgheal.cpp
@@ -516,7 +516,7 @@ int damage_hp(
             }
             if (element == 52)
             {
-                if (rnd(3 + (victim.quality >= 4) * 3) == 0)
+                if (rnd(3 + (victim.quality >= Quality::miracle) * 3) == 0)
                 {
                     ++victim.paralyzed;
                 }
@@ -1280,7 +1280,7 @@ void heal_sp(Character& cc, int delta)
 
 void damage_insanity(Character& cc, int delta)
 {
-    if (cc.quality >= 4)
+    if (cc.quality >= Quality::miracle)
         return;
 
     int resistance = std::max(sdata(54, cc.index) / 50, 1);

--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -507,7 +507,7 @@ void initialize_building_daga()
 
 void initialize_pc_character()
 {
-    cdata.player().quality = 2;
+    cdata.player().quality = Quality::good;
     cdata.player().relationship = 10;
     cdata.player().original_relationship = 10;
     cdata.player().has_own_sprite() = true;
@@ -1058,7 +1058,7 @@ void getinheritance(int prm_440, elona_vector1<int>& inhlist_, int& inhmax_)
 
 
 
-void flt(int level, int quality)
+void flt(int level, Quality quality)
 {
     filtermax = 0;
     fltselect = 0;
@@ -1066,7 +1066,7 @@ void flt(int level, int quality)
     flttypeminor = 0;
     fltnrace = "";
     objlv = level == 0 ? calcobjlv(gdata_current_dungeon_level) : level;
-    fixlv = quality == 0 ? calcfixlv(2) : quality;
+    fixlv = quality == Quality::none ? calcfixlv(Quality::bad) : quality;
 }
 
 
@@ -2484,7 +2484,8 @@ int try_to_cast_spell()
         }
         for (int cnt = 0, cnt_end = (2 + rnd(3)); cnt < cnt_end; ++cnt)
         {
-            flt(calcobjlv(cdata.player().level * 3 / 2 + 3), calcfixlv(2));
+            flt(calcobjlv(cdata.player().level * 3 / 2 + 3),
+                calcfixlv(Quality::bad));
             int stat =
                 chara_create(-1, 0, cdata[cc].position.x, cdata[cc].position.y);
             if (stat != 0)
@@ -2690,7 +2691,7 @@ void proc_turn_end(int cc)
         }
         if (cc >= 16)
         {
-            if (cdata[cc].quality >= 4)
+            if (cdata[cc].quality >= Quality::miracle)
             {
                 if (rnd(200) == 0)
                 {
@@ -3113,7 +3114,7 @@ int convertartifact(int prm_930, int prm_931)
 
     while (1)
     {
-        flt(the_item_db[inv[prm_930].id]->level, 4);
+        flt(the_item_db[inv[prm_930].id]->level, Quality::miracle);
         flttypeminor = the_item_db[inv[prm_930].id]->subcategory;
         inv[prm_930].remove();
 
@@ -3609,7 +3610,7 @@ void character_drops_item()
         {
             f = 1;
         }
-        if (cdata[rc].quality >= 4)
+        if (cdata[rc].quality >= Quality::miracle)
         {
             if (rnd(2) == 0)
             {
@@ -3691,8 +3692,8 @@ void character_drops_item()
         }
         inv[ci].remove();
     }
-    if (cdata[rc].quality >= 4 || rnd(20) == 0 || cdata[rc].drops_gold() == 1
-        || rc < 16)
+    if (cdata[rc].quality >= Quality::miracle || rnd(20) == 0
+        || cdata[rc].drops_gold() == 1 || rc < 16)
     {
         if (cdata[rc].gold > 0)
         {
@@ -3714,7 +3715,7 @@ void character_drops_item()
         if (rnd(20) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 52000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3724,7 +3725,7 @@ void character_drops_item()
         if (rnd(20) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 52000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3734,7 +3735,7 @@ void character_drops_item()
         if (rnd(20) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 52000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3744,7 +3745,7 @@ void character_drops_item()
         if (rnd(20) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 53000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3752,7 +3753,7 @@ void character_drops_item()
         if (rnd(40) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 54000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3762,7 +3763,7 @@ void character_drops_item()
         if (rnd(20) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 52000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3772,7 +3773,7 @@ void character_drops_item()
         if (rnd(50) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 54000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3789,7 +3790,7 @@ void character_drops_item()
         if (rnd(40) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 52000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3797,7 +3798,7 @@ void character_drops_item()
         if (rnd(40) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 53000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3805,7 +3806,7 @@ void character_drops_item()
         if (rnd(40) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = choice(fsetwear);
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3813,7 +3814,7 @@ void character_drops_item()
         if (rnd(40) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = choice(fsetweapon);
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3821,7 +3822,7 @@ void character_drops_item()
         if (rnd(20) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 68000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3831,7 +3832,7 @@ void character_drops_item()
         if (rnd(20) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 62000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3842,7 +3843,7 @@ void character_drops_item()
         if (rnd(20) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 62000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3853,7 +3854,7 @@ void character_drops_item()
         if (rnd(10) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 32000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3861,7 +3862,7 @@ void character_drops_item()
         if (rnd(10) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 34000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3869,7 +3870,7 @@ void character_drops_item()
         if (rnd(20) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 54000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3877,7 +3878,7 @@ void character_drops_item()
         if (rnd(10) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 52000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3885,7 +3886,7 @@ void character_drops_item()
         if (rnd(10) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 53000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3893,7 +3894,7 @@ void character_drops_item()
         if (rnd(20) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 72000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3901,7 +3902,7 @@ void character_drops_item()
         if (rnd(10) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 68000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3909,7 +3910,7 @@ void character_drops_item()
         if (rnd(10) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 77000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3919,7 +3920,7 @@ void character_drops_item()
         if (rnd(5) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = choice(fsetwear);
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3927,7 +3928,7 @@ void character_drops_item()
         if (rnd(5) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = choice(fsetweapon);
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3935,7 +3936,7 @@ void character_drops_item()
         if (rnd(20) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 72000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3943,7 +3944,7 @@ void character_drops_item()
         if (rnd(4) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 68000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3953,7 +3954,7 @@ void character_drops_item()
         if (rnd(5) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = choice(fsetwear);
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3961,7 +3962,7 @@ void character_drops_item()
         if (rnd(5) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = choice(fsetweapon);
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3969,7 +3970,7 @@ void character_drops_item()
         if (rnd(15) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 54000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3977,7 +3978,7 @@ void character_drops_item()
         if (rnd(5) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 52000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3985,7 +3986,7 @@ void character_drops_item()
         if (rnd(5) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 53000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3993,7 +3994,7 @@ void character_drops_item()
         if (rnd(10) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 72000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -4001,7 +4002,7 @@ void character_drops_item()
         if (rnd(4) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 68000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -4009,7 +4010,7 @@ void character_drops_item()
         if (rnd(4) == 0)
         {
             p = 0;
-            flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+            flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
             flttypemajor = 77000;
             flttypeminor = 0;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -4020,7 +4021,7 @@ void character_drops_item()
     if (rnd(40) == 0)
     {
         p = 0;
-        flt(calcobjlv(cdata[tc].level), calcfixlv(2));
+        flt(calcobjlv(cdata[tc].level), calcfixlv(Quality::bad));
         flttypemajor = 62000;
         flttypeminor = 0;
         itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -4034,9 +4035,9 @@ void character_drops_item()
     if (gdata_current_map != mdata_t::MapId::arena
         && cdata[rc].character_role != 20)
     {
-        if (rnd(175) == 0 || cdata[rc].quality == 6 || 0
-            || (cdata[rc].quality == 4 && rnd(2) == 0)
-            || (cdata[rc].quality == 5 && rnd(3) == 0))
+        if (rnd(175) == 0 || cdata[rc].quality == Quality::special || 0
+            || (cdata[rc].quality == Quality::miracle && rnd(2) == 0)
+            || (cdata[rc].quality == Quality::godly && rnd(3) == 0))
         {
             flt();
             itemcreate(-1, 504, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -4044,9 +4045,9 @@ void character_drops_item()
             inv[ci].subname = cdata[rc].id;
             cell_refresh(inv[ci].position.x, inv[ci].position.y);
         }
-        if (rnd(175) == 0 || cdata[rc].quality == 6 || 0
-            || (cdata[rc].quality == 4 && rnd(2) == 0)
-            || (cdata[rc].quality == 5 && rnd(3) == 0))
+        if (rnd(175) == 0 || cdata[rc].quality == Quality::special || 0
+            || (cdata[rc].quality == Quality::miracle && rnd(2) == 0)
+            || (cdata[rc].quality == Quality::godly && rnd(3) == 0))
         {
             flt();
             itemcreate(-1, 503, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -4062,7 +4063,7 @@ void character_drops_item()
         inv[ci].param1 = cdata[rc].shop_store_id;
         inv[ci].own_state = 2;
     }
-    if (rollanatomy == 1 || cdata[rc].quality >= 4 || 0
+    if (rollanatomy == 1 || cdata[rc].quality >= Quality::miracle || 0
         || cdata[rc].is_livestock() == 1 || 0)
     {
         flt();
@@ -4275,7 +4276,7 @@ void character_drops_item()
     {
         for (int cnt = 0, cnt_end = (2 + rnd(4)); cnt < cnt_end; ++cnt)
         {
-            flt(cdata[rc].level, 2);
+            flt(cdata[rc].level, Quality::good);
             flttypemajor = 92000;
             nostack = 1;
             itemcreate(-1, 0, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -4641,7 +4642,7 @@ void proc_negative_equipments()
                                  ++cnt)
                             {
                                 flt(calcobjlv(cdata.player().level * 3 / 2 + 3),
-                                    calcfixlv(2));
+                                    calcfixlv(Quality::bad));
                                 chara_create(
                                     -1,
                                     0,
@@ -5500,7 +5501,8 @@ void map_proc_regen_and_update()
                     {
                         if (inv_sum(rc) < 8)
                         {
-                            flt(calcobjlv(cdata[rc].level), calcfixlv(2));
+                            flt(calcobjlv(cdata[rc].level),
+                                calcfixlv(Quality::bad));
                             int stat = itemcreate(rc, 0, -1, -1, 0);
                             if (stat != 0)
                             {
@@ -7486,7 +7488,8 @@ void supply_income()
         {
             dbid = 0;
             flt(calcobjlv((100 - gdata((120 + cnt2)) / 100) / 2 + 1),
-                calcfixlv(3 + (rnd(12) < trait(39))));
+                calcfixlv(
+                    (rnd(12) < trait(39)) ? Quality::miracle : Quality::great));
             flttypemajor = choice(fsetincome);
             if (rnd(5) == 0)
             {
@@ -9829,7 +9832,10 @@ void create_cnpc()
     }
     if (userdata(5, cun))
     {
-        fixlv = clamp(userdata(5, cun), 0, 6);
+        fixlv = static_cast<Quality>(clamp(
+            userdata(5, cun),
+            static_cast<int>(Quality::none),
+            static_cast<int>(Quality::special)));
     }
     cspecialeq = 0;
     cdata[rc].original_relationship = cdata[rc].relationship;
@@ -11466,7 +11472,8 @@ int drink_well()
             txt(i18n::s.get("core.locale.action.drink.well.effect.monster"));
             for (int cnt = 0, cnt_end = (1 + rnd(3)); cnt < cnt_end; ++cnt)
             {
-                flt(calcobjlv(cdata[cc].level * 3 / 2 + 3), calcfixlv(2));
+                flt(calcobjlv(cdata[cc].level * 3 / 2 + 3),
+                    calcfixlv(Quality::bad));
                 chara_create(-1, 0, cdata[cc].position.x, cdata[cc].position.y);
             }
             break;
@@ -12658,7 +12665,7 @@ TurnResult do_bash()
             flt(calcobjlv(
                     gdata_current_dungeon_level
                     * (gdata_current_map != mdata_t::MapId::shelter_)),
-                calcfixlv(2));
+                calcfixlv(Quality::bad));
             flttypemajor = choice(fsetbarrel);
             itemcreate(-1, 0, x, y, 0);
             if (is_in_fov(cdata[cc]))
@@ -12713,7 +12720,8 @@ TurnResult do_bash()
                 }
                 if (rnd(3) == 0)
                 {
-                    if (cdata[cc].quality < 4 && encfind(cc, 60010) == -1)
+                    if (cdata[cc].quality < Quality::miracle
+                        && encfind(cc, 60010) == -1)
                     {
                         --cdata[cc].attr_adjs[0];
                         chara_refresh(cc);
@@ -13459,30 +13467,31 @@ void open_box()
     for (int cnt = 0, cnt_end = (p); cnt < cnt_end; ++cnt)
     {
         dbid = 0;
+        Quality base_quality;
         if (cnt == 0)
         {
-            p = 3;
+            base_quality = Quality::great;
         }
         else
         {
-            p = 2;
+            base_quality = Quality::good;
         }
         if (inv[ri].id == 239)
         {
             if (cnt == 0 && rnd(3) == 0)
             {
-                p = 4;
+                base_quality = Quality::miracle;
             }
             else
             {
-                p = 3;
+                base_quality = Quality::great;
             }
             if (rnd(60) == 0)
             {
                 dbid = 559;
             }
         }
-        flt(calcobjlv(inv[ri].param1), calcfixlv(p));
+        flt(calcobjlv(inv[ri].param1), calcfixlv(base_quality));
         flttypemajor = choice(fsetchest);
         if (cnt > 0)
         {
@@ -13517,10 +13526,10 @@ void open_box()
         {
             flttypeminor = 0;
             flttypemajor = choice(fsetwear);
-            fixlv = 3;
+            fixlv = Quality::great;
             if (inv[ri].id == 416)
             {
-                fixlv = 4;
+                fixlv = Quality::miracle;
             }
             if (rnd(30) == 0)
             {
@@ -13622,7 +13631,8 @@ void open_new_year_gift()
             }
             for (int cnt = 0, cnt_end = (3 + rnd(3)); cnt < cnt_end; ++cnt)
             {
-                flt(calcobjlv(cdata.player().level * 3 / 2 + 3), calcfixlv(2));
+                flt(calcobjlv(cdata.player().level * 3 / 2 + 3),
+                    calcfixlv(Quality::bad));
                 chara_create(-1, 0, cdata[cc].position.x, cdata[cc].position.y);
             }
             return;
@@ -15055,7 +15065,7 @@ void create_harvested_item()
 {
     chara_gain_skill_exp(cdata.player(), 180, 75);
     snd(55);
-    flt(sdata(180, 0) / 2 + 15, 2);
+    flt(sdata(180, 0) / 2 + 15, Quality::good);
     dbid = 0;
     if (feat(2) == 39)
     {
@@ -15068,7 +15078,7 @@ void create_harvested_item()
     if (feat(2) == 40 || (feat(2) == 39 && rnd(50) == 0))
     {
         flttypemajor = choice(fsetplantartifact);
-        fixlv = 4;
+        fixlv = Quality::miracle;
         autosave = 1 * (gdata_current_map != mdata_t::MapId::show_house);
     }
     if (feat(2) == 36)

--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -3062,7 +3062,7 @@ int convertartifact(int prm_930, int prm_931)
     {
         return prm_930;
     }
-    if (inv[prm_930].quality != 6)
+    if (inv[prm_930].quality != Quality::special)
     {
         return prm_930;
     }
@@ -3123,7 +3123,7 @@ int convertartifact(int prm_930, int prm_931)
             inv[prm_930].position.x,
             inv[prm_930].position.y,
             0);
-        if (inv[prm_930].quality != 6)
+        if (inv[prm_930].quality != Quality::special)
         {
             break;
         }
@@ -3601,7 +3601,7 @@ void character_drops_item()
         {
             break;
         }
-        if (inv[ci].quality > 4 || inv[ci].id == 55)
+        if (inv[ci].quality > Quality::miracle || inv[ci].id == 55)
         {
             f = 1;
         }
@@ -3630,7 +3630,7 @@ void character_drops_item()
                 f = 0;
             }
         }
-        if (inv[ci].quality == 6)
+        if (inv[ci].quality == Quality::special)
         {
             f = 1;
         }
@@ -3648,7 +3648,7 @@ void character_drops_item()
             {
                 if (the_item_db[inv[ci].id]->category < 50000)
                 {
-                    if (inv[ci].quality >= 3)
+                    if (inv[ci].quality >= Quality::great)
                     {
                         if (rnd(3))
                         {
@@ -4705,7 +4705,9 @@ void auto_identify()
                         "core.locale.misc.identify.almost_identified",
                         inv[ci],
                         i18n::_(
-                            u8"ui", u8"quality", u8"_"s + inv[ci].quality)));
+                            u8"ui",
+                            u8"quality",
+                            u8"_"s + static_cast<int>(inv[ci].quality))));
                 }
                 item_identify(inv[ci], IdentifyState::almost_identified);
                 chara_gain_skill_exp(cdata.player(), 162, 50);
@@ -9697,7 +9699,7 @@ void load_gene_files()
         {
             continue;
         }
-        if (inv[cnt].quality == 6)
+        if (inv[cnt].quality == Quality::special)
         {
             continue;
         }
@@ -14131,9 +14133,9 @@ label_22191_internal:
         }
         if (attackskill != 106)
         {
-            if (inv[cw].quality >= 4)
+            if (inv[cw].quality >= Quality::miracle)
             {
-                if (inv[cw].quality == 6)
+                if (inv[cw].quality == Quality::special)
                 {
                     s(1) = i18n::s.get("core.locale.misc.wields_proudly")
                         + iknownnameref(inv[cw].id);
@@ -14149,7 +14151,7 @@ label_22191_internal:
                     s(1) = i18n::s.get("core.locale.misc.wields_proudly")
                         + iknownnameref(inv[cw].id);
                 }
-                if (inv[cw].quality == 5)
+                if (inv[cw].quality == Quality::godly)
                 {
                     s(1) = i18n::s.get("core.locale.item.godly_paren", s(1));
                 }

--- a/src/enchantment.cpp
+++ b/src/enchantment.cpp
@@ -1347,11 +1347,11 @@ void add_enchantments()
     {
         inv[ci].count = -1;
     }
-    if (fixlv <= 2)
+    if (fixlv <= Quality::good)
     {
         return;
     }
-    if (fixlv == 6)
+    if (fixlv == Quality::special)
     {
         egolv = 4;
     }
@@ -1359,8 +1359,11 @@ void add_enchantments()
     {
         egolv = rnd(clamp(rnd(objlv / 10 + 3), 0, 4) + 1);
         inv[ci].value = inv[ci].value * 3;
-        inv[ci].difficulty_of_identification =
-            50 + rnd((std::abs((fixlv - 2)) * 100 + 100));
+        inv[ci].difficulty_of_identification = 50
+            + rnd(std::abs(
+                      static_cast<int>(fixlv) - static_cast<int>(Quality::good))
+                      * 100
+                  + 100);
     }
     if (reftypeminor == 10006)
     {
@@ -1391,7 +1394,7 @@ void add_enchantments()
             }
         }
     }
-    if (fixlv < 4)
+    if (fixlv < Quality::miracle)
     {
         if (rnd(2))
         {
@@ -1402,10 +1405,11 @@ void add_enchantments()
             add_enchantment_by_fixed_ego();
         }
     }
-    if (fixlv == 4 || fixlv == 5)
+    if (fixlv == Quality::miracle || fixlv == Quality::godly)
     {
         inv[ci].subname = 40000 + rnd(30000);
-        if (fixlv == 5 || (fixlv == 4 && rnd(10) == 0))
+        if (fixlv == Quality::godly
+            || (fixlv == Quality::miracle && rnd(10) == 0))
         {
             enchantment_add(ci, enchantment_generate(99), enchantment_gen_p());
         }
@@ -1418,11 +1422,11 @@ void add_enchantments()
                 return;
             }
         }
-        if (fixlv == 4)
+        if (fixlv == Quality::miracle)
         {
             p = rnd(rnd(rnd(10) + 1) + 3) + 3;
         }
-        if (fixlv == 5)
+        if (fixlv == Quality::godly)
         {
             p = rnd(rnd(rnd(10) + 1) + 3) + 6;
         }
@@ -1444,12 +1448,12 @@ void add_enchantments()
             enchantment_add(
                 ci,
                 enchantment_generate(enchantment_gen_level(egolv)),
-                enchantment_gen_p() + (fixlv == 5) * 100
+                enchantment_gen_p() + (fixlv == Quality::godly) * 100
                     + (ibit(15, ci) == 1) * 100,
-                20 - (fixlv == 5) * 10 - (ibit(15, ci) == 1) * 20);
+                20 - (fixlv == Quality::godly) * 10 - (ibit(15, ci) == 1) * 20);
         }
     }
-    if (fixlv == 6)
+    if (fixlv == Quality::special)
     {
         for (int cnt = 0, cnt_end = (rnd(3)); cnt < cnt_end; ++cnt)
         {

--- a/src/enums.hpp
+++ b/src/enums.hpp
@@ -96,6 +96,28 @@ enum class IdentifyState : int
     completely_identified = 3,
 };
 
+
+
+/**
+ * Quality of items or characters. They are mainly used for identification.
+ * "unique" is also used instead of special.
+ */
+enum class Quality : int
+{
+    none,
+    bad,
+    good,
+    great,
+    miracle,
+    godly,
+    special,
+};
+
+
+ENUMUTIL_DEFINE_COMPARISON_OPERATORS(Quality)
+
+
+
 enum class DamageSource : int
 {
     trap = -1,

--- a/src/equipment.cpp
+++ b/src/equipment.cpp
@@ -250,11 +250,11 @@ void supply_new_equipment()
         }
         if (cdata[rc].character_role == 13)
         {
-            flt(cdata[rc].level, 3);
+            flt(cdata[rc].level, Quality::great);
         }
         else
         {
-            flt(cdata[rc].level, calcfixlv(2));
+            flt(cdata[rc].level, calcfixlv(Quality::bad));
         }
         mustequip = 0;
         for (int cnt = 0; cnt < 30; ++cnt)
@@ -396,17 +396,17 @@ void supply_initial_equipments()
         fixeq = 0;
         probeq = 10;
     }
-    else if (cdata[rc].quality <= 2)
+    else if (cdata[rc].quality <= Quality::good)
     {
         probeq = 3;
         fixeq = 0;
     }
-    else if (cdata[rc].quality == 3)
+    else if (cdata[rc].quality == Quality::great)
     {
         probeq = 6;
         fixeq = 0;
     }
-    else if (cdata[rc].quality == 4)
+    else if (cdata[rc].quality == Quality::miracle)
     {
         probeq = 8;
         fixeq = 1;
@@ -633,7 +633,7 @@ void supply_initial_equipments()
             eqcloack(1) = 1;
         }
     }
-    if (cdata[rc].quality >= 4)
+    if (cdata[rc].quality >= Quality::miracle)
     {
         for (int cnt = 0; cnt < 2; ++cnt)
         {
@@ -739,7 +739,7 @@ void supply_initial_equipments()
                 if (eqamulet1 >= 10000)
                 {
                     flt(calcobjlv(cdata[rc].level),
-                        calcfixlv(fixeq + eqamulet1(1)));
+                        calcfixlv(static_cast<Quality>(fixeq + eqamulet1(1))));
                     flttypeminor = eqamulet1;
                     dbid = -1;
                 }
@@ -759,7 +759,7 @@ void supply_initial_equipments()
                 if (eqamulet2 >= 10000)
                 {
                     flt(calcobjlv(cdata[rc].level),
-                        calcfixlv(fixeq + eqamulet2(1)));
+                        calcfixlv(static_cast<Quality>(fixeq + eqamulet2(1))));
                     flttypeminor = eqamulet2;
                     dbid = -1;
                 }
@@ -782,7 +782,7 @@ void supply_initial_equipments()
                 if (eqring1 >= 10000)
                 {
                     flt(calcobjlv(cdata[rc].level),
-                        calcfixlv(fixeq + eqring1(1)));
+                        calcfixlv(static_cast<Quality>(fixeq + eqring1(1))));
                     flttypeminor = eqring1;
                     dbid = -1;
                 }
@@ -802,7 +802,7 @@ void supply_initial_equipments()
                 if (eqring2 >= 10000)
                 {
                     flt(calcobjlv(cdata[rc].level),
-                        calcfixlv(fixeq + eqring2(1)));
+                        calcfixlv(static_cast<Quality>(fixeq + eqring2(1))));
                     flttypeminor = eqring2;
                     dbid = -1;
                 }
@@ -825,7 +825,7 @@ void supply_initial_equipments()
                 if (eqcloack >= 10000)
                 {
                     flt(calcobjlv(cdata[rc].level),
-                        calcfixlv(fixeq + eqcloack(1)));
+                        calcfixlv(static_cast<Quality>(fixeq + eqcloack(1))));
                     flttypeminor = eqcloack;
                     dbid = -1;
                 }
@@ -849,7 +849,7 @@ void supply_initial_equipments()
                 if (eqgirdle >= 10000)
                 {
                     flt(calcobjlv(cdata[rc].level),
-                        calcfixlv(fixeq + eqgirdle(1)));
+                        calcfixlv(static_cast<Quality>(fixeq + eqgirdle(1))));
                     flttypeminor = eqgirdle;
                     dbid = -1;
                 }
@@ -873,7 +873,7 @@ void supply_initial_equipments()
                 if (eqhelm >= 10000)
                 {
                     flt(calcobjlv(cdata[rc].level),
-                        calcfixlv(fixeq + eqhelm(1)));
+                        calcfixlv(static_cast<Quality>(fixeq + eqhelm(1))));
                     flttypeminor = eqhelm;
                     dbid = -1;
                 }
@@ -897,7 +897,7 @@ void supply_initial_equipments()
                 if (eqarmor >= 10000)
                 {
                     flt(calcobjlv(cdata[rc].level),
-                        calcfixlv(fixeq + eqarmor(1)));
+                        calcfixlv(static_cast<Quality>(fixeq + eqarmor(1))));
                     flttypeminor = eqarmor;
                     dbid = -1;
                 }
@@ -921,7 +921,7 @@ void supply_initial_equipments()
                 if (eqglove >= 10000)
                 {
                     flt(calcobjlv(cdata[rc].level),
-                        calcfixlv(fixeq + eqglove(1)));
+                        calcfixlv(static_cast<Quality>(fixeq + eqglove(1))));
                     flttypeminor = eqglove;
                     dbid = -1;
                 }
@@ -945,7 +945,7 @@ void supply_initial_equipments()
                 if (eqboots >= 10000)
                 {
                     flt(calcobjlv(cdata[rc].level),
-                        calcfixlv(fixeq + eqboots(1)));
+                        calcfixlv(static_cast<Quality>(fixeq + eqboots(1))));
                     flttypeminor = eqboots;
                     dbid = -1;
                 }
@@ -968,7 +968,8 @@ void supply_initial_equipments()
             {
                 for (int cnt = 0; cnt < 15; ++cnt)
                 {
-                    flt(calcobjlv(cdata[rc].level), calcfixlv(2 + fixeq));
+                    flt(calcobjlv(cdata[rc].level),
+                        calcfixlv(static_cast<Quality>(2 + fixeq)));
                     itemcreate(rc, eqmultiweapon, -1, -1, 0);
                     if (inv[ci].weight > 1500)
                     {
@@ -992,7 +993,8 @@ void supply_initial_equipments()
                     for (int cnt = 0; cnt < 15; ++cnt)
                     {
                         flt(calcobjlv(cdata[rc].level),
-                            calcfixlv(fixeq + eqweapon1(1)));
+                            calcfixlv(
+                                static_cast<Quality>(fixeq + eqweapon1(1))));
                         flttypeminor = eqweapon1;
                         dbid = -1;
                         itemcreate(rc, dbid, -1, -1, 0);
@@ -1039,7 +1041,8 @@ void supply_initial_equipments()
                     for (int cnt = 0; cnt < 15; ++cnt)
                     {
                         flt(calcobjlv(cdata[rc].level),
-                            calcfixlv(fixeq + eqweapon2(1)));
+                            calcfixlv(
+                                static_cast<Quality>(fixeq + eqweapon2(1))));
                         flttypeminor = eqweapon2;
                         dbid = -1;
                         itemcreate(rc, dbid, -1, -1, 0);
@@ -1073,7 +1076,7 @@ void supply_initial_equipments()
                 if (eqshield >= 10000)
                 {
                     flt(calcobjlv(cdata[rc].level),
-                        calcfixlv(fixeq + eqshield(1)));
+                        calcfixlv(static_cast<Quality>(fixeq + eqshield(1))));
                     flttypeminor = eqshield;
                     dbid = -1;
                 }
@@ -1097,7 +1100,7 @@ void supply_initial_equipments()
                 if (eqrange >= 10000)
                 {
                     flt(calcobjlv(cdata[rc].level),
-                        calcfixlv(fixeq + eqrange(1)));
+                        calcfixlv(static_cast<Quality>(fixeq + eqrange(1))));
                     flttypeminor = eqrange;
                     dbid = -1;
                 }
@@ -1121,7 +1124,7 @@ void supply_initial_equipments()
                 if (eqammo >= 10000)
                 {
                     flt(calcobjlv(cdata[rc].level),
-                        calcfixlv(fixeq + eqammo(1)));
+                        calcfixlv(static_cast<Quality>(fixeq + eqammo(1))));
                     flttypeminor = eqammo;
                     dbid = -1;
                 }

--- a/src/equipment.cpp
+++ b/src/equipment.cpp
@@ -325,7 +325,7 @@ void supply_new_equipment()
             break;
         }
         inv[ci].identification_state = IdentifyState::completely_identified;
-        if (inv[ci].quality >= 4)
+        if (inv[ci].quality >= Quality::miracle)
         {
             if (the_item_db[inv[ci].id]->category < 50000)
             {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1201,13 +1201,13 @@ void initialize_noa_items()
     }
     for (int cnt = 0; cnt < 40; ++cnt)
     {
-        flt(50, 5);
+        flt(50, Quality::godly);
         flttypemajor = 56000;
         itemcreate(0, -1, -1, -1, 0);
-        flt(50, 5);
+        flt(50, Quality::godly);
         flttypemajor = 34000;
         itemcreate(0, -1, -1, -1, 0);
-        flt(50, 5);
+        flt(50, Quality::godly);
         flttypemajor = 32000;
         itemcreate(0, -1, -1, -1, 0);
     }

--- a/src/initialize_map.cpp
+++ b/src/initialize_map.cpp
@@ -794,7 +794,7 @@ label_1741_internal:
         }
         if (arenaop == 0)
         {
-            fixlv = arenaop(2);
+            fixlv = static_cast<Quality>(arenaop(2));
             chara_create(
                 -1,
                 arenaop(1),
@@ -810,7 +810,7 @@ label_1741_internal:
         {
             for (int cnt = 0, cnt_end = (3 + rnd(4)); cnt < cnt_end; ++cnt)
             {
-                flt(arenaop(1), 2);
+                flt(arenaop(1), Quality::good);
                 chara_create(
                     -1,
                     0,
@@ -857,7 +857,7 @@ label_1741_internal:
         petarenawin = 0;
         for (int cnt = 0, cnt_end = (arenaop(1)); cnt < cnt_end; ++cnt)
         {
-            flt(arenaop(2), calcfixlv(3));
+            flt(arenaop(2), calcfixlv(Quality::good));
             chara_create(-1, 0, -3, 0);
             map(cdata[rc].position.x, cdata[rc].position.y, 1) = 0;
             f = 1;
@@ -2298,7 +2298,7 @@ label_1741_internal:
             p = rnd(3) + 5;
             for (int cnt = 0, cnt_end = (p); cnt < cnt_end; ++cnt)
             {
-                flt(qdata(5, rq), 3);
+                flt(qdata(5, rq), Quality::great);
                 int stat = chara_create(
                     -1,
                     0,
@@ -2346,12 +2346,12 @@ label_1741_internal:
             }
             for (int cnt = 0, cnt_end = (2 + p); cnt < cnt_end; ++cnt)
             {
-                flt(calcobjlv(encounterlv), calcfixlv(2));
+                flt(calcobjlv(encounterlv), calcfixlv(Quality::bad));
                 if (gdata_weather == 1)
                 {
                     if ((33 > gdata(62) || gdata(62) >= 66) && rnd(3) == 0)
                     {
-                        fixlv = 5;
+                        fixlv = Quality::godly;
                     }
                 }
                 if (cnt < 4)

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -916,7 +916,7 @@ std::string itemname(int prm_518, int prm_519, int prm_520)
     {
         return i18n::s.get("core.locale.item.unknown_item");
     }
-    if (inv[prm_518].quality >= 5)
+    if (inv[prm_518].quality >= Quality::godly)
     {
         iqiality_(prm_518) = 5;
     }
@@ -1175,9 +1175,9 @@ std::string itemname(int prm_518, int prm_519, int prm_520)
                         + i18n::space_if_needed();
                 }
             }
-            if (inv[prm_518].quality != 6)
+            if (inv[prm_518].quality != Quality::special)
             {
-                if (inv[prm_518].quality >= 4)
+                if (inv[prm_518].quality >= Quality::miracle)
                 {
                     s_ += i18n::_(
                               u8"item_material",
@@ -1215,7 +1215,7 @@ std::string itemname(int prm_518, int prm_519, int prm_520)
         inv[prm_518].identification_state
         != IdentifyState::completely_identified)
     {
-        if (inv[prm_518].quality < 4 || a_ >= 50000)
+        if (inv[prm_518].quality < Quality::miracle || a_ >= 50000)
         {
             s_ += ioriginalnameref(inv[prm_518].id);
         }
@@ -1224,7 +1224,7 @@ std::string itemname(int prm_518, int prm_519, int prm_520)
             s_ += iknownnameref(inv[prm_518].id);
         }
     }
-    else if (inv[prm_518].quality == 6 || ibit(5, prm_518) == 1)
+    else if (inv[prm_518].quality == Quality::special || ibit(5, prm_518) == 1)
     {
         if (jp)
         {
@@ -1237,7 +1237,7 @@ std::string itemname(int prm_518, int prm_519, int prm_520)
     }
     else
     {
-        if (inv[prm_518].quality >= 4 && jp)
+        if (inv[prm_518].quality >= Quality::miracle && jp)
         {
             s_ = u8"☆"s + s_;
         }
@@ -1257,7 +1257,7 @@ std::string itemname(int prm_518, int prm_519, int prm_520)
         if (inv[prm_518].subname >= 40000)
         {
             randomize(inv[prm_518].subname - 40000);
-            if (inv[prm_518].quality == 4)
+            if (inv[prm_518].quality == Quality::miracle)
             {
                 s_ += i18n::space_if_needed()
                     + i18n::s.get(
@@ -1279,7 +1279,7 @@ label_0313_internal:
         {
             if (inv[prm_518].identification_state
                     == IdentifyState::completely_identified
-                && (inv[prm_518].quality >= 4 && a_ < 50000))
+                && (inv[prm_518].quality >= Quality::miracle && a_ < 50000))
             {
                 s_ = u8"the "s + s_;
             }
@@ -1385,7 +1385,10 @@ label_0313_internal:
         && a_ < 50000)
     {
         s_ += u8" ("s
-            + cnven(i18n::_(u8"ui", u8"quality", u8"_"s + inv[prm_518].quality))
+            + cnven(i18n::_(
+                  u8"ui",
+                  u8"quality",
+                  u8"_"s + static_cast<int>(inv[prm_518].quality)))
             + u8")"s;
         if (jp)
         {
@@ -1508,7 +1511,8 @@ void remain_make(int ci, int cc)
 
 int item_stack(int inventory_id, int ci, int show_message)
 {
-    if (inv[ci].quality == 6 && the_item_db[inv[ci].id]->category < 50000)
+    if (inv[ci].quality == Quality::special
+        && the_item_db[inv[ci].id]->category < 50000)
     {
         return 0;
     }
@@ -1708,7 +1712,8 @@ bool item_fire(int owner, int ci)
             continue;
         }
 
-        if (a_ == 72000 || a_ == 59000 || a_ == 68000 || inv[ci_].quality >= 4)
+        if (a_ == 72000 || a_ == 59000 || a_ == 68000
+            || inv[ci_].quality >= Quality::miracle)
         {
             continue;
         }
@@ -1908,7 +1913,7 @@ bool item_cold(int owner, int ci)
         {
             continue;
         }
-        if (inv[ci_].quality >= 4 || inv[ci_].body_part != 0)
+        if (inv[ci_].quality >= Quality::miracle || inv[ci_].body_part != 0)
         {
             continue;
         }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1636,7 +1636,8 @@ bool item_fire(int owner, int ci)
 
     if (owner != -1)
     {
-        if (sdata(50, owner) / 50 >= 6 || cdata[owner].quality >= 4)
+        if (sdata(50, owner) / 50 >= 6
+            || cdata[owner].quality >= Quality::miracle)
         {
             return false;
         }
@@ -1865,7 +1866,8 @@ bool item_cold(int owner, int ci)
     }
     if (owner != -1)
     {
-        if (sdata(51, owner) / 50 >= 6 || cdata[owner].quality >= 4)
+        if (sdata(51, owner) / 50 >= 6
+            || cdata[owner].quality >= Quality::miracle)
         {
             return false;
         }

--- a/src/item.hpp
+++ b/src/item.hpp
@@ -51,7 +51,7 @@ struct Item
     int value = 0;
     int image = 0;
     int id = 0;
-    int quality = 0;
+    Quality quality = Quality::none;
     Position position;
     int weight = 0;
     IdentifyState identification_state = IdentifyState::unidentified;

--- a/src/itemgen.cpp
+++ b/src/itemgen.cpp
@@ -228,7 +228,7 @@ int do_create_item(int slot, int x, int y)
 
     ++itemmemory(1, dbid);
 
-    inv[ci].quality = fixlv;
+    inv[ci].quality = static_cast<Quality>(fixlv);
     if (fixlv == 6 && mode != 6 && nooracle == 0)
     {
         int owner = inv_getowner(ci);
@@ -289,11 +289,11 @@ int do_create_item(int slot, int x, int y)
     if (inv[ci].id == 54)
     {
         inv[ci].set_number(calcinitgold(slot));
-        if (inv[ci].quality == 3)
+        if (inv[ci].quality == Quality::great)
         {
             inv[ci].set_number(inv[ci].number() * 2);
         }
-        if (inv[ci].quality >= 4)
+        if (inv[ci].quality >= Quality::miracle)
         {
             inv[ci].set_number(inv[ci].number() * 4);
         }
@@ -515,7 +515,7 @@ void init_item_quality_curse_state_material_and_equipments()
             }
         }
     }
-    if (cm || mode == 1 || inv[ci].quality == 6)
+    if (cm || mode == 1 || inv[ci].quality == Quality::special)
     {
         inv[ci].curse_state = CurseState::none;
     }
@@ -552,9 +552,9 @@ void init_item_quality_curse_state_material_and_equipments()
     {
         add_enchantments();
     }
-    else if (inv[ci].quality != 6)
+    else if (inv[ci].quality != Quality::special)
     {
-        inv[ci].quality = 2;
+        inv[ci].quality = Quality::good;
     }
     return;
 }
@@ -678,7 +678,7 @@ void change_item_material()
     inv[ci].color = 0;
     p = inv[ci].material;
     reftype = the_item_db[inv[ci].id]->category;
-    fixlv = inv[ci].quality;
+    fixlv = static_cast<int>(inv[ci].quality);
     for (auto e : the_item_material_db[p]->enchantments)
     {
         enchantment_remove(ci, e.id, e.power);

--- a/src/itemgen.cpp
+++ b/src/itemgen.cpp
@@ -93,11 +93,11 @@ void get_random_item_id()
 
 int do_create_item(int slot, int x, int y)
 {
-    if ((slot == 0 || slot == -1) && fixlv < 5)
+    if ((slot == 0 || slot == -1) && fixlv < Quality::godly)
     {
         if (sdata(19, 0) > rnd(5000)) // TODO coupling
         {
-            ++fixlv;
+            fixlv = static_cast<Quality>(static_cast<int>(fixlv) + 1);
         }
     }
 
@@ -172,14 +172,14 @@ int do_create_item(int slot, int x, int y)
     {
         if (fltselect == 0 && mode != 6)
         {
-            if (fixlv == 3)
+            if (fixlv == Quality::great)
             {
                 if (rnd(1000) == 0)
                 {
                     fltselect = 2;
                 }
             }
-            if (fixlv == 4)
+            if (fixlv == Quality::miracle)
             {
                 if (rnd(100) == 0)
                 {
@@ -193,7 +193,7 @@ int do_create_item(int slot, int x, int y)
         {
             if (fltselect == 2)
             {
-                fixlv = 4;
+                fixlv = Quality::miracle;
             }
             objlv += 10;
             fltselect = 0;
@@ -229,7 +229,7 @@ int do_create_item(int slot, int x, int y)
     ++itemmemory(1, dbid);
 
     inv[ci].quality = static_cast<Quality>(fixlv);
-    if (fixlv == 6 && mode != 6 && nooracle == 0)
+    if (fixlv == Quality::special && mode != 6 && nooracle == 0)
     {
         int owner = inv_getowner(ci);
         if (owner != -1)
@@ -678,7 +678,7 @@ void change_item_material()
     inv[ci].color = 0;
     p = inv[ci].material;
     reftype = the_item_db[inv[ci].id]->category;
-    fixlv = static_cast<int>(inv[ci].quality);
+    fixlv = inv[ci].quality;
     for (auto e : the_item_material_db[p]->enchantments)
     {
         enchantment_remove(ci, e.id, e.power);
@@ -730,17 +730,17 @@ void apply_item_material()
     }
     p(1) = 120;
     p(2) = 80;
-    if (fixlv == 1)
+    if (fixlv == Quality::bad)
     {
         p(1) = 150;
         p(2) = 80;
     }
-    if (fixlv == 3)
+    if (fixlv == Quality::great)
     {
         p(1) = 100;
         p(2) = 70;
     }
-    if (fixlv >= 4)
+    if (fixlv >= Quality::miracle)
     {
         p(1) = 80;
         p(2) = 70;

--- a/src/lib/enumutil.hpp
+++ b/src/lib/enumutil.hpp
@@ -49,3 +49,21 @@
     ENUMUTIL_DEFINE_BITWISE_OR_OPERATOR(Enum) \
     ENUMUTIL_DEFINE_BITWISE_XOR_OPERATOR(Enum) \
     ENUMUTIL_DEFINE_BITWISE_NOT_OPERATOR(Enum)
+
+
+
+#define ENUMUTIL_INTERNAL_DEFINE_COMPARISON_OPERATOR(Enum, op) \
+    inline constexpr bool operator op(Enum lhs, Enum rhs) \
+    { \
+        using underlying_type = std::underlying_type_t<Enum>; \
+        return static_cast<underlying_type>(lhs) \
+            op static_cast<underlying_type>(rhs); \
+    }
+
+
+/// Define 4 comparison operators.
+#define ENUMUTIL_DEFINE_COMPARISON_OPERATORS(Enum) \
+    ENUMUTIL_INTERNAL_DEFINE_COMPARISON_OPERATOR(Enum, <) \
+    ENUMUTIL_INTERNAL_DEFINE_COMPARISON_OPERATOR(Enum, <=) \
+    ENUMUTIL_INTERNAL_DEFINE_COMPARISON_OPERATOR(Enum, >) \
+    ENUMUTIL_INTERNAL_DEFINE_COMPARISON_OPERATOR(Enum, >=)

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -3199,7 +3199,8 @@ label_2181_internal:
         invctrl(1) = 0;
         snd(100);
         ctrl_inventory();
-        if (inv[ci].quality < 4 || inv[ci].quality == 6)
+        if (inv[ci].quality < Quality::miracle
+            || inv[ci].quality == Quality::special)
         {
             txt(i18n::s.get("core.locale.common.it_is_impossible"));
             obvious = 0;
@@ -3238,7 +3239,7 @@ label_2181_internal:
                 break;
             }
         }
-        if (inv[ci].quality >= 4 || ibit(10, ci) == 1)
+        if (inv[ci].quality >= Quality::miracle || ibit(10, ci) == 1)
         {
             txt(i18n::s.get("core.locale.magic.garoks_hammer.no_effect"));
             fixmaterial = 0;
@@ -3248,7 +3249,7 @@ label_2181_internal:
         randomize(inv[efcibk].param1);
         equip = inv[ci].body_part;
         animeload(8, cc);
-        inv[ci].quality = 4;
+        inv[ci].quality = Quality::miracle;
         fixmaterial = inv[ci].material;
         change_item_material();
         randomize(inv[efcibk].param1);
@@ -3296,7 +3297,7 @@ label_2181_internal:
             MenuResult result = ctrl_inventory();
             f = result.succeeded ? 1 : 0;
         }
-        if (inv[ci].quality == 5 || ibit(10, ci) == 1)
+        if (inv[ci].quality == Quality::godly || ibit(10, ci) == 1)
         {
             if (efid == 1127)
             {
@@ -3306,7 +3307,7 @@ label_2181_internal:
         equip = inv[ci].body_part;
         if (f == 1)
         {
-            if (inv[ci].quality == 6)
+            if (inv[ci].quality == Quality::special)
             {
                 if (efp < 350)
                 {
@@ -3699,7 +3700,7 @@ label_2181_internal:
         }
         if (f)
         {
-            if (inv[ci].quality > 4 || ibit(5, ci) == 1)
+            if (inv[ci].quality > Quality::miracle || ibit(5, ci) == 1)
             {
                 f = 0;
             }

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -696,7 +696,7 @@ int magic()
                 if (efid == 613)
                 {
                     p = rnd(10);
-                    if ((cdata[tc].quality >= 4 && rnd(4))
+                    if ((cdata[tc].quality >= Quality::miracle && rnd(4))
                         || encfind(tc, 60010 + p) != -1)
                     {
                         p = -1;
@@ -759,7 +759,7 @@ int magic()
                 for (int cnt = 0, cnt_end = (1 + rnd(p(0))); cnt < cnt_end;
                      ++cnt)
                 {
-                    flt(calcobjlv(efp), 2);
+                    flt(calcobjlv(efp), Quality::good);
                     dbid = 0;
                     if (efid == 425)
                     {
@@ -2009,7 +2009,7 @@ label_2181_internal:
             txt(i18n::s.get("core.locale.magic.resurrection.cursed"));
             for (int cnt = 0, cnt_end = (4 + rnd(4)); cnt < cnt_end; ++cnt)
             {
-                flt(calcobjlv(cdata.player().level), calcfixlv(3));
+                flt(calcobjlv(cdata.player().level), calcfixlv(Quality::good));
                 fltn(u8"undead"s);
                 chara_create(
                     -1,
@@ -2549,7 +2549,7 @@ label_2181_internal:
         {
             break;
         }
-        if (cdata[tc].quality >= 4)
+        if (cdata[tc].quality >= Quality::miracle)
         {
             break;
         }
@@ -2727,7 +2727,7 @@ label_2181_internal:
             const auto attr = p(cnt) - 10;
             if (is_cursed(efstatus))
             {
-                if (cdata[tc].quality <= 3)
+                if (cdata[tc].quality <= Quality::great)
                 {
                     cdata[tc].attr_adjs[attr] -=
                         rnd(sdata.get(p(cnt), tc).original_level) / 5 + rnd(5);
@@ -3024,7 +3024,7 @@ label_2181_internal:
             txt(i18n::s.get("core.locale.common.nothing_happens"));
             break;
         }
-        flt(cdata.player().level / 2 + 5, 3);
+        flt(cdata.player().level / 2 + 5, Quality::great);
         p = 0;
         if (rnd(3) == 0)
         {
@@ -3078,7 +3078,8 @@ label_2181_internal:
         {
             f = 0;
         }
-        if (cdata[tc].quality >= 4 || cdata[tc].character_role != 0
+        if (cdata[tc].quality >= Quality::miracle
+            || cdata[tc].character_role != 0
             || cdata[tc].is_lord_of_dungeon() == 1)
         {
             f = -1;
@@ -3262,9 +3263,9 @@ label_2181_internal:
             enchantment_add(
                 ci,
                 enchantment_generate(enchantment_gen_level(egolv)),
-                enchantment_gen_p() + (fixlv == 5) * 100
+                enchantment_gen_p() + (fixlv == Quality::godly) * 100
                     + (ibit(15, ci) == 1) * 100,
-                20 - (fixlv == 5) * 10 - (ibit(15, ci) == 1) * 20);
+                20 - (fixlv == Quality::godly) * 10 - (ibit(15, ci) == 1) * 20);
         }
         randomize();
         txt(i18n::s.get("core.locale.magic.garoks_hammer.apply", inv[ci]));
@@ -3588,8 +3589,8 @@ label_2181_internal:
         {
             f = 0;
         }
-        if (cdata[tc].quality >= 4 || cdata[tc].character_role != 0
-            || cdata[tc].is_escorted() == 1
+        if (cdata[tc].quality >= Quality::miracle
+            || cdata[tc].character_role != 0 || cdata[tc].is_escorted() == 1
             || cdata[tc].is_lord_of_dungeon() == 1)
         {
             f = -1;
@@ -3602,7 +3603,7 @@ label_2181_internal:
         {
             animeload(8, tc);
             txt(i18n::s.get("core.locale.magic.change.apply", cdata[tc]));
-            flt(calcobjlv(cdata[tc].level + 3), 2);
+            flt(calcobjlv(cdata[tc].level + 3), Quality::good);
             chara_create(56, 0, -3, 0);
             chara_relocate(cdata.tmp(), tc(0), CharaRelocationMode::change);
             cdata[tc].enemy_id = cc;
@@ -3714,7 +3715,7 @@ label_2181_internal:
             inv[ci].remove();
             for (int cnt = 0;; ++cnt)
             {
-                flt(calcobjlv(efp / 10) + 5, calcfixlv(3));
+                flt(calcobjlv(efp / 10) + 5, calcfixlv(Quality::good));
                 if (cnt < 10)
                 {
                     flttypemajor = fltbk;
@@ -4191,7 +4192,7 @@ label_2181_internal:
         for (int i = 0; i < clamp(4 + rnd(efp / 50 + 1), 1, 15); ++i)
         {
             snd(64);
-            flt(calcobjlv(efp / 10), calcfixlv(3));
+            flt(calcobjlv(efp / 10), calcfixlv(Quality::good));
             dbid = 54;
             int number = 400 + rnd(efp);
             if (rnd(30) == 0)

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -1455,7 +1455,8 @@ void map_randsite(int prm_971, int prm_972)
         }
         if (rnd(18) == 0)
         {
-            flt(calcobjlv(rnd(cdata.player().level + 10)), calcfixlv(3));
+            flt(calcobjlv(rnd(cdata.player().level + 10)),
+                calcfixlv(Quality::good));
             flttypemajor = choice(fsetwear);
             itemcreate(-1, 0, x_at_m169, y_at_m169, 0);
             return;
@@ -2081,7 +2082,8 @@ void generate_random_nefia()
         {
             if (rnd(2) == 0)
             {
-                flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(2));
+                flt(calcobjlv(gdata_current_dungeon_level),
+                    calcfixlv(Quality::bad));
                 flttypemajor = fltsetdungeon();
                 itemcreate(-1, 0, rnd(rw) + rx, rnd(rh) + ry, 0);
             }
@@ -2100,7 +2102,7 @@ void generate_random_nefia()
                                  cnt < cnt_end;
                                  ++cnt)
                             {
-                                flt(cdata[rc].level, calcfixlv(2));
+                                flt(cdata[rc].level, calcfixlv(Quality::bad));
                                 flttypemajor = creaturepack;
                                 chara_create(-1, 0, rnd(rw) + rx, rnd(rh) + ry);
                             }
@@ -2157,7 +2159,7 @@ void generate_random_nefia()
     {
         flt();
         flttypemajor = choice(fsetwear);
-        fixlv = 4;
+        fixlv = Quality::miracle;
         itemcreate(-1, 0, -1, -1, 0);
         mobdensity = mdata_map_max_crowd_density / 2;
         itemdensity = mdata_map_max_crowd_density / 3;
@@ -2184,7 +2186,7 @@ void generate_random_nefia()
     }
     for (int cnt = 0, cnt_end = (itemdensity); cnt < cnt_end; ++cnt)
     {
-        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(2));
+        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(Quality::bad));
         flttypemajor = fltsetdungeon();
         itemcreate(-1, 0, -1, -1, 0);
     }
@@ -2942,7 +2944,7 @@ int initialize_quest_map_party()
              cnt < cnt_end;
              ++cnt)
         {
-            flt(roomdiff * 5, calcfixlv(2));
+            flt(roomdiff * 5, calcfixlv(Quality::bad));
             initlv = roomdiff * 7 + rnd(5);
             dbid = list(rnd(3), roomdiff);
             chara_create(-1, dbid, rnd(rw) + rx, rnd(rh) + ry);
@@ -3065,7 +3067,7 @@ void initialize_quest_map_town()
         gdata(87) = 9999;
         flt();
         initlv = qdata(5, gdata_executing_immediate_quest);
-        fixlv = 5;
+        fixlv = Quality::godly;
         chara_create(-1, qdata(12, gdata_executing_immediate_quest), -3, 0);
         cdata[rc].relationship = -3;
         cdata[rc].original_relationship = -3;
@@ -3077,7 +3079,7 @@ void initialize_quest_map_town()
         {
             flt();
             initlv = qdata(5, gdata_executing_immediate_quest) * 3 / 2;
-            fixlv = 1;
+            fixlv = Quality::bad;
             chara_create(-1, qdata(12, gdata_executing_immediate_quest), -3, 0);
             cdata[rc].relationship = -3;
             cdata[rc].original_relationship = -3;

--- a/src/proc_event.cpp
+++ b/src/proc_event.cpp
@@ -180,7 +180,7 @@ void proc_event()
             u8"bg_re14");
         for (int i = 0; i < 5; ++i)
         {
-            flt(calcobjlv(cdata[marry].level + 5), calcfixlv(3));
+            flt(calcobjlv(cdata[marry].level + 5), calcfixlv(Quality::good));
             flttypemajor = choice(fsetchest);
             itemcreate(
                 -1, 0, cdata.player().position.x, cdata.player().position.y, 0);
@@ -206,7 +206,7 @@ void proc_event()
         });
         randomize();
         flt();
-        fixlv = 4;
+        fixlv = Quality::miracle;
         initlv = clamp(gdata_current_dungeon_level / 4, 50, 250);
         chara_create(-1, c, -3, 0);
         cdata[rc].is_lord_of_dungeon() = true;
@@ -225,7 +225,7 @@ void proc_event()
         while (1)
         {
             chara_set_generation_filter();
-            fixlv = 4;
+            fixlv = Quality::miracle;
             initlv = gdata_current_dungeon_level + rnd(5);
             int stat = chara_create(-1, 0, -3, 0);
             if (stat == 0)
@@ -389,7 +389,7 @@ void proc_event()
         }
         if (rnd(3) == 0)
         {
-            flt(0, 2);
+            flt(0, Quality::good);
             for (int i = 0; i < 1; ++i)
             {
                 if (gdata_last_month_when_trainer_visited != gdata_month
@@ -859,7 +859,7 @@ void proc_event()
             mapitem_fire(x, y);
             if (i % 4 == 0)
             {
-                flt(100, calcfixlv(3));
+                flt(100, calcfixlv(Quality::good));
                 if (rnd(4))
                 {
                     fltnrace = u8"dragon"s;

--- a/src/quest.cpp
+++ b/src/quest.cpp
@@ -437,7 +437,7 @@ void quest_on_map_initialize()
         {
             continue;
         }
-        if (cnt.quality == 6)
+        if (cnt.quality == Quality::special)
         {
             continue;
         }
@@ -549,7 +549,7 @@ int quest_generate()
             {
                 continue;
             }
-            flt(40, 2);
+            flt(40, Quality::good);
             flttypemajor = choice(fsetcollect);
             int stat = itemcreate(n, 0, -1, -1, 0);
             if (stat != 0)
@@ -591,7 +591,7 @@ int quest_generate()
             minlevel = clamp(qdata(5, rq) / 7, 5, 30);
             for (int cnt = 0; cnt < 50; ++cnt)
             {
-                flt(qdata(5, rq), 2);
+                flt(qdata(5, rq), Quality::good);
                 chara_create(56, 0, -3, 0);
                 if (cmshade)
                 {
@@ -627,7 +627,7 @@ int quest_generate()
             minlevel = clamp(qdata(5, rq) / 4, 5, 30);
             for (int cnt = 0; cnt < 50; ++cnt)
             {
-                flt(qdata(5, rq), 2);
+                flt(qdata(5, rq), Quality::good);
                 chara_create(56, 0, -3, 0);
                 if (cmshade)
                 {
@@ -1286,13 +1286,13 @@ void quest_complete()
         }
         for (int cnt = 0, cnt_end = (p); cnt < cnt_end; ++cnt)
         {
-            fixlv = 2;
+            fixlv = Quality::good;
             if (rnd(2))
             {
-                fixlv = 3;
+                fixlv = Quality::great;
                 if (rnd(12) == 0)
                 {
-                    fixlv = 4;
+                    fixlv = Quality::miracle;
                 }
             }
             flt((qdata(5, rq) + cdata.player().level) / 2 + 1,

--- a/src/random_event.cpp
+++ b/src/random_event.cpp
@@ -521,7 +521,7 @@ void run_random_event(RandomEvent event)
             modify_karma(cdata.player(), -2);
             for (int cnt = 0, cnt_end = (1 + rnd(3)); cnt < cnt_end; ++cnt)
             {
-                flt(0, calcfixlv(3));
+                flt(0, calcfixlv(Quality::good));
                 if (rnd(3) == 0)
                 {
                     flttypemajor = fsetwear(rnd(fsetwear.size()));

--- a/src/shop.cpp
+++ b/src/shop.cpp
@@ -93,7 +93,7 @@ void shop_refresh()
     }
     for (int cnt = 0, cnt_end = (p); cnt < cnt_end; ++cnt)
     {
-        flt(calcobjlv(cdata[tc].shop_rank), calcfixlv(2));
+        flt(calcobjlv(cdata[tc].shop_rank), calcfixlv(Quality::bad));
         dbid = 0;
         if (cdata[tc].character_role == 1004)
         {
@@ -161,11 +161,11 @@ void shop_refresh()
             }
             if (rnd(3) == 0)
             {
-                fixlv = 3;
+                fixlv = Quality::great;
             }
             if (rnd(10) == 0)
             {
-                fixlv = 4;
+                fixlv = Quality::miracle;
             }
         }
         if (cdata[tc].character_role == 1006)
@@ -236,21 +236,21 @@ void shop_refresh()
             flttypemajor = choice(fsetwear);
             if (rnd(3) == 0)
             {
-                fixlv = 3;
+                fixlv = Quality::great;
             }
             if (rnd(10) == 0)
             {
-                fixlv = 4;
+                fixlv = Quality::miracle;
             }
         }
         if (cdata[tc].character_role == 1010
             || cdata[tc].character_role == 2003)
         {
             flttypemajor = choice(fsetwear);
-            fixlv = 3;
+            fixlv = Quality::great;
             if (rnd(2) == 0)
             {
-                fixlv = 4;
+                fixlv = Quality::miracle;
             }
         }
         if (cdata[tc].character_role == 1005)

--- a/src/status_ailment.cpp
+++ b/src/status_ailment.cpp
@@ -55,7 +55,7 @@ void dmgcon(int cc, StatusAilment status_ailment, int power)
     case StatusAilment::blinded:
         if (cdata[cc].is_immune_to_blindness())
             return;
-        if (cdata[cc].quality > 3 && rnd(cdata[cc].level / 2 + 1))
+        if (cdata[cc].quality > Quality::great && rnd(cdata[cc].level / 2 + 1))
             return;
         power =
             calc_power_decreased_by_resistance(cc, power, Element::darkness);
@@ -83,7 +83,7 @@ void dmgcon(int cc, StatusAilment status_ailment, int power)
             return;
         if (buff_has(cdata[cc], 7))
             return;
-        if (cdata[cc].quality > 3 && rnd(cdata[cc].level / 2 + 1))
+        if (cdata[cc].quality > Quality::great && rnd(cdata[cc].level / 2 + 1))
             return;
         power = calc_power_decreased_by_resistance(cc, power, Element::mind);
         turn = power / 7;
@@ -108,7 +108,7 @@ void dmgcon(int cc, StatusAilment status_ailment, int power)
     case StatusAilment::paralyzed:
         if (cdata[cc].is_immune_to_paralyzation())
             return;
-        if (cdata[cc].quality > 3 && rnd(cdata[cc].level + 1))
+        if (cdata[cc].quality > Quality::great && rnd(cdata[cc].level + 1))
             return;
         power = calc_power_decreased_by_resistance(cc, power, Element::nerve);
         turn = power / 10;
@@ -133,7 +133,7 @@ void dmgcon(int cc, StatusAilment status_ailment, int power)
     case StatusAilment::poisoned:
         if (cdata[cc].is_immune_to_poison())
             return;
-        if (cdata[cc].quality > 3 && rnd(cdata[cc].level / 3 + 1))
+        if (cdata[cc].quality > Quality::great && rnd(cdata[cc].level / 3 + 1))
             return;
         power = calc_power_decreased_by_resistance(cc, power, Element::poison);
         turn = power / 5;
@@ -158,7 +158,7 @@ void dmgcon(int cc, StatusAilment status_ailment, int power)
     case StatusAilment::sleep:
         if (cdata[cc].is_immune_to_sleep())
             return;
-        if (cdata[cc].quality > 3 && rnd(cdata[cc].level / 5 + 1))
+        if (cdata[cc].quality > Quality::great && rnd(cdata[cc].level / 5 + 1))
             return;
         power = calc_power_decreased_by_resistance(cc, power, Element::nerve);
         turn = power / 4;
@@ -187,7 +187,7 @@ void dmgcon(int cc, StatusAilment status_ailment, int power)
             return;
         if (buff_has(cdata[cc], 7))
             return;
-        if (cdata[cc].quality > 3 && rnd(cdata[cc].level / 5 + 1))
+        if (cdata[cc].quality > Quality::great && rnd(cdata[cc].level / 5 + 1))
             return;
         power = calc_power_decreased_by_resistance(cc, power, Element::mind);
         turn = power / 7;
@@ -204,7 +204,7 @@ void dmgcon(int cc, StatusAilment status_ailment, int power)
         }
         return;
     case StatusAilment::dimmed:
-        if (cdata[cc].quality > 3 && rnd(cdata[cc].level / 3 + 1))
+        if (cdata[cc].quality > Quality::great && rnd(cdata[cc].level / 3 + 1))
             return;
         if (cdatan(2, cc) == u8"golem"s)
             return;
@@ -229,7 +229,7 @@ void dmgcon(int cc, StatusAilment status_ailment, int power)
         rowactend(cc);
         return;
     case StatusAilment::bleeding:
-        if (cdata[cc].quality > 3)
+        if (cdata[cc].quality > Quality::great)
         {
             power /= 2;
         }

--- a/src/talk.cpp
+++ b/src/talk.cpp
@@ -117,7 +117,7 @@ void talk_to_npc()
     }
     chatval_unique_chara_id = none;
     chatval_show_impress = true;
-    if (cdata[tc].quality == 6 && tc >= 16)
+    if (cdata[tc].quality == Quality::special && tc >= 16)
     {
         chatval_unique_chara_id = cdata[tc].id;
         chatval_show_impress = false;

--- a/src/talk_npc.cpp
+++ b/src/talk_npc.cpp
@@ -283,7 +283,7 @@ TalkResult talk_arena_master(int chatval_)
             }
             minlevel = arenaop(1) / 3 * 2;
             flt(arenaop(1));
-            fixlv = arenaop(2);
+            fixlv = static_cast<Quality>(arenaop(2));
             chara_create(56, 0, -3, 0);
             if (cmshade)
             {
@@ -663,7 +663,7 @@ TalkResult talk_slave_buy(int chatval_)
     for (int cnt = 0; cnt < 10; ++cnt)
     {
         flt(cdata.player().level / 2 + 5);
-        fixlv = 2;
+        fixlv = Quality::good;
         if (chatval_ == 36)
         {
             fltn(u8"man"s);
@@ -1686,7 +1686,7 @@ TalkResult talk_quest_giver()
                 {
                     dbid = 0;
                 }
-                flt(qdata(5, rq) + cnt, 1);
+                flt(qdata(5, rq) + cnt, Quality::bad);
                 fltn(u8"man"s);
                 int stat = chara_create(56, dbid, -3, 0);
                 f = stat;

--- a/src/talk_unique.cpp
+++ b/src/talk_unique.cpp
@@ -251,10 +251,10 @@ TalkResult talk_unique_loyter()
 
 void _miches_receive_reward()
 {
-    flt(calcobjlv(10), calcfixlv(3));
+    flt(calcobjlv(10), calcfixlv(Quality::good));
     itemcreate(
         -1, 449, cdata.player().position.x, cdata.player().position.y, 0);
-    flt(calcobjlv(10), calcfixlv(3));
+    flt(calcobjlv(10), calcfixlv(Quality::good));
     itemcreate(-1, 66, cdata.player().position.x, cdata.player().position.y, 0);
     flt();
     itemcreate(
@@ -1136,7 +1136,7 @@ void _slan_receive_reward()
 {
     for (int cnt = 0; cnt < 4; ++cnt)
     {
-        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(2));
+        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(Quality::bad));
         flttypemajor = fltsetdungeon();
         itemcreate(-1, 0, cdata[tc].position.x, cdata[tc].position.y, 0);
     }
@@ -1607,7 +1607,7 @@ void _karam_receive_reward()
 {
     for (int cnt = 0; cnt < 4; ++cnt)
     {
-        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(2));
+        flt(calcobjlv(gdata_current_dungeon_level), calcfixlv(Quality::bad));
         flttypemajor = fltsetdungeon();
         itemcreate(-1, 0, cdata[tc].position.x, cdata[tc].position.y, 0);
     }
@@ -4086,7 +4086,7 @@ void _doria_start_trial()
         {
             continue;
         }
-        if (cdata.tmp().quality >= 4)
+        if (cdata.tmp().quality >= Quality::miracle)
         {
             continue;
         }
@@ -4139,7 +4139,7 @@ void _doria_update_quota()
         {
             continue;
         }
-        if (cdata.tmp().quality >= 4)
+        if (cdata.tmp().quality >= Quality::miracle)
         {
             continue;
         }
@@ -4155,7 +4155,7 @@ void _doria_update_quota()
 void _doria_receive_reward()
 {
     gdata_fighters_guild_quota2 = 0;
-    flt(51 - gdata(128) / 200, calcfixlv(3));
+    flt(51 - gdata(128) / 200, calcfixlv(Quality::good));
     flttypemajor = 10000;
     itemcreate(-1, 0, cdata.player().position.x, cdata.player().position.y, 0);
     flt();
@@ -4570,7 +4570,7 @@ void _strange_scientist_pick_reward()
         }
         if (f)
         {
-            flt(cdata.player().level * 3 / 2, calcfixlv(3));
+            flt(cdata.player().level * 3 / 2, calcfixlv(Quality::good));
             int stat = itemcreate(-1, cnt, -1, -1, 0);
             if (stat == 1)
             {

--- a/src/talk_unique.cpp
+++ b/src/talk_unique.cpp
@@ -4574,7 +4574,7 @@ void _strange_scientist_pick_reward()
             int stat = itemcreate(-1, cnt, -1, -1, 0);
             if (stat == 1)
             {
-                if (inv[ci].quality < 4)
+                if (inv[ci].quality < Quality::miracle)
                 {
                     inv[ci].remove();
                 }

--- a/src/tests/lua_api.cpp
+++ b/src/tests/lua_api.cpp
@@ -12,7 +12,7 @@ void lua_testcase(const std::string& filename)
 {
     std::cout << "TEST FILE: " << filename << std::endl;
     elona::testing::reset_state();
-    elona::fixlv = 0;
+    elona::fixlv = Quality::none;
     elona::lua::lua->get_state()->open_libraries(sol::lib::os);
     elona::lua::lua->get_api_manager().set_on(*elona::lua::lua);
     REQUIRE_NOTHROW(elona::lua::lua->get_state()->safe_script_file(

--- a/src/tests/lua_handles.cpp
+++ b/src/tests/lua_handles.cpp
@@ -394,7 +394,7 @@ TEST_CASE(
     REQUIRE(handle["__index"].get<int>() == first_index);
 
     int tc = elona::rc;
-    flt(20, 2);
+    flt(20, Quality::good);
     REQUIRE(chara_create(56, 0, -3, 0));
     chara_relocate(cdata.tmp(), tc, CharaRelocationMode::change);
 

--- a/src/tests/util.cpp
+++ b/src/tests/util.cpp
@@ -66,7 +66,7 @@ Item& create_item(int id, int number)
 
 Character& create_chara(int id, int x, int y)
 {
-    elona::fixlv = 0;
+    elona::fixlv = Quality::none;
     REQUIRE(chara_create(-1, id, x, y));
     return elona::cdata[elona::rc];
 }

--- a/src/tests/util.cpp
+++ b/src/tests/util.cpp
@@ -31,11 +31,11 @@ void set_japanese()
 
 void normalize_item(Item& i)
 {
-    i.quality = 3;
+    i.quality = Quality::great;
     i.curse_state = CurseState::none;
     i.identification_state = IdentifyState::completely_identified;
     i.material = 34;
-    i.quality = 1;
+    i.quality = Quality::bad;
     i.dv = 0;
     i.pv = 0;
     i.count = 1;

--- a/src/variables.hpp
+++ b/src/variables.hpp
@@ -466,7 +466,7 @@ ELONA_EXTERN(int firstturn);
 ELONA_EXTERN(int fish);
 ELONA_EXTERN(int fishx);
 ELONA_EXTERN(int fishy);
-ELONA_EXTERN(int fixlv);
+ELONA_EXTERN(Quality fixlv);
 ELONA_EXTERN(int fixmaterial);
 ELONA_EXTERN(int fixtransfermap);
 ELONA_EXTERN(int fltselect);
@@ -861,7 +861,7 @@ void removeworker(int = 0);
 //// flt
 int fltsetdungeon();
 std::string fltname(int = 0);
-void flt(int = 0, int = 0);
+void flt(int = 0, Quality quality = Quality::none);
 void fltn(const std::string&);
 
 

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -547,10 +547,10 @@ bool wish_for_item(const std::string& input)
 
         const auto id = *opt_id;
 
-        flt(cdata.player().level + 10, 4);
+        flt(cdata.player().level + 10, Quality::miracle);
         if (id == 558 || id == 556 || id == 557 || id == 664)
         {
-            fixlv = calcfixlv(3);
+            fixlv = calcfixlv(Quality::good);
         }
         if (id == 630)
         {

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -563,7 +563,7 @@ bool wish_for_item(const std::string& input)
         nooracle = 0;
 
         // Unwishable item
-        if (ibit(5, ci) || inv[ci].quality == 6)
+        if (ibit(5, ci) || inv[ci].quality == Quality::special)
         {
             if (!gdata_wizard)
             {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

#850


# Summary

Defines `enum class Quality` instead of hard-coded numbers. `Quality` is derived from `int` so this change keeps the compatibility of save data.