### PR TITLE
Overwrite SNAIL_HEADLESS flag if you specify WITH_TESTS=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,14 +294,18 @@ if(ANDROID)
   target_link_libraries( ${PROJECT_NAME} android log SDL2 SDL2_image SDL2_ttf SDL2_mixer lua boost_filesystem boost_system boost_iostreams snail )
 else()
   # Options
-  option(WITH_TESTS "Build test executable (TESTS or BENCH)" "NONE")
+  option(WITH_TESTS "Build test executable (TESTS or BENCH)" "OFF")
 
   if((WITH_TESTS STREQUAL "TESTS") OR (WITH_TESTS STREQUAL "BENCH"))
+    unset(SNAIL_HEADLESS CACHE)
     SET(SNAIL_HEADLESS ON CACHE BOOL "Snail headless")
     add_definitions(-DSNAIL_RENDERER_HEADLESS)
-  else()
+  elseif(WITH_TESTS STREQUAL "OFF")
+    unset(SNAIL_HEADLESS CACHE)
     SET(SNAIL_HEADLESS OFF CACHE BOOL "Snail SDL")
     add_definitions(-DSNAIL_RENDERER_SDL)
+  else()
+    # Use the previous flags.
   endif()
 
   # Executable
@@ -470,8 +474,10 @@ else()
 
   if((WITH_TESTS STREQUAL "TESTS") OR (WITH_TESTS STREQUAL "BENCH"))
     target_link_libraries(${PROJECT_NAME} snail_headless)
-  else()
+  elseif(WITH_TESTS STREQUAL "OFF")
     target_link_libraries(${PROJECT_NAME} snail)
+  else()
+    # Use the previous flags.
   endif()
 
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ MKDIR := mkdir
 .PHONY: FORCE
 
 
-all: build
+all:
+	cd $(BIN_DIR); cmake .. $(CMAKE_ARGS); make
 
 
 build: $(BIN_DIR) $(PROGRAM)
@@ -37,7 +38,7 @@ $(BIN_DIR):
 
 
 $(PROGRAM): FORCE
-	cd $(BIN_DIR); cmake .. $(CMAKE_ARGS); make
+	cd $(BIN_DIR); cmake .. $(CMAKE_ARGS) -DWITH_TESTS=OFF; make
 
 
 $(TEST_RUNNER):

--- a/Makefile.win
+++ b/Makefile.win
@@ -18,7 +18,8 @@ CMAKE_ARGS = \
         -G "Visual Studio 15 2017 Win64"
 
 
-all: build
+all:
+	cd $(BIN_DIR) & cmake .. $(CMAKE_ARGS) & cmake --build .
 
 
 build: $(BIN_DIR) $(PROGRAM)
@@ -35,7 +36,7 @@ $(BIN_DIR):
 
 
 $(PROGRAM): FORCE
-	cd $(BIN_DIR) & cmake .. $(CMAKE_ARGS) & cmake --build .
+	cd $(BIN_DIR) & cmake .. $(CMAKE_ARGS) -DWITH_TESTS=OFF & cmake --build .
 
 
 $(TEST_RUNNER):


### PR DESCRIPTION

# Summary

When you run `make`, and then `make tests`, build fails because `SNAIL_HEADLESS` is a cache variable, which does not change until you explicitly `unset` and `snail` library is built in SDL mode.

This pull request provides these make targets.

- `make build`: Build the normal executable.
- `make tests`: Build test runner.
- `make bench`: Build benchmark runner.
- `make`: Build the target previously built. You may usually `make` this target.