### PR TITLE
Delete unnecessary return statement

### DIFF
--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -36,7 +36,6 @@ void rowact_check(int prm_789)
             cdata[prm_789].stops_continuous_action_if_damaged = 1;
         }
     }
-    return;
 }
 
 
@@ -209,7 +208,6 @@ void prompt_stop_continuous_action()
             u8"_"s + static_cast<int>(cdata[cc].continuous_action.type))));
     ELONA_YES_NO_PROMPT();
     rtval = show_prompt(promptx, prompty, 160);
-    return;
 }
 
 
@@ -632,7 +630,6 @@ void continuous_action_perform()
     {
         chara_gain_skill_exp(cdata[cc], 183, experience, 0, 0);
     }
-    return;
 }
 
 void continuous_action_sex()
@@ -852,7 +849,6 @@ void continuous_action_eating()
     }
     continuous_action_eating_finish();
     cdata[cc].continuous_action.finish();
-    return;
 }
 
 
@@ -920,7 +916,6 @@ void continuous_action_eating_finish()
         }
         ++cdata[cc].choked;
     }
-    return;
 }
 
 void continuous_action_others()
@@ -1414,7 +1409,6 @@ void continuous_action_others()
         }
     }
     cdata[cc].continuous_action.finish();
-    return;
 }
 
 
@@ -1456,7 +1450,6 @@ void select_random_fish()
             }
         }
     }
-    return;
 }
 
 
@@ -1470,7 +1463,6 @@ void get_fish()
     inv[ci].weight = the_fish_db[fish]->weight;
     txt(i18n::s.get("core.locale.activity.fishing.get", inv[ci]));
     item_stack(0, ci, 1);
-    return;
 }
 
 
@@ -1627,7 +1619,6 @@ void spot_fishing()
     }
     txt(i18n::s.get("core.locale.activity.fishing.fail"));
     cdata[cc].continuous_action.finish();
-    return;
 }
 
 
@@ -1649,7 +1640,6 @@ void spot_material()
         return;
     }
     cdata[cc].continuous_action.finish();
-    return;
 }
 
 
@@ -1763,7 +1753,6 @@ void spot_digging()
     }
     spillfrag(refx, refy, 1);
     cdata[cc].continuous_action.finish();
-    return;
 }
 
 
@@ -1899,7 +1888,6 @@ void spot_mining_or_wall()
     }
     txt(i18n::s.get("core.locale.activity.dig_mining.fail"));
     cdata[cc].continuous_action.finish();
-    return;
 }
 
 TurnResult do_dig_after_sp_check()
@@ -2108,7 +2096,6 @@ void matdelmain(int material_id, int amount)
     txtef(4);
     txt(i18n::s.get(
         "core.locale.activity.material.lose_total", mat(material_id)));
-    return;
 }
 
 

--- a/src/adventurer.cpp
+++ b/src/adventurer.cpp
@@ -23,7 +23,6 @@ void create_all_adventurers()
         rc = cnt;
         create_adventurer();
     }
-    return;
 }
 
 
@@ -68,7 +67,6 @@ void create_adventurer()
     cdata[rc].current_dungeon_level = 1;
     cdata[rc].fame = cdata[rc].level * cdata[rc].level * 30
         + rnd((cdata[rc].level * 200 + 100)) + rnd(500);
-    return;
 }
 
 
@@ -115,7 +113,6 @@ void addnews2(const std::string& prm_401, int prm_402)
     }
     talk_conv(n_at_m36, 38 - en * 5);
     newsbuff += n_at_m36 + u8"\n"s;
-    return;
 }
 
 
@@ -126,7 +123,6 @@ void addnewstopic(const std::string& prm_403, const std::string& prm_404)
         prm_403 + u8" "s + game_data.date.year + u8"/"s + game_data.date.month
         + u8"/"s + game_data.date.day + u8" h"s + game_data.date.hour + ""s
         + u8" "s + prm_404);
-    return;
 }
 
 
@@ -303,7 +299,6 @@ void adventurer_update()
             notedel(0);
         }
     }
-    return;
 }
 
 

--- a/src/blending.cpp
+++ b/src/blending.cpp
@@ -118,7 +118,6 @@ label_19341_internal:
         goto label_19341_internal;
     }
     cdata[cc].continuous_action.finish();
-    return;
 }
 
 void initialize_recipememory()
@@ -127,7 +126,6 @@ void initialize_recipememory()
     {
         recipememory(200 + cnt) = 1;
     }
-    return;
 }
 
 void initialize_recipe()
@@ -331,7 +329,6 @@ void initialize_recipe()
     rfnameorg(1, 5) = i18n::s.get_enum("core.locale.blending.ingredient", 4);
     rfnameorg(0, 4) = "";
     rfnameorg(1, 4) = i18n::s.get_enum("core.locale.blending.ingredient", 5);
-    return;
 }
 
 void window_recipe2(int val0)
@@ -647,7 +644,6 @@ void window_recipe_(
         dy_at_m184 += 16;
         ++p_at_m184;
     }
-    return;
 }
 
 TurnResult blending_menu()
@@ -1539,7 +1535,6 @@ void clear_rprefmat()
     {
         rpref(10 + cnt * 2) = -1;
     }
-    return;
 }
 
 
@@ -1664,7 +1659,6 @@ void blending_start_attempt()
     }
     --rpref(1);
     blending_spend_materials();
-    return;
 }
 
 // TODO: Much duplication with do_dip_command()
@@ -1862,7 +1856,6 @@ void blending_proc_on_success_events()
         cell_refresh(inv[ci].position.x, inv[ci].position.y);
     }
     chara_refresh(0);
-    return;
 }
 
 } // namespace elona

--- a/src/building.cpp
+++ b/src/building.cpp
@@ -195,7 +195,6 @@ void initialize_home_adata()
         adata(2, p) = cdata.player().position.y;
     }
     adata(30, p) = gdata(850);
-    return;
 }
 
 TurnResult build_new_building()
@@ -339,7 +338,6 @@ void addbuilding(int prm_1082, int prm_1083, int prm_1084, int prm_1085)
     bddata(1, prm_1082, p_at_m194) = prm_1084;
     bddata(2, prm_1082, p_at_m194) = prm_1085;
     bddata(3, prm_1082, p_at_m194) = bdref(0, prm_1083) + 363;
-    return;
 }
 
 TurnResult show_house_board()
@@ -946,7 +944,6 @@ void update_shop_and_report()
     {
         update_shop();
     }
-    return;
 }
 
 void show_shop_log()
