### PR TITLE
Add `/MT` flag for release build on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,6 +448,10 @@ else()
     set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -DDEBUG")
   endif()
 
+  if(MSVC)
+    set(CMAKE_CXX_FLAGS_RELEASE "/MT")
+  endif()
+
   if(WITH_TESTS STREQUAL "BENCH")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
   endif()


### PR DESCRIPTION

# Summary

It is the very cause why v0.2.7 release build failed.

`/MT` flag specified in `CMAKE_CXX_FLAGS` was overridden by `/MD` in release builds for some reason.