### PR TITLE
Define struct ContinuousAction

### DIFF
--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -28,9 +28,10 @@ int digy = 0;
 
 void rowact_check(int prm_789)
 {
-    if (cdata[prm_789].continuous_action_id != 0)
+    if (cdata[prm_789].continuous_action)
     {
-        if (cdata[prm_789].continuous_action_id != 3)
+        if (cdata[prm_789].continuous_action.type
+            != ContinuousAction::Type::travel)
         {
             cdata[prm_789].stops_continuous_action_if_damaged = 1;
         }
@@ -48,15 +49,16 @@ void rowact_item(int prm_790)
         {
             continue;
         }
-        if (cc.continuous_action_turn <= 0)
+        if (cc.continuous_action.turn <= 0)
         {
             continue;
         }
-        if (cc.continuous_action_id == 1 || cc.continuous_action_id == 2)
+        if (cc.continuous_action.type == ContinuousAction::Type::eat
+            || cc.continuous_action.type == ContinuousAction::Type::read)
         {
-            if (cc.continuous_action_item == prm_790)
+            if (cc.continuous_action.item == prm_790)
             {
-                rowactend(cc.index);
+                cdata[cc.index].continuous_action.finish();
                 txt(i18n::s.get("core.locale.activity.cancel.item", cc));
             }
         }
@@ -65,21 +67,13 @@ void rowact_item(int prm_790)
 
 
 
-void rowactend(int cc)
-{
-    cdata[cc].continuous_action_id = 0;
-    cdata[cc].continuous_action_turn = 0;
-    cdata[cc].continuous_action_item = 0;
-}
-
-
-
 void activity_handle_damage(Character& chara)
 {
     if (chara.index == 0)
     {
-        if (chara.continuous_action_id != 1 && chara.continuous_action_id != 2
-            && chara.continuous_action_id != 3)
+        if (chara.continuous_action.type != ContinuousAction::Type::eat
+            && chara.continuous_action.type != ContinuousAction::Type::read
+            && chara.continuous_action.type != ContinuousAction::Type::travel)
         {
             rtval = 0;
         }
@@ -98,9 +92,11 @@ void activity_handle_damage(Character& chara)
                 "core.locale.activity.cancel.normal",
                 chara,
                 i18n::_(
-                    u8"ui", u8"action", u8"_"s + chara.continuous_action_id)));
+                    u8"ui",
+                    u8"action",
+                    u8"_"s + static_cast<int>(chara.continuous_action.type))));
         }
-        rowactend(chara.index);
+        chara.continuous_action.finish();
     }
     screenupdate = -1;
     update_screen();
