### PR TITLE
Improve serialization portability

### DIFF
--- a/src/defines.hpp
+++ b/src/defines.hpp
@@ -3,6 +3,7 @@
 #include <boost/predef.h>
 
 
+// Operating system
 #if BOOST_OS_WINDOWS
 #define ELONA_OS_WINDOWS
 #define NOMINMAX
@@ -15,6 +16,17 @@
 #else
 #define ELONA_OS_OTHERS
 #endif
+
+
+// Endianness
+#if BOOST_ENDIAN_BIG_BYTE
+#define ELONA_BIG_ENDIAN
+#elif BOOST_ENDIAN_LITTLE_BYTE
+#define ELONA_LITTLE_ENDIAN
+#else
+#error "Unsupported endianness"
+#endif
+
 
 #ifdef ELONA_OS_ANDROID
 #undef bcopy

--- a/src/putit.hpp
+++ b/src/putit.hpp
@@ -17,9 +17,11 @@ class IArchiveBase
 };
 
 
+
 class OArchiveBase
 {
 };
+
 
 
 class BinaryIArchive : public IArchiveBase
@@ -27,7 +29,6 @@ class BinaryIArchive : public IArchiveBase
 public:
     BinaryIArchive(std::istream& in)
         : in(in)
-        , memory(new char[sizeof(long long)])
     {
     }
 
@@ -52,11 +53,8 @@ public:
             nullptr>
     void primitive(T& data)
     {
-        char* buf;
-        buf = memory.get();
-
-        in.read(buf, sizeof(T));
-        data = *reinterpret_cast<T*>(buf);
+        in.read(memory, sizeof(T));
+        data = *reinterpret_cast<T*>(memory);
     }
 
 
@@ -93,8 +91,10 @@ public:
 
 
 private:
+    static constexpr auto memory_size = sizeof(long long);
+
     std::istream& in;
-    std::unique_ptr<char[]> memory;
+    char memory[memory_size];
 };
 
 

--- a/src/putit.hpp
+++ b/src/putit.hpp
@@ -78,6 +78,11 @@ public:
     template <typename T>
     void primitive_array(T* data, size_t size)
     {
+        if (size == 0)
+        {
+            return;
+        }
+
         char* buf = new char[sizeof(T) * size];
 
         in.read(buf, sizeof(T) * size);
@@ -132,6 +137,11 @@ public:
     template <typename T>
     void primitive_array(const T* data, size_t size)
     {
+        if (size == 0)
+        {
+            return;
+        }
+
         out.write(reinterpret_cast<const char*>(data), sizeof(T) * size);
     }
 
@@ -220,7 +230,7 @@ template <
         std::nullptr_t> = nullptr>
 void serialize(Archive& ar, std::string& data)
 {
-    std::string::size_type length;
+    uint64_t length;
     ar.primitive(length);
     std::unique_ptr<char[]> buf{new char[length]};
     ar.primitive_array(buf.get(), length);
@@ -236,7 +246,7 @@ template <
         std::nullptr_t> = nullptr>
 void serialize(Archive& ar, std::string& data)
 {
-    const auto length = data.size();
+    const uint64_t length = data.size();
     ar.primitive(length);
     ar.primitive_array(data.c_str(), length);
 }
@@ -251,7 +261,7 @@ template <
         std::nullptr_t> = nullptr>
 void serialize(Archive& ar, std::vector<T>& data)
 {
-    typename std::vector<T>::size_type length;
+    uint64_t length;
     ar.primitive(length);
     std::unique_ptr<T[]> buf{new T[length]};
     ar.primitive_array(buf.get(), length);
@@ -268,12 +278,9 @@ template <
         std::nullptr_t> = nullptr>
 void serialize(Archive& ar, std::vector<T>& data)
 {
-    const auto length = data.size();
+    const uint64_t length = data.size();
     ar.primitive(length);
-    if (length != 0)
-    {
-        ar.primitive_array(data.data(), length);
-    }
+    ar.primitive_array(data.data(), length);
 }
 
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

#895 


# Summary

- Uses `uint64_t` instead of `size_t`.
- Add conversion between little endian and big endian on saving/loading in BE machine. All data are saved in LE even if the machine runs in BE, in order to make the save portable.