@@ -1210,7 +1207,6 @@ void show_shop_log()
     mode = 0;
     ctrl_file(FileOperation2::map_items_write, u8"shop5.s2");
     ctrl_file(FileOperation2::map_items_read, u8"shoptmp.s2");
-    return;
 }
 
 void update_shop()
@@ -1239,7 +1235,6 @@ void update_shop()
         }
         cell_refresh(x, y);
     }
-    return;
 }
 
 void calc_collection_value(bool val0)
@@ -1274,7 +1269,6 @@ void calc_collection_value(bool val0)
             rtval = 15;
         }
     }
-    return;
 }
 
 void update_museum()
@@ -1333,7 +1327,6 @@ void update_museum()
             rankn(10, 3)));
     }
     mdata_map_max_crowd_density = (100 - gdata(123) / 100) / 2 + 1;
-    return;
 }
 
 
@@ -1414,7 +1407,6 @@ void calc_home_rank()
             ranktitle(4),
             rankn(10, 4)));
     }
-    return;
 }
 
 

--- a/src/casino.cpp
+++ b/src/casino.cpp
@@ -55,7 +55,6 @@ void casino_dealer()
         return;
     }
     casino_acquire_items();
-    return;
 }
 
 void casino_choose_card()
@@ -289,7 +288,6 @@ void casino_adv_draw_mat()
     }
     gmode(2);
     atxpic = 0;
-    return;
 }
 
 void casino_fade_in_choices()
@@ -309,7 +307,6 @@ void casino_fade_in_choices()
         await(15);
         redraw();
     }
-    return;
 }
 
 void casino_prepare_choice_graphic()
@@ -351,7 +348,6 @@ void casino_prepare_choice_graphic()
     gsel(0);
     gmode(2);
     cs = 0;
-    return;
 }
 
 void casino_acquire_items()
@@ -385,7 +381,6 @@ void casino_acquire_items()
     await(100);
     snd(39);
     play_music();
-    return;
 }
 
 void casino_random_site()
@@ -851,7 +846,6 @@ void casino_adv_finish_search()
     txtadvscreenupdate = 1;
     casino_choose_card();
     casino_acquire_items();
-    return;
 }
 
 void casino_wrapper()

--- a/src/casino_card.cpp
+++ b/src/casino_card.cpp
@@ -25,7 +25,6 @@ void cardplayerinit(int prm_417, int prm_418)
     DIM3(cardplayer_at_cardcontrol, 100, prm_417);
     cardplayermax_at_cardcontrol = prm_417;
     cardholdermax_at_cardcontrol = prm_418;
-    return;
 }
 
 void cardplayeradd(int prm_419, int prm_420, int prm_421)
@@ -36,7 +35,6 @@ void cardplayeradd(int prm_419, int prm_420, int prm_421)
     {
         cardplayer_at_cardcontrol(10 + cnt, prm_419) = -1;
     }
-    return;
 }
 
 void initcard(int prm_422, int prm_423, int)
@@ -73,7 +71,6 @@ void initcard(int prm_422, int prm_423, int)
         card_at_cardcontrol(0, i_at_cardcontrol(1)) = p_at_cardcontrol;
         card_at_cardcontrol(1, i_at_cardcontrol(1)) = p_at_cardcontrol(1);
     }
-    return;
 }
 
 void showcard2(int prm_425, int prm_426)
@@ -228,7 +225,6 @@ void showcard2(int prm_425, int prm_426)
             font(12 - en * 2);
         }
     }
-    return;
 }
 
 void showcardpile()
@@ -276,7 +272,6 @@ void showcard()
         }
         showcard2(cnt);
     }
-    return;
 }
 
 int servecard(int prm_427)
@@ -368,7 +363,6 @@ void showcardholder()
             gcopy(3, 528, 216, 80, 112);
         }
     }
-    return;
 }
 
 int opencard2(int prm_428, int prm_429)

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1034,7 +1034,6 @@ void chara_set_generation_filter()
         return;
     }
     flt(calcobjlv(cdata.player().level), calcfixlv(Quality::bad));
-    return;
 }
 
 
@@ -1122,7 +1121,6 @@ void initialize_character()
     cdata[rc].set_state(Character::State::alive);
 
     cm = 0;
-    return;
 }
 
 

--- a/src/character_making.cpp
+++ b/src/character_making.cpp
@@ -602,7 +602,6 @@ void draw_race_or_class_info()
             ty += 14;
         }
     }
-    return;
 }
 
 } // namespace elona

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -847,7 +847,6 @@ void initialize_map_chip()
         chipm(2, 476) = 0;
         chipm(2, 509) = 0;
     }
-    return;
 }
 
 

--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -445,7 +445,6 @@ void initialize_rankn()
     ranknorma(1) = 60;
     ranknorma(2) = 45;
     ranknorma(6) = 30;
-    return;
 }
 
 
@@ -481,7 +480,6 @@ void initialize_post_data()
     pochart(0, 2, 0) = 5;
     pochart(1, 2, 0) = 6;
     DIM3(podata, 300, 20);
-    return;
 }
 
 
@@ -564,7 +562,6 @@ void initialize_pc_character()
         inv[cnt].identification_state = IdentifyState::completely_identified;
     }
     chara_refresh(0);
-    return;
 }
 
 
@@ -588,7 +585,6 @@ void clear_trait_data()
     DIM2(traitref, 10);
     SDIM3(traitrefn, 80, 9);
     SDIM3(traitrefn2, 20, 6);
-    return;
 }
 
 
@@ -643,7 +639,6 @@ void gain_race_feat()
         trait(160) = 1;
         trait(161) = 1;
     }
-    return;
 }
 
 
@@ -675,7 +670,6 @@ void setunid(int prm_282, int prm_283)
     cdata[prm_282].cnpc_id = prm_283;
     cdata[prm_282].image = 825 + prm_283;
     cdata[prm_282].image += 0;
-    return;
 }
 
 
@@ -929,7 +923,6 @@ void initialize_picfood()
     picfood(7, 7) = 113;
     picfood(8, 7) = 115;
     picfood(9, 7) = 111;
-    return;
 }
 
 
@@ -971,7 +964,6 @@ void csvsort(
         }
         p_at_m40(0) += strsize;
     }
-    return;
 }
 
 
@@ -1053,7 +1045,6 @@ void getinheritance(int prm_440, elona_vector1<int>& inhlist_, int& inhmax_)
         }
     }
     randomize();
-    return;
 }
 
 
@@ -1088,7 +1079,6 @@ void fltn(const std::string& prm_447)
         p_at_m44 += strsize;
         ++filtermax;
     }
-    return;
 }
 
 
@@ -1133,7 +1123,6 @@ void csvstr2(elona_vector1<std::string>& prm_532, const std::string& prm_533)
         }
         p_at_m67 += strsize;
     }