@@ -109,49 +105,49 @@ void activity_handle_damage(Character& chara)
 
 optional<TurnResult> activity_proc(Character& chara)
 {
-    ci = chara.continuous_action_item;
-    --chara.continuous_action_turn;
-    if (chara.continuous_action_id == 7)
+    ci = chara.continuous_action.item;
+    --chara.continuous_action.turn;
+    if (chara.continuous_action.type == ContinuousAction::Type::fish)
     {
         auto_turn(Config::instance().animewait * 2);
         spot_fishing();
     }
-    if (chara.continuous_action_id == 5)
+    if (chara.continuous_action.type == ContinuousAction::Type::dig_wall)
     {
         auto_turn(Config::instance().animewait * 0.75);
         spot_mining_or_wall();
     }
-    if (chara.continuous_action_id == 8)
+    if (chara.continuous_action.type == ContinuousAction::Type::search_material)
     {
         auto_turn(Config::instance().animewait * 0.75);
         spot_material();
     }
-    if (chara.continuous_action_id == 9)
+    if (chara.continuous_action.type == ContinuousAction::Type::dig_ground)
     {
         auto_turn(Config::instance().animewait * 0.75);
         spot_digging();
     }
-    if (chara.continuous_action_id == 4)
+    if (chara.continuous_action.type == ContinuousAction::Type::sleep)
     {
         auto_turn(Config::instance().animewait / 4);
         do_rest();
     }
-    if (chara.continuous_action_id == 1)
+    if (chara.continuous_action.type == ContinuousAction::Type::eat)
     {
         auto_turn(Config::instance().animewait * 5);
         return do_eat_command();
     }
-    if (chara.continuous_action_id == 2)
+    if (chara.continuous_action.type == ContinuousAction::Type::read)
     {
         auto_turn(Config::instance().animewait * 1.25);
         return do_read_command();
     }
-    if (chara.continuous_action_id == 11)
+    if (chara.continuous_action.type == ContinuousAction::Type::sex)
     {
         auto_turn(Config::instance().animewait * 2.5);
         continuous_action_sex();
     }
-    if (chara.continuous_action_id == 10)
+    if (chara.continuous_action.type == ContinuousAction::Type::others)
     {
         if (gdata(91) == 103)
         {
@@ -171,26 +167,26 @@ optional<TurnResult> activity_proc(Character& chara)
         }
         continuous_action_others();
     }
-    if (chara.continuous_action_id == 12)
+    if (chara.continuous_action.type == ContinuousAction::Type::blend)
     {
         auto_turn(Config::instance().animewait);
         continuous_action_blending();
     }
-    if (chara.continuous_action_id == 6)
+    if (chara.continuous_action.type == ContinuousAction::Type::perform)
     {
         auto_turn(Config::instance().animewait * 2);
         continuous_action_perform();
     }
-    if (chara.continuous_action_id == 3)
+    if (chara.continuous_action.type == ContinuousAction::Type::travel)
     {
         map_global_proc_travel_events();
         return proc_movement_event();
     }
-    if (chara.continuous_action_turn > 0)
+    if (chara.continuous_action.turn > 0)
     {
         return TurnResult::turn_end;
     }
-    rowactend(cc);
+    cdata[cc].continuous_action.finish();
     if (cc == 0)
     {
         if (chatteleport == 1)
@@ -207,7 +203,10 @@ void prompt_stop_continuous_action()
 {
     txt(i18n::s.get(
         "core.locale.activity.cancel.prompt",
-        i18n::_(u8"ui", u8"action", u8"_"s + cdata[cc].continuous_action_id)));
+        i18n::_(
+            u8"ui",
+            u8"action",
+            u8"_"s + static_cast<int>(cdata[cc].continuous_action.type))));
     ELONA_YES_NO_PROMPT();
     rtval = show_prompt(promptx, prompty, 160);
     return;
@@ -219,16 +218,16 @@ void continuous_action_perform()
 {
     static int performtips;
 
-    if (cdata[cc].continuous_action_id == 0)
+    if (!cdata[cc].continuous_action)
     {
         if (is_in_fov(cdata[cc]))
         {
             txt(i18n::s.get(
                 "core.locale.activity.perform.start", cdata[cc], inv[ci]));
         }
-        cdata[cc].continuous_action_id = 6;
-        cdata[cc].continuous_action_turn = 61;
-        cdata[cc].continuous_action_item = ci;
+        cdata[cc].continuous_action.type = ContinuousAction::Type::perform;
+        cdata[cc].continuous_action.turn = 61;
+        cdata[cc].continuous_action.item = ci;
         cdata[cc].quality_of_performance = 40;
         cdata[cc].tip_gold = 0;
         if (cc == 0)
@@ -237,10 +236,10 @@ void continuous_action_perform()
         }
         return;
     }
-    if (cdata[cc].continuous_action_turn > 0)
+    if (cdata[cc].continuous_action.turn > 0)
     {
-        ci = cdata[cc].continuous_action_item;
-        if (cdata[cc].continuous_action_turn % 10 == 0)
+        ci = cdata[cc].continuous_action.item;
+        if (cdata[cc].continuous_action.turn % 10 == 0)
         {
             if (is_in_fov(cdata[cc]))
             {
@@ -254,7 +253,7 @@ void continuous_action_perform()
                 txt(i18n::s.get("core.locale.activity.perform.sound.cha"));
             }
         }
-        if (cdata[cc].continuous_action_turn % 20 == 0)
+        if (cdata[cc].continuous_action.turn % 20 == 0)
         {
             gold = 0;
             make_sound(cdata[cc].position.x, cdata[cc].position.y, 5, 1, 1, cc);
@@ -371,7 +370,7 @@ void continuous_action_perform()
                     p = cdata[cc].quality_of_performance
                             * cdata[cc].quality_of_performance
                             * (100
-                               + inv[cdata[cc].continuous_action_item].param1
+                               + inv[cdata[cc].continuous_action.item].param1
                                    / 5)
                             / 100 / 1000
                         + rnd(10);
@@ -421,7 +420,7 @@ void continuous_action_perform()
                         cdata[cc].quality_of_performance -= p;
                     }
                 }
-                if (encfindspec(cdata[cc].continuous_action_item, 60))
+                if (encfindspec(cdata[cc].continuous_action.item, 60))
                 {
                     if (rnd(15) == 0)
                     {
@@ -470,7 +469,7 @@ void continuous_action_perform()
                                         continue;
                                     }
                                     if (encfindspec(
-                                            cdata[cc].continuous_action_item,
+                                            cdata[cc].continuous_action.item,
                                             49))
                                     {
                                         flt(calcobjlv(
@@ -615,7 +614,7 @@ void continuous_action_perform()
     if (cdata[cc].quality_of_performance > 40)
     {
         cdata[cc].quality_of_performance = cdata[cc].quality_of_performance
-            * (100 + inv[cdata[cc].continuous_action_item].param1 / 5) / 100;
+            * (100 + inv[cdata[cc].continuous_action.item].param1 / 5) / 100;
     }
     if (cdata[cc].tip_gold != 0)
     {
@@ -627,7 +626,7 @@ void continuous_action_perform()
                 cdata[cc].tip_gold));
         }
     }
-    rowactend(cc);
+    cdata[cc].continuous_action.finish();
     int experience = cdata[cc].quality_of_performance - sdata(183, cc) + 50;
     if (experience > 0)
     {
@@ -639,13 +638,13 @@ void continuous_action_perform()
 void continuous_action_sex()
 {
     int sexhost = 0;
-    if (cdata[cc].continuous_action_id == 0)
+    if (!cdata[cc].continuous_action)
     {
-        cdata[cc].continuous_action_id = 11;
-        cdata[cc].continuous_action_turn = 25 + rnd(10);
+        cdata[cc].continuous_action.type = ContinuousAction::Type::sex;
+        cdata[cc].continuous_action.turn = 25 + rnd(10);
         cdata[cc].continuous_action_target = tc;
-        cdata[tc].continuous_action_id = 11;
-        cdata[tc].continuous_action_turn = cdata[cc].continuous_action_turn * 2;
+        cdata[tc].continuous_action.type = ContinuousAction::Type::sex;
+        cdata[tc].continuous_action.turn = cdata[cc].continuous_action.turn * 2;
         cdata[tc].continuous_action_target = cc + 10000;
         if (is_in_fov(cdata[cc]))
         {
@@ -662,7 +661,7 @@ void continuous_action_sex()
         sexhost = 0;
     }
     if (cdata[tc].state() != Character::State::alive
-        || cdata[tc].continuous_action_id != 11)
+        || cdata[tc].continuous_action.type != ContinuousAction::Type::sex)
     {
         if (is_in_fov(cdata[cc]))
         {
@@ -671,8 +670,8 @@ void continuous_action_sex()
                 i18n::_(u8"ui", u8"sex2", u8"_"s + cdata[tc].sex),
                 cdata[tc]));
         }
-        rowactend(cc);
-        rowactend(tc);
+        cdata[cc].continuous_action.finish();
+        cdata[tc].continuous_action.finish();
         return;
     }
     if (cc == 0)
@@ -680,17 +679,17 @@ void continuous_action_sex()
         if (!action_sp(cdata.player(), 1 + rnd(2)))
         {
             txt(i18n::s.get("core.locale.magic.common.too_exhausted"));
-            rowactend(cc);
-            rowactend(tc);
+            cdata[cc].continuous_action.finish();
+            cdata[tc].continuous_action.finish();
             return;
         }
     }
     cdata[cc].emotion_icon = 317;
-    if (cdata[cc].continuous_action_turn > 0)
+    if (cdata[cc].continuous_action.turn > 0)
     {
         if (sexhost == 0)
         {
-            if (cdata[cc].continuous_action_turn % 5 == 0)
+            if (cdata[cc].continuous_action.turn % 5 == 0)
             {
                 if (is_in_fov(cdata[cc]))
                 {
@@ -703,7 +702,7 @@ void continuous_action_sex()
     }
     if (sexhost == 0)
     {
-        rowactend(cc);
+        cdata[cc].continuous_action.finish();
         return;
     }
     for (int cnt = 0; cnt < 2; ++cnt)
@@ -803,19 +802,19 @@ void continuous_action_sex()
     }
     txt(i18n::s.get("core.locale.activity.sex.format", dialog_head, dialog_tail)
         + dialog_after);
-    rowactend(cc);
-    rowactend(tc);
+    cdata[cc].continuous_action.finish();
+    cdata[tc].continuous_action.finish();
     return;
 }
 
 
 void continuous_action_eating()
 {
-    if (cdata[cc].continuous_action_id == 0)
+    if (!cdata[cc].continuous_action)
     {
-        cdata[cc].continuous_action_id = 1;
-        cdata[cc].continuous_action_turn = 8;
-        cdata[cc].continuous_action_item = ci;
+        cdata[cc].continuous_action.type = ContinuousAction::Type::eat;
+        cdata[cc].continuous_action.turn = 8;
+        cdata[cc].continuous_action.item = ci;
         if (is_in_fov(cdata[cc]))
         {
             snd(18);
@@ -840,7 +839,7 @@ void continuous_action_eating()
         }
         return;
     }
-    if (cdata[cc].continuous_action_turn > 0)
+    if (cdata[cc].continuous_action.turn > 0)
     {
         return;
     }
@@ -849,7 +848,7 @@ void continuous_action_eating()
         txt(i18n::s.get("core.locale.activity.eat.finish", cdata[cc], inv[ci]));
     }
     continuous_action_eating_finish();
-    rowactend(cc);
+    cdata[cc].continuous_action.finish();
     return;
 }
 
@@ -925,18 +924,18 @@ void continuous_action_others()
 {
     if (cc != 0)
     {
-        rowactend(cc);
+        cdata[cc].continuous_action.finish();
         return;
     }
-    if (cdata[cc].continuous_action_id == 0)
+    if (!cdata[cc].continuous_action)
     {
-        cdata[cc].continuous_action_id = 10;
-        cdata[cc].continuous_action_item = ci;
+        cdata[cc].continuous_action.type = ContinuousAction::Type::others;
+        cdata[cc].continuous_action.item = ci;
         cdata[cc].continuous_action_target = tc;
         if (gdata(91) == 105)
         {
             txt(i18n::s.get("core.locale.activity.steal.start", inv[ci]));
-            cdata[cc].continuous_action_turn =
+            cdata[cc].continuous_action.turn =
                 2 + clamp(inv[ci].weight / 500, 0, 50);
         }
         if (gdata(91) == 100)
@@ -946,28 +945,28 @@ void continuous_action_others()
                 || mdata_map_type == mdata_t::MapType::guild)
             {
                 txt(i18n::s.get("core.locale.activity.sleep.start.other"));
-                cdata[cc].continuous_action_turn = 5;
+                cdata[cc].continuous_action.turn = 5;
             }
             else
             {
                 txt(i18n::s.get("core.locale.activity.sleep.start.global"));
-                cdata[cc].continuous_action_turn = 20;
+                cdata[cc].continuous_action.turn = 20;
             }
         }
         if (gdata(91) == 101)
         {
             txt(i18n::s.get("core.locale.activity.construct.start", inv[ci]));
-            cdata[cc].continuous_action_turn = 25;
+            cdata[cc].continuous_action.turn = 25;
         }
         if (gdata(91) == 102)
         {
             txt(i18n::s.get("core.locale.activity.pull_hatch.start", inv[ci]));
-            cdata[cc].continuous_action_turn = 10;
+            cdata[cc].continuous_action.turn = 10;
         }
         if (gdata(91) == 103)
         {
             txt(i18n::s.get("core.locale.activity.dig", inv[ci]));
-            cdata[cc].continuous_action_turn = 10
+            cdata[cc].continuous_action.turn = 10
                 + clamp(inv[ci].weight
                             / (1 + sdata(10, 0) * 10 + sdata(180, 0) * 40),
                         1,
@@ -982,7 +981,7 @@ void continuous_action_others()
                         + gdata_year * 24 * 30 * 12)
                 {
                     txt(i18n::s.get("core.locale.activity.study.start.bored"));
-                    rowactend(cc);
+                    cdata[cc].continuous_action.finish();
                     return;
                 }
             }
@@ -1014,13 +1013,13 @@ void continuous_action_others()
                         "core.locale.activity.study.start.weather_is_bad"));
                 }
             }
