### PR TITLE
Fix shadow of selecting save window disappearing once you change page

### DIFF
--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -344,7 +344,6 @@ MainMenuResult main_menu_continue()
         ++save_data_count;
     }
     listmax = save_data_count;
-    windowshadow = 1;
 
     while (true)
     {
@@ -370,6 +369,7 @@ MainMenuResult main_menu_continue()
             s = u8"Which save game do you want to continue?"s;
         }
         draw_caption();
+        windowshadow = 1;
     savegame_draw_page:
         if (jp)
         {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #898.


# Summary

Fixes shadow of window in selecting save menu.