-    return;
 }
 
 
@@ -1523,7 +1512,6 @@ void cursor_check()
     {
         key = key_list(cs);
     }
-    return;
 }
 
 
@@ -1540,7 +1528,6 @@ void lenfix(std::string& prm_644, int prm_645)
     {
         prm_644 += u8" "s;
     }
-    return;
 }
 
 
@@ -1573,7 +1560,6 @@ void page_save()
     pagebk = page;
     csprev = cs;
     pagesaved = 1;
-    return;
 }
 
 
@@ -1586,7 +1572,6 @@ void page_load()
         cs = csprev;
         pagesaved = 0;
     }
-    return;
 }
 
 
@@ -1629,7 +1614,6 @@ void imeset(int prm_709)
     himc_at_ime_control = ImmGetContext(hwnd);
     ImmSetOpenStatus(himc_at_ime_control, prm_709);
     ImmReleaseContext(hwnd, himc_at_ime_control);
-    return;
 }
 
 
@@ -1706,7 +1690,6 @@ void fixaiact(int prm_753)
     {
         cdata[prm_753].ai_heal = 0;
     }
-    return;
 }
 
 
@@ -2028,7 +2011,6 @@ void animeload(int prm_807, int prm_808)
         await(i_at_m133(1));
     }
     gmode(2);
-    return;
 }
 
 
@@ -2188,7 +2170,6 @@ void spillblood(int prm_830, int prm_831, int prm_832)
             ++map(dx_at_m136, dy_at_m136, 7);
         }
     }
-    return;
 }
 
 
@@ -2222,7 +2203,6 @@ void spillfrag(int prm_833, int prm_834, int prm_835)
                 + (map(dx_at_m136, dy_at_m136, 7) / 10 + 1) * 10;
         }
     }
-    return;
 }
 
 
@@ -2303,7 +2283,6 @@ void check_kill(int prm_836, int prm_837)
     {
         modify_karma(cdata.player(), p_at_m137);
     }
-    return;
 }
 
 
@@ -2361,7 +2340,6 @@ void cnvbonus(int prm_895, int prm_896)
                 + u8"に <red>"s + prm_896 + u8"<col> のマイナス修正\n"s;
         }
     }
-    return;
 }
 
 
@@ -2603,7 +2581,6 @@ void start_stealing()
 {
     gdata(91) = 105;
     continuous_action_others();
-    return;
 }
 
 
@@ -2919,7 +2896,6 @@ void refresh_burden_state()
         cdata.player().inventory_weight_type = 0;
     }
     refresh_speed(cdata.player());
-    return;
 }
 
 
@@ -2968,7 +2944,6 @@ void chara_set_revived_status()
     cdata[rc].relationship = cdata[rc].original_relationship;
     cdata[rc].nutrition = 8000;
     cdata[rc].set_state(Character::State::alive);
-    return;
 }
 
 
@@ -3015,7 +2990,6 @@ void chara_clear_status_effects()
         }
     }
     chara_refresh(rc);
-    return;
 }
 
 
@@ -3050,7 +3024,6 @@ void revive_player()
         chara_gain_fixed_skill_exp(cdata[rc], 183, 1000);
     }
     chara_refresh(rc);
-    return;
 }
 
 
@@ -4331,7 +4304,6 @@ void character_drops_item()
     {
         supply_new_equipment();
     }
-    return;
 }
 
 
@@ -5593,7 +5565,6 @@ void map_prepare_tileset_atlas()
     gmode(0);
     gsel(0);
     gmode(2);
-    return;
 }
 
 
@@ -5672,7 +5643,6 @@ void map_global_proc_diastrophism()
         map_global_prepare();
     }
     gdata(79) = 0;
-    return;
 }
 
 
@@ -5681,7 +5651,6 @@ void map_global_prepare()
 {
     map_clear_material_spots_and_light();
     map_global_place_entrances();
-    return;
 }
 
 
@@ -5783,7 +5752,6 @@ void map_global_place_entrances()
             map(adata(1, cnt), adata(2, cnt), 9) = 11;
         }
     }
-    return;
 }
 
 
@@ -5805,7 +5773,6 @@ void map_clear_material_spots_and_light()
             map(x, y, 9) = 0;
         }
     }
-    return;
 }
 
 
@@ -6526,7 +6493,6 @@ void initialize_adata()
     adata(11, p) = 0;
     adata(12, p) = 0;
     adata(30, p) = 4;
-    return;
 }
 
 
@@ -7218,7 +7184,6 @@ void map_reload_noyel()
             }
         }
     }
-    return;
 }
 
 
@@ -7333,7 +7298,6 @@ void atxinit()
         gcopy(0, 120, 88, windoww - 120, windowh - inf_verh - 112, 200, 90);
         gsel(0);
     }
-    return;
 }
 
 
@@ -7345,7 +7309,6 @@ void begintempinv()
     {
         inv[cnt].remove();
     }
-    return;
 }
 
 
@@ -7353,7 +7316,6 @@ void begintempinv()
 void exittempinv()
 {
     ctrl_file(FileOperation2::map_items_read, u8"shoptmp.s2");
-    return;
 }
 
 
@@ -7379,7 +7341,6 @@ void god_fail_to_take_over_penalty()
         tc = 0;
         magic();
     }
-    return;
 }
 
 
@@ -7601,7 +7562,6 @@ void supply_income()
             }
         }
     }
-    return;
 }
 
 
@@ -7757,7 +7717,6 @@ void txttargetnpc(int prm_1057, int prm_1058, int prm_1059)
         }
     }
     cansee = 1;
-    return;
 }
 
 
@@ -8612,7 +8571,6 @@ void sort_list_by_column1()
             break;
         }
     }
-    return;
 }
 
 
@@ -8650,7 +8608,6 @@ void sort_list_and_listn_by_column1()
             break;
         }
     }
-    return;
 }
 
 
@@ -8665,7 +8622,6 @@ void savecycle()
             lastctrl = invctrl;
         }
     }
-    return;
 }
 
 
@@ -8900,7 +8856,6 @@ void build_target_list()
             break;
         }
     }
-    return;
 }
 
 
@@ -9334,7 +9289,6 @@ void remove_card_and_figures()
             inv[cnt].remove();
         }
     }
-    return;
 }
 
 
@@ -9647,7 +9601,6 @@ void get_inheritance()
     {
         mat(cnt) = mat(cnt) / 3;
     }
-    return;
 }
 
 
@@ -9827,7 +9780,6 @@ void create_cnpc()
     cdata[rc].original_relationship = cdata[rc].relationship;
     fixaiact(rc);
     setunid(rc, cun);