-            cdata[cc].continuous_action_turn = 50;
+            cdata[cc].continuous_action.turn = 50;
         }
         update_screen();
         return;
     }
     tc = cdata[cc].continuous_action_target;
-    if (cdata[cc].continuous_action_turn > 0)
+    if (cdata[cc].continuous_action.turn > 0)
     {
         if (gdata(91) == 103)
         {
@@ -1094,7 +1093,7 @@ void continuous_action_others()
             {
                 if (rnd(15) == 0)
                 {
-                    rowactend(cc);
+                    cdata[cc].continuous_action.finish();
                     txt(i18n::s.get("core.locale.activity.iron_maiden"));
                     damage_hp(cdata[cc], 9999, -18);
                     return;
@@ -1104,7 +1103,7 @@ void continuous_action_others()
             {
                 if (rnd(15) == 0)
                 {
-                    rowactend(cc);
+                    cdata[cc].continuous_action.finish();
                     txt(i18n::s.get("core.locale.activity.guillotine"));
                     damage_hp(cdata[cc], 9999, -19);
                     return;
@@ -1293,7 +1292,7 @@ void continuous_action_others()
             if (f)
             {
                 txt(i18n::s.get("core.locale.activity.steal.abort"));
-                rowactend(cc);
+                cdata[cc].continuous_action.finish();
             }
         }
         return;
@@ -1305,7 +1304,7 @@ void continuous_action_others()
             || inv[ci].number() <= 0)
         {
             txt(i18n::s.get("core.locale.activity.steal.abort"));
-            rowactend(cc);
+            cdata[cc].continuous_action.finish();
             return;
         }
         in = 1;
@@ -1415,7 +1414,7 @@ void continuous_action_others()
             txt(i18n::s.get("core.locale.activity.study.finish.training"));
         }
     }
-    rowactend(cc);
+    cdata[cc].continuous_action.finish();
     return;
 }
 
@@ -1426,7 +1425,7 @@ void select_random_fish()
     {
         return;
     }
-    ci = cdata.player().continuous_action_item;
+    ci = cdata.player().continuous_action.item;
     int dbmax = 0;
     int dbsum = 0;
     for (const auto fish : the_fish_db)
@@ -1481,16 +1480,16 @@ void spot_fishing()
 {
     static int fishstat;
 
-    if (cdata[cc].continuous_action_id == 0)
+    if (!cdata[cc].continuous_action)
     {
         txt(i18n::s.get("core.locale.activity.fishing.start"));
         snd(87);
         if (rowactre == 0)
         {
-            cdata[cc].continuous_action_item = ci;
+            cdata[cc].continuous_action.item = ci;
         }
-        cdata[cc].continuous_action_id = 7;
-        cdata[cc].continuous_action_turn = 100;
+        cdata[cc].continuous_action.type = ContinuousAction::Type::fish;
+        cdata[cc].continuous_action.turn = 100;
         racount = 0;
         fishstat = 0;
         gsel(9);
@@ -1504,7 +1503,7 @@ void spot_fishing()
         search_material_spot();
         return;
     }
-    if (cdata[cc].continuous_action_turn > 0)
+    if (cdata[cc].continuous_action.turn > 0)
     {
         if (rnd(5) == 0)
         {
@@ -1616,7 +1615,7 @@ void spot_fishing()
             }
             snd(14 + rnd(2));
             fishanime = 0;
-            rowactend(cc);
+            cdata[cc].continuous_action.finish();
             get_fish();
             gain_fishing_experience(0);
             cdata.player().emotion_icon = 306;
@@ -1628,7 +1627,7 @@ void spot_fishing()
         return;
     }
     txt(i18n::s.get("core.locale.activity.fishing.fail"));
-    rowactend(cc);
+    cdata[cc].continuous_action.finish();
     return;
 }
 
@@ -1636,10 +1635,11 @@ void spot_fishing()
 
 void spot_material()
 {
-    if (cdata[cc].continuous_action_id == 0)
+    if (!cdata[cc].continuous_action)
     {
-        cdata[cc].continuous_action_id = 8;
-        cdata[cc].continuous_action_turn = 40;
+        cdata[cc].continuous_action.type =
+            ContinuousAction::Type::search_material;
+        cdata[cc].continuous_action.turn = 40;
         txt(i18n::s.get("core.locale.activity.material.start"));
         racount = 0;
         return;
@@ -1649,7 +1649,7 @@ void spot_material()
         search_material_spot();
         return;
     }
-    rowactend(cc);
+    cdata[cc].continuous_action.finish();
     return;
 }
 
@@ -1657,10 +1657,10 @@ void spot_material()
 
 void spot_digging()
 {
-    if (cdata[cc].continuous_action_id == 0)
+    if (!cdata[cc].continuous_action)
     {
-        cdata[cc].continuous_action_id = 9;
-        cdata[cc].continuous_action_turn = 20;
+        cdata[cc].continuous_action.type = ContinuousAction::Type::dig_ground;
+        cdata[cc].continuous_action.turn = 20;
         if (rowactre == 0)
         {
             txt(i18n::s.get("core.locale.activity.dig_spot.start.global"));
@@ -1677,7 +1677,7 @@ void spot_digging()
         search_material_spot();
         return;
     }
-    if (cdata[cc].continuous_action_turn > 0)
+    if (cdata[cc].continuous_action.turn > 0)
     {
         if (cdata[cc].turn % 5 == 0)
         {
@@ -1763,7 +1763,7 @@ void spot_digging()
         }
     }
     spillfrag(refx, refy, 1);
-    rowactend(cc);
+    cdata[cc].continuous_action.finish();
     return;
 }
 
@@ -1773,10 +1773,10 @@ void spot_mining_or_wall()
 {
     static int countdig{};
 
-    if (cdata[cc].continuous_action_id == 0)
+    if (!cdata[cc].continuous_action)
     {
-        cdata[cc].continuous_action_id = 5;
-        cdata[cc].continuous_action_turn = 40;
+        cdata[cc].continuous_action.type = ContinuousAction::Type::dig_wall;
+        cdata[cc].continuous_action.turn = 40;
         if (rowactre == 0)
         {
             txt(i18n::s.get("core.locale.activity.dig_mining.start.wall"));
@@ -1798,7 +1798,7 @@ void spot_mining_or_wall()
         search_material_spot();
         return;
     }
-    if (cdata[cc].continuous_action_turn > 0)
+    if (cdata[cc].continuous_action.turn > 0)
     {
         if (rnd(5) == 0)
         {
@@ -1888,7 +1888,7 @@ void spot_mining_or_wall()
                 txt(i18n::s.get("core.locale.activity.dig_mining.finish.find"));
             }
             gain_digging_experience();
-            rowactend(cc);
+            cdata[cc].continuous_action.finish();
         }
         else if (cdata[cc].turn % 5 == 0)
         {
@@ -1898,7 +1898,7 @@ void spot_mining_or_wall()
         return;
     }
     txt(i18n::s.get("core.locale.activity.dig_mining.fail"));
-    rowactend(cc);
+    cdata[cc].continuous_action.finish();
     return;
 }
 
@@ -2044,7 +2044,7 @@ int search_material_spot()
             s = i18n::s.get("core.locale.activity.material.harvesting.no_more");
         }
         txt(s);
-        rowactend(cc);
+        cdata[cc].continuous_action.finish();
         map(cdata.player().position.x, cdata.player().position.y, 6) = 0;
     }
     return 0;

--- a/src/activity.hpp
+++ b/src/activity.hpp
@@ -9,7 +9,6 @@ struct Character;
 
 void rowact_check(int = 0);
 void rowact_item(int = 0);
-void rowactend(int = 0);
 
 void activity_handle_damage(Character&);
 optional<TurnResult> activity_proc(Character&);

--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -420,9 +420,10 @@ TurnResult proc_npc_movement_event(bool retreat)
                     txt(i18n::s.get(
                         "core.locale.ai.swap.displace", cdata[cc], cdata[tc]));
                 }
