### PR TITLE
Fix crash of itemname in burning item

### DIFF
--- a/runtime/locale/en/item.hcl
+++ b/runtime/locale/en/item.hcl
@@ -72,16 +72,16 @@ locale {
 
         item_on_the_ground_get_broiled = "${itemname(_1)} on the ground get${_s(_1)} perfectly broiled."
         someones_item_get_broiled = "${name(_2)}${his_owned(_2)} ${itemname(_1, 0, false)} get${_s(_1)} perfectly broiled."
-        fireproof_blanket_protects_item = "${itemname(_1, 1)} protects {name(_2)}{his_owned(_2)} stuff from fire."
+        fireproof_blanket_protects_item = "${itemname(_1, 1)} protects ${name(_2)}${his_owned(_2)} stuff from fire."
         fireproof_blanket_turns_to_dust = "${itemname(_1, 1)} turns to dust."
-        item_someone_equips_turns_to_dust = "${itemname(_1, _2)} ${name(_3)} equip${s(_3)} turn${s2(_2)} to dust."
-        someones_item_turns_to_dust = "${name(_3)}${his_owned(_3)} ${itemname(_1, _2, false)} turn${s2(_2)} to dust."
-        item_on_the_ground_turns_to_dust = "${itemname(_1, _2)} on the ground turn${s2(_2)} to dust."
+        item_someone_equips_turns_to_dust = "${_1} ${name(_3)} equip${s(_3)} turn${s2(_2)} to dust."
+        someones_item_turns_to_dust = "${name(_3)}${his_owned(_3)} ${_1} turn${s2(_2)} to dust."
+        item_on_the_ground_turns_to_dust = "${_1} on the ground turn${s2(_2)} to dust."
 
-        coldproof_blanket_protects_item = "${itemname(_1, 1)} protects {name(_2)}{his_owned(_2)} stuff from cold."
+        coldproof_blanket_protects_item = "${itemname(_1, 1)} protects ${name(_2)}${his_owned(_2)} stuff from cold."
         coldproof_blanket_is_broken_to_pieces = "${itemname(_1, 1)} is broken to pieces."
-        someones_item_breaks_to_pieces = "${name(_3)}${his_owned(_3)} ${itemname(_1, _2, false)} break${s2(_2)} to pieces."
-        item_on_the_ground_breaks_to_pieces = "${itemname(_1, _2)} on the ground break${s2(_2)} to pieces."
+        someones_item_breaks_to_pieces = "${name(_3)}${his_owned(_3)} ${_1} break${s2(_2)} to pieces."
+        item_on_the_ground_breaks_to_pieces = "${_1} on the ground break${s2(_2)} to pieces."
 
         items_are_destroyed = "Too many item data! Some items in this area are destroyed."
 

--- a/runtime/locale/jp/item.hcl
+++ b/runtime/locale/jp/item.hcl
@@ -74,14 +74,14 @@ locale {
         someones_item_get_broiled = "${name(_2)}の${itemname(_1)}はこんがりと焼き上がった。"
         fireproof_blanket_protects_item = "${itemname(_1, 1)}が{name(_2)}の持ち物を炎から守った。"
         fireproof_blanket_turns_to_dust = "${itemname(_1, 1)}は灰と化した。"
-        item_someone_equips_turns_to_dust = "${name(_3)}の装備している${itemname(_1, _2)}は灰と化した。"
-        someones_item_turns_to_dust = "${name(_3)}の${itemname(_1, _2)}は灰と化した。"
-        item_on_the_ground_turns_to_dust = "地面の${itemname(_1, _2)}は灰と化した。"
+        item_someone_equips_turns_to_dust = "${name(_3)}の装備している${_1}は灰と化した。"
+        someones_item_turns_to_dust = "${name(_3)}の${_1}は灰と化した。"
+        item_on_the_ground_turns_to_dust = "地面の${_1}は灰と化した。"
 
         coldproof_blanket_protects_item = "${itemname(_1, 1)}が{name(_2)}の持ち物を冷気から守った。"
         coldproof_blanket_is_broken_to_pieces = "${itemname(_1, 1)}は粉々に砕けた。"
-        someones_item_breaks_to_pieces = "${name(_3)}の${itemname(_1, _2)}は粉々に砕けた。"
-        item_on_the_ground_breaks_to_pieces = "地面の${itemname(_1, _2)}は粉々に砕けた。"
+        someones_item_breaks_to_pieces = "${name(_3)}の${_1}は粉々に砕けた。"
+        item_on_the_ground_breaks_to_pieces = "地面の${_1}は粉々に砕けた。"
 
         items_are_destroyed = "アイテム情報が多すぎる！幾つかのアイテムは破壊された。"
 

--- a/src/i18n.hpp
+++ b/src/i18n.hpp
@@ -134,6 +134,16 @@ inline bool ident_eq(std::string ident, int count)
 }
 
 
+/**
+ * NOTE: When using functions in inline HCL, only the first argument position
+ * can have a substituted argument. For example, itemname(_1, 1) is valid, but
+ * itemname(_1, _2) is not. This is because the formatting uses a variadic
+ * parameter and each function has to be evaluated when looking at an individual
+ * argument that is in the function's first argument position.
+ *
+ * This could be fixed by defining all the functions in Lua instead.
+ */
+
 std::string format_builtins_argless(const hil::FunctionCall&);
 std::string format_builtins_bool(const hil::FunctionCall&, bool);
 std::string format_builtins_string(const hil::FunctionCall&, std::string);

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1772,7 +1772,7 @@ bool item_fire(int owner, int ci)
                     txtef(8);
                     txt(i18n::s.get(
                         "core.locale.item.item_someone_equips_turns_to_dust",
-                        inv[ci_],
+                        itemname(inv[ci_].index, p_),
                         p_,
                         cdata[owner]));
                 }
@@ -1787,7 +1787,7 @@ bool item_fire(int owner, int ci)
                 txtef(8);
                 txt(i18n::s.get(
                     "core.locale.item.someones_item_turns_to_dust",
-                    inv[ci_],
+                    itemname(inv[ci_].index, p_, 1),
                     p_,
                     cdata[owner]));
             }
@@ -1797,7 +1797,7 @@ bool item_fire(int owner, int ci)
             txtef(8);
             txt(i18n::s.get(
                 "core.locale.item.item_on_the_ground_turns_to_dust",
-                inv[ci_],
+                itemname(inv[ci_].index, p_),
                 p_));
         }
         inv[ci_].modify_number(-p_);
@@ -1953,7 +1953,7 @@ bool item_cold(int owner, int ci)
                 txtef(8);
                 txt(i18n::s.get(
                     "core.locale.item.someones_item_breaks_to_pieces",
-                    inv[ci_],
+                    itemname(inv[ci_].index, p_, 1),
                     p_,
                     cdata[owner]));
             }
@@ -1963,7 +1963,7 @@ bool item_cold(int owner, int ci)
             txtef(8);
             txt(i18n::s.get(
                 "core.locale.item.item_on_the_ground_breaks_to_pieces",
-                inv[ci_],
+                itemname(inv[ci_].index, p_),
                 p_));
         }
         inv[ci_].modify_number(-p_);


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #861.


# Summary
The current interpolation code can only handle a single passed-in argument per function call, in the first argument position. This is due to the use of a variadic argument with a recursive function to format each function call, so only the argument at the head of the variadic arguments is passed in per function. The workaround is to call `itemname` in C++ instead with the second argument and pass the string to the formatter.

Multiple arguments could be supported by moving the I18N functions to Lua (which would be necessary for other reasons).