-    return;
 }
 
 
@@ -10425,7 +10377,6 @@ label_21451_internal:
             }
         }
     }
-    return;
 }
 
 
@@ -10679,7 +10630,6 @@ void do_rest()
     }
     txt(i18n::s.get("core.locale.activity.rest.finish"));
     cdata[cc].continuous_action.finish();
-    return;
 }
 
 
@@ -10821,7 +10771,6 @@ void map_global_proc_travel_events()
     traveldone = 1;
     gdata_distance_between_town += 4;
     cdata[cc].continuous_action.finish();
-    return;
 }
 
 
@@ -12053,7 +12002,6 @@ void heal_completely()
     cdata[tc].hp = cdata[tc].max_hp;
     cdata[tc].mp = cdata[tc].max_mp;
     cdata[tc].sp = cdata[tc].max_sp;
-    return;
 }
 
 
@@ -12461,7 +12409,6 @@ void lost_body_part(int cc)
                 cdata[cc].body_parts[cnt] / 10000 * 10000;
         }
     }
-    return;
 }
 
 
@@ -13270,7 +13217,6 @@ void sense_map_feats_on_move()
             }
         }
     }
-    return;
 }
 
 
@@ -13506,7 +13452,6 @@ void open_box()
     {
         modify_karma(cdata.player(), -8);
     }
-    return;
 }
 
 
@@ -13672,7 +13617,6 @@ void open_new_year_gift()
         cdata.player().position.x,
         cdata.player().position.y,
         1);
-    return;
 }
 
 
@@ -13966,7 +13910,6 @@ void try_to_melee_attack()
         do_physical_attack();
     }
     attackvar = 0;
-    return;
 }
 
 
@@ -14595,7 +14538,6 @@ void proc_weapon_enchantments()
                 sdata(attackskill, cc) * 10 + 100);
         }
     }
-    return;
 }
 
 
@@ -14603,7 +14545,6 @@ void proc_weapon_enchantments()
 void discover_trap()
 {
     cell_featset(refx, refy, tile_trap, -1, -1);
-    return;
 }
 
 
@@ -14612,7 +14553,6 @@ void discover_hidden_path()
 {
     map(refx, refy, 0) = tile_tunnel;
     cell_featset(refx, refy, 0, 0);
-    return;
 }
 
 
@@ -14646,7 +14586,6 @@ void dipcursed(int prm_1078, int)
         return;
     }
     txt(i18n::s.get("core.locale.common.nothing_happens"));
-    return;
 }
 
 
@@ -14866,7 +14805,6 @@ void grow_plant(int val0)
             try_to_grow_plant(val0);
         }
     }
-    return;
 }
 
 
@@ -14910,7 +14848,6 @@ void try_to_grow_plant(int val0)
     {
         feat(3) += 50;
     }
-    return;
 }
 
 
@@ -14958,7 +14895,6 @@ void harvest_plant(int val)
         feat(3));
     txtef(2);
     txt(i18n::s.get("core.locale.action.plant.new_plant_grows"));
-    return;
 }
 
 
@@ -15006,7 +14942,6 @@ void create_harvested_item()
     itemcreate(0, dbid, -1, -1, 0);
     txt(i18n::s.get("core.locale.action.plant.harvest", inv[ci]));
     item_stack(0, ci, 1);
-    return;
 }
 
 
@@ -15105,7 +15040,6 @@ void initialize_economy()
     initialize_map();
     initeco = 0;
     msgtemp = "";
-    return;
 }
 
 
@@ -15407,7 +15341,6 @@ void scene_fade_to_black()
     scenemode = 0;
     msgtemp = msgtempprev;
     msgtempprev = "";
-    return;
 }
 
 
@@ -15436,7 +15369,6 @@ void weather_changes_by_location()
             txt(i18n::s.get("core.locale.action.weather.changes"));
         }
     }
-    return;
 }
 
 
@@ -16012,7 +15944,6 @@ void play_the_last_scene_again()
     }
     gdata_main_quest_flag = 180;
     update_screen();
-    return;
 }
 
 

--- a/src/enchantment.cpp
+++ b/src/enchantment.cpp
@@ -463,7 +463,6 @@ void initialize_enchantment_data()
     encprocref(3, 25) = 10000;
     encprocref(4, 25) = 0;
     encprocref(5, 25) = 100;
-    return;
 }
 
 std::string enchantment_print_level(int prm_448)
@@ -1049,7 +1048,6 @@ void enchantment_sort(int prm_454)
             break;
         }
     }
-    return;
 }
 
 
@@ -1092,7 +1090,6 @@ void enchantment_remove(int prm_455, int prm_456, int prm_457)
     }
     inv[prm_455].value = inv[prm_455].value * 100 / encref(1, p_at_m48);
     enchantment_sort(prm_455);
-    return;
 }
 
 
@@ -1297,7 +1294,6 @@ void add_enchantments_depending_on_ego()
             8);
     }
     inv[ci].subname = 20000 + rnd(maxegominorn);
-    return;
 }
 
 
@@ -1344,7 +1340,6 @@ void add_enchantment_by_fixed_ego()
             enchantment_gen_p(),
             25);
     }
-    return;
 }
 
 
@@ -1499,7 +1494,6 @@ void add_enchantments()
             enchantment_add(ci, enchantment_generate(-1), enchantment_gen_p());
         }
     }
-    return;
 }
 
 
@@ -1607,6 +1601,5 @@ void ego_add(int prm_465, int prm_466)
             egoenc(cnt * 2, prm_466),
             enchantment_gen_p(egoenc(cnt * 2 + 1, prm_466)));
     }
-    return;
 }
 } // namespace elona

--- a/src/equipment.cpp
+++ b/src/equipment.cpp
@@ -77,7 +77,6 @@ void equipinfo(int prm_529, int prm_530, int prm_531)
             color(0, 0, 0);
         }
     }
-    return;
 }
 
 
@@ -129,7 +128,6 @@ void eqrandweaponmage(int prm_929)
         eqweapon1(0) = 10006;
         eqweapon1(1) = prm_929;
     }
-    return;
 }
 
 void wear_most_valuable_equipment_for_all_body_parts()
@@ -143,7 +141,6 @@ void wear_most_valuable_equipment_for_all_body_parts()
         }
         wear_most_valuable_equipment();
     }
-    return;
 }
 
 
@@ -208,7 +205,6 @@ void wear_most_valuable_equipment()
             }
         }
     }
-    return;
 }
 
 
@@ -344,7 +340,6 @@ void supply_new_equipment()
             }
         }
     }
-    return;
 }
 
 