-                if (cdata[tc].continuous_action_id == 1)
+                if (cdata[tc].continuous_action.type
+                    == ContinuousAction::Type::eat)
                 {
-                    if (cdata[tc].continuous_action_turn > 0)
+                    if (cdata[tc].continuous_action.turn > 0)
                     {
                         if (is_in_fov(cdata[cc]))
                         {
@@ -431,7 +432,7 @@ TurnResult proc_npc_movement_event(bool retreat)
                                 cdata[cc],
                                 cdata[tc]));
                         }
-                        rowactend(tc);
+                        cdata[tc].continuous_action.finish();
                     }
                 }
                 return TurnResult::turn_end;
@@ -728,7 +729,7 @@ label_2692_internal:
         {
             if (gdata_hour >= 22 || gdata_hour < 7)
             {
-                if (cdata[cc].continuous_action_id == 0)
+                if (!cdata[cc].continuous_action)
                 {
                     if (rnd(100) == 0)
                     {
@@ -1020,7 +1021,7 @@ label_2692_internal:
             {
                 if (distance == 1)
                 {
-                    if (cdata[tc].continuous_action_id == 0)
+                    if (!cdata[tc].continuous_action)
                     {
                         cdata[cc].enemy_id = 0;
                         continuous_action_sex();

--- a/src/blending.cpp
+++ b/src/blending.cpp
@@ -38,19 +38,19 @@ label_19341_internal:
     rpid = rpref(0);
     if (rpid == 0)
     {
-        rowactend(cc);
+        cdata[cc].continuous_action.finish();
         return;
     }
-    if (cdata[cc].continuous_action_id == 0)
+    if (!cdata[cc].continuous_action)
     {
         txtnew();
         txt(i18n::s.get(
             "core.locale.blending.started", cdata[cc], rpname(rpid)));
-        cdata[cc].continuous_action_id = 12;
-        cdata[cc].continuous_action_turn = rpref(2) % 10000;
+        cdata[cc].continuous_action.type = ContinuousAction::Type::blend;
+        cdata[cc].continuous_action.turn = rpref(2) % 10000;
         return;
     }
-    if (cdata[cc].continuous_action_turn > 0)
+    if (cdata[cc].continuous_action.turn > 0)
     {
         if (rnd(30) == 0)
         {
@@ -61,7 +61,7 @@ label_19341_internal:
     }
     if (rpref(2) >= 10000)
     {
-        cdata[cc].continuous_action_turn = rpref(2) / 10000;
+        cdata[cc].continuous_action.turn = rpref(2) / 10000;
         for (int cnt = 0;; ++cnt)
         {
             mode = 12;
@@ -77,8 +77,8 @@ label_19341_internal:
             await(Config::instance().animewait * 5);
             gdata_minute = 0;
             cc = 0;
-            --cdata[cc].continuous_action_turn;
-            if (cdata[cc].continuous_action_turn <= 0)
+            --cdata[cc].continuous_action.turn;
+            if (cdata[cc].continuous_action.turn <= 0)
             {
                 int stat = blending_find_required_mat();
                 if (stat == 0)
@@ -90,7 +90,7 @@ label_19341_internal:
                 blending_start_attempt();
                 if (rpref(1) > 0)
                 {
-                    cdata[cc].continuous_action_turn = rpref(2) / 10000;
+                    cdata[cc].continuous_action.turn = rpref(2) / 10000;
                     cnt = 0 - 1;
                     continue;
                 }
@@ -100,7 +100,7 @@ label_19341_internal:
                 }
             }
         }
-        rowactend(cc);
+        cdata[cc].continuous_action.finish();
         mode = 0;
         return;
     }
@@ -108,16 +108,16 @@ label_19341_internal:
     if (stat == 0)
     {
         txt(i18n::s.get("core.locale.blending.required_material_not_found"));
-        rowactend(cc);
+        cdata[cc].continuous_action.finish();
         return;
     }
     blending_start_attempt();
     if (rpref(1) > 0)
     {
-        cdata[cc].continuous_action_id = 0;
+        cdata[cc].continuous_action.type = ContinuousAction::Type::none;
         goto label_19341_internal;
     }
-    rowactend(cc);
+    cdata[cc].continuous_action.finish();
     return;
 }
 

--- a/src/building.cpp
+++ b/src/building.cpp
@@ -807,7 +807,7 @@ void prompt_move_ally()
         cdata[tc].initial_position.x = tlocx;
         cdata[tc].position.y = tlocy;
         cdata[tc].initial_position.y = tlocy;
-        rowactend(tc);
+        cdata[tc].continuous_action.finish();
         txtnew();
         txt(i18n::s.get("core.locale.building.home.move.is_moved", cdata[tc]));
         snd(43);
@@ -1042,14 +1042,13 @@ void show_shop_log()
                 {
                     continue;
                 }
-                if (cnt.continuous_action_id == 0
-                    || cnt.continuous_action_turn == 0)
+                if (!cnt.continuous_action || cnt.continuous_action.turn == 0)
                 {
                     continue;
                 }
-                if (cnt.continuous_action_item == ci)
+                if (cnt.continuous_action.item == ci)
                 {
-                    rowactend(cnt.index);
+                    cdata[cnt.index].continuous_action.finish();
                 }
             }
         }

--- a/src/cell_draw.cpp
+++ b/src/cell_draw.cpp
@@ -1293,7 +1293,8 @@ void cell_draw()
 
                 if (py_ < windowh - inf_verh - 24)
                 {
-                    if (cdata.player().continuous_action_id == 7)
+                    if (cdata.player().continuous_action.type
+                        == ContinuousAction::Type::fish)
                     {
                         ani_ = 0;
                     }

--- a/src/character.hpp
+++ b/src/character.hpp
@@ -39,6 +39,67 @@ struct Buff
 
 
 
+struct ContinuousAction
+{
+    enum class Type : int
+    {
+        none,
+        eat,
+        read,
+        travel,
+        sleep,
+        dig_wall,
+        perform,
+        fish,
+        search_material,
+        dig_ground,
+        others,
+        sex,
+        blend,
+    };
+
+    Type type = ContinuousAction::Type::none;
+    int turn = 0;
+    int item = 0;
+
+
+    bool is_doing_nothing() const
+    {
+        return type == ContinuousAction::Type::none;
+    }
+
+
+    bool is_doing_something() const
+    {
+        return !is_doing_nothing();
+    }
+
+
+    explicit operator bool() const
+    {
+        return is_doing_something();
+    }
+
+
+    void finish()
+    {
+        type = ContinuousAction::Type::none;
+        turn = 0;
+        item = 0;
+    }
+
+
+    template <typename Archive>
+    void serialize(Archive& ar)
+    {
+        ar(type);
+        ar(turn);
+        ar(item);
+    }
+};
+
+
+
 struct Character
 {
     enum class State : int
@@ -150,9 +211,7 @@ struct Character
     int nullify_damage = 0;
     int cut_counterattack = 0;
     int anorexia_count = 0;
-    int continuous_action_id = 0;
-    int continuous_action_turn = 0;
-    int continuous_action_item = 0;
+    ContinuousAction continuous_action;
     int stops_continuous_action_if_damaged = 0;
     int quality_of_performance = 0;
     int tip_gold = 0;
@@ -311,9 +370,7 @@ struct Character
         ar(nullify_damage);
         ar(cut_counterattack);
         ar(anorexia_count);
-        ar(continuous_action_id);
-        ar(continuous_action_turn);
-        ar(continuous_action_item);
+        ar(continuous_action);
         ar(stops_continuous_action_if_damaged);
         ar(quality_of_performance);
         ar(tip_gold);

--- a/src/character_status.cpp
+++ b/src/character_status.cpp
@@ -96,7 +96,7 @@ void modify_ether_disease_stage(int delta)
                 {
                     if (mode == 0)
                     {
-                        if (cdata.player().continuous_action_turn == 0)
+                        if (cdata.player().continuous_action.turn == 0)
                         {
                             gdata(215) = 1;
                             ghelp = 15;

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -3046,14 +3046,15 @@ TurnResult do_movement_command()
     }
     if (gdata_mount != 0)
     {
-        if (cdata[gdata_mount].continuous_action_id != 0)
+        if (cdata[gdata_mount].continuous_action)
         {
-            if (cdata[gdata_mount].continuous_action_turn > 0)
+            if (cdata[gdata_mount].continuous_action.turn > 0)
             {
                 txt(i18n::s.get(
                     "core.locale.action.move.interrupt", cdata[gdata_mount]));
-                cdata[gdata_mount].continuous_action_id = 0;
-                cdata[gdata_mount].continuous_action_turn = 0;
+                cdata[gdata_mount].continuous_action.type =
+                    ContinuousAction::Type::none;
+                cdata[gdata_mount].continuous_action.turn = 0;
             }
         }
     }
@@ -3113,14 +3114,16 @@ TurnResult do_movement_command()
                         }
                     }
                 }
-                if (cdata[tc].continuous_action_id == 1)
+                if (cdata[tc].continuous_action.type
+                    == ContinuousAction::Type::eat)
                 {
-                    if (cdata[tc].continuous_action_turn > 0)
+                    if (cdata[tc].continuous_action.turn > 0)
                     {
                         txt(i18n::s.get(
                             "core.locale.action.move.interrupt", cdata[tc]));
-                        cdata[tc].continuous_action_id = 0;
-                        cdata[tc].continuous_action_turn = 0;
+                        cdata[tc].continuous_action.type =
+                            ContinuousAction::Type::none;
+                        cdata[tc].continuous_action.turn = 0;
                     }
                 }
                 sense_map_feats_on_move();
@@ -3309,7 +3312,7 @@ TurnResult do_eat_command()
         tc = itemusingfind(ci);
         if (tc != cc)
         {
-            rowactend(tc);
+            cdata[tc].continuous_action.finish();
             if (is_in_fov(cdata[cc]))
             {
                 txt(i18n::s.get(

--- a/src/ctrl_inventory.cpp
+++ b/src/ctrl_inventory.cpp
@@ -1740,11 +1740,11 @@ label_2061_internal:
                 txt(i18n::s.get("core.locale.ui.inv.common.set_as_no_drop"));
                 goto label_2060_internal;
             }
-            if (cdata[tc].continuous_action_id != 0)
+            if (cdata[tc].continuous_action)
             {
-                cdata[tc].continuous_action_id = 0;
-                cdata[tc].continuous_action_turn = 0;
-                cdata[tc].continuous_action_item = 0;
+                cdata[tc].continuous_action.type = ContinuousAction::Type::none;
+                cdata[tc].continuous_action.turn = 0;
+                cdata[tc].continuous_action.item = 0;
             }
             snd(13);
             ibitmod(12, citrade, 0);

--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -1721,7 +1721,7 @@ void ride_begin(int mount)
     map(cdata[mount].position.x, cdata[mount].position.y, 1) = 0;
     gdata_mount = mount;
     create_pcpic(0, true);
-    rowactend(gdata_mount);
+    cdata[gdata_mount].continuous_action.finish();
     refresh_speed(cdata[gdata_mount]);
     txt(""s + cdata[mount].current_speed + u8") "s);
     if (cdata[gdata_mount].is_suitable_for_mount())
@@ -1740,7 +1740,7 @@ void ride_end()
 {
     int mount = gdata_mount;
     cdata[mount].is_ridden() = false;
-    rowactend(mount);
+    cdata[mount].continuous_action.finish();
     gdata_mount = 0;
     create_pcpic(0, true);
     refresh_speed(cdata[mount]);
@@ -1887,7 +1887,7 @@ void hostileaction(int prm_787, int prm_788)
             }
         }
     }
-    rowactend(prm_788);
+    cdata[prm_788].continuous_action.finish();
 }
 
 
@@ -2805,7 +2805,8 @@ void proc_turn_end(int cc)
         {
             if (cdata[cc].nutrition < 1000)
             {
-                if (cdata[cc].continuous_action_id != 1)
+                if (cdata[cc].continuous_action.type
+                    != ContinuousAction::Type::eat)
                 {
                     damage_hp(
                         cdata[cc], rnd(2) + cdata.player().max_hp / 50, -3);
@@ -2974,7 +2975,7 @@ void chara_set_revived_status()
 void chara_clear_status_effects()
 {
     cdata[rc].is_contracting_with_reaper() = false;
-    rowactend(rc);
+    cdata[rc].continuous_action.finish();
     cdata[rc].poisoned = 0;
     cdata[rc].sleep = 0;
     cdata[rc].confused = 0;
@@ -4851,7 +4852,7 @@ TurnResult exit_map()
             {
                 if (mode == 0)
                 {
-                    if (cdata.player().continuous_action_turn == 0)
+                    if (cdata.player().continuous_action.turn == 0)
                     {
                         gdata(201) = 1;
                         ghelp = 1;
@@ -5181,7 +5182,7 @@ TurnResult exit_map()
     {
         cdata[cnt].hate = 0;
         cdata[cnt].enemy_id = 0;
-        rowactend(cnt);
+        cdata[cnt].continuous_action.finish();
         if (cdata[cnt].state() != Character::State::alive)
         {
             if (cdata[cnt].state() == Character::State::pet_in_other_map)
@@ -5252,7 +5253,7 @@ void prepare_charas_for_map_unload()
     // interrupt continuous actions
     for (int cnt = 0; cnt < 57; ++cnt)
     {
-        rowactend(cnt);
+        cdata[cnt].continuous_action.finish();
         cdata[cnt].item_which_will_be_used = 0;
     }
 
@@ -7602,7 +7603,7 @@ void supply_income()
         {
             if (mode == 0)
             {
-                if (cdata.player().continuous_action_turn == 0)
+                if (cdata.player().continuous_action.turn == 0)
                 {
                     gdata(216) = 1;
                     ghelp = 16;
@@ -7833,7 +7834,7 @@ TurnResult step_into_gate()
         {
             if (mode == 0)
             {
-                if (cdata.player().continuous_action_turn == 0)
+                if (cdata.player().continuous_action.turn == 0)
                 {
                     gdata(217) = 1;
                     ghelp = 17;
@@ -8578,7 +8579,7 @@ void equip_melee_weapon()
 
 TurnResult try_interact_with_npc()
 {
-    if (cdata[tc].continuous_action_turn != 0)
+    if (cdata[tc].continuous_action.turn != 0)
     {
         i18n::s.get("core.locale.action.npc.is_busy_now", cdata[tc]);
         update_screen();
@@ -10359,7 +10360,7 @@ label_21451_internal:
                                     "core.locale.magic.teleport.disappears",
                                     cdata[cc]));
                             }
-                            rowactend(cc);
+                            cdata[cc].continuous_action.finish();
                             update_screen();
                             break;
                         }
@@ -10577,13 +10578,13 @@ void sleep_start()
     txtef(2);
     txt(i18n::s.get("core.locale.activity.sleep.slept_for", timeslept));
     f = 0;
-    if (cdata.player().continuous_action_item == -1)
+    if (cdata.player().continuous_action.item == -1)
     {
         f = 1;
     }
     else
     {
-        ci = cdata.player().continuous_action_item;
+        ci = cdata.player().continuous_action.item;
         if (inv[ci].param1 == 0 || inv[ci].number() == 0
             || the_item_db[inv[ci].id]->subcategory != 60004)
         {
@@ -10642,21 +10643,21 @@ void sleep_start()
 
 void do_rest()
 {
-    if (cdata[cc].continuous_action_id == 0)
+    if (!cdata[cc].continuous_action)
     {
-        cdata[cc].continuous_action_id = 4;
-        cdata[cc].continuous_action_turn = 50;
+        cdata[cc].continuous_action.type = ContinuousAction::Type::sleep;
+        cdata[cc].continuous_action.turn = 50;
         txt(i18n::s.get("core.locale.activity.rest.start"));
         update_screen();
         return;
     }
-    if (cdata[cc].continuous_action_turn > 0)
+    if (cdata[cc].continuous_action.turn > 0)
     {
-        if (cdata[cc].continuous_action_turn % 2 == 0)
+        if (cdata[cc].continuous_action.turn % 2 == 0)
         {
             heal_sp(cdata[cc], 1);
         }
-        if (cdata[cc].continuous_action_turn % 3 == 0)
+        if (cdata[cc].continuous_action.turn % 3 == 0)
         {
             heal_hp(cdata[cc], 1);
             heal_mp(cdata[cc], 1);
@@ -10677,14 +10678,14 @@ void do_rest()
         if (f == 1)
         {
             txt(i18n::s.get("core.locale.activity.rest.drop_off_to_sleep"));
-            cdata[cc].continuous_action_item = -1;
+            cdata[cc].continuous_action.item = -1;
             sleep_start();
-            rowactend(cc);
+            cdata[cc].continuous_action.finish();
             return;
         }
     }
     txt(i18n::s.get("core.locale.activity.rest.finish"));
-    rowactend(cc);
+    cdata[cc].continuous_action.finish();
     return;
 }
 
@@ -10692,33 +10693,33 @@ void do_rest()
 
 void map_global_proc_travel_events()
 {
-    if (cdata[cc].continuous_action_id == 0)
+    if (!cdata[cc].continuous_action)
     {
-        cdata[cc].continuous_action_id = 3;
-        cdata[cc].continuous_action_turn = 20;
+        cdata[cc].continuous_action.type = ContinuousAction::Type::travel;
+        cdata[cc].continuous_action.turn = 20;
         if (gdata_weather == 3)
         {
-            cdata[cc].continuous_action_turn =
-                cdata[cc].continuous_action_turn * 13 / 10;
+            cdata[cc].continuous_action.turn =
+                cdata[cc].continuous_action.turn * 13 / 10;
         }
         if (gdata_weather == 4)
         {
-            cdata[cc].continuous_action_turn =
-                cdata[cc].continuous_action_turn * 16 / 10;
+            cdata[cc].continuous_action.turn =
+                cdata[cc].continuous_action.turn * 16 / 10;
         }
         if (gdata_weather == 2
             || chipm(0, map(cdata[cc].position.x, cdata[cc].position.y, 0))
                 == 4)
         {
-            cdata[cc].continuous_action_turn =
-                cdata[cc].continuous_action_turn * 22 / 10;
+            cdata[cc].continuous_action.turn =
+                cdata[cc].continuous_action.turn * 22 / 10;
         }
         if (gdata_weather == 1)
         {
-            cdata[cc].continuous_action_turn =
-                cdata[cc].continuous_action_turn * 5 / 10;
+            cdata[cc].continuous_action.turn =
+                cdata[cc].continuous_action.turn * 5 / 10;
         }
-        cdata[cc].continuous_action_turn = cdata[cc].continuous_action_turn
+        cdata[cc].continuous_action.turn = cdata[cc].continuous_action.turn
             * 100 / (100 + gdata_seven_league_boot_effect + sdata(182, 0));
         return;
     }
@@ -10761,7 +10762,7 @@ void map_global_proc_travel_events()
                     txtef(9);
                     txt(i18n::s.get(
                         "core.locale.action.move.global.weather.snow.sound"));
-                    cdata[cc].continuous_action_turn += 10;
+                    cdata[cc].continuous_action.turn += 10;
                 }
             }
             if (rnd(1000) == 0)
@@ -10769,7 +10770,7 @@ void map_global_proc_travel_events()
                 txtef(8);
                 txt(i18n::s.get(
                     "core.locale.action.move.global.weather.snow.message"));
-                cdata[cc].continuous_action_turn += 50;
+                cdata[cc].continuous_action.turn += 50;
             }
         }
         if (cdata.player().nutrition <= 2000)
@@ -10798,7 +10799,7 @@ void map_global_proc_travel_events()
                     txt(i18n::s.get(
                         "core.locale.action.move.global.weather.heavy_rain."
                         "sound"));
-                    cdata[cc].continuous_action_turn += 5;
+                    cdata[cc].continuous_action.turn += 5;
                 }
             }
             if (cdata.player().confused == 0)
@@ -10819,14 +10820,14 @@ void map_global_proc_travel_events()
         }
         cdata.player().blind = 3;
     }
-    if (cdata[cc].continuous_action_turn > 0)
+    if (cdata[cc].continuous_action.turn > 0)
     {
         ++gdata_minute;
         return;
     }
     traveldone = 1;
     gdata_distance_between_town += 4;
-    rowactend(cc);
+    cdata[cc].continuous_action.finish();
     return;
 }
 
@@ -10834,7 +10835,7 @@ void map_global_proc_travel_events()
 int decode_book()
 {
     int cibkread = 0;
-    if (cdata[cc].continuous_action_id == 0)
+    if (!cdata[cc].continuous_action)
     {
         if (inv[ci].id == 687)
         {
@@ -10854,7 +10855,7 @@ int decode_book()
             }
             return 0;
         }
-        cdata[cc].continuous_action_id = 2;
+        cdata[cc].continuous_action.type = ContinuousAction::Type::read;
         if (inv[ci].id == 783)
         {
             p = 50;
@@ -10867,8 +10868,8 @@ int decode_book()
         {
             p = the_ability_db[efid]->sdataref4;
         }
-        cdata[cc].continuous_action_turn = p / (2 + sdata(150, 0)) + 1;
-        cdata[cc].continuous_action_item = ci;
+        cdata[cc].continuous_action.turn = p / (2 + sdata(150, 0)) + 1;
+        cdata[cc].continuous_action.item = ci;
         if (is_in_fov(cdata[cc]))
         {
             txt(i18n::s.get(
@@ -10877,9 +10878,9 @@ int decode_book()
         item_separate(ci);
         return 0;
     }
-    if (cdata[cc].continuous_action_turn > 0)
+    if (cdata[cc].continuous_action.turn > 0)
     {
-        ci = cdata[cc].continuous_action_item;
+        ci = cdata[cc].continuous_action.item;
         cibkread = ci;
         gain_literacy_experience();
         if (inv[ci].id == 783)
@@ -10909,7 +10910,7 @@ int decode_book()
         ci = cibkread;
         if (stat == 0)
         {
-            rowactend(cc);
+            cdata[cc].continuous_action.finish();
             --inv[ci].count;
             if (inv[ci].count < 0)
             {
@@ -10936,7 +10937,7 @@ int decode_book()
     {
         if (inv[ci].param1 == 0)
         {
-            rowactend(cc);
+            cdata[cc].continuous_action.finish();
             return 1;
         }
         txt(i18n::s.get("core.locale.action.read.recipe.learned", inv[ci]));
@@ -10948,7 +10949,7 @@ int decode_book()
             txt(i18n::s.get(
                 "core.locale.action.read.book.falls_apart", inv[ci]));
         }
-        rowactend(cc);
+        cdata[cc].continuous_action.finish();
         return 1;
     }
     if (inv[ci].id == 687)
@@ -10994,7 +10995,7 @@ int decode_book()
             }
         }
     }
-    rowactend(cc);
+    cdata[cc].continuous_action.finish();
     return 1;
 }
 
@@ -12096,9 +12097,9 @@ int pick_up_item()
     {
         if (gdata_mount != 0)
         {
-            if (cdata[gdata_mount].continuous_action_id != 0)
+            if (cdata[gdata_mount].continuous_action)
             {
-                if (cdata[gdata_mount].continuous_action_item == ci)
+                if (cdata[gdata_mount].continuous_action.item == ci)
                 {
                     txt(i18n::s.get(
                         "core.locale.action.pick_up.used_by_mount",
@@ -12111,7 +12112,7 @@ int pick_up_item()
         {
             if (inv[ci].own_state == 4)
             {
-                if (cdata.player().continuous_action_id == 0)
+                if (!cdata.player().continuous_action)
                 {
                     if (!inv_getspace(0))
                     {
@@ -13228,7 +13229,7 @@ void sense_map_feats_on_move()
                         {
                             if (mode == 0)
                             {
-                                if (cdata.player().continuous_action_turn == 0)
+                                if (cdata.player().continuous_action.turn == 0)
                                 {
                                     gdata(206) = 1;
                                     ghelp = 6;
@@ -13346,7 +13347,7 @@ void sense_map_feats_on_move()
                     {
                         if (mode == 0)
                         {
-                            if (cdata.player().continuous_action_turn == 0)
+                            if (cdata.player().continuous_action.turn == 0)
                             {
                                 gdata(205) = 1;
                                 ghelp = 5;
@@ -15668,7 +15669,7 @@ void weather_changes()
                 {
                     if (mode == 0)
                     {
-                        if (cdata.player().continuous_action_turn == 0)
+                        if (cdata.player().continuous_action.turn == 0)
                         {
                             gdata(211) = 1;
                             ghelp = 11;
@@ -15686,7 +15687,7 @@ void weather_changes()
                 {
                     if (mode == 0)
                     {
-                        if (cdata.player().continuous_action_turn == 0)
+                        if (cdata.player().continuous_action.turn == 0)
                         {
                             gdata(212) = 1;
                             ghelp = 12;
@@ -15704,7 +15705,7 @@ void weather_changes()
                 {
                     if (mode == 0)
                     {
-                        if (cdata.player().continuous_action_turn == 0)
+                        if (cdata.player().continuous_action.turn == 0)
                         {
                             gdata(213) = 1;
                             ghelp = 13;
@@ -15758,7 +15759,7 @@ void weather_changes()
             {
                 if (mode == 0)
                 {
-                    if (cdata.player().continuous_action_turn == 0)
+                    if (cdata.player().continuous_action.turn == 0)
                     {
                         gdata(209) = 1;
                         ghelp = 9;
@@ -15776,7 +15777,7 @@ void weather_changes()
             {
                 if (mode == 0)
                 {
-                    if (cdata.player().continuous_action_turn == 0)
+                    if (cdata.player().continuous_action.turn == 0)
                     {
                         gdata(210) = 1;
                         ghelp = 10;
@@ -15881,9 +15882,10 @@ void weather_changes()
     {
         cdata.player().piety_point = 0;
     }
-    if (cdata.player().continuous_action_turn != 0)
+    if (cdata.player().continuous_action.turn != 0)
     {
-        if (cdata.player().continuous_action_id != 3)
+        if (cdata.player().continuous_action.type
+            != ContinuousAction::Type::travel)
         {
             update_screen();
         }

--- a/src/initialize_map.cpp
+++ b/src/initialize_map.cpp
@@ -3419,7 +3419,7 @@ label_1744_internal:
             {
                 if (mode == 0)
                 {
-                    if (cdata.player().continuous_action_turn == 0)
+                    if (cdata.player().continuous_action.turn == 0)
                     {
                         gdata(202) = 1;
                         ghelp = 2;
@@ -3437,7 +3437,7 @@ label_1744_internal:
             {
                 if (mode == 0)
                 {
-                    if (cdata.player().continuous_action_turn == 0)
+                    if (cdata.player().continuous_action.turn == 0)
                     {
                         gdata(203) = 1;
                         ghelp = 3;
@@ -3455,7 +3455,7 @@ label_1744_internal:
             {
                 if (mode == 0)
                 {
-                    if (cdata.player().continuous_action_turn == 0)
+                    if (cdata.player().continuous_action.turn == 0)
                     {
                         gdata(214) = 1;
                         ghelp = 14;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -285,9 +285,10 @@ int itemusingfind(int ci, bool disallow_pc)
         {
             continue;
         }
-        if (cnt.continuous_action_id != 0 && cnt.continuous_action_id != 11
-            && cnt.continuous_action_turn > 0
-            && cnt.continuous_action_item == ci)
+        if (cnt.continuous_action
+            && cnt.continuous_action.type != ContinuousAction::Type::sex
+            && cnt.continuous_action.turn > 0
+            && cnt.continuous_action.item == ci)
         {
             if (!disallow_pc || cnt.index != 0)
             {

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -980,7 +980,7 @@ int magic()
                                     cdata[tc]));
                             }
                         }
-                        rowactend(cc);
+                        cdata[cc].continuous_action.finish();
                         ccprev = cc;
                         cc = tc;
                         proc_trap();

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -1535,7 +1535,7 @@ TurnResult show_quest_board()
         {
             if (mode == 0)
             {
-                if (cdata.player().continuous_action_turn == 0)
+                if (cdata.player().continuous_action.turn == 0)
                 {
                     gdata(204) = 1;
                     ghelp = 4;

--- a/src/random_event.cpp
+++ b/src/random_event.cpp
@@ -162,7 +162,7 @@ optional<RandomEvent> generate_random_event()
     }
     if (mdata_map_type != mdata_t::MapType::world_map)
     {
-        if (cdata.player().continuous_action_id != 0)
+        if (cdata.player().continuous_action)
         {
             return none;
         }

--- a/src/status_ailment.cpp
+++ b/src/status_ailment.cpp
@@ -76,7 +76,7 @@ void dmgcon(int cc, StatusAilment status_ailment, int power)
         {
             cdata[cc].blind += turn / 3 + 1;
         }
-        rowactend(cc);
+        cdata[cc].continuous_action.finish();
         return;
     case StatusAilment::confused:
         if (cdata[cc].is_immune_to_confusion())
@@ -103,7 +103,7 @@ void dmgcon(int cc, StatusAilment status_ailment, int power)
         {
             cdata[cc].confused += turn / 3 + 1;
         }
-        rowactend(cc);
+        cdata[cc].continuous_action.finish();
         return;
     case StatusAilment::paralyzed:
         if (cdata[cc].is_immune_to_paralyzation())
@@ -128,7 +128,7 @@ void dmgcon(int cc, StatusAilment status_ailment, int power)
         {
             cdata[cc].paralyzed += turn / 3 + 1;
         }
-        rowactend(cc);
+        cdata[cc].continuous_action.finish();
         return;
     case StatusAilment::poisoned:
         if (cdata[cc].is_immune_to_poison())
@@ -153,7 +153,7 @@ void dmgcon(int cc, StatusAilment status_ailment, int power)
         {
             cdata[cc].poisoned += turn / 3 + 3;
         }
-        rowactend(cc);
+        cdata[cc].continuous_action.finish();
         return;
     case StatusAilment::sleep:
         if (cdata[cc].is_immune_to_sleep())
@@ -178,7 +178,7 @@ void dmgcon(int cc, StatusAilment status_ailment, int power)
         {
             cdata[cc].sleep += turn / 3 + 1;
         }
-        rowactend(cc);
+        cdata[cc].continuous_action.finish();
         return;
     case StatusAilment::fear:
         if (cdata[cc].is_immune_to_fear())
@@ -226,7 +226,7 @@ void dmgcon(int cc, StatusAilment status_ailment, int power)
         {
             cdata[cc].dimmed += turn / 3 + 1;
         }
-        rowactend(cc);
+        cdata[cc].continuous_action.finish();
         return;
     case StatusAilment::bleeding:
         if (cdata[cc].quality > 3)
@@ -250,7 +250,7 @@ void dmgcon(int cc, StatusAilment status_ailment, int power)
         {
             cdata[cc].bleeding += turn;
         }
-        rowactend(cc);
+        cdata[cc].continuous_action.finish();
         return;
     case StatusAilment::drunk:
         turn = power / 10;
@@ -288,7 +288,7 @@ void dmgcon(int cc, StatusAilment status_ailment, int power)
         {
             cdata[cc].insane += turn / 3 + 1;
         }
-        rowactend(cc);
+        cdata[cc].continuous_action.finish();
         return;
     case StatusAilment::sick:
         turn = power / 10;

--- a/src/talk.cpp
+++ b/src/talk.cpp
@@ -46,7 +46,7 @@ void talk_to_npc()
             {
                 if (mode == 0)
                 {
-                    if (cdata.player().continuous_action_turn == 0)
+                    if (cdata.player().continuous_action.turn == 0)
                     {
                         gdata(207) = 1;
                         ghelp = 7;
@@ -66,7 +66,7 @@ void talk_to_npc()
             {
                 if (mode == 0)
                 {
-                    if (cdata.player().continuous_action_turn == 0)
+                    if (cdata.player().continuous_action.turn == 0)
                     {
                         gdata(208) = 1;
                         ghelp = 8;
@@ -137,7 +137,7 @@ void talk_to_npc()
         talk_wrapper(TalkResult::talk_sleeping);
         return;
     }
-    if (cdata[tc].continuous_action_id)
+    if (cdata[tc].continuous_action)
     {
         talk_wrapper(TalkResult::talk_busy);
         return;

--- a/src/turn_sequence.cpp
+++ b/src/turn_sequence.cpp
@@ -329,7 +329,8 @@ TurnResult npc_turn()
                             && cdata.player().position.y
                                 < cdata[cc].position.y + 10)
                         {
-                            if (cdata.player().continuous_action_id != 6)
+                            if (cdata.player().continuous_action.type
+                                != ContinuousAction::Type::perform)
                             {
                                 if (cdata[cc].hate <= 0)
                                 {
@@ -733,7 +734,7 @@ TurnResult turn_begin()
     bool update_turn_cost = true;
     if (mdata_map_type == mdata_t::MapType::world_map)
     {
-        if (cdata.player().continuous_action_turn > 2)
+        if (cdata.player().continuous_action.turn > 2)
         {
             cdata.player().turn_cost = mdata_map_turn_cost;
             update_turn_cost = false;
@@ -858,7 +859,7 @@ TurnResult pass_one_turn(bool label_2738_flg)
         }
         if (p == 4)
         {
-            if (cdata.player().continuous_action_id == 0)
+            if (!cdata.player().continuous_action)
             {
                 heal_sp(cdata.player(), 2);
             }
@@ -1109,7 +1110,7 @@ TurnResult pass_one_turn(bool label_2738_flg)
             proc_pregnant();
         }
     }
-    if (cdata[cc].continuous_action_id != 0)
+    if (cdata[cc].continuous_action)
     {
         if (auto result = activity_proc(cdata[cc]))
         {

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1284,7 +1284,7 @@ void render_hud()
         {
             if (mdata_map_type != mdata_t::MapType::world_map)
             {
-                if (cdata.player().continuous_action_id == 0)
+                if (!cdata.player().continuous_action)
                 {
                     gmode(4, 150);
                 }
@@ -1328,22 +1328,25 @@ void load_continuous_action_animation()
 {
     gsel(9);
     pos(0, 0);
-    if (cdata.player().continuous_action_id == 5)
+    if (cdata.player().continuous_action.type
+        == ContinuousAction::Type::dig_wall)
     {
         picload(filesystem::dir::graphic() / u8"anime1.bmp");
     }
-    if (cdata.player().continuous_action_id == 7)
+    if (cdata.player().continuous_action.type == ContinuousAction::Type::fish)
     {
         if (rowactre)
         {
             picload(filesystem::dir::graphic() / u8"anime2.bmp");
         }
     }
-    if (cdata.player().continuous_action_id == 8)
+    if (cdata.player().continuous_action.type
+        == ContinuousAction::Type::search_material)
     {
         picload(filesystem::dir::graphic() / u8"anime3.bmp");
     }
-    if (cdata.player().continuous_action_id == 9)
+    if (cdata.player().continuous_action.type
+        == ContinuousAction::Type::dig_ground)
     {
         picload(filesystem::dir::graphic() / u8"anime4.bmp");
     }
@@ -1359,14 +1362,15 @@ void render_autoturn_animation()
         load_continuous_action_animation();
     }
     if (msgtemp != ""s
-        || (cdata.player().continuous_action_id == 7 && rowactre == 0
-            && fishanime == 0))
+        || (cdata.player().continuous_action.type
+                == ContinuousAction::Type::fish
+            && rowactre == 0 && fishanime == 0))
     {
         ui_render_non_hud();
         msgtemp = "";
         render_hud();
     }
-    if (cdata.player().continuous_action_id == 7)
+    if (cdata.player().continuous_action.type == ContinuousAction::Type::fish)
     {
         if (rowactre == 0 && Config::instance().animewait != 0)
         {
@@ -1384,10 +1388,15 @@ void render_autoturn_animation()
     gmode(2);
     draw_rotated("hourglass", sx + 18, sy + 12, gdata_minute / 4 * 24);
 
-    if (cdata.player().continuous_action_id == 9
-        || cdata.player().continuous_action_id == 5
-        || cdata.player().continuous_action_id == 8
-        || (cdata.player().continuous_action_id == 7 && rowactre != 0))
+    if (cdata.player().continuous_action.type
+            == ContinuousAction::Type::dig_ground
+        || cdata.player().continuous_action.type
+            == ContinuousAction::Type::dig_wall
+        || cdata.player().continuous_action.type
+            == ContinuousAction::Type::search_material
+        || (cdata.player().continuous_action.type
+                == ContinuousAction::Type::fish
+            && rowactre != 0))
     {
         if (Config::instance().animewait != 0)
         {
@@ -1398,7 +1407,8 @@ void render_autoturn_animation()
                 {
                     gmode(0);
                     pos(sx + 2, sy - 102);
-                    if (cdata.player().continuous_action_id == 5)
+                    if (cdata.player().continuous_action.type
+                        == ContinuousAction::Type::dig_wall)
                     {
                         if (cnt == 2)
                         {
@@ -1407,7 +1417,8 @@ void render_autoturn_animation()
                         gcopy(9, cnt / 2 % 5 * 144, 0, 144, 96);
                         await(Config::instance().animewait * 2);
                     }
-                    if (cdata.player().continuous_action_id == 7)
+                    if (cdata.player().continuous_action.type
+                        == ContinuousAction::Type::fish)
                     {
                         if (racount == 0)
                         {
@@ -1419,7 +1430,8 @@ void render_autoturn_animation()
                         gcopy(9, cnt / 3 % 3 * 144, 0, 144, 96);
                         await(Config::instance().animewait * 2.5);
                     }
-                    if (cdata.player().continuous_action_id == 8)
+                    if (cdata.player().continuous_action.type
+                        == ContinuousAction::Type::search_material)
                     {
                         if (cnt == 4)
                         {
@@ -1428,7 +1440,8 @@ void render_autoturn_animation()
                         gcopy(9, cnt / 2 % 3 * 144, 0, 144, 96);
                         await(Config::instance().animewait * 2.75);
                     }
-                    if (cdata.player().continuous_action_id == 9)
+                    if (cdata.player().continuous_action.type
+                        == ContinuousAction::Type::dig_ground)
                     {
                         if (cnt == 2)
                         {


### PR DESCRIPTION

# Summary

Define `struct ContinuousAction` instead of `Character`'s three fields:

- `continuous_action_id`
- `continuous_action_turn`
- `continuous_action_item`

`ContinousAction` has the same layout as the three fields so this change does not affect save data's compatibility.