### PR TITLE
Do not play breaking animation if you cannot see there

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -1196,6 +1196,11 @@ void RagnarokAnimation::do_play()
 
 void BreakingAnimation::do_play()
 {
+    if (!is_in_fov(position))
+    {
+        return;
+    }
+
     do_particle_animation(
         rendering_base_position_center(position),
         "breaking_effect",


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Breaking animation was always drawn even if you can't see there.

# Summary

Checks PC's vision.