@@ -1177,7 +1172,6 @@ void supply_initial_equipments()
     eqtwohand = 0;
     eqtwowield = 0;
     eqmultiweapon = 0;
-    return;
 }
 
 void colorres(int)
@@ -1227,7 +1221,6 @@ void colorres(int)
     {
         color(150, 50, 0);
     }
-    return;
 }
 
 } // namespace elona

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -55,7 +55,6 @@ void event_add(int prm_289, int prm_290, int prm_291)
         evdata2(evnum) = prm_291;
     }
     ++evnum;
-    return;
 }
 
 TurnResult event_start_proc()

--- a/src/food.cpp
+++ b/src/food.cpp
@@ -122,7 +122,6 @@ void eat_rotten_food()
     nutrition = 1000;
     dmgcon(cc, StatusAilment::paralyzed, 100);
     dmgcon(cc, StatusAilment::confused, 200);
-    return;
 }
 
 
@@ -377,7 +376,6 @@ void cook()
         chara_gain_skill_exp(cdata[cc], 184, 30 + rank * 5);
     }
     refresh_burden_state();
-    return;
 }
 
 
@@ -1356,7 +1354,6 @@ void apply_general_eating_effect(int cieat)
         }
     }
     eatstatus(inv[cieat].curse_state, cc);
-    return;
 }
 
 

--- a/src/god.cpp
+++ b/src/god.cpp
@@ -106,7 +106,6 @@ void set_npc_religion()
     {
         cdata[tc].has_learned_words() = true;
     }
-    return;
 }
 
 
@@ -395,7 +394,6 @@ void god_proc_switching_penalty()
         msg_halt();
     }
     chara_refresh(0);
-    return;
 }
 
 
@@ -436,7 +434,6 @@ void switch_religion()
         }
         txtgod(cdata.player().god_id, 5);
     }
-    return;
 }
 
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -445,7 +445,6 @@ void cell_refresh(int prm_493, int prm_494)
         }
         map(prm_493, prm_494, 4) *= -1;
     }
-    return;
 }
 
 
@@ -900,7 +899,6 @@ void itemname_additional_info()
             s_ += lang(u8"ジュアの"s, u8" of Jure"s);
         }
     }
-    return;
 }
 
 

--- a/src/itemgen.cpp
+++ b/src/itemgen.cpp
@@ -555,7 +555,6 @@ void init_item_quality_curse_state_material_and_equipments()
     {
         inv[ci].quality = Quality::good;
     }
-    return;
 }
 
 void calc_furniture_value()
@@ -567,7 +566,6 @@ void calc_furniture_value()
             inv[ci].value = inv[ci].value * (80 + inv[ci].subname * 20) / 100;
         }
     }
-    return;
 }
 
 
@@ -575,7 +573,6 @@ void initialize_item_material()
 {
     determine_item_material();
     apply_item_material();
-    return;
 }
 
 void determine_item_material()
@@ -669,7 +666,6 @@ void determine_item_material()
     {
         inv[ci].material = 35;
     }
-    return;
 }
 
 void change_item_material()
@@ -700,7 +696,6 @@ void change_item_material()
     apply_item_material();
     calc_furniture_value();
     chara_refresh(cc);
-    return;
 }
 
 void apply_item_material()
@@ -770,7 +765,6 @@ void apply_item_material()
             inv[ci].dice_y * the_item_material_db[p]->dice_y / (p(1) + rnd(25));
     }
     set_material_specific_attributes();
-    return;
 }
 
 void set_material_specific_attributes()
@@ -791,7 +785,6 @@ void set_material_specific_attributes()
             ibitmod(2, ci, 1);
         }
     }
-    return;
 }
 
 } // namespace elona

--- a/src/map_cell.cpp
+++ b/src/map_cell.cpp
@@ -53,7 +53,6 @@ void cell_featset(
     }
     map(prm_592, prm_593, 6) = feat_at_m80 + feat_at_m80(1) * 1000
         + feat_at_m80(2) * 100000 + feat_at_m80(3) * 10000000;
-    return;
 }
 
 
@@ -72,7 +71,6 @@ int cell_featread(int prm_598, int prm_599, int)
 void cell_featclear(int prm_601, int prm_602)
 {
     map(prm_601, prm_602, 6) = 0;
-    return;
 }
 
 
@@ -105,7 +103,6 @@ void cell_check(int prm_603, int prm_604)
     {
         cellaccess = 0;
     }
-    return;
 }
 
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -71,7 +71,6 @@ void map_initialize()
     DIM3(mapsync, mdata_map_width, mdata_map_height);
     DIM3(mef, 9, MEF_MAX);
     map_tileset(mdata_map_tileset);
-    return;
 }
 
 
@@ -183,7 +182,6 @@ void initialize_cell_object_data()
     cellobjdata(3, maxobjid) = tile_doorclosed4;
     cellobjname(maxobjid) = u8"扉JAIL"s;
     ++maxobjid;
-    return;
 }
 
 
@@ -228,7 +226,6 @@ void map_converttile()
             }
         }
     }
-    return;
 }
 
 
@@ -397,7 +394,6 @@ void map_placecharaonentrance(int prm_936, int prm_937, int prm_938)
     cyinit = y_at_m167;
     rc = prm_936;
     chara_place();
-    return;
 }
 
 
@@ -434,7 +430,6 @@ void map_placearena(int prm_939, int prm_940)
         }
         map(cdata[prm_939].position.x, cdata[prm_939].position.y, 1) = 0;
     }
-    return;
 }
 
 
@@ -486,7 +481,6 @@ void map_placeplayer()
         }
         map_placecharaonentrance(cnt, game_data.entrance_type);
     }
-    return;
 }
 
 
@@ -500,7 +494,6 @@ void map_randomtile(int prm_941, int prm_942)
     {
         map(rnd(mdata_map_width), rnd(mdata_map_height), 0) = prm_941;
     }
-    return;
 }
 
 
@@ -889,7 +882,6 @@ void map_setfog(int, int)
                 tile_fog + (rnd(tile_fog(2)) == 0) * rnd(tile_fog(1));
         }
     }
-    return;
 }
 
 void rndshuffle(elona_vector1<int>& prm_534)
@@ -905,7 +897,6 @@ void rndshuffle(elona_vector1<int>& prm_534)
         prm_534(r_at_m68) = prm_534(p_at_m68);
         prm_534(p_at_m68) = i_at_m68;
     }
-    return;
 }
 
 void map_createroomdoor()
@@ -996,7 +987,6 @@ void map_createroomdoor()
             break;
         }
     }
-    return;
 }
 
 
@@ -1466,7 +1456,6 @@ void map_randsite(int prm_971, int prm_972)
         itemcreate(-1, 0, x_at_m169, y_at_m169, 0);
         return;
     }
-    return;
 }
 
 
@@ -2236,7 +2225,6 @@ void generate_random_nefia()
             cell_featset(x, y, tile_downlocked, 11);
         }
     }
-    return;
 }
 
 
@@ -2285,7 +2273,6 @@ void initialize_random_nefia_rdtype6()
         itemcreate(-1, 0, -1, -1, 0);
         inv[ci].own_state = 1;
     }
-    return;
 }
 
 
@@ -3110,7 +3097,6 @@ void initialize_quest_map_town()
             map(x, y, 6) = 0;
         }
     }
-    return;
 }
 
 
@@ -3198,7 +3184,6 @@ void initialize_random_nefia_rdtype8()
             break;
         }
     }
-    return;
 }
 
 
@@ -3215,7 +3200,6 @@ void dimmix(elona_vector1<int>& prm_983)
         prm_983(r_at_m172) = prm_983(cnt);
         prm_983(cnt) = tmp_at_m172;
     }
-    return;
 }
 
 
@@ -3230,7 +3214,6 @@ void initialize_random_nefia_rdtype9()
     rdsecond = 1;
     mapgen_dig_maze();
     rdsecond = 0;
-    return;
 }
 
 
@@ -3433,7 +3416,6 @@ void mapgen_dig_maze()
         map_placedownstairs(dx, dy);
         break;
     }
-    return;
 }
 
 
@@ -3635,7 +3617,6 @@ void initialize_random_nefia_rdtype10()
             }
         }
     }
-    return;
 }
 
 void map_tileset(int prm_933)
@@ -3815,7 +3796,6 @@ void map_tileset(int prm_933)
             tile_default = 45;
         }
     }
-    return;
 }
 
 void initialize_home_mdata()
@@ -3851,7 +3831,6 @@ void initialize_home_mdata()
         mdata_map_max_item_count = 400;
         gdata_basic_point_of_home_rank = 10000;
     }
-    return;
 }
 
 void map_initcustom(const std::string& prm_934)
@@ -3912,7 +3891,6 @@ void map_initcustom(const std::string& prm_934)
     }
     nooracle = 0;
     mdata_map_user_map_flag = 1;
-    return;
 }
 
 

--- a/src/mef.cpp
+++ b/src/mef.cpp
@@ -57,7 +57,6 @@ void mef_delete(int prm_581)
         }
         --i_at_m79;
     }
-    return;
 }
 
 
@@ -114,7 +113,6 @@ void mef_add(
     mef(7, i_at_m79) = prm_589;
     mef(8, i_at_m79) = prm_590;
     map(pos_x, pos_y, 8) = i_at_m79 + 1;
-    return;
 }
 
 void mef_update()

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -483,7 +483,6 @@ label_2700_internal:
     cs = 0;
     update_screen();
     quickkeywait = 1;
-    return;
 }
 
 void show_ex_help()
@@ -571,7 +570,6 @@ void show_ex_help()
             break;
         }
     }
-    return;
 }
 
 void show_game_help()
@@ -612,7 +610,6 @@ void load_showroom_user_info()
     usermsg = ""s + s;
     noteget(s, 6);
     userrelation = elona::stoi(s(0));
-    return;
 }
 
 int cnvjkey(const std::string& prm_1092)
@@ -738,7 +735,6 @@ void draw_spell_power_entry(int skill_id)
         s += u8" "s;
     }
     s += i18n::_(u8"ability", std::to_string(skill_id), u8"description");
-    return;
 }
 
 MenuResult _show_character_sheet_menu(size_t menu_index)
@@ -979,7 +975,6 @@ void set_pcc_info(int val0)
             rtvaln = "";
         }
     }
-    return;
 }
 
 int change_appearance()
@@ -1451,7 +1446,6 @@ void append_accuracy_info(int val0)
         s(1) = i18n::s.get("core.locale.ui.chara_sheet.damage.dist");
         show_weapon_dice(val0);
     }
-    return;
 }
 
 void show_weapon_dice(int val0)
@@ -1502,7 +1496,6 @@ void show_weapon_dice(int val0)
         noteadd(s(1) + "   : " + fixtxt(s(3), 12) + " " + fixtxt(s, 20));
     }
     ++p(2);
-    return;
 }
 
 static TurnResult _visit_quest_giver(int quest_index)

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -93,7 +93,6 @@ namespace elona
 void txtcontinue()
 {
     tcontinue_at_txtfunc = 1;
-    return;
 }
 
 
@@ -138,7 +137,6 @@ void anime_halt()
         redraw();
     }
     gmode(2);
-    return;
 }
 
 
@@ -150,7 +148,6 @@ void msg_halt()
     anime_halt();
     screenupdate = -1;
     update_screen();
-    return;
 }
 
 
@@ -160,7 +157,6 @@ void help_halt()
     x_at_txtfunc = wx + dx - 140;
     y_at_txtfunc = wy + dy - 1;
     anime_halt();
-    return;
 }
 
 
@@ -223,7 +219,6 @@ void msg_newline()
     }
     gmode(2);
     msgtempprev = "";
-    return;
 }
 
 
@@ -238,7 +233,6 @@ void txtnew()
             message_width = 2;
         }
     }
-    return;
 }
 
 
@@ -250,7 +244,6 @@ void msg_clear()
     {
         msg_newline();
     }
-    return;
 }
 
 

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -118,7 +118,6 @@ void netload(const std::string& prm_194)
     }
     neterror(estr_at_m0);
     dialog(u8"エラー:"s + estr_at_m0);
-    return;
 }
 
 
@@ -580,7 +579,6 @@ void initialize_server_info()
         votereadurl = u8"http://www."s + cgiurl3 + u8"/voteen.txt"s;
     }
     textreadurl = u8"http://www."s + cgiurl3 + u8"/text.txt"s;
-    return;
 }
 
 
@@ -629,7 +627,6 @@ void show_chat_dialog()
               inputlog(0)));
     chatturn = 0;
     chatdeny = 1;
-    return;
 }
 
 

--- a/src/quest.cpp
+++ b/src/quest.cpp
@@ -187,7 +187,6 @@ void quest_check()
             }
         }
     }
-    return;
 }
 
 
@@ -420,7 +419,6 @@ void quest_set_data(int val0)
         }
     }
     randomize();
-    return;
 }
 
 
@@ -925,7 +923,6 @@ void quest_gen_scale_by_level()
                + clamp((qdata(5, rq) - cdata.player().level) / 5 * 25, 0, 200))
             / 100;
     }
-    return;
 }
 
 void quest_check_all_for_failed()
@@ -953,7 +950,6 @@ void quest_check_all_for_failed()
             quest_failed(qdata(3, rq));
         }
     }
-    return;
 }
 
 
@@ -1000,7 +996,6 @@ void quest_exit_map()
     gdata(71) = 0;
     gdata_executing_immediate_quest = 0;
     gdata(73) = 0;
-    return;
 }
 
 
@@ -1105,7 +1100,6 @@ void quest_failed(int val0)
     p = stat;
     txtef(3);
     txt(i18n::s.get("core.locale.quest.lose_fame", p(0)));
-    return;
 }
 
 
@@ -1156,7 +1150,6 @@ void quest_team_victorious()
             txt(i18n::s.get("core.locale.quest.lose_fame", p(0)));
         }
     }
-    return;
 }
 
 
@@ -1206,7 +1199,6 @@ void quest_all_targets_killed()
         txtef(2);
         txt(i18n::s.get("core.locale.quest.conquer.complete"));
     }
-    return;
 }
 
 void quest_complete()
@@ -1328,7 +1320,6 @@ void quest_complete()
     qdata(3, rq) = 0;
     qdata(8, rq) = 0;
     autosave = 1 * (gdata_current_map != mdata_t::MapId::show_house);
-    return;
 }
 
 } // namespace elona

--- a/src/shop.cpp
+++ b/src/shop.cpp
@@ -50,7 +50,6 @@ void shop_refresh_on_talk()
     }
     invfile = cdata[tc].shop_store_id;
     shop_load_shoptmp();
-    return;
 }
 
 void shop_load_shoptmp()
@@ -58,7 +57,6 @@ void shop_load_shoptmp()
     ctrl_file(FileOperation2::map_items_write, u8"shop"s + invfile + u8".s2");
     ctrl_file(FileOperation2::map_items_read, u8"shoptmp.s2");
     mode = 0;
-    return;
 }
 
 void shop_refresh()
@@ -766,7 +764,6 @@ void calc_number_of_items_sold_at_shop()
         rtval = 1;
         return;
     }
-    return;
 }
 
 void calc_trade_goods_price()
@@ -847,7 +844,6 @@ void calc_trade_goods_price()
         trate(cnt) += rnd(15) - rnd(15);
     }
     randomize();
-    return;
 }
 
 void shop_sell_item()
@@ -864,7 +860,6 @@ void shop_sell_item()
         }
     }
     ctrl_inventory();
-    return;
 }
 
 } // namespace elona

--- a/src/status_ailment.cpp
+++ b/src/status_ailment.cpp
@@ -579,7 +579,6 @@ void healcon(int prm_827, int prm_828, int prm_829)
             }
         }
     }
-    return;
 }
 
 

--- a/src/talk.cpp
+++ b/src/talk.cpp
@@ -34,7 +34,6 @@ void talk_start()
     gsel(7);
     picload(filesystem::dir::graphic() / u8"ie_chat.bmp");
     gsel(0);
-    return;
 }
 
 void talk_to_npc()
@@ -566,7 +565,6 @@ void talk_end()
         screenupdate = -1;
         update_screen();
     }
-    return;
 }
 
 

--- a/src/tcg.cpp
+++ b/src/tcg.cpp
@@ -151,7 +151,6 @@ void cpflip()
         ch_at_tcg = 3;
         th_at_tcg = 0;
     }
-    return;
 }
 
 
@@ -176,7 +175,6 @@ void cpisme()
         ch_at_tcg = 3;
         th_at_tcg = 0;
     }
-    return;
 }
 
 
@@ -201,7 +199,6 @@ void cpisenemy()
         ch_at_tcg = 0;
         th_at_tcg = 3;
     }
-    return;
 }
 
 
@@ -364,7 +361,6 @@ void makecardlist()
         }
     }
     tcg_proc_ai_elist();
-    return;
 }
 
 
@@ -391,7 +387,6 @@ void cardhelp(const std::string& prm_992, int prm_993 = 0)
     }
     helpmsg_at_tcg = prm_992;
     helpdur_at_tcg = dur_at_tcg;
-    return;
 }
 
 
@@ -541,7 +536,6 @@ void tcgdrawcard(int prm_994, int prm_995)
             }
         }
     }
-    return;
 }
 
 
@@ -815,7 +809,6 @@ void efllistadd(
             break;
         }
     }
-    return;
 }
 
 
@@ -894,7 +887,6 @@ void cardpos(int prm_1004, int prm_1005)
         card_at_tcg(4, p_at_tcg) = x_at_tcg + cnt * x2_at_tcg;
         card_at_tcg(5, p_at_tcg) = spotiy_at_tcg(prm_1004);
     }
-    return;
 }
 
 
@@ -939,7 +931,6 @@ void gravecard(int prm_1006)
     makecardlist();
     cardpos(card_at_tcg(1, prm_1006), -1);
     tcg_update_mana();
-    return;
 }
 
 
@@ -964,7 +955,6 @@ void dmgcard(int prm_1007, int prm_1008)
         tcgdraw();
         gravecard(prm_1007);
     }
-    return;
 }
 
 
@@ -981,7 +971,6 @@ void dmgplayer(int prm_1009, int prm_1010)
     {
         cpdata_at_tcg(4, prm_1009) = 0;
     }
-    return;
 }
 
 
@@ -1008,7 +997,6 @@ void delbottomcard(int prm_1011)
     }
     tcgdraw();
     gravecard(delcard_at_tcg);
-    return;
 }
 
 
@@ -1198,7 +1186,6 @@ void getrandomcard(int prm_1018)
         delbottomcard(prm_1018);
     }
     makecardlist();
-    return;
 }
 
 
@@ -1257,7 +1244,6 @@ void saccard(int prm_1019, int prm_1020)
         card_at_tcg(3, prm_1019),
         cpx_at_tcg(prm_1020),
         cpy_at_tcg(prm_1020));
-    return;
 }
 
 
@@ -1267,7 +1253,6 @@ void opencard(int prm_1021)
     snd(71);
     cdbitmod(1, prm_1021, 1);
     tcgdraw();
-    return;
 }
 
 
@@ -1284,7 +1269,6 @@ void tcg_show_refs()
     p_at_tcg = 3;
     cdrefn_at_tcg(p_at_tcg) =
         i18n::s.get("core.locale.tcg.ref.return_creature");
-    return;
 }
 
 
@@ -1450,7 +1434,6 @@ void actionproc()
 void tcg_clear_stack()
 {
     stack_at_tcg = 0;
-    return;
 }
 
 
@@ -1556,7 +1539,6 @@ void tcgdrawbg()
         }
     }
     gmode(2);
-    return;
 }
 
 
@@ -1638,7 +1620,6 @@ void tcginit()
     picload(filesystem::dir::graphic() / u8"bg_card.bmp", 1);
     tcg_prepare_cnt2();
     tcgdrawbg();
-    return;
 }
 
 
@@ -1655,7 +1636,6 @@ void calcstartattb(int prm_1027)
 {
     cpdata_at_tcg(4, prm_1027) = 40 - cpdata_at_tcg(9, prm_1027) * 5;
     cpdata_at_tcg(6, prm_1027) = 0;
-    return;
 }
 
 
@@ -1687,7 +1667,6 @@ void calcdomain()
         }
         calcstartattb(p_at_tcg);
     }
-    return;
 }
 
 
@@ -1717,7 +1696,6 @@ void calcdecksize()
         }
     }
     calcstartattb(0);
-    return;
 }
 
 
@@ -1897,7 +1875,6 @@ void tcgmain()
 
 void tcg_game_over()
 {
-    return;
 }
 
 
@@ -1925,7 +1902,6 @@ void tcg_phase_one()
         card_at_tcg(12, cnt) = card_at_tcg(16, cnt);
         cdbitmod(0, cnt, 0);
     }
-    return;
 }
 
 
@@ -1937,7 +1913,6 @@ void tcg_phase_two()
     await(50);
     getrandomcard(cp_at_tcg);
     tcgdraw();
-    return;
 }
 
 
@@ -1957,7 +1932,6 @@ void tcg_phase_three()
         selectmode_at_tcg = -1;
         tcg_proc_ai();
     }
-    return;
 }
 
 
@@ -1977,7 +1951,6 @@ void tcg_phase_four()
     {
         tcgdraw();
     }
-    return;
 }
 
 
@@ -2014,7 +1987,6 @@ void csfix()
     {
         cs_at_tcg = clistmax_at_tcg(csline_at_tcg) - 1;
     }
-    return;
 }
 
 
@@ -2050,7 +2022,6 @@ void cslineup()
     {
         cs_at_tcg = clistmax_at_tcg(csline_at_tcg) - 1;
     }
-    return;
 }
 
 
@@ -2090,7 +2061,6 @@ void cslinedown()
     {
         cs_at_tcg = clistmax_at_tcg(csline_at_tcg) - 1;
     }
-    return;
 }
 
 
@@ -2179,7 +2149,6 @@ void tcg_update_mana()
     }
     color(0, 0, 0);
     gsel(0);
-    return;
 }
 
 
@@ -2266,7 +2235,6 @@ void tcg_draw_selection()
     mes(u8"Page "s + dsc_at_tcg / 8 / 3 + u8"/"s
         + (dlistmax_at_tcg - 1) / 8 / 3);
     color(0, 0, 0);
-    return;
 }
 
 
@@ -2390,7 +2358,6 @@ void tcg_draw_deck_editor()
     font(12 + en - en * 2);
     pos(basex_at_tcg + 146, basey_at_tcg + 545);
     mes(helpmsg_at_tcg);
-    return;
 }
 
 
@@ -2403,7 +2370,6 @@ void tcg_prepare_cnt2()
         cnt2_at_tcg = cnt;
     }
     gsel(0);
-    return;
 }
 
 
@@ -2427,7 +2393,6 @@ void tcg_update_page()
         page_at_tcg = dsc_at_tcg / 8;
     }
     page_at_tcg = page_at_tcg - page_at_tcg % 3;
-    return;
 }
 
 
@@ -3019,7 +2984,6 @@ void tcg_prompt_action()
 void tcg_clear_cursor()
 {
     cursor_at_tcg = 0;
-    return;
 }
 
 
@@ -3119,7 +3083,6 @@ void tcg_update_selection()
 
 void tcg_card_selected()
 {
-    return;
 }
 
 
@@ -3213,7 +3176,6 @@ void tcg_proc_ai_elist()
             break;
         }
     }
-    return;
 }
 
 
@@ -3374,7 +3336,6 @@ void tcg_proc_ai_sacrifice()
     {
         return;
     }
-    return;
 }
 
 

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -913,7 +913,6 @@ void parse_talk_file()
     noteget(s, p);
     buff = s;
     text_replace_tags_in_quest_board();
-    return;
 }
 
 
@@ -934,7 +933,6 @@ void read_talk_file(const std::string& valn)
     }
     p = instr(buff, 0, valn + u8","s + i18n::s.get("core.locale.meta.tag"));
     parse_talk_file();
-    return;
 }
 
 
@@ -1064,7 +1062,6 @@ void get_npc_talk()
             buff, 0, u8"%DEFAULT,"s + i18n::s.get("core.locale.meta.tag"));
     }
     parse_talk_file();
-    return;
 }
 
 
@@ -1133,7 +1130,6 @@ void quest_update_main_quest_journal()
     talk_conv(s1, 40 - en * 4);
     buff += s1;
     noteadd(""s);
-    return;
 }
 
 
@@ -2039,7 +2035,6 @@ void append_subquest_journal(int val0)
             noteadd(""s);
         }
     }
-    return;
 }
 
 
@@ -2076,7 +2071,6 @@ void append_quest_item_journal()
             + i18n::s.get("core.locale.quest.journal.item.sages_magic_stone")
             + "]");
     }
-    return;
 }
 
 
@@ -2108,7 +2102,6 @@ void parse_quest_board_text(int val0)
     {
         buff = buff2;
     }
-    return;
 }
 
 
@@ -2545,7 +2538,6 @@ void text_replace_tags_in_quest_text()
         }
         buff = s(1) + s + s(2);
     }
-    return;
 }
 
 

--- a/src/ui/ui_menu_character_sheet.cpp
+++ b/src/ui/ui_menu_character_sheet.cpp
@@ -242,7 +242,6 @@ static void _trainer_get_gainable_skills()
             ++listmax;
         }
     }
-    return;
 }
 
 static void _load_skill_list(CharacterSheetOperation op)

--- a/src/ui/ui_menu_game_help.cpp
+++ b/src/ui/ui_menu_game_help.cpp
@@ -82,7 +82,6 @@ void UIMenuGameHelp::_remove_parenthesis_around_keys()
             instr(s(cnt), 0, u8"("s) + 1,
             instr(s(cnt), 0, u8")"s) - instr(s(cnt), 0, u8"("s) - 1));
     }
-    return;
 }
 
 void UIMenuGameHelp::_update_key_list()


### PR DESCRIPTION
# Summary

Deletes return statements like this:

```cpp
void foo()
{
    // Do something...
    return;
}
```

It is legacy of HSP. In HSP, you need to explicitly return.