### PR TITLE
Refactor all other raw usages of gdata(n)

### DIFF
--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -148,15 +148,15 @@ optional<TurnResult> activity_proc(Character& chara)
     }
     if (chara.continuous_action.type == ContinuousAction::Type::others)
     {
-        if (gdata_continuous_action_about_to_start == 103)
+        if (game_data.continuous_action_about_to_start == 103)
         {
             auto_turn(Config::instance().animewait * 2);
         }
-        else if (gdata_continuous_action_about_to_start == 104)
+        else if (game_data.continuous_action_about_to_start == 104)
         {
             auto_turn(Config::instance().animewait * 2);
         }
-        else if (gdata_continuous_action_about_to_start == 105)
+        else if (game_data.continuous_action_about_to_start == 105)
         {
             auto_turn(Config::instance().animewait * 2.5);
         }
@@ -930,13 +930,13 @@ void continuous_action_others()
         cdata[cc].continuous_action.type = ContinuousAction::Type::others;
         cdata[cc].continuous_action.item = ci;
         cdata[cc].continuous_action_target = tc;
-        if (gdata_continuous_action_about_to_start == 105)
+        if (game_data.continuous_action_about_to_start == 105)
         {
             txt(i18n::s.get("core.locale.activity.steal.start", inv[ci]));
             cdata[cc].continuous_action.turn =
                 2 + clamp(inv[ci].weight / 500, 0, 50);
         }
-        if (gdata_continuous_action_about_to_start == 100)
+        if (game_data.continuous_action_about_to_start == 100)
         {
             if (mdata_map_type == mdata_t::MapType::player_owned
                 || mdata_map_type == mdata_t::MapType::town
@@ -951,17 +951,17 @@ void continuous_action_others()
                 cdata[cc].continuous_action.turn = 20;
             }
         }
-        if (gdata_continuous_action_about_to_start == 101)
+        if (game_data.continuous_action_about_to_start == 101)
         {
             txt(i18n::s.get("core.locale.activity.construct.start", inv[ci]));
             cdata[cc].continuous_action.turn = 25;
         }
-        if (gdata_continuous_action_about_to_start == 102)
+        if (game_data.continuous_action_about_to_start == 102)
         {
             txt(i18n::s.get("core.locale.activity.pull_hatch.start", inv[ci]));
             cdata[cc].continuous_action.turn = 10;
         }
-        if (gdata_continuous_action_about_to_start == 103)
+        if (game_data.continuous_action_about_to_start == 103)
         {
             txt(i18n::s.get("core.locale.activity.dig", inv[ci]));
             cdata[cc].continuous_action.turn = 10
@@ -970,7 +970,7 @@ void continuous_action_others()
                         1,
                         100);
         }
-        if (gdata_continuous_action_about_to_start == 104)
+        if (game_data.continuous_action_about_to_start == 104)
         {
             if (game_data.weather == 0 || game_data.weather == 3)
             {
@@ -1017,7 +1017,7 @@ void continuous_action_others()
     tc = cdata[cc].continuous_action_target;
     if (cdata[cc].continuous_action.turn > 0)
     {
-        if (gdata_continuous_action_about_to_start == 103)
+        if (game_data.continuous_action_about_to_start == 103)
         {
             if (rnd(5) == 0)
             {
@@ -1050,7 +1050,7 @@ void continuous_action_others()
                 txt(i18n::s.get("core.locale.activity.harvest.sound"));
             }
         }
-        if (gdata_continuous_action_about_to_start == 104)
+        if (game_data.continuous_action_about_to_start == 104)
         {
             p = 25;
             if (game_data.weather != 0 && game_data.weather != 3)
@@ -1083,7 +1083,7 @@ void continuous_action_others()
                 chara_gain_skill_exp(cdata[cc], randattb(), 25);
             }
         }
-        if (gdata_continuous_action_about_to_start == 105)
+        if (game_data.continuous_action_about_to_start == 105)
         {
             if (inv[ci].id == 688)
             {
@@ -1293,7 +1293,7 @@ void continuous_action_others()
         }
         return;
     }
-    if (gdata_continuous_action_about_to_start == 105)
+    if (game_data.continuous_action_about_to_start == 105)
     {
         tg = inv_getowner(ci);
         if ((tg != -1 && cdata[tg].state() != Character::State::alive)
@@ -1361,18 +1361,18 @@ void continuous_action_others()
             }
         }
     }
-    if (gdata_continuous_action_about_to_start == 100)
+    if (game_data.continuous_action_about_to_start == 100)
     {
         txt(i18n::s.get("core.locale.activity.sleep.finish"));
         sleep_start();
     }
-    if (gdata_continuous_action_about_to_start == 101)
+    if (game_data.continuous_action_about_to_start == 101)
     {
         snd(58);
         txt(i18n::s.get("core.locale.activity.construct.finish", inv[ci]));
         item_build_shelter(inv[ci]);
     }
-    if (gdata_continuous_action_about_to_start == 102)
+    if (game_data.continuous_action_about_to_start == 102)
     {
         txt(i18n::s.get("core.locale.activity.pull_hatch.finish"));
         chatteleport = 1;
@@ -1385,7 +1385,7 @@ void continuous_action_others()
         levelexitby = 2;
         snd(49);
     }
-    if (gdata_continuous_action_about_to_start == 103)
+    if (game_data.continuous_action_about_to_start == 103)
     {
         txt(i18n::s.get(
             "core.locale.activity.harvest.finish",
@@ -1394,7 +1394,7 @@ void continuous_action_others()
         in = inv[ci].number();
         pick_up_item();
     }
-    if (gdata_continuous_action_about_to_start == 104)
+    if (game_data.continuous_action_about_to_start == 104)
     {
         if (inv[ci].id == 563)
         {
@@ -1940,20 +1940,23 @@ int search_material_spot()
         {
             atxlv = 30 + rnd((rnd(atxlv - 30) + 1));
         }
-        if (4 <= gdata_stood_world_map_tile && gdata_stood_world_map_tile < 9)
+        if (4 <= game_data.stood_world_map_tile
+            && game_data.stood_world_map_tile < 9)
         {
             atxspot = 10;
         }
-        if (264 <= gdata_stood_world_map_tile
-            && gdata_stood_world_map_tile < 363)
+        if (264 <= game_data.stood_world_map_tile
+            && game_data.stood_world_map_tile < 363)
         {
             atxspot = 11;
         }
-        if (9 <= gdata_stood_world_map_tile && gdata_stood_world_map_tile < 13)
+        if (9 <= game_data.stood_world_map_tile
+            && game_data.stood_world_map_tile < 13)
         {
             atxspot = 10;
         }
-        if (13 <= gdata_stood_world_map_tile && gdata_stood_world_map_tile < 17)
+        if (13 <= game_data.stood_world_map_tile
+            && game_data.stood_world_map_tile < 17)
         {
             atxspot = 11;
         }

--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -148,15 +148,15 @@ optional<TurnResult> activity_proc(Character& chara)
     }
     if (chara.continuous_action.type == ContinuousAction::Type::others)
     {
-        if (gdata(91) == 103)
+        if (gdata_continuous_action_about_to_start == 103)
         {
             auto_turn(Config::instance().animewait * 2);
         }
-        else if (gdata(91) == 104)
+        else if (gdata_continuous_action_about_to_start == 104)
         {
             auto_turn(Config::instance().animewait * 2);
         }
-        else if (gdata(91) == 105)
+        else if (gdata_continuous_action_about_to_start == 105)
         {
             auto_turn(Config::instance().animewait * 2.5);
         }
@@ -930,13 +930,13 @@ void continuous_action_others()
         cdata[cc].continuous_action.type = ContinuousAction::Type::others;
         cdata[cc].continuous_action.item = ci;
         cdata[cc].continuous_action_target = tc;
-        if (gdata(91) == 105)
+        if (gdata_continuous_action_about_to_start == 105)
         {
             txt(i18n::s.get("core.locale.activity.steal.start", inv[ci]));
             cdata[cc].continuous_action.turn =
                 2 + clamp(inv[ci].weight / 500, 0, 50);
         }
-        if (gdata(91) == 100)
+        if (gdata_continuous_action_about_to_start == 100)
         {
             if (mdata_map_type == mdata_t::MapType::player_owned
                 || mdata_map_type == mdata_t::MapType::town
@@ -951,17 +951,17 @@ void continuous_action_others()
                 cdata[cc].continuous_action.turn = 20;
             }
         }
-        if (gdata(91) == 101)
+        if (gdata_continuous_action_about_to_start == 101)
         {
             txt(i18n::s.get("core.locale.activity.construct.start", inv[ci]));
             cdata[cc].continuous_action.turn = 25;
         }
-        if (gdata(91) == 102)
+        if (gdata_continuous_action_about_to_start == 102)
         {
             txt(i18n::s.get("core.locale.activity.pull_hatch.start", inv[ci]));
             cdata[cc].continuous_action.turn = 10;
         }
-        if (gdata(91) == 103)
+        if (gdata_continuous_action_about_to_start == 103)
         {
             txt(i18n::s.get("core.locale.activity.dig", inv[ci]));
             cdata[cc].continuous_action.turn = 10
@@ -970,7 +970,7 @@ void continuous_action_others()
                         1,
                         100);
         }
-        if (gdata(91) == 104)
+        if (gdata_continuous_action_about_to_start == 104)
         {
             if (game_data.weather == 0 || game_data.weather == 3)
             {
@@ -1017,7 +1017,7 @@ void continuous_action_others()
     tc = cdata[cc].continuous_action_target;
     if (cdata[cc].continuous_action.turn > 0)
     {
-        if (gdata(91) == 103)
+        if (gdata_continuous_action_about_to_start == 103)
         {
             if (rnd(5) == 0)
             {
@@ -1050,7 +1050,7 @@ void continuous_action_others()
                 txt(i18n::s.get("core.locale.activity.harvest.sound"));
             }
         }
-        if (gdata(91) == 104)
+        if (gdata_continuous_action_about_to_start == 104)
         {
             p = 25;
             if (game_data.weather != 0 && game_data.weather != 3)
@@ -1083,7 +1083,7 @@ void continuous_action_others()
                 chara_gain_skill_exp(cdata[cc], randattb(), 25);
             }
         }
-        if (gdata(91) == 105)
+        if (gdata_continuous_action_about_to_start == 105)
         {
             if (inv[ci].id == 688)
             {
@@ -1293,7 +1293,7 @@ void continuous_action_others()
         }
         return;
     }
-    if (gdata(91) == 105)
+    if (gdata_continuous_action_about_to_start == 105)
     {
         tg = inv_getowner(ci);
         if ((tg != -1 && cdata[tg].state() != Character::State::alive)
@@ -1361,18 +1361,18 @@ void continuous_action_others()
             }
         }
     }
-    if (gdata(91) == 100)
+    if (gdata_continuous_action_about_to_start == 100)
     {
         txt(i18n::s.get("core.locale.activity.sleep.finish"));
         sleep_start();
     }
-    if (gdata(91) == 101)
+    if (gdata_continuous_action_about_to_start == 101)
     {
         snd(58);
         txt(i18n::s.get("core.locale.activity.construct.finish", inv[ci]));
         item_build_shelter(inv[ci]);
     }
-    if (gdata(91) == 102)
+    if (gdata_continuous_action_about_to_start == 102)
     {
         txt(i18n::s.get("core.locale.activity.pull_hatch.finish"));
         chatteleport = 1;
@@ -1385,7 +1385,7 @@ void continuous_action_others()
         levelexitby = 2;
         snd(49);
     }
-    if (gdata(91) == 103)
+    if (gdata_continuous_action_about_to_start == 103)
     {
         txt(i18n::s.get(
             "core.locale.activity.harvest.finish",
@@ -1394,7 +1394,7 @@ void continuous_action_others()
         in = inv[ci].number();
         pick_up_item();
     }
-    if (gdata(91) == 104)
+    if (gdata_continuous_action_about_to_start == 104)
     {
         if (inv[ci].id == 563)
         {
@@ -1940,19 +1940,20 @@ int search_material_spot()
         {
             atxlv = 30 + rnd((rnd(atxlv - 30) + 1));
         }
-        if (4 <= gdata(62) && gdata(62) < 9)
+        if (4 <= gdata_stood_world_map_tile && gdata_stood_world_map_tile < 9)
         {
             atxspot = 10;
         }
-        if (264 <= gdata(62) && gdata(62) < 363)
+        if (264 <= gdata_stood_world_map_tile
+            && gdata_stood_world_map_tile < 363)
         {
             atxspot = 11;
         }
-        if (9 <= gdata(62) && gdata(62) < 13)
+        if (9 <= gdata_stood_world_map_tile && gdata_stood_world_map_tile < 13)
         {
             atxspot = 10;
         }
-        if (13 <= gdata(62) && gdata(62) < 17)
+        if (13 <= gdata_stood_world_map_tile && gdata_stood_world_map_tile < 17)
         {
             atxspot = 11;
         }

--- a/src/building.cpp
+++ b/src/building.cpp
@@ -965,7 +965,7 @@ void show_shop_log()
     income(0) = 0;
     income(1) = 0;
     listmax = 0;
-    shoplv = 100 - gdata_rank(5) / 100;
+    shoplv = 100 - game_data.ranks.at(5) / 100;
     customer = 0;
     for (int cnt = 0; cnt < 3; ++cnt)
     {
@@ -1201,7 +1201,7 @@ void show_shop_log()
         chara_gain_skill_exp(
             cdata[worker], 156, clamp(int(std::sqrt(income(0))) * 6, 25, 1000));
     }
-    if (sold > (110 - gdata_rank(5) / 100) / 10)
+    if (sold > (110 - game_data.ranks.at(5) / 100) / 10)
     {
         modrank(5, 30, 2);
     }
@@ -1212,7 +1212,7 @@ void show_shop_log()
 
 void update_shop()
 {
-    mdata_map_max_crowd_density = (100 - gdata_rank(5) / 100) / 4 + 1;
+    mdata_map_max_crowd_density = (100 - game_data.ranks.at(5) / 100) / 4 + 1;
     for (int cnt = 0, cnt_end = (mdata_map_height); cnt < cnt_end; ++cnt)
     {
         y = cnt;
@@ -1274,7 +1274,7 @@ void calc_collection_value(bool val0)
 
 void update_museum()
 {
-    rankorg = gdata_rank(3);
+    rankorg = game_data.ranks.at(3);
     rankcur = 0;
     DIM3(dblist, 2, 800);
     for (const auto& cnt : items(-1))
@@ -1308,7 +1308,7 @@ void update_museum()
     {
         rankcur = 100;
     }
-    gdata_rank(3) = rankcur;
+    game_data.ranks.at(3) = rankcur;
     if (rankorg != rankcur)
     {
         if (rankorg > rankcur)
@@ -1327,7 +1327,7 @@ void update_museum()
             ranktitle(3),
             rankn(10, 3)));
     }
-    mdata_map_max_crowd_density = (100 - gdata_rank(3) / 100) / 2 + 1;
+    mdata_map_max_crowd_density = (100 - game_data.ranks.at(3) / 100) / 2 + 1;
 }
 
 
@@ -1338,7 +1338,7 @@ void calc_home_rank()
     {
         return;
     }
-    rankorg = gdata_rank(4);
+    rankorg = game_data.ranks.at(4);
     rankcur = 0;
     game_data.total_deco_value = 0;
     game_data.total_heirloom_value = 0;
@@ -1389,7 +1389,7 @@ void calc_home_rank()
     {
         rankcur = 100;
     }
-    gdata_rank(4) = rankcur;
+    game_data.ranks.at(4) = rankcur;
     if (rankorg != rankcur)
     {
         if (rankorg > rankcur)

--- a/src/building.cpp
+++ b/src/building.cpp
@@ -145,7 +145,7 @@ void add_heirloom_if_valuable_enough(
     const auto category = the_item_db[heirloom.id]->category;
     if (category == 60000)
     {
-        gdata(77) += clamp(heirloom.value / 50, 50, 500);
+        gdata_total_deco_value += clamp(heirloom.value / 50, 50, 500);
     }
 
     const auto value = calc_heirloom_value(heirloom);
@@ -749,8 +749,8 @@ void show_home_value()
     s(2) = i18n::s.get("core.locale.building.home.rank.type.heir");
     s(3) = i18n::s.get("core.locale.building.home.rank.type.total");
     p(0) = game_data.basic_point_of_home_rank;
-    p(1) = gdata(77);
-    p(2) = gdata(78);
+    p(1) = gdata_total_deco_value;
+    p(2) = gdata_total_heirloom_value;
     p(3) = (p + p(1) + p(2)) / 3;
     for (int cnt = 0; cnt < 4; ++cnt)
     {
@@ -1340,8 +1340,8 @@ void calc_home_rank()
     }
     rankorg = gdata_rank(4);
     rankcur = 0;
-    gdata(77) = 0;
-    gdata(78) = 0;
+    gdata_total_deco_value = 0;
+    gdata_total_heirloom_value = 0;
 
     std::vector<ItemAndValue> heirlooms{heirloom_list_size};
     for (const auto& cnt : items(-1))
@@ -1370,19 +1370,21 @@ void calc_home_rank()
     {
         if (list(0, cnt) != 0)
         {
-            gdata(78) += clamp(list(1, cnt), 100, 2000);
+            gdata_total_heirloom_value += clamp(list(1, cnt), 100, 2000);
         }
     }
-    if (gdata(77) > 10000)
+    if (gdata_total_deco_value > 10000)
     {
-        gdata(77) = 10000;
+        gdata_total_deco_value = 10000;
     }
-    if (gdata(78) > 10000)
+    if (gdata_total_heirloom_value > 10000)
     {
-        gdata(78) = 10000;
+        gdata_total_heirloom_value = 10000;
     }
     rankcur = 10000
-        - (game_data.basic_point_of_home_rank + gdata(77) + gdata(78)) / 3;
+        - (game_data.basic_point_of_home_rank + gdata_total_deco_value
+           + gdata_total_heirloom_value)
+            / 3;
     if (rankcur < 100)
     {
         rankcur = 100;
@@ -1401,8 +1403,8 @@ void calc_home_rank()
         txtnew();
         txt(i18n::s.get(
             "core.locale.building.home.rank.change",
-            gdata(77) / 100,
-            gdata(78) / 100,
+            gdata_total_deco_value / 100,
+            gdata_total_heirloom_value / 100,
             cnvrank(rankorg / 100),
             cnvrank(rankcur / 100),
             ranktitle(4),

--- a/src/building.cpp
+++ b/src/building.cpp
@@ -195,7 +195,7 @@ void initialize_home_adata()
         area_data[p].position.x = cdata.player().position.x;
         area_data[p].position.y = cdata.player().position.y;
     }
-    area_data[p].outer_map = gdata(850);
+    area_data[p].outer_map = gdata_destination_outer_map;
 }
 
 TurnResult build_new_building()
@@ -271,7 +271,7 @@ TurnResult build_new_building()
     area_data[p].deepest_level = 1;
     area_data[p].tile_set = 1;
     area_data[p].entrance = 8;
-    area_data[p].outer_map = gdata(850);
+    area_data[p].outer_map = gdata_destination_outer_map;
     if (inv[ci].id == 521)
     {
         area_data[p].id = static_cast<int>(mdata_t::MapId::museum);
@@ -965,7 +965,7 @@ void show_shop_log()
     income(0) = 0;
     income(1) = 0;
     listmax = 0;
-    shoplv = 100 - gdata(125) / 100;
+    shoplv = 100 - gdata_rank(5) / 100;
     customer = 0;
     for (int cnt = 0; cnt < 3; ++cnt)
     {
@@ -1201,7 +1201,7 @@ void show_shop_log()
         chara_gain_skill_exp(
             cdata[worker], 156, clamp(int(std::sqrt(income(0))) * 6, 25, 1000));
     }
-    if (sold > (110 - gdata(125) / 100) / 10)
+    if (sold > (110 - gdata_rank(5) / 100) / 10)
     {
         modrank(5, 30, 2);
     }
@@ -1212,7 +1212,7 @@ void show_shop_log()
 
 void update_shop()
 {
-    mdata_map_max_crowd_density = (100 - gdata(125) / 100) / 4 + 1;
+    mdata_map_max_crowd_density = (100 - gdata_rank(5) / 100) / 4 + 1;
     for (int cnt = 0, cnt_end = (mdata_map_height); cnt < cnt_end; ++cnt)
     {
         y = cnt;
@@ -1274,7 +1274,7 @@ void calc_collection_value(bool val0)
 
 void update_museum()
 {
-    rankorg = gdata(123);
+    rankorg = gdata_rank(3);
     rankcur = 0;
     DIM3(dblist, 2, 800);
     for (const auto& cnt : items(-1))
@@ -1308,7 +1308,7 @@ void update_museum()
     {
         rankcur = 100;
     }
-    gdata(123) = rankcur;
+    gdata_rank(3) = rankcur;
     if (rankorg != rankcur)
     {
         if (rankorg > rankcur)
@@ -1327,7 +1327,7 @@ void update_museum()
             ranktitle(3),
             rankn(10, 3)));
     }
-    mdata_map_max_crowd_density = (100 - gdata(123) / 100) / 2 + 1;
+    mdata_map_max_crowd_density = (100 - gdata_rank(3) / 100) / 2 + 1;
 }
 
 
@@ -1338,7 +1338,7 @@ void calc_home_rank()
     {
         return;
     }
-    rankorg = gdata(124);
+    rankorg = gdata_rank(4);
     rankcur = 0;
     gdata(77) = 0;
     gdata(78) = 0;
@@ -1387,7 +1387,7 @@ void calc_home_rank()
     {
         rankcur = 100;
     }
-    gdata(124) = rankcur;
+    gdata_rank(4) = rankcur;
     if (rankorg != rankcur)
     {
         if (rankorg > rankcur)

--- a/src/building.cpp
+++ b/src/building.cpp
@@ -145,7 +145,7 @@ void add_heirloom_if_valuable_enough(
     const auto category = the_item_db[heirloom.id]->category;
     if (category == 60000)
     {
-        gdata_total_deco_value += clamp(heirloom.value / 50, 50, 500);
+        game_data.total_deco_value += clamp(heirloom.value / 50, 50, 500);
     }
 
     const auto value = calc_heirloom_value(heirloom);
@@ -195,7 +195,7 @@ void initialize_home_adata()
         area_data[p].position.x = cdata.player().position.x;
         area_data[p].position.y = cdata.player().position.y;
     }
-    area_data[p].outer_map = gdata_destination_outer_map;
+    area_data[p].outer_map = game_data.destination_outer_map;
 }
 
 TurnResult build_new_building()
@@ -271,7 +271,7 @@ TurnResult build_new_building()
     area_data[p].deepest_level = 1;
     area_data[p].tile_set = 1;
     area_data[p].entrance = 8;
-    area_data[p].outer_map = gdata_destination_outer_map;
+    area_data[p].outer_map = game_data.destination_outer_map;
     if (inv[ci].id == 521)
     {
         area_data[p].id = static_cast<int>(mdata_t::MapId::museum);
@@ -749,8 +749,8 @@ void show_home_value()
     s(2) = i18n::s.get("core.locale.building.home.rank.type.heir");
     s(3) = i18n::s.get("core.locale.building.home.rank.type.total");
     p(0) = game_data.basic_point_of_home_rank;
-    p(1) = gdata_total_deco_value;
-    p(2) = gdata_total_heirloom_value;
+    p(1) = game_data.total_deco_value;
+    p(2) = game_data.total_heirloom_value;
     p(3) = (p + p(1) + p(2)) / 3;
     for (int cnt = 0; cnt < 4; ++cnt)
     {
@@ -1340,8 +1340,8 @@ void calc_home_rank()
     }
     rankorg = gdata_rank(4);
     rankcur = 0;
-    gdata_total_deco_value = 0;
-    gdata_total_heirloom_value = 0;
+    game_data.total_deco_value = 0;
+    game_data.total_heirloom_value = 0;
 
     std::vector<ItemAndValue> heirlooms{heirloom_list_size};
     for (const auto& cnt : items(-1))
@@ -1370,20 +1370,20 @@ void calc_home_rank()
     {
         if (list(0, cnt) != 0)
         {
-            gdata_total_heirloom_value += clamp(list(1, cnt), 100, 2000);
+            game_data.total_heirloom_value += clamp(list(1, cnt), 100, 2000);
         }
     }
-    if (gdata_total_deco_value > 10000)
+    if (game_data.total_deco_value > 10000)
     {
-        gdata_total_deco_value = 10000;
+        game_data.total_deco_value = 10000;
     }
-    if (gdata_total_heirloom_value > 10000)
+    if (game_data.total_heirloom_value > 10000)
     {
-        gdata_total_heirloom_value = 10000;
+        game_data.total_heirloom_value = 10000;
     }
     rankcur = 10000
-        - (game_data.basic_point_of_home_rank + gdata_total_deco_value
-           + gdata_total_heirloom_value)
+        - (game_data.basic_point_of_home_rank + game_data.total_deco_value
+           + game_data.total_heirloom_value)
             / 3;
     if (rankcur < 100)
     {
@@ -1403,8 +1403,8 @@ void calc_home_rank()
         txtnew();
         txt(i18n::s.get(
             "core.locale.building.home.rank.change",
-            gdata_total_deco_value / 100,
-            gdata_total_heirloom_value / 100,
+            game_data.total_deco_value / 100,
+            game_data.total_heirloom_value / 100,
             cnvrank(rankorg / 100),
             cnvrank(rankcur / 100),
             ranktitle(4),

--- a/src/casino.cpp
+++ b/src/casino.cpp
@@ -414,19 +414,23 @@ void casino_random_site()
         if (mdata_map_type == mdata_t::MapType::world_map)
         {
             atxlv = cdata.player().level;
-            if (4 <= gdata(62) && gdata(62) < 9)
+            if (4 <= gdata_stood_world_map_tile
+                && gdata_stood_world_map_tile < 9)
             {
                 atxid(1) = 2;
             }
-            if (264 <= gdata(62) && gdata(62) < 363)
+            if (264 <= gdata_stood_world_map_tile
+                && gdata_stood_world_map_tile < 363)
             {
                 atxid(1) = 3;
             }
-            if (9 <= gdata(62) && gdata(62) < 13)
+            if (9 <= gdata_stood_world_map_tile
+                && gdata_stood_world_map_tile < 13)
             {
                 atxid(1) = 2;
             }
-            if (13 <= gdata(62) && gdata(62) < 17)
+            if (13 <= gdata_stood_world_map_tile
+                && gdata_stood_world_map_tile < 17)
             {
                 atxid(1) = 3;
             }

--- a/src/casino.cpp
+++ b/src/casino.cpp
@@ -414,23 +414,23 @@ void casino_random_site()
         if (mdata_map_type == mdata_t::MapType::world_map)
         {
             atxlv = cdata.player().level;
-            if (4 <= gdata_stood_world_map_tile
-                && gdata_stood_world_map_tile < 9)
+            if (4 <= game_data.stood_world_map_tile
+                && game_data.stood_world_map_tile < 9)
             {
                 atxid(1) = 2;
             }
-            if (264 <= gdata_stood_world_map_tile
-                && gdata_stood_world_map_tile < 363)
+            if (264 <= game_data.stood_world_map_tile
+                && game_data.stood_world_map_tile < 363)
             {
                 atxid(1) = 3;
             }
-            if (9 <= gdata_stood_world_map_tile
-                && gdata_stood_world_map_tile < 13)
+            if (9 <= game_data.stood_world_map_tile
+                && game_data.stood_world_map_tile < 13)
             {
                 atxid(1) = 2;
             }
-            if (13 <= gdata_stood_world_map_tile
-                && gdata_stood_world_map_tile < 17)
+            if (13 <= game_data.stood_world_map_tile
+                && game_data.stood_world_map_tile < 17)
             {
                 atxid(1) = 3;
             }

--- a/src/cell_draw.cpp
+++ b/src/cell_draw.cpp
@@ -796,7 +796,8 @@ bool you_can_see(const Character& chara)
 
 bool hp_bar_visible(const Character& chara)
 {
-    return chara.has_been_used_stethoscope() || gdata(94) == chara.index
+    return chara.has_been_used_stethoscope()
+        || gdata_chara_last_attacked_by_player == chara.index
         || debug::voldemort;
 }
 

--- a/src/cell_draw.cpp
+++ b/src/cell_draw.cpp
@@ -797,7 +797,7 @@ bool you_can_see(const Character& chara)
 bool hp_bar_visible(const Character& chara)
 {
     return chara.has_been_used_stethoscope()
-        || gdata_chara_last_attacked_by_player == chara.index
+        || game_data.chara_last_attacked_by_player == chara.index
         || debug::voldemort;
 }
 
@@ -1181,7 +1181,7 @@ void cell_draw()
         scrturnnew_ = 0;
     }
 
-    int light_ = gdata_light;
+    int light_ = game_data.light;
     randomize(scrturn_);
 
     if (game_data.torch == 1)

--- a/src/cell_draw.cpp
+++ b/src/cell_draw.cpp
@@ -1181,7 +1181,7 @@ void cell_draw()
         scrturnnew_ = 0;
     }
 
-    int light_ = gdata(89);
+    int light_ = gdata_light;
     randomize(scrturn_);
 
     if (game_data.torch == 1)

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1199,7 +1199,7 @@ void chara_refresh(int cc)
         game_data.ether_disease_speed = 0;
         game_data.protects_from_etherwind = 0;
         game_data.protects_from_bad_weather = 0;
-        gdata(89) = 70;
+        gdata_light = 70;
         game_data.catches_god_signal = 0;
         game_data.reveals_religion = 0;
     }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1199,7 +1199,7 @@ void chara_refresh(int cc)
         game_data.ether_disease_speed = 0;
         game_data.protects_from_etherwind = 0;
         game_data.protects_from_bad_weather = 0;
-        gdata_light = 70;
+        game_data.light = 70;
         game_data.catches_god_signal = 0;
         game_data.reveals_religion = 0;
     }

--- a/src/character_status.cpp
+++ b/src/character_status.cpp
@@ -121,7 +121,7 @@ void modify_ether_disease_stage(int delta)
                 }
                 --trait(tid);
                 i_at_m134 = original_amount + cnt2_at_m134;
-                gdata_ether_disease_history(i_at_m134) = tid;
+                game_data.ether_disease_history.at(i_at_m134) = tid;
                 txtef(8);
                 txt(i18n::s.get("core.locale.chara.corruption.add"));
                 txtef(3);
@@ -171,9 +171,9 @@ void modify_ether_disease_stage(int delta)
                 if (cnt == 0)
                 {
                     i_at_m134 = original_amount - cnt2_at_m134 - 1;
-                    if (gdata_ether_disease_history(i_at_m134) != 0)
+                    if (game_data.ether_disease_history.at(i_at_m134) != 0)
                     {
-                        tid = gdata_ether_disease_history(i_at_m134);
+                        tid = game_data.ether_disease_history.at(i_at_m134);
                     }
                 }
                 int stat = trait_get_info(0, tid);

--- a/src/character_status.cpp
+++ b/src/character_status.cpp
@@ -92,13 +92,13 @@ void modify_ether_disease_stage(int delta)
             txt(i18n::s.get("core.locale.chara.corruption.symptom"));
             if (Config::instance().extrahelp)
             {
-                if (gdata(215) == 0)
+                if (gdata_exhelp_flag(15) == 0)
                 {
                     if (mode == 0)
                     {
                         if (cdata.player().continuous_action.turn == 0)
                         {
-                            gdata(215) = 1;
+                            gdata_exhelp_flag(15) = 1;
                             ghelp = 15;
                             show_ex_help();
                         }

--- a/src/character_status.cpp
+++ b/src/character_status.cpp
@@ -64,29 +64,29 @@ namespace elona
 
 void modify_ether_disease_stage(int delta)
 {
-    int org_at_m134 = 0;
-    int p_at_m134 = 0;
-    int mod_at_m134 = 0;
+    int original_amount = 0;
+    int add_amount = 0;
+    int mod_amount = 0;
     int cnt2_at_m134 = 0;
     int i_at_m134 = 0;
-    org_at_m134 = game_data.ether_disease_stage / 1000;
-    p_at_m134 = delta + (delta > 0) * game_data.ether_disease_speed;
+    original_amount = game_data.ether_disease_stage / 1000;
+    add_amount = delta + (delta > 0) * game_data.ether_disease_speed;
     if (trait(168))
     {
         if (delta > 0)
         {
-            p_at_m134 = p_at_m134 * 100 / 150;
+            add_amount = add_amount * 100 / 150;
         }
     }
-    game_data.ether_disease_stage += p_at_m134;
+    game_data.ether_disease_stage += add_amount;
     if (game_data.ether_disease_stage < 0)
     {
         game_data.ether_disease_stage = 0;
     }
-    mod_at_m134 = game_data.ether_disease_stage / 1000 - org_at_m134;
-    if (mod_at_m134 > 0)
+    mod_amount = game_data.ether_disease_stage / 1000 - original_amount;
+    if (mod_amount > 0)
     {
-        if (org_at_m134 == 0)
+        if (original_amount == 0)
         {
             txtef(8);
             txt(i18n::s.get("core.locale.chara.corruption.symptom"));
@@ -106,18 +106,18 @@ void modify_ether_disease_stage(int delta)
                 }
             }
         }
-        if (org_at_m134 + mod_at_m134 >= 20)
+        if (original_amount + mod_amount >= 20)
         {
-            p_at_m134 = 20 - org_at_m134;
+            add_amount = 20 - original_amount;
         }
         else
         {
-            p_at_m134 = mod_at_m134;
+            add_amount = mod_amount;
         }
-        for (int cnt = 0, cnt_end = (p_at_m134); cnt < cnt_end; ++cnt)
+        for (int cnt = 0, cnt_end = (add_amount); cnt < cnt_end; ++cnt)
         {
             cnt2_at_m134 = cnt;
-            if (org_at_m134 + cnt2_at_m134 > 20)
+            if (original_amount + cnt2_at_m134 > 20)
             {
                 break;
             }
@@ -134,8 +134,8 @@ void modify_ether_disease_stage(int delta)
                     continue;
                 }
                 --trait(tid);
-                i_at_m134 = 700 + org_at_m134 + cnt2_at_m134;
-                gdata(i_at_m134) = tid;
+                i_at_m134 = original_amount + cnt2_at_m134;
+                gdata_ether_disease_history(i_at_m134) = tid;
                 txtef(8);
                 txt(i18n::s.get("core.locale.chara.corruption.add"));
                 txtef(3);
@@ -162,21 +162,21 @@ void modify_ether_disease_stage(int delta)
         chara_refresh(0);
         return;
     }
-    if (mod_at_m134 < 0)
+    if (mod_amount < 0)
     {
-        if (org_at_m134 + mod_at_m134 < 0)
+        if (original_amount + mod_amount < 0)
         {
-            p_at_m134 = org_at_m134;
+            add_amount = original_amount;
         }
         else
         {
-            p_at_m134 = std::abs(mod_at_m134);
+            add_amount = std::abs(mod_amount);
         }
-        if (p_at_m134 < 0)
+        if (add_amount < 0)
         {
-            p_at_m134 = 0;
+            add_amount = 0;
         }
-        for (int cnt = 0, cnt_end = (p_at_m134); cnt < cnt_end; ++cnt)
+        for (int cnt = 0, cnt_end = (add_amount); cnt < cnt_end; ++cnt)
         {
             cnt2_at_m134 = cnt;
             for (int cnt = 0; cnt < 100000; ++cnt)
@@ -184,10 +184,10 @@ void modify_ether_disease_stage(int delta)
                 int tid = rnd(17) + 200;
                 if (cnt == 0)
                 {
-                    i_at_m134 = 700 + org_at_m134 - cnt2_at_m134 - 1;
-                    if (gdata(i_at_m134) != 0)
+                    i_at_m134 = original_amount - cnt2_at_m134 - 1;
+                    if (gdata_ether_disease_history(i_at_m134) != 0)
                     {
-                        tid = gdata(i_at_m134);
+                        tid = gdata_ether_disease_history(i_at_m134);
                     }
                 }
                 int stat = trait_get_info(0, tid);

--- a/src/character_status.cpp
+++ b/src/character_status.cpp
@@ -90,21 +90,7 @@ void modify_ether_disease_stage(int delta)
         {
             txtef(8);
             txt(i18n::s.get("core.locale.chara.corruption.symptom"));
-            if (Config::instance().extrahelp)
-            {
-                if (gdata_exhelp_flag(15) == 0)
-                {
-                    if (mode == 0)
-                    {
-                        if (cdata.player().continuous_action.turn == 0)
-                        {
-                            gdata_exhelp_flag(15) = 1;
-                            ghelp = 15;
-                            show_ex_help();
-                        }
-                    }
-                }
-            }
+            maybe_show_ex_help(15);
         }
         if (original_amount + mod_amount >= 20)
         {

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -3570,23 +3570,23 @@ TurnResult do_cast_command()
 TurnResult do_short_cut_command()
 {
     menucycle = 0;
-    if (gdata(40 + sc) == 0)
+    if (gdata_skill_shortcut(sc) == 0)
     {
         ++msgdup;
         txt(i18n::s.get("core.locale.action.shortcut.unassigned"));
         update_screen();
         return TurnResult::pc_turn_user_error;
     }
-    if (gdata(40 + sc) >= 10000)
+    if (gdata_skill_shortcut(sc) >= 10000)
     {
-        invsc = gdata((40 + sc)) % 10000;
-        invctrl(0) = gdata((40 + sc)) / 10000;
+        invsc = gdata_skill_shortcut(sc) % 10000;
+        invctrl(0) = gdata_skill_shortcut(sc) / 10000;
         invctrl(1) = 0;
         MenuResult mr = ctrl_inventory();
         assert(mr.turn_result != TurnResult::none);
         return mr.turn_result;
     }
-    efid = gdata(40 + sc);
+    efid = gdata_skill_shortcut(sc);
     if (efid >= 300 && efid < 400)
     {
         return do_use_magic();

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -1609,7 +1609,7 @@ TurnResult do_use_command()
             update_screen();
             return TurnResult::pc_turn_user_error;
         }
-        gdata(91) = 100;
+        gdata_continuous_action_about_to_start = 100;
         continuous_action_others();
         return TurnResult::turn_end;
     }
@@ -1929,14 +1929,14 @@ TurnResult do_use_command()
         if (tc == 0)
         {
             txt(i18n::s.get("core.locale.action.use.stethoscope.self"));
-            gdata(94) = 0;
+            gdata_chara_last_attacked_by_player = 0;
             return TurnResult::turn_end;
         }
         if (tc > 0 && tc < 16)
         {
             if (cdata[tc].state() == Character::State::alive)
             {
-                gdata(94) = 0;
+                gdata_chara_last_attacked_by_player = 0;
                 if (cdata[tc].has_been_used_stethoscope() == 1)
                 {
                     cdata[tc].has_been_used_stethoscope() = false;
@@ -2138,7 +2138,7 @@ TurnResult do_use_command()
                 update_screen();
                 return TurnResult::pc_turn_user_error;
             }
-            gdata(91) = 101;
+            gdata_continuous_action_about_to_start = 101;
             continuous_action_others();
             return TurnResult::turn_end;
         }
@@ -2162,7 +2162,7 @@ TurnResult do_use_command()
                 }
             }
         }
-        gdata(91) = 102;
+        gdata_continuous_action_about_to_start = 102;
         continuous_action_others();
         goto label_2229_internal;
     case 11:
@@ -2884,7 +2884,8 @@ TurnResult do_use_stairs_command(int val0)
                 {
                     movelevelbystairs = 1;
                     if (game_data.current_map == mdata_t::MapId::the_void
-                        && game_data.current_dungeon_level >= gdata(186))
+                        && game_data.current_dungeon_level
+                            >= gdata_void_next_lord_floor)
                     {
                         txt(
                             i18n::s.get("core.locale.action.use_stairs.blocked_"
@@ -3228,7 +3229,7 @@ TurnResult do_movement_command()
             txt(i18n::s.get("core.locale.action.move.leave.prompt", mdatan(0)));
             if (mdata_map_type == mdata_t::MapType::temporary)
             {
-                if (gdata(73) != 3)
+                if (gdata_executing_immediate_quest_status != 3)
                 {
                     txt(i18n::s.get(
                         "core.locale.action.move.leave.abandoning_quest"));
@@ -3239,8 +3240,8 @@ TurnResult do_movement_command()
             update_screen();
             if (rtval == 0)
             {
-                gdata(60) = cdata.player().position.x;
-                gdata(61) = cdata.player().position.y;
+                gdata_player_x_on_map_leave = cdata.player().position.x;
+                gdata_player_y_on_map_leave = cdata.player().position.y;
                 snd(49);
                 --game_data.current_dungeon_level;
                 levelexitby = 4;

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -3570,23 +3570,23 @@ TurnResult do_cast_command()
 TurnResult do_short_cut_command()
 {
     menucycle = 0;
-    if (gdata_skill_shortcut(sc) == 0)
+    if (game_data.skill_shortcuts.at(sc) == 0)
     {
         ++msgdup;
         txt(i18n::s.get("core.locale.action.shortcut.unassigned"));
         update_screen();
         return TurnResult::pc_turn_user_error;
     }
-    if (gdata_skill_shortcut(sc) >= 10000)
+    if (game_data.skill_shortcuts.at(sc) >= 10000)
     {
-        invsc = gdata_skill_shortcut(sc) % 10000;
-        invctrl(0) = gdata_skill_shortcut(sc) / 10000;
+        invsc = game_data.skill_shortcuts.at(sc) % 10000;
+        invctrl(0) = game_data.skill_shortcuts.at(sc) / 10000;
         invctrl(1) = 0;
         MenuResult mr = ctrl_inventory();
         assert(mr.turn_result != TurnResult::none);
         return mr.turn_result;
     }
-    efid = gdata_skill_shortcut(sc);
+    efid = game_data.skill_shortcuts.at(sc);
     if (efid >= 300 && efid < 400)
     {
         return do_use_magic();

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -1609,7 +1609,7 @@ TurnResult do_use_command()
             update_screen();
             return TurnResult::pc_turn_user_error;
         }
-        gdata_continuous_action_about_to_start = 100;
+        game_data.continuous_action_about_to_start = 100;
         continuous_action_others();
         return TurnResult::turn_end;
     }
@@ -1929,14 +1929,14 @@ TurnResult do_use_command()
         if (tc == 0)
         {
             txt(i18n::s.get("core.locale.action.use.stethoscope.self"));
-            gdata_chara_last_attacked_by_player = 0;
+            game_data.chara_last_attacked_by_player = 0;
             return TurnResult::turn_end;
         }
         if (tc > 0 && tc < 16)
         {
             if (cdata[tc].state() == Character::State::alive)
             {
-                gdata_chara_last_attacked_by_player = 0;
+                game_data.chara_last_attacked_by_player = 0;
                 if (cdata[tc].has_been_used_stethoscope() == 1)
                 {
                     cdata[tc].has_been_used_stethoscope() = false;
@@ -2138,7 +2138,7 @@ TurnResult do_use_command()
                 update_screen();
                 return TurnResult::pc_turn_user_error;
             }
-            gdata_continuous_action_about_to_start = 101;
+            game_data.continuous_action_about_to_start = 101;
             continuous_action_others();
             return TurnResult::turn_end;
         }
@@ -2162,7 +2162,7 @@ TurnResult do_use_command()
                 }
             }
         }
-        gdata_continuous_action_about_to_start = 102;
+        game_data.continuous_action_about_to_start = 102;
         continuous_action_others();
         goto label_2229_internal;
     case 11:
@@ -2885,7 +2885,7 @@ TurnResult do_use_stairs_command(int val0)
                     movelevelbystairs = 1;
                     if (game_data.current_map == mdata_t::MapId::the_void
                         && game_data.current_dungeon_level
-                            >= gdata_void_next_lord_floor)
+                            >= game_data.void_next_lord_floor)
                     {
                         txt(
                             i18n::s.get("core.locale.action.use_stairs.blocked_"
@@ -3229,7 +3229,7 @@ TurnResult do_movement_command()
             txt(i18n::s.get("core.locale.action.move.leave.prompt", mdatan(0)));
             if (mdata_map_type == mdata_t::MapType::temporary)
             {
-                if (gdata_executing_immediate_quest_status != 3)
+                if (game_data.executing_immediate_quest_status != 3)
                 {
                     txt(i18n::s.get(
                         "core.locale.action.move.leave.abandoning_quest"));
@@ -3240,8 +3240,8 @@ TurnResult do_movement_command()
             update_screen();
             if (rtval == 0)
             {
-                gdata_player_x_on_map_leave = cdata.player().position.x;
-                gdata_player_y_on_map_leave = cdata.player().position.y;
+                game_data.player_x_on_map_leave = cdata.player().position.x;
+                game_data.player_y_on_map_leave = cdata.player().position.y;
                 snd(49);
                 --game_data.current_dungeon_level;
                 levelexitby = 4;

--- a/src/ctrl_inventory.cpp
+++ b/src/ctrl_inventory.cpp
@@ -1392,7 +1392,7 @@ label_2061_internal:
             snd(13);
             txtnew();
             txt(i18n::s.get("core.locale.ui.inv.equip.you_equip", inv[ci]));
-            gdata_player_is_changing_equipment = 1;
+            game_data.player_is_changing_equipment = 1;
             switch (inv[ci].curse_state)
             {
             case CurseState::doomed:

--- a/src/ctrl_inventory.cpp
+++ b/src/ctrl_inventory.cpp
@@ -1392,7 +1392,7 @@ label_2061_internal:
             snd(13);
             txtnew();
             txt(i18n::s.get("core.locale.ui.inv.equip.you_equip", inv[ci]));
-            gdata(808) = 1;
+            gdata_player_is_changing_equipment = 1;
             switch (inv[ci].curse_state)
             {
             case CurseState::doomed:

--- a/src/ctrl_inventory.cpp
+++ b/src/ctrl_inventory.cpp
@@ -994,7 +994,8 @@ label_2061_internal:
         }
         for (int cnt = 0; cnt < 20; ++cnt)
         {
-            if (gdata_skill_shortcut(cnt) == inv[p].id + invctrl * 10000)
+            if (game_data.skill_shortcuts.at(cnt)
+                == inv[p].id + invctrl * 10000)
             {
                 s += u8"{"s + cnt + u8"}"s;
             }
@@ -2227,19 +2228,19 @@ label_2061_internal:
             }
             snd(20);
             p = inv[list(0, pagesize * page + cs)].id + invctrl * 10000;
-            if (gdata_skill_shortcut(sc) == p)
+            if (game_data.skill_shortcuts.at(sc) == p)
             {
-                gdata_skill_shortcut(sc) = 0;
+                game_data.skill_shortcuts.at(sc) = 0;
                 goto label_2060_internal;
             }
             for (int cnt = 0; cnt < 20; ++cnt)
             {
-                if (gdata_skill_shortcut(cnt) == p)
+                if (game_data.skill_shortcuts.at(cnt) == p)
                 {
-                    gdata_skill_shortcut(cnt) = 0;
+                    game_data.skill_shortcuts.at(cnt) = 0;
                 }
             }
-            gdata_skill_shortcut(sc) = p;
+            game_data.skill_shortcuts.at(sc) = p;
             txt(i18n::s.get("core.locale.ui.assign_shortcut", sc));
             goto label_2060_internal;
         }

--- a/src/ctrl_inventory.cpp
+++ b/src/ctrl_inventory.cpp
@@ -994,7 +994,7 @@ label_2061_internal:
         }
         for (int cnt = 0; cnt < 20; ++cnt)
         {
-            if (gdata(40 + cnt) == inv[p].id + invctrl * 10000)
+            if (gdata_skill_shortcut(cnt) == inv[p].id + invctrl * 10000)
             {
                 s += u8"{"s + cnt + u8"}"s;
             }
@@ -2227,19 +2227,19 @@ label_2061_internal:
             }
             snd(20);
             p = inv[list(0, pagesize * page + cs)].id + invctrl * 10000;
-            if (gdata(40 + sc) == p)
+            if (gdata_skill_shortcut(sc) == p)
             {
-                gdata(40 + sc) = 0;
+                gdata_skill_shortcut(sc) = 0;
                 goto label_2060_internal;
             }
             for (int cnt = 0; cnt < 20; ++cnt)
             {
-                if (gdata(40 + cnt) == p)
+                if (gdata_skill_shortcut(cnt) == p)
                 {
-                    gdata(40 + cnt) = 0;
+                    gdata_skill_shortcut(cnt) = 0;
                 }
             }
-            gdata(40 + sc) = p;
+            gdata_skill_shortcut(sc) = p;
             txt(i18n::s.get("core.locale.ui.assign_shortcut", sc));
             goto label_2060_internal;
         }

--- a/src/dmgheal.cpp
+++ b/src/dmgheal.cpp
@@ -52,7 +52,7 @@ void end_dmghp(const Character& victim)
             }
         }
     }
-    gdata(809) = 0;
+    gdata_proc_damage_events_flag = 0;
     txt3rd = 0;
 }
 
@@ -262,7 +262,7 @@ int damage_hp(
     }
     if (victim.index == 0)
     {
-        gdata(30) = 0;
+        gdata_player_cellaccess_check_flag = 0;
         if (victim.hp < 0)
         {
             if (event_id() != -1)
@@ -330,7 +330,7 @@ int damage_hp(
         {
             spillblood(victim.position.x, victim.position.y, 1 + rnd(2));
         }
-        if (gdata(809) == 1)
+        if (gdata_proc_damage_events_flag == 1)
         {
             txteledmg(0, attacker_is_player ? 0 : -1, victim.index, element);
             goto label_1369_internal;
@@ -350,7 +350,7 @@ int damage_hp(
                 }
             }
         }
-        if (gdata(809) == 2)
+        if (gdata_proc_damage_events_flag == 2)
         {
             txtcontinue();
             if (damage_level == -1)
@@ -599,7 +599,7 @@ int damage_hp(
         if (attacker_is_player)
         {
             hostileaction(0, victim.index);
-            gdata(94) = victim.index;
+            gdata_chara_last_attacked_by_player = victim.index;
         }
         if (victim.index == 0)
         {
@@ -636,7 +636,7 @@ int damage_hp(
         }
         if (victim.splits())
         {
-            if (gdata(809) != 1)
+            if (gdata_proc_damage_events_flag != 1)
             {
                 if (dmg_at_m141 > victim.max_hp / 20 || rnd(10) == 0)
                 {
@@ -653,7 +653,7 @@ int damage_hp(
         }
         if (victim.splits2())
         {
-            if (gdata(809) != 1)
+            if (gdata_proc_damage_events_flag != 1)
             {
                 if (rnd(3) == 0)
                 {
@@ -675,7 +675,7 @@ int damage_hp(
         }
         if (victim.is_quick_tempered())
         {
-            if (gdata(809) != 1)
+            if (gdata_proc_damage_events_flag != 1)
             {
                 if (victim.furious == 0)
                 {
@@ -761,7 +761,7 @@ int damage_hp(
         {
             if (element)
             {
-                if (victim.index >= 16 && gdata(809) == 2)
+                if (victim.index >= 16 && gdata_proc_damage_events_flag == 2)
                 {
                     txtcontinue();
                     txteledmg(1, attacker_is_player, victim.index, element);
@@ -776,7 +776,8 @@ int damage_hp(
                 int death_type = rnd(4);
                 if (death_type == 0)
                 {
-                    if (victim.index >= 16 && gdata(809) == 2)
+                    if (victim.index >= 16
+                        && gdata_proc_damage_events_flag == 2)
                     {
                         txtcontinue();
                         txt(i18n::s.get(
@@ -796,7 +797,8 @@ int damage_hp(
                 }
                 if (death_type == 1)
                 {
-                    if (victim.index >= 16 && gdata(809) == 2)
+                    if (victim.index >= 16
+                        && gdata_proc_damage_events_flag == 2)
                     {
                         txtcontinue();
                         txt(i18n::s.get(
@@ -814,7 +816,8 @@ int damage_hp(
                 }
                 if (death_type == 2)
                 {
-                    if (victim.index >= 16 && gdata(809) == 2)
+                    if (victim.index >= 16
+                        && gdata_proc_damage_events_flag == 2)
                     {
                         txtcontinue();
                         txt(i18n::s.get(
@@ -832,7 +835,8 @@ int damage_hp(
                 }
                 if (death_type == 3)
                 {
-                    if (victim.index >= 16 && gdata(809) == 2)
+                    if (victim.index >= 16
+                        && gdata_proc_damage_events_flag == 2)
                     {
                         txtcontinue();
                         txt(i18n::s.get(
@@ -953,9 +957,9 @@ int damage_hp(
         {
             ++game_data.death_count;
         }
-        if (victim.index == gdata(94))
+        if (victim.index == gdata_chara_last_attacked_by_player)
         {
-            gdata(94) = 0;
+            gdata_chara_last_attacked_by_player = 0;
         }
         if (attacker)
         {
@@ -985,7 +989,7 @@ int damage_hp(
             {
                 attacker->enemy_id = 0;
                 cdata.player().enemy_id = 0;
-                gdata(94) = 0;
+                gdata_chara_last_attacked_by_player = 0;
             }
         }
         if (victim.index != 0)

--- a/src/dmgheal.cpp
+++ b/src/dmgheal.cpp
@@ -52,7 +52,7 @@ void end_dmghp(const Character& victim)
             }
         }
     }
-    gdata_proc_damage_events_flag = 0;
+    game_data.proc_damage_events_flag = 0;
     txt3rd = 0;
 }
 
@@ -262,7 +262,7 @@ int damage_hp(
     }
     if (victim.index == 0)
     {
-        gdata_player_cellaccess_check_flag = 0;
+        game_data.player_cellaccess_check_flag = 0;
         if (victim.hp < 0)
         {
             if (event_id() != -1)
@@ -330,7 +330,7 @@ int damage_hp(
         {
             spillblood(victim.position.x, victim.position.y, 1 + rnd(2));
         }
-        if (gdata_proc_damage_events_flag == 1)
+        if (game_data.proc_damage_events_flag == 1)
         {
             txteledmg(0, attacker_is_player ? 0 : -1, victim.index, element);
             goto label_1369_internal;
@@ -350,7 +350,7 @@ int damage_hp(
                 }
             }
         }
-        if (gdata_proc_damage_events_flag == 2)
+        if (game_data.proc_damage_events_flag == 2)
         {
             txtcontinue();
             if (damage_level == -1)
@@ -599,7 +599,7 @@ int damage_hp(
         if (attacker_is_player)
         {
             hostileaction(0, victim.index);
-            gdata_chara_last_attacked_by_player = victim.index;
+            game_data.chara_last_attacked_by_player = victim.index;
         }
         if (victim.index == 0)
         {
@@ -636,7 +636,7 @@ int damage_hp(
         }
         if (victim.splits())
         {
-            if (gdata_proc_damage_events_flag != 1)
+            if (game_data.proc_damage_events_flag != 1)
             {
                 if (dmg_at_m141 > victim.max_hp / 20 || rnd(10) == 0)
                 {
@@ -653,7 +653,7 @@ int damage_hp(
         }
         if (victim.splits2())
         {
-            if (gdata_proc_damage_events_flag != 1)
+            if (game_data.proc_damage_events_flag != 1)
             {
                 if (rnd(3) == 0)
                 {
@@ -675,7 +675,7 @@ int damage_hp(
         }
         if (victim.is_quick_tempered())
         {
-            if (gdata_proc_damage_events_flag != 1)
+            if (game_data.proc_damage_events_flag != 1)
             {
                 if (victim.furious == 0)
                 {
@@ -761,7 +761,8 @@ int damage_hp(
         {
             if (element)
             {
-                if (victim.index >= 16 && gdata_proc_damage_events_flag == 2)
+                if (victim.index >= 16
+                    && game_data.proc_damage_events_flag == 2)
                 {
                     txtcontinue();
                     txteledmg(1, attacker_is_player, victim.index, element);
@@ -777,7 +778,7 @@ int damage_hp(
                 if (death_type == 0)
                 {
                     if (victim.index >= 16
-                        && gdata_proc_damage_events_flag == 2)
+                        && game_data.proc_damage_events_flag == 2)
                     {
                         txtcontinue();
                         txt(i18n::s.get(
@@ -798,7 +799,7 @@ int damage_hp(
                 if (death_type == 1)
                 {
                     if (victim.index >= 16
-                        && gdata_proc_damage_events_flag == 2)
+                        && game_data.proc_damage_events_flag == 2)
                     {
                         txtcontinue();
                         txt(i18n::s.get(
@@ -817,7 +818,7 @@ int damage_hp(
                 if (death_type == 2)
                 {
                     if (victim.index >= 16
-                        && gdata_proc_damage_events_flag == 2)
+                        && game_data.proc_damage_events_flag == 2)
                     {
                         txtcontinue();
                         txt(i18n::s.get(
@@ -836,7 +837,7 @@ int damage_hp(
                 if (death_type == 3)
                 {
                     if (victim.index >= 16
-                        && gdata_proc_damage_events_flag == 2)
+                        && game_data.proc_damage_events_flag == 2)
                     {
                         txtcontinue();
                         txt(i18n::s.get(
@@ -957,9 +958,9 @@ int damage_hp(
         {
             ++game_data.death_count;
         }
-        if (victim.index == gdata_chara_last_attacked_by_player)
+        if (victim.index == game_data.chara_last_attacked_by_player)
         {
-            gdata_chara_last_attacked_by_player = 0;
+            game_data.chara_last_attacked_by_player = 0;
         }
         if (attacker)
         {
@@ -989,7 +990,7 @@ int damage_hp(
             {
                 attacker->enemy_id = 0;
                 cdata.player().enemy_id = 0;
-                gdata_chara_last_attacked_by_player = 0;
+                game_data.chara_last_attacked_by_player = 0;
             }
         }
         if (victim.index != 0)

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -299,7 +299,7 @@ void show_hp_bar(HPBarSide side, int inf_clocky)
             {
                 for (int i = 0; i < 10; ++i)
                 {
-                    if (gdata_tracked_skill(i) % 10000 != 0)
+                    if (game_data.tracked_skills.at(i) % 10000 != 0)
                     {
                         y += 16;
                     }

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -299,7 +299,7 @@ void show_hp_bar(HPBarSide side, int inf_clocky)
             {
                 for (int i = 0; i < 10; ++i)
                 {
-                    if (gdata(750 + i) % 10000 != 0)
+                    if (gdata_tracked_skill(i) % 10000 != 0)
                     {
                         y += 16;
                     }
@@ -431,7 +431,7 @@ void show_damage_popups()
         }
 
         const auto& cc = cdata[damage_popup.character];
-        if (gdata(20) != 40)
+        if (game_data.current_map != mdata_t::MapId::pet_arena)
         {
             if (!is_in_fov(cc.position))
             {

--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -2578,7 +2578,7 @@ int try_to_perceive_npc(int cc)
 
 void start_stealing()
 {
-    gdata_continuous_action_about_to_start = 105;
+    game_data.continuous_action_about_to_start = 105;
     continuous_action_others();
 }
 
@@ -4812,7 +4812,7 @@ TurnResult exit_map()
     int previous_dungeon_level = game_data.current_dungeon_level;
     int fixstart = 0;
     game_data.left_minutes_of_executing_quest = 0;
-    gdata_rogue_boss_encountered = 0;
+    game_data.rogue_boss_encountered = 0;
     if (mdata_map_type == mdata_t::MapType::player_owned)
     {
         maybe_show_ex_help(1);
@@ -4973,7 +4973,7 @@ TurnResult exit_map()
                 || mdata_map_type == mdata_t::MapType::shelter
                 || mdata_map_type == mdata_t::MapType::guild)
             {
-                game_data.current_map = gdata_destination_outer_map;
+                game_data.current_map = game_data.destination_outer_map;
             }
         }
         if (mdata_t::is_nefia(mdata_map_type)
@@ -4982,7 +4982,7 @@ TurnResult exit_map()
             if (game_data.current_dungeon_level
                 < area_data[game_data.current_map].danger_level)
             {
-                game_data.current_map = gdata_destination_outer_map;
+                game_data.current_map = game_data.destination_outer_map;
             }
         }
         if (area_data[game_data.current_map].type == mdata_t::MapType::town)
@@ -5041,7 +5041,7 @@ TurnResult exit_map()
         rc = 0;
         revive_player();
         game_data.current_map = static_cast<int>(mdata_t::MapId::your_home);
-        gdata_destination_outer_map = area_data[7].outer_map;
+        game_data.destination_outer_map = area_data[7].outer_map;
         game_data.current_dungeon_level = 1;
     }
     if (rdtry > 1)
@@ -5606,7 +5606,7 @@ int initialize_world_map()
 
 void map_global_proc_diastrophism()
 {
-    if (gdata_reset_world_map_in_diastrophism_flag == 1)
+    if (game_data.reset_world_map_in_diastrophism_flag == 1)
     {
         initialize_adata();
         map_global_prepare();
@@ -5631,7 +5631,7 @@ void map_global_proc_diastrophism()
         }
     }
     if (p <= 25 || rnd(150) == 0 || game_data.diastrophism_flag != 0
-        || gdata_reset_world_map_in_diastrophism_flag)
+        || game_data.reset_world_map_in_diastrophism_flag)
     {
         game_data.diastrophism_flag = 0;
         msgtemp += i18n::s.get("core.locale.action.move.global.diastrophism");
@@ -5648,7 +5648,7 @@ void map_global_proc_diastrophism()
         initialize_world_map();
         map_global_prepare();
     }
-    gdata_reset_world_map_in_diastrophism_flag = 0;
+    game_data.reset_world_map_in_diastrophism_flag = 0;
 }
 
 
@@ -5667,7 +5667,7 @@ void map_global_place_entrances()
     for (int cnt = 0; cnt < 20; ++cnt)
     {
         int cnt2 = cnt;
-        if (gdata_destination_outer_map != 4)
+        if (game_data.destination_outer_map != 4)
         {
             break;
         }
@@ -5693,7 +5693,7 @@ void map_global_place_entrances()
         {
             continue;
         }
-        if (area_data[cnt].outer_map != gdata_destination_outer_map)
+        if (area_data[cnt].outer_map != game_data.destination_outer_map)
         {
             continue;
         }
@@ -6581,7 +6581,7 @@ int place_random_nefias()
         area_data[p].tile_type = 1;
         area_data[p].turn_cost_base = 10000;
         area_data[p].is_indoor = true;
-        area_data[p].outer_map = gdata_destination_outer_map;
+        area_data[p].outer_map = game_data.destination_outer_map;
         if (rnd(3))
         {
             area_data[p].danger_level = rnd(cdata.player().level + 5) + 1;
@@ -8792,7 +8792,7 @@ void try_to_return()
     p = 0;
     p = 0;
     i = 7;
-    if (area_data[i].outer_map == gdata_destination_outer_map)
+    if (area_data[i].outer_map == game_data.destination_outer_map)
     {
         list(0, p) = i;
         list(1, p) = 1;
@@ -8806,7 +8806,7 @@ void try_to_return()
         {
             continue;
         }
-        if (area_data[i].outer_map != gdata_destination_outer_map)
+        if (area_data[i].outer_map != game_data.destination_outer_map)
         {
             continue;
         }
@@ -8951,7 +8951,7 @@ int read_textbook()
             }
         }
     }
-    gdata_continuous_action_about_to_start = 104;
+    game_data.continuous_action_about_to_start = 104;
     continuous_action_others();
     return 1;
 }
@@ -9248,7 +9248,7 @@ void initialize_map_adjust_spawns()
 
 void clear_existing_quest_list()
 {
-    ++gdata_map_regenerate_count;
+    ++game_data.map_regenerate_count;
     DIM3(qdata, 20, 500);
     SDIM3(qname, 40, 500);
     game_data.number_of_existing_quests = 0;
@@ -10153,7 +10153,7 @@ void sleep_start()
     if (game_data.current_map == mdata_t::MapId::quest)
     {
         txt(i18n::s.get("core.locale.activity.sleep.but_you_cannot"));
-        gdata_character_and_status_for_gene = 0;
+        game_data.character_and_status_for_gene = 0;
         return;
     }
     if (game_data.catches_god_signal)
@@ -10225,7 +10225,7 @@ void sleep_start()
         draw_sleep_background_frame();
         await(Config::instance().animewait * 25);
     }
-    if (gdata_character_and_status_for_gene != 0)
+    if (game_data.character_and_status_for_gene != 0)
     {
         tc = -1;
         for (int cnt = 1; cnt < 16; ++cnt)
@@ -10253,7 +10253,7 @@ void sleep_start()
         }
     }
     draw_sleep_background_frame();
-    gdata_character_and_status_for_gene = 0;
+    game_data.character_and_status_for_gene = 0;
     mode = 0;
     wake_up();
     cdata[cc].nutrition -= 1500 / (trait(158) + 1);
@@ -11800,7 +11800,7 @@ int pick_up_item()
                             "core.locale.ui.inv.common.inventory_is_full"));
                         return 0;
                     }
-                    gdata_continuous_action_about_to_start = 103;
+                    game_data.continuous_action_about_to_start = 103;
                     continuous_action_others();
                     return -1;
                 }
@@ -12445,7 +12445,7 @@ TurnResult proc_movement_event()
         if (cc == 0)
         {
             encounter = 0;
-            gdata_stood_world_map_tile =
+            game_data.stood_world_map_tile =
                 map(cdata[cc].position.x, cdata[cc].position.y, 0);
             if (map(cdata[cc].position.x, cdata[cc].position.y, 6) == 0)
             {
@@ -12740,24 +12740,24 @@ void sense_map_feats_on_move()
 {
     if (cc == 0)
     {
-        gdata_player_x_on_map_leave = -1;
-        gdata_player_y_on_map_leave = -1;
+        game_data.player_x_on_map_leave = -1;
+        game_data.player_y_on_map_leave = -1;
         x = cdata.player().position.x;
         y = cdata.player().position.y;
-        if (key_shift && gdata_player_cellaccess_check_flag == 0
+        if (key_shift && game_data.player_cellaccess_check_flag == 0
             && cdata.player().confused == 0 && cdata.player().dimmed == 0)
         {
             if (mdata_map_type != mdata_t::MapType::world_map)
             {
-                gdata_player_cellaccess_check_flag = 1;
+                game_data.player_cellaccess_check_flag = 1;
                 cell_check(cdata[cc].position.x + 1, cdata[cc].position.y);
-                gdata_player_cellaccess_e = cellaccess;
+                game_data.player_cellaccess_e = cellaccess;
                 cell_check(cdata[cc].position.x - 1, cdata[cc].position.y);
-                gdata_player_cellaccess_w = cellaccess;
+                game_data.player_cellaccess_w = cellaccess;
                 cell_check(cdata[cc].position.x, cdata[cc].position.y + 1);
-                gdata_player_cellaccess_s = cellaccess;
+                game_data.player_cellaccess_s = cellaccess;
                 cell_check(cdata[cc].position.x, cdata[cc].position.y - 1);
-                gdata_player_cellaccess_n = cellaccess;
+                game_data.player_cellaccess_n = cellaccess;
             }
         }
         if (map(x, y, 4) != 0)
@@ -13760,7 +13760,7 @@ label_22191_internal:
             {
                 if (tc >= 16)
                 {
-                    gdata_proc_damage_events_flag = 2;
+                    game_data.proc_damage_events_flag = 2;
                     txt(i18n::s.get(
                         "core.locale.damage.weapon.attacks_unarmed_and",
                         cdata[cc],
@@ -13793,7 +13793,7 @@ label_22191_internal:
                 {
                     if (tc >= 16)
                     {
-                        gdata_proc_damage_events_flag = 2;
+                        game_data.proc_damage_events_flag = 2;
                         if (attackskill == 111)
                         {
                             txt(i18n::s.get(
@@ -14045,7 +14045,7 @@ label_22191_internal:
     }
     if (tc == 0)
     {
-        gdata_player_cellaccess_check_flag = 0;
+        game_data.player_cellaccess_check_flag = 0;
     }
     rowact_check(tc);
     if (attackskill != 106)
@@ -14148,7 +14148,7 @@ void proc_weapon_enchantments()
             s = chara_refstr(cdata[tc].id, 8);
             if (strutil::contains(s(0), u8"/dragon/"))
             {
-                gdata_proc_damage_events_flag = 1;
+                game_data.proc_damage_events_flag = 1;
                 damage_hp(cdata[tc], orgdmg / 2, cc);
             }
             continue;
@@ -14158,7 +14158,7 @@ void proc_weapon_enchantments()
             s = chara_refstr(cdata[tc].id, 8);
             if (strutil::contains(s(0), u8"/god/"))
             {
-                gdata_proc_damage_events_flag = 1;
+                game_data.proc_damage_events_flag = 1;
                 damage_hp(cdata[tc], orgdmg / 2, cc);
             }
             continue;
@@ -14168,7 +14168,7 @@ void proc_weapon_enchantments()
             s = chara_refstr(cdata[tc].id, 8);
             if (strutil::contains(s(0), u8"/undead/"))
             {
-                gdata_proc_damage_events_flag = 1;
+                game_data.proc_damage_events_flag = 1;
                 damage_hp(cdata[tc], orgdmg / 2, cc);
             }
             continue;
@@ -14188,7 +14188,7 @@ void proc_weapon_enchantments()
                 {
                     continue;
                 }
-                gdata_proc_damage_events_flag = 1;
+                game_data.proc_damage_events_flag = 1;
                 damage_hp(
                     cdata[tc],
                     rnd(orgdmg * (100 + inv[cw].enchantments[cnt].power) / 1000
@@ -14242,7 +14242,7 @@ void proc_weapon_enchantments()
     {
         if (cdata[tc].state() == Character::State::alive)
         {
-            gdata_proc_damage_events_flag = 1;
+            game_data.proc_damage_events_flag = 1;
             damage_hp(
                 cdata[tc],
                 orgdmg * 2 / 3,
@@ -14664,7 +14664,7 @@ void initialize_economy()
     elona_vector1<int> bkdata;
     if (initeco)
     {
-        gdata_politics_map_id = static_cast<int>(mdata_t::MapId::palmia);
+        game_data.politics_map_id = static_cast<int>(mdata_t::MapId::palmia);
     }
     bkdata(0) = game_data.current_map;
     bkdata(1) = game_data.current_dungeon_level;
@@ -14747,7 +14747,7 @@ void initialize_economy()
     game_data.current_dungeon_level = bkdata(1);
     cdata.player().position.x = bkdata(2);
     cdata.player().position.y = bkdata(3);
-    gdata_reset_world_map_in_diastrophism_flag = 1;
+    game_data.reset_world_map_in_diastrophism_flag = 1;
     mode = 3;
     mapsubroutine = 1;
     initialize_map();

--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -232,27 +232,26 @@ int extraattack = 0;
 
 
 
-std::string ranktitle(int prm_265)
+std::string ranktitle(int rank_id)
 {
-    int p_at_m6 = 0;
-    p_at_m6 = gdata((prm_265 + 120)) / 100;
-    if (p_at_m6 == 1)
+    int rank_value = gdata_rank(rank_id) / 100;
+    if (rank_value == 1)
     {
-        return rankn(0, prm_265);
+        return rankn(0, rank_id);
     }
-    if (p_at_m6 <= 5)
+    if (rank_value <= 5)
     {
-        return rankn(1, prm_265);
+        return rankn(1, rank_id);
     }
-    if (p_at_m6 <= 10)
+    if (rank_value <= 10)
     {
-        return rankn(2, prm_265);
+        return rankn(2, rank_id);
     }
-    if (p_at_m6 <= 80)
+    if (rank_value <= 80)
     {
-        return rankn(p_at_m6 / 15 + 3, prm_265);
+        return rankn(rank_value / 15 + 3, rank_id);
     }
-    return rankn(9, prm_265);
+    return rankn(9, rank_id);
 }
 
 
@@ -7373,47 +7372,46 @@ void god_fail_to_take_over_penalty()
 
 
 
-int calcincome(int prm_1036)
+int calcincome(int rank_id)
 {
-    int p_at_m176 = 0;
-    p_at_m176 = 100 - gdata((120 + prm_1036)) / 100;
-    if (p_at_m176 == 99)
+    int rank_amount = 100 - gdata_rank(rank_id) / 100;
+    if (rank_amount == 99)
     {
-        p_at_m176 = p_at_m176 * 70;
+        rank_amount = rank_amount * 70;
     }
     else
     {
-        p_at_m176 = p_at_m176 * 50;
+        rank_amount = rank_amount * 50;
     }
-    if (prm_1036 == 2)
+    if (rank_id == 2)
     {
-        p_at_m176 = p_at_m176 * 120 / 100;
+        rank_amount = rank_amount * 120 / 100;
     }
-    if (prm_1036 == 4)
+    if (rank_id == 4)
     {
-        p_at_m176 = p_at_m176 * 60 / 100;
+        rank_amount = rank_amount * 60 / 100;
     }
-    if (prm_1036 == 0)
+    if (rank_id == 0)
     {
-        p_at_m176 = p_at_m176 * 80 / 100;
+        rank_amount = rank_amount * 80 / 100;
     }
-    if (prm_1036 == 1)
+    if (rank_id == 1)
     {
-        p_at_m176 = p_at_m176 * 70 / 100;
+        rank_amount = rank_amount * 70 / 100;
     }
-    if (prm_1036 == 6)
+    if (rank_id == 6)
     {
-        p_at_m176 = p_at_m176 * 25 / 100;
+        rank_amount = rank_amount * 25 / 100;
     }
-    if (prm_1036 == 5)
+    if (rank_id == 5)
     {
-        p_at_m176 = p_at_m176 * 20 / 100;
+        rank_amount = rank_amount * 20 / 100;
     }
-    if (prm_1036 == 8)
+    if (rank_id == 8)
     {
-        p_at_m176 = p_at_m176 * 15 / 100;
+        rank_amount = rank_amount * 15 / 100;
     }
-    return p_at_m176;
+    return rank_amount;
 }
 
 
@@ -7457,11 +7455,11 @@ void supply_income()
             continue;
         }
         p = rnd(rnd(3) + 1) + 1;
-        int cnt2 = cnt;
+        int rank_id = cnt;
         for (int cnt = 0, cnt_end = (p); cnt < cnt_end; ++cnt)
         {
             dbid = 0;
-            flt(calcobjlv((100 - gdata((120 + cnt2)) / 100) / 2 + 1),
+            flt(calcobjlv((100 - gdata_rank(rank_id) / 100) / 2 + 1),
                 calcfixlv(
                     (rnd(12) < trait(39)) ? Quality::miracle : Quality::great));
             flttypemajor = choice(fsetincome);
@@ -7469,7 +7467,7 @@ void supply_income()
             {
                 flttypemajor = choice(fsetwear);
             }
-            if (rnd(100 + gdata((120 + cnt2)) / 5) < 2)
+            if (rnd(100 + gdata_rank(rank_id) / 5) < 2)
             {
                 dbid = 559;
             }
@@ -8398,77 +8396,6 @@ int target_position()
             return -1;
         }
     }
-}
-
-
-
-TurnResult do_short_cut()
-{
-    menucycle = 0;
-    if (gdata_skill_shortcut(sc) == 0)
-    {
-        ++msgdup;
-        txt(i18n::s.get("core.locale.action.shortcut.unassigned"));
-        update_screen();
-        return TurnResult::pc_turn_user_error;
-    }
-    if (gdata_skill_shortcut(sc) >= 10000)
-    {
-        invsc = gdata_skill_shortcut(sc) % 10000;
-        invctrl(0) = gdata_skill_shortcut(sc) / 10000;
-        invctrl(1) = 0;
-        MenuResult mr = ctrl_inventory();
-        assert(mr.turn_result != TurnResult::none);
-        return mr.turn_result;
-    }
-    efid = gdata_skill_shortcut(sc);
-    if (efid >= 300 && efid < 400)
-    {
-        return do_use_magic();
-    }
-    if (efid >= 600)
-    {
-        if (mdata_map_type == mdata_t::MapType::world_map)
-        {
-            txtnew();
-            txt(i18n::s.get("core.locale.action.cannot_do_in_global"));
-            display_msg();
-            redraw();
-            return TurnResult::pc_turn_user_error;
-        }
-        if (efid < 661)
-        {
-            if (spact(efid - 600) == 0)
-            {
-                txt(i18n::s.get(
-                    "core.locale.action.shortcut.cannot_use_anymore"));
-                update_screen();
-                return TurnResult::pc_turn_user_error;
-            }
-        }
-        return do_use_magic();
-    }
-    if (efid >= 400)
-    {
-        if (mdata_map_type == mdata_t::MapType::world_map)
-        {
-            txtnew();
-            txt(i18n::s.get("core.locale.action.cannot_do_in_global"));
-            display_msg();
-            redraw();
-            return TurnResult::pc_turn_user_error;
-        }
-        if (spell(efid - 400) <= 0)
-        {
-            ++msgdup;
-            txt(i18n::s.get(
-                "core.locale.action.shortcut.cannot_use_spell_anymore"));
-            update_screen();
-            return TurnResult::pc_turn_user_error;
-        }
-        return do_cast_command();
-    }
-    return TurnResult::pc_turn_user_error;
 }
 
 
@@ -15503,23 +15430,22 @@ void weather_changes()
         txtef(5);
         txt(i18n::s.get("core.locale.action.new_day"));
         update_shop_and_report();
-        for (int cnt = 0; cnt < 9; ++cnt)
+        for (int rank_id = 0; rank_id < 9; ++rank_id)
         {
-            p = 120 + cnt;
-            if (gdata(p) >= 10000)
+            if (gdata_rank(rank_id) >= 10000)
             {
-                gdata(p) = 10000;
+                gdata_rank(rank_id) = 10000;
                 continue;
             }
-            if (cnt == 3 || cnt == 4 || cnt == 5 || cnt == 8)
+            if (rank_id == 3 || rank_id == 4 || rank_id == 5 || rank_id == 8)
             {
                 continue;
             }
-            --gdata(140 + cnt);
-            if (gdata(140 + cnt) <= 0)
+            --gdata_rank_deadline(rank_id);
+            if (gdata_rank_deadline(rank_id) <= 0)
             {
-                modrank(cnt, (gdata(p) / 12 + 100) * -1);
-                gdata(140 + cnt) = ranknorma(cnt);
+                modrank(rank_id, (gdata_rank(rank_id) / 12 + 100) * -1);
+                gdata_rank_deadline(rank_id) = ranknorma(rank_id);
             }
         }
         snd(74);

--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -234,7 +234,7 @@ int extraattack = 0;
 
 std::string ranktitle(int rank_id)
 {
-    int rank_value = gdata_rank(rank_id) / 100;
+    int rank_value = game_data.ranks.at(rank_id) / 100;
     if (rank_value == 1)
     {
         return rankn(0, rank_id);
@@ -1249,14 +1249,14 @@ void modrank(int rank_id, int amount, int prm_554)
 {
     int orgrank_at_m75 = 0;
     int i_at_m75 = 0;
-    int rank_factor = gdata_rank(rank_id) / 100;
-    orgrank_at_m75 = gdata_rank(rank_id);
+    int rank_factor = game_data.ranks.at(rank_id) / 100;
+    orgrank_at_m75 = game_data.ranks.at(rank_id);
     i_at_m75 = amount;
     if (amount > 0)
     {
         i_at_m75 = amount * (rank_factor + 20) * (rank_factor + 20) / 2500;
-        gdata_rank_deadline(rank_id) = ranknorma(rank_id);
-        if (gdata_rank(rank_id) == 100)
+        game_data.rank_deadlines.at(rank_id) = ranknorma(rank_id);
+        if (game_data.ranks.at(rank_id) == 100)
         {
             return;
         }
@@ -1268,18 +1268,18 @@ void modrank(int rank_id, int amount, int prm_554)
             }
         }
     }
-    gdata_rank(rank_id) -= i_at_m75;
-    if (gdata_rank(rank_id) >= 10000)
+    game_data.ranks.at(rank_id) -= i_at_m75;
+    if (game_data.ranks.at(rank_id) >= 10000)
     {
-        gdata_rank(rank_id) = 10000;
+        game_data.ranks.at(rank_id) = 10000;
     }
-    if (gdata_rank(rank_id) < 100)
+    if (game_data.ranks.at(rank_id) < 100)
     {
-        gdata_rank(rank_id) = 100;
+        game_data.ranks.at(rank_id) = 100;
     }
-    if (orgrank_at_m75 / 100 != gdata_rank(rank_id) / 100)
+    if (orgrank_at_m75 / 100 != game_data.ranks.at(rank_id) / 100)
     {
-        i_at_m75 = gdata_rank(rank_id) / 100 - orgrank_at_m75 / 100;
+        i_at_m75 = game_data.ranks.at(rank_id) / 100 - orgrank_at_m75 / 100;
         if (i_at_m75 < 0)
         {
             txtef(2);
@@ -1289,7 +1289,7 @@ void modrank(int rank_id, int amount, int prm_554)
             txtef(8);
         }
         const auto from = orgrank_at_m75 / 100;
-        const auto to = gdata_rank(rank_id) / 100;
+        const auto to = game_data.ranks.at(rank_id) / 100;
         txt(i18n::s.get(
             "core.locale.misc.ranking.changed",
             rankn(10, rank_id),
@@ -6852,7 +6852,7 @@ void map_proc_special_events()
                     {
                         break;
                     }
-                    if (gdata_rank(3) > 8000)
+                    if (game_data.ranks.at(3) > 8000)
                     {
                         txt(u8"「退屈ぅー」"s,
                             u8"「あまり見るものがないな」"s,
@@ -6860,7 +6860,7 @@ void map_proc_special_events()
                             u8"館内は少し寂しい…"s);
                         break;
                     }
-                    if (gdata_rank(3) > 5000)
+                    if (game_data.ranks.at(3) > 5000)
                     {
                         txt(u8"「いいんじゃない〜」"s,
                             u8"「まあ、普通の博物館だ」"s,
@@ -6868,7 +6868,7 @@ void map_proc_special_events()
                             u8"まあまあの客足だ。"s);
                         break;
                     }
-                    if (gdata_rank(3) > 2500)
+                    if (game_data.ranks.at(3) > 2500)
                     {
                         txt(u8"「この雰囲気好きだなぁ」"s,
                             u8"「もう一度来ようよ」"s,
@@ -6876,7 +6876,7 @@ void map_proc_special_events()
                             u8"館内はなかなか賑わっている。"s);
                         break;
                     }
-                    if (gdata_rank(3) > 500)
+                    if (game_data.ranks.at(3) > 500)
                     {
                         txt(u8"「来て良かった♪」"s,
                             u8"「よくこんなに集めたなあ」"s,
@@ -7360,7 +7360,7 @@ void god_fail_to_take_over_penalty()
 
 int calcincome(int rank_id)
 {
-    int rank_amount = 100 - gdata_rank(rank_id) / 100;
+    int rank_amount = 100 - game_data.ranks.at(rank_id) / 100;
     if (rank_amount == 99)
     {
         rank_amount = rank_amount * 70;
@@ -7423,7 +7423,7 @@ void supply_income()
     income(1) = 0;
     for (int cnt = 0; cnt < 9; ++cnt)
     {
-        if (gdata_rank(cnt) >= 10000)
+        if (game_data.ranks.at(cnt) >= 10000)
         {
             continue;
         }
@@ -7445,7 +7445,7 @@ void supply_income()
         for (int cnt = 0, cnt_end = (p); cnt < cnt_end; ++cnt)
         {
             dbid = 0;
-            flt(calcobjlv((100 - gdata_rank(rank_id) / 100) / 2 + 1),
+            flt(calcobjlv((100 - game_data.ranks.at(rank_id) / 100) / 2 + 1),
                 calcfixlv(
                     (rnd(12) < trait(39)) ? Quality::miracle : Quality::great));
             flttypemajor = choice(fsetincome);
@@ -7453,7 +7453,7 @@ void supply_income()
             {
                 flttypemajor = choice(fsetwear);
             }
-            if (rnd(100 + gdata_rank(rank_id) / 5) < 2)
+            if (rnd(100 + game_data.ranks.at(rank_id) / 5) < 2)
             {
                 dbid = 559;
             }
@@ -9174,9 +9174,11 @@ void dump_player_info()
     noteadd(""s);
     for (int cnt = 0; cnt < 9; ++cnt)
     {
-        if (gdata_rank(cnt) < 10000)
+        if (game_data.ranks.at(cnt) < 10000)
         {
-            noteadd(""s + ranktitle(cnt) + u8" Rank."s + gdata_rank(cnt) / 100);
+            noteadd(
+                ""s + ranktitle(cnt) + u8" Rank."s
+                + game_data.ranks.at(cnt) / 100);
             s = u8"給料: 約 "s + calcincome(cnt) + u8" gold  "s + u8"ノルマ: "s;
             gold += calcincome(cnt);
             if (cnt == 3 || cnt == 4 || cnt == 5 || cnt == 8)
@@ -9185,7 +9187,7 @@ void dump_player_info()
             }
             else
             {
-                s += ""s + gdata_rank_deadline(cnt) + u8"日以内"s;
+                s += ""s + game_data.rank_deadlines.at(cnt) + u8"日以内"s;
             }
             noteadd(s);
             noteadd(""s);
@@ -12493,7 +12495,7 @@ TurnResult proc_movement_event()
                 {
                     for (int cnt = 0; cnt < 5; ++cnt)
                     {
-                        rq = gdata_taken_quest(cnt);
+                        rq = game_data.taken_quests.at(cnt);
                         if (qdata(3, rq) == 1007)
                         {
                             if (qdata(8, rq) == 1)
@@ -15293,20 +15295,20 @@ void weather_changes()
         update_shop_and_report();
         for (int rank_id = 0; rank_id < 9; ++rank_id)
         {
-            if (gdata_rank(rank_id) >= 10000)
+            if (game_data.ranks.at(rank_id) >= 10000)
             {
-                gdata_rank(rank_id) = 10000;
+                game_data.ranks.at(rank_id) = 10000;
                 continue;
             }
             if (rank_id == 3 || rank_id == 4 || rank_id == 5 || rank_id == 8)
             {
                 continue;
             }
-            --gdata_rank_deadline(rank_id);
-            if (gdata_rank_deadline(rank_id) <= 0)
+            --game_data.rank_deadlines.at(rank_id);
+            if (game_data.rank_deadlines.at(rank_id) <= 0)
             {
-                modrank(rank_id, (gdata_rank(rank_id) / 12 + 100) * -1);
-                gdata_rank_deadline(rank_id) = ranknorma(rank_id);
+                modrank(rank_id, (game_data.ranks.at(rank_id) / 12 + 100) * -1);
+                game_data.rank_deadlines.at(rank_id) = ranknorma(rank_id);
             }
         }
         snd(74);

--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -4815,21 +4815,7 @@ TurnResult exit_map()
     gdata_rogue_boss_encountered = 0;
     if (mdata_map_type == mdata_t::MapType::player_owned)
     {
-        if (Config::instance().extrahelp)
-        {
-            if (gdata_exhelp_flag(1) == 0)
-            {
-                if (mode == 0)
-                {
-                    if (cdata.player().continuous_action.turn == 0)
-                    {
-                        gdata_exhelp_flag(1) = 1;
-                        ghelp = 1;
-                        show_ex_help();
-                    }
-                }
-            }
-        }
+        maybe_show_ex_help(1);
     }
     if (mdata_map_type == mdata_t::MapType::temporary)
     {
@@ -7574,21 +7560,7 @@ void supply_income()
     ctrl_file(FileOperation2::map_items_write, u8"shop"s + invfile + u8".s2");
     ctrl_file(FileOperation2::map_items_read, u8"shoptmp.s2");
     mode = 0;
-    if (Config::instance().extrahelp)
-    {
-        if (gdata_exhelp_flag(16) == 0)
-        {
-            if (mode == 0)
-            {
-                if (cdata.player().continuous_action.turn == 0)
-                {
-                    gdata_exhelp_flag(16) = 1;
-                    ghelp = 16;
-                    show_ex_help();
-                }
-            }
-        }
-    }
+    maybe_show_ex_help(16);
 }
 
 
@@ -7803,24 +7775,11 @@ int key_direction()
 
 TurnResult step_into_gate()
 {
-    if (Config::instance().extrahelp)
+    if (maybe_show_ex_help(17, true))
     {
-        if (gdata_exhelp_flag(17) == 0)
-        {
-            if (mode == 0)
-            {
-                if (cdata.player().continuous_action.turn == 0)
-                {
-                    gdata_exhelp_flag(17) = 1;
-                    ghelp = 17;
-                    show_ex_help();
-                    screenupdate = -1;
-                    update_screen();
-                    return TurnResult::pc_turn_user_error;
-                }
-            }
-        }
+        return TurnResult::pc_turn_user_error;
     }
+
     if (1 && game_data.wizard == 0)
     {
         do_save_game();
@@ -12863,21 +12822,7 @@ void sense_map_feats_on_move()
                 if (area_data[feat(2) + feat(3) * 100].id
                     == mdata_t::MapId::random_dungeon)
                 {
-                    if (Config::instance().extrahelp)
-                    {
-                        if (gdata_exhelp_flag(6) == 0)
-                        {
-                            if (mode == 0)
-                            {
-                                if (cdata.player().continuous_action.turn == 0)
-                                {
-                                    gdata_exhelp_flag(6) = 1;
-                                    ghelp = 6;
-                                    show_ex_help();
-                                }
-                            }
-                        }
-                    }
+                    maybe_show_ex_help(6);
                 }
             }
             if (feat(1) == 34)
@@ -12981,21 +12926,7 @@ void sense_map_feats_on_move()
             }
             if (feat(1) >= 24 && feat(1) <= 28)
             {
-                if (Config::instance().extrahelp)
-                {
-                    if (gdata_exhelp_flag(5) == 0)
-                    {
-                        if (mode == 0)
-                        {
-                            if (cdata.player().continuous_action.turn == 0)
-                            {
-                                gdata_exhelp_flag(5) = 1;
-                                ghelp = 5;
-                                show_ex_help();
-                            }
-                        }
-                    }
-                }
+                maybe_show_ex_help(5);
             }
         }
     }
@@ -15294,57 +15225,15 @@ void weather_changes()
         }
         if (game_data.weather == 4)
         {
-            if (Config::instance().extrahelp)
-            {
-                if (gdata_exhelp_flag(11) == 0)
-                {
-                    if (mode == 0)
-                    {
-                        if (cdata.player().continuous_action.turn == 0)
-                        {
-                            gdata_exhelp_flag(11) = 1;
-                            ghelp = 11;
-                            show_ex_help();
-                        }
-                    }
-                }
-            }
+            maybe_show_ex_help(11);
         }
         if (game_data.weather == 2)
         {
-            if (Config::instance().extrahelp)
-            {
-                if (gdata_exhelp_flag(12) == 0)
-                {
-                    if (mode == 0)
-                    {
-                        if (cdata.player().continuous_action.turn == 0)
-                        {
-                            gdata_exhelp_flag(12) = 1;
-                            ghelp = 12;
-                            show_ex_help();
-                        }
-                    }
-                }
-            }
+            maybe_show_ex_help(12);
         }
         if (game_data.weather == 1)
         {
-            if (Config::instance().extrahelp)
-            {
-                if (gdata_exhelp_flag(13) == 0)
-                {
-                    if (mode == 0)
-                    {
-                        if (cdata.player().continuous_action.turn == 0)
-                        {
-                            gdata_exhelp_flag(13) = 1;
-                            ghelp = 13;
-                            show_ex_help();
-                        }
-                    }
-                }
-            }
+            maybe_show_ex_help(13);
         }
         if (p != game_data.weather)
         {
@@ -15384,39 +15273,11 @@ void weather_changes()
     }
     if (game_data.continuous_active_hours >= 15)
     {
-        if (Config::instance().extrahelp)
-        {
-            if (gdata_exhelp_flag(9) == 0)
-            {
-                if (mode == 0)
-                {
-                    if (cdata.player().continuous_action.turn == 0)
-                    {
-                        gdata_exhelp_flag(9) = 1;
-                        ghelp = 9;
-                        show_ex_help();
-                    }
-                }
-            }
-        }
+        maybe_show_ex_help(9);
     }
     if (cdata.player().nutrition < 5000)
     {
-        if (Config::instance().extrahelp)
-        {
-            if (gdata_exhelp_flag(10) == 0)
-            {
-                if (mode == 0)
-                {
-                    if (cdata.player().continuous_action.turn == 0)
-                    {
-                        gdata_exhelp_flag(10) = 1;
-                        ghelp = 10;
-                        show_ex_help();
-                    }
-                }
-            }
-        }
+        maybe_show_ex_help(10);
     }
     if (game_data.date.hour >= 24)
     {

--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -1246,20 +1246,18 @@ void go_hostile()
 
 
 
-void modrank(int prm_552, int prm_553, int prm_554)
+void modrank(int rank_id, int amount, int prm_554)
 {
-    elona_vector1<int> p_at_m75;
     int orgrank_at_m75 = 0;
     int i_at_m75 = 0;
-    p_at_m75 = 120 + prm_552;
-    p_at_m75(1) = gdata(p_at_m75) / 100;
-    orgrank_at_m75 = gdata(p_at_m75);
-    i_at_m75 = prm_553;
-    if (prm_553 > 0)
+    int rank_factor = gdata_rank(rank_id) / 100;
+    orgrank_at_m75 = gdata_rank(rank_id);
+    i_at_m75 = amount;
+    if (amount > 0)
     {
-        i_at_m75 = prm_553 * (p_at_m75(1) + 20) * (p_at_m75(1) + 20) / 2500;
-        gdata(140 + prm_552) = ranknorma(prm_552);
-        if (gdata(p_at_m75) == 100)
+        i_at_m75 = amount * (rank_factor + 20) * (rank_factor + 20) / 2500;
+        gdata_rank_deadline(rank_id) = ranknorma(rank_id);
+        if (gdata_rank(rank_id) == 100)
         {
             return;
         }
@@ -1271,18 +1269,18 @@ void modrank(int prm_552, int prm_553, int prm_554)
             }
         }
     }
-    gdata(p_at_m75) -= i_at_m75;
-    if (gdata(p_at_m75) >= 10000)
+    gdata_rank(rank_id) -= i_at_m75;
+    if (gdata_rank(rank_id) >= 10000)
     {
-        gdata(p_at_m75) = 10000;
+        gdata_rank(rank_id) = 10000;
     }
-    if (gdata(p_at_m75) < 100)
+    if (gdata_rank(rank_id) < 100)
     {
-        gdata(p_at_m75) = 100;
+        gdata_rank(rank_id) = 100;
     }
-    if (orgrank_at_m75 / 100 != gdata(p_at_m75) / 100)
+    if (orgrank_at_m75 / 100 != gdata_rank(rank_id) / 100)
     {
-        i_at_m75 = gdata(p_at_m75) / 100 - orgrank_at_m75 / 100;
+        i_at_m75 = gdata_rank(rank_id) / 100 - orgrank_at_m75 / 100;
         if (i_at_m75 < 0)
         {
             txtef(2);
@@ -1292,13 +1290,13 @@ void modrank(int prm_552, int prm_553, int prm_554)
             txtef(8);
         }
         const auto from = orgrank_at_m75 / 100;
-        const auto to = gdata(p_at_m75) / 100;
+        const auto to = gdata_rank(rank_id) / 100;
         txt(i18n::s.get(
             "core.locale.misc.ranking.changed",
-            rankn(10, prm_552),
+            rankn(10, rank_id),
             from,
             to,
-            ranktitle(prm_552)));
+            ranktitle(rank_id)));
     }
     else if (i_at_m75 > 0)
     {
@@ -2581,7 +2579,7 @@ int try_to_perceive_npc(int cc)
 
 void start_stealing()
 {
-    gdata(91) = 105;
+    gdata_continuous_action_about_to_start = 105;
     continuous_action_others();
 }
 
@@ -4815,18 +4813,18 @@ TurnResult exit_map()
     int previous_dungeon_level = game_data.current_dungeon_level;
     int fixstart = 0;
     game_data.left_minutes_of_executing_quest = 0;
-    gdata(171) = 0;
+    gdata_rogue_boss_encountered = 0;
     if (mdata_map_type == mdata_t::MapType::player_owned)
     {
         if (Config::instance().extrahelp)
         {
-            if (gdata(201) == 0)
+            if (gdata_exhelp_flag(1) == 0)
             {
                 if (mode == 0)
                 {
                     if (cdata.player().continuous_action.turn == 0)
                     {
-                        gdata(201) = 1;
+                        gdata_exhelp_flag(1) = 1;
                         ghelp = 1;
                         show_ex_help();
                     }
@@ -4990,7 +4988,7 @@ TurnResult exit_map()
                 || mdata_map_type == mdata_t::MapType::shelter
                 || mdata_map_type == mdata_t::MapType::guild)
             {
-                game_data.current_map = gdata(850);
+                game_data.current_map = gdata_destination_outer_map;
             }
         }
         if (mdata_t::is_nefia(mdata_map_type)
@@ -4999,7 +4997,7 @@ TurnResult exit_map()
             if (game_data.current_dungeon_level
                 < area_data[game_data.current_map].danger_level)
             {
-                game_data.current_map = gdata(850);
+                game_data.current_map = gdata_destination_outer_map;
             }
         }
         if (area_data[game_data.current_map].type == mdata_t::MapType::town)
@@ -5058,7 +5056,7 @@ TurnResult exit_map()
         rc = 0;
         revive_player();
         game_data.current_map = static_cast<int>(mdata_t::MapId::your_home);
-        gdata(850) = area_data[7].outer_map;
+        gdata_destination_outer_map = area_data[7].outer_map;
         game_data.current_dungeon_level = 1;
     }
     if (rdtry > 1)
@@ -5623,7 +5621,7 @@ int initialize_world_map()
 
 void map_global_proc_diastrophism()
 {
-    if (gdata(79) == 1)
+    if (gdata_reset_world_map_in_diastrophism_flag == 1)
     {
         initialize_adata();
         map_global_prepare();
@@ -5648,7 +5646,7 @@ void map_global_proc_diastrophism()
         }
     }
     if (p <= 25 || rnd(150) == 0 || game_data.diastrophism_flag != 0
-        || gdata(79))
+        || gdata_reset_world_map_in_diastrophism_flag)
     {
         game_data.diastrophism_flag = 0;
         msgtemp += i18n::s.get("core.locale.action.move.global.diastrophism");
@@ -5665,7 +5663,7 @@ void map_global_proc_diastrophism()
         initialize_world_map();
         map_global_prepare();
     }
-    gdata(79) = 0;
+    gdata_reset_world_map_in_diastrophism_flag = 0;
 }
 
 
@@ -5684,7 +5682,7 @@ void map_global_place_entrances()
     for (int cnt = 0; cnt < 20; ++cnt)
     {
         int cnt2 = cnt;
-        if (gdata(850) != 4)
+        if (gdata_destination_outer_map != 4)
         {
             break;
         }
@@ -5710,7 +5708,7 @@ void map_global_place_entrances()
         {
             continue;
         }
-        if (area_data[cnt].outer_map != gdata(850))
+        if (area_data[cnt].outer_map != gdata_destination_outer_map)
         {
             continue;
         }
@@ -6598,7 +6596,7 @@ int place_random_nefias()
         area_data[p].tile_type = 1;
         area_data[p].turn_cost_base = 10000;
         area_data[p].is_indoor = true;
-        area_data[p].outer_map = gdata(850);
+        area_data[p].outer_map = gdata_destination_outer_map;
         if (rnd(3))
         {
             area_data[p].danger_level = rnd(cdata.player().level + 5) + 1;
@@ -6869,7 +6867,7 @@ void map_proc_special_events()
                     {
                         break;
                     }
-                    if (gdata(123) > 8000)
+                    if (gdata_rank(3) > 8000)
                     {
                         txt(u8"「退屈ぅー」"s,
                             u8"「あまり見るものがないな」"s,
@@ -6877,7 +6875,7 @@ void map_proc_special_events()
                             u8"館内は少し寂しい…"s);
                         break;
                     }
-                    if (gdata(123) > 5000)
+                    if (gdata_rank(3) > 5000)
                     {
                         txt(u8"「いいんじゃない〜」"s,
                             u8"「まあ、普通の博物館だ」"s,
@@ -6885,7 +6883,7 @@ void map_proc_special_events()
                             u8"まあまあの客足だ。"s);
                         break;
                     }
-                    if (gdata(123) > 2500)
+                    if (gdata_rank(3) > 2500)
                     {
                         txt(u8"「この雰囲気好きだなぁ」"s,
                             u8"「もう一度来ようよ」"s,
@@ -6893,7 +6891,7 @@ void map_proc_special_events()
                             u8"館内はなかなか賑わっている。"s);
                         break;
                     }
-                    if (gdata(123) > 500)
+                    if (gdata_rank(3) > 500)
                     {
                         txt(u8"「来て良かった♪」"s,
                             u8"「よくこんなに集めたなあ」"s,
@@ -7441,7 +7439,7 @@ void supply_income()
     income(1) = 0;
     for (int cnt = 0; cnt < 9; ++cnt)
     {
-        if (gdata(120 + cnt) >= 10000)
+        if (gdata_rank(cnt) >= 10000)
         {
             continue;
         }
@@ -7580,13 +7578,13 @@ void supply_income()
     mode = 0;
     if (Config::instance().extrahelp)
     {
-        if (gdata(216) == 0)
+        if (gdata_exhelp_flag(16) == 0)
         {
             if (mode == 0)
             {
                 if (cdata.player().continuous_action.turn == 0)
                 {
-                    gdata(216) = 1;
+                    gdata_exhelp_flag(16) = 1;
                     ghelp = 16;
                     show_ex_help();
                 }
@@ -7809,13 +7807,13 @@ TurnResult step_into_gate()
 {
     if (Config::instance().extrahelp)
     {
-        if (gdata(217) == 0)
+        if (gdata_exhelp_flag(17) == 0)
         {
             if (mode == 0)
             {
                 if (cdata.player().continuous_action.turn == 0)
                 {
-                    gdata(217) = 1;
+                    gdata_exhelp_flag(17) = 1;
                     ghelp = 17;
                     show_ex_help();
                     screenupdate = -1;
@@ -8407,23 +8405,23 @@ int target_position()
 TurnResult do_short_cut()
 {
     menucycle = 0;
-    if (gdata(40 + sc) == 0)
+    if (gdata_skill_shortcut(sc) == 0)
     {
         ++msgdup;
         txt(i18n::s.get("core.locale.action.shortcut.unassigned"));
         update_screen();
         return TurnResult::pc_turn_user_error;
     }
-    if (gdata(40 + sc) >= 10000)
+    if (gdata_skill_shortcut(sc) >= 10000)
     {
-        invsc = gdata((40 + sc)) % 10000;
-        invctrl(0) = gdata((40 + sc)) / 10000;
+        invsc = gdata_skill_shortcut(sc) % 10000;
+        invctrl(0) = gdata_skill_shortcut(sc) / 10000;
         invctrl(1) = 0;
         MenuResult mr = ctrl_inventory();
         assert(mr.turn_result != TurnResult::none);
         return mr.turn_result;
     }
-    efid = gdata(40 + sc);
+    efid = gdata_skill_shortcut(sc);
     if (efid >= 300 && efid < 400)
     {
         return do_use_magic();
@@ -8908,7 +8906,7 @@ void try_to_return()
     p = 0;
     p = 0;
     i = 7;
-    if (area_data[i].outer_map == gdata(850))
+    if (area_data[i].outer_map == gdata_destination_outer_map)
     {
         list(0, p) = i;
         list(1, p) = 1;
@@ -8922,7 +8920,7 @@ void try_to_return()
         {
             continue;
         }
-        if (area_data[i].outer_map != gdata(850))
+        if (area_data[i].outer_map != gdata_destination_outer_map)
         {
             continue;
         }
@@ -9067,7 +9065,7 @@ int read_textbook()
             }
         }
     }
-    gdata(91) = 104;
+    gdata_continuous_action_about_to_start = 104;
     continuous_action_others();
     return 1;
 }
@@ -9290,10 +9288,9 @@ void dump_player_info()
     noteadd(""s);
     for (int cnt = 0; cnt < 9; ++cnt)
     {
-        if (gdata(120 + cnt) < 10000)
+        if (gdata_rank(cnt) < 10000)
         {
-            noteadd(
-                ""s + ranktitle(cnt) + u8" Rank."s + gdata((120 + cnt)) / 100);
+            noteadd(""s + ranktitle(cnt) + u8" Rank."s + gdata_rank(cnt) / 100);
             s = u8"給料: 約 "s + calcincome(cnt) + u8" gold  "s + u8"ノルマ: "s;
             gold += calcincome(cnt);
             if (cnt == 3 || cnt == 4 || cnt == 5 || cnt == 8)
@@ -9302,7 +9299,7 @@ void dump_player_info()
             }
             else
             {
-                s += ""s + gdata((140 + cnt)) + u8"日以内"s;
+                s += ""s + gdata_rank_deadline(cnt) + u8"日以内"s;
             }
             noteadd(s);
             noteadd(""s);
@@ -9365,7 +9362,7 @@ void initialize_map_adjust_spawns()
 
 void clear_existing_quest_list()
 {
-    ++gdata(184);
+    ++gdata_map_regenerate_count;
     DIM3(qdata, 20, 500);
     SDIM3(qname, 40, 500);
     game_data.number_of_existing_quests = 0;
@@ -10270,7 +10267,7 @@ void sleep_start()
     if (game_data.current_map == mdata_t::MapId::quest)
     {
         txt(i18n::s.get("core.locale.activity.sleep.but_you_cannot"));
-        gdata(98) = 0;
+        gdata_character_and_status_for_gene = 0;
         return;
     }
     if (game_data.catches_god_signal)
@@ -10342,7 +10339,7 @@ void sleep_start()
         draw_sleep_background_frame();
         await(Config::instance().animewait * 25);
     }
-    if (gdata(98) != 0)
+    if (gdata_character_and_status_for_gene != 0)
     {
         tc = -1;
         for (int cnt = 1; cnt < 16; ++cnt)
@@ -10370,7 +10367,7 @@ void sleep_start()
         }
     }
     draw_sleep_background_frame();
-    gdata(98) = 0;
+    gdata_character_and_status_for_gene = 0;
     mode = 0;
     wake_up();
     cdata[cc].nutrition -= 1500 / (trait(158) + 1);
@@ -11917,7 +11914,7 @@ int pick_up_item()
                             "core.locale.ui.inv.common.inventory_is_full"));
                         return 0;
                     }
-                    gdata(91) = 103;
+                    gdata_continuous_action_about_to_start = 103;
                     continuous_action_others();
                     return -1;
                 }
@@ -12562,7 +12559,8 @@ TurnResult proc_movement_event()
         if (cc == 0)
         {
             encounter = 0;
-            gdata(62) = map(cdata[cc].position.x, cdata[cc].position.y, 0);
+            gdata_stood_world_map_tile =
+                map(cdata[cc].position.x, cdata[cc].position.y, 0);
             if (map(cdata[cc].position.x, cdata[cc].position.y, 6) == 0)
             {
                 p = map(cdata[cc].position.x, cdata[cc].position.y, 0);
@@ -12609,7 +12607,7 @@ TurnResult proc_movement_event()
                 {
                     for (int cnt = 0; cnt < 5; ++cnt)
                     {
-                        rq = gdata(160 + cnt);
+                        rq = gdata_taken_quest(cnt);
                         if (qdata(3, rq) == 1007)
                         {
                             if (qdata(8, rq) == 1)
@@ -12856,24 +12854,24 @@ void sense_map_feats_on_move()
 {
     if (cc == 0)
     {
-        gdata(60) = -1;
-        gdata(61) = -1;
+        gdata_player_x_on_map_leave = -1;
+        gdata_player_y_on_map_leave = -1;
         x = cdata.player().position.x;
         y = cdata.player().position.y;
-        if (key_shift && gdata(30) == 0 && cdata.player().confused == 0
-            && cdata.player().dimmed == 0)
+        if (key_shift && gdata_player_cellaccess_check_flag == 0
+            && cdata.player().confused == 0 && cdata.player().dimmed == 0)
         {
             if (mdata_map_type != mdata_t::MapType::world_map)
             {
-                gdata(30) = 1;
+                gdata_player_cellaccess_check_flag = 1;
                 cell_check(cdata[cc].position.x + 1, cdata[cc].position.y);
-                gdata(33) = cellaccess;
+                gdata_player_cellaccess_e = cellaccess;
                 cell_check(cdata[cc].position.x - 1, cdata[cc].position.y);
-                gdata(31) = cellaccess;
+                gdata_player_cellaccess_w = cellaccess;
                 cell_check(cdata[cc].position.x, cdata[cc].position.y + 1);
-                gdata(34) = cellaccess;
+                gdata_player_cellaccess_s = cellaccess;
                 cell_check(cdata[cc].position.x, cdata[cc].position.y - 1);
-                gdata(32) = cellaccess;
+                gdata_player_cellaccess_n = cellaccess;
             }
         }
         if (map(x, y, 4) != 0)
@@ -12940,13 +12938,13 @@ void sense_map_feats_on_move()
                 {
                     if (Config::instance().extrahelp)
                     {
-                        if (gdata(206) == 0)
+                        if (gdata_exhelp_flag(6) == 0)
                         {
                             if (mode == 0)
                             {
                                 if (cdata.player().continuous_action.turn == 0)
                                 {
-                                    gdata(206) = 1;
+                                    gdata_exhelp_flag(6) = 1;
                                     ghelp = 6;
                                     show_ex_help();
                                 }
@@ -13058,13 +13056,13 @@ void sense_map_feats_on_move()
             {
                 if (Config::instance().extrahelp)
                 {
-                    if (gdata(205) == 0)
+                    if (gdata_exhelp_flag(5) == 0)
                     {
                         if (mode == 0)
                         {
                             if (cdata.player().continuous_action.turn == 0)
                             {
-                                gdata(205) = 1;
+                                gdata_exhelp_flag(5) = 1;
                                 ghelp = 5;
                                 show_ex_help();
                             }
@@ -13904,7 +13902,7 @@ label_22191_internal:
             {
                 if (tc >= 16)
                 {
-                    gdata(809) = 2;
+                    gdata_proc_damage_events_flag = 2;
                     txt(i18n::s.get(
                         "core.locale.damage.weapon.attacks_unarmed_and",
                         cdata[cc],
@@ -13937,7 +13935,7 @@ label_22191_internal:
                 {
                     if (tc >= 16)
                     {
-                        gdata(809) = 2;
+                        gdata_proc_damage_events_flag = 2;
                         if (attackskill == 111)
                         {
                             txt(i18n::s.get(
@@ -14189,7 +14187,7 @@ label_22191_internal:
     }
     if (tc == 0)
     {
-        gdata(30) = 0;
+        gdata_player_cellaccess_check_flag = 0;
     }
     rowact_check(tc);
     if (attackskill != 106)
@@ -14292,7 +14290,7 @@ void proc_weapon_enchantments()
             s = chara_refstr(cdata[tc].id, 8);
             if (strutil::contains(s(0), u8"/dragon/"))
             {
-                gdata(809) = 1;
+                gdata_proc_damage_events_flag = 1;
                 damage_hp(cdata[tc], orgdmg / 2, cc);
             }
             continue;
@@ -14302,7 +14300,7 @@ void proc_weapon_enchantments()
             s = chara_refstr(cdata[tc].id, 8);
             if (strutil::contains(s(0), u8"/god/"))
             {
-                gdata(809) = 1;
+                gdata_proc_damage_events_flag = 1;
                 damage_hp(cdata[tc], orgdmg / 2, cc);
             }
             continue;
@@ -14312,7 +14310,7 @@ void proc_weapon_enchantments()
             s = chara_refstr(cdata[tc].id, 8);
             if (strutil::contains(s(0), u8"/undead/"))
             {
-                gdata(809) = 1;
+                gdata_proc_damage_events_flag = 1;
                 damage_hp(cdata[tc], orgdmg / 2, cc);
             }
             continue;
@@ -14332,7 +14330,7 @@ void proc_weapon_enchantments()
                 {
                     continue;
                 }
-                gdata(809) = 1;
+                gdata_proc_damage_events_flag = 1;
                 damage_hp(
                     cdata[tc],
                     rnd(orgdmg * (100 + inv[cw].enchantments[cnt].power) / 1000
@@ -14386,7 +14384,7 @@ void proc_weapon_enchantments()
     {
         if (cdata[tc].state() == Character::State::alive)
         {
-            gdata(809) = 1;
+            gdata_proc_damage_events_flag = 1;
             damage_hp(
                 cdata[tc],
                 orgdmg * 2 / 3,
@@ -14808,7 +14806,7 @@ void initialize_economy()
     elona_vector1<int> bkdata;
     if (initeco)
     {
-        gdata(815) = 15;
+        gdata_politics_map_id = static_cast<int>(mdata_t::MapId::palmia);
     }
     bkdata(0) = game_data.current_map;
     bkdata(1) = game_data.current_dungeon_level;
@@ -14891,7 +14889,7 @@ void initialize_economy()
     game_data.current_dungeon_level = bkdata(1);
     cdata.player().position.x = bkdata(2);
     cdata.player().position.y = bkdata(3);
-    gdata(79) = 1;
+    gdata_reset_world_map_in_diastrophism_flag = 1;
     mode = 3;
     mapsubroutine = 1;
     initialize_map();
@@ -15371,13 +15369,13 @@ void weather_changes()
         {
             if (Config::instance().extrahelp)
             {
-                if (gdata(211) == 0)
+                if (gdata_exhelp_flag(11) == 0)
                 {
                     if (mode == 0)
                     {
                         if (cdata.player().continuous_action.turn == 0)
                         {
-                            gdata(211) = 1;
+                            gdata_exhelp_flag(11) = 1;
                             ghelp = 11;
                             show_ex_help();
                         }
@@ -15389,13 +15387,13 @@ void weather_changes()
         {
             if (Config::instance().extrahelp)
             {
-                if (gdata(212) == 0)
+                if (gdata_exhelp_flag(12) == 0)
                 {
                     if (mode == 0)
                     {
                         if (cdata.player().continuous_action.turn == 0)
                         {
-                            gdata(212) = 1;
+                            gdata_exhelp_flag(12) = 1;
                             ghelp = 12;
                             show_ex_help();
                         }
@@ -15407,13 +15405,13 @@ void weather_changes()
         {
             if (Config::instance().extrahelp)
             {
-                if (gdata(213) == 0)
+                if (gdata_exhelp_flag(13) == 0)
                 {
                     if (mode == 0)
                     {
                         if (cdata.player().continuous_action.turn == 0)
                         {
-                            gdata(213) = 1;
+                            gdata_exhelp_flag(13) = 1;
                             ghelp = 13;
                             show_ex_help();
                         }
@@ -15461,13 +15459,13 @@ void weather_changes()
     {
         if (Config::instance().extrahelp)
         {
-            if (gdata(209) == 0)
+            if (gdata_exhelp_flag(9) == 0)
             {
                 if (mode == 0)
                 {
                     if (cdata.player().continuous_action.turn == 0)
                     {
-                        gdata(209) = 1;
+                        gdata_exhelp_flag(9) = 1;
                         ghelp = 9;
                         show_ex_help();
                     }
@@ -15479,13 +15477,13 @@ void weather_changes()
     {
         if (Config::instance().extrahelp)
         {
-            if (gdata(210) == 0)
+            if (gdata_exhelp_flag(10) == 0)
             {
                 if (mode == 0)
                 {
                     if (cdata.player().continuous_action.turn == 0)
                     {
-                        gdata(210) = 1;
+                        gdata_exhelp_flag(10) = 1;
                         ghelp = 10;
                         show_ex_help();
                     }

--- a/src/gdata.cpp
+++ b/src/gdata.cpp
@@ -41,10 +41,19 @@ FoobarData foobar_data;
     SERIALIZE(27, next_shelter_serial_id); \
     SERIALIZE(28, seven_league_boot_effect); \
     SERIALIZE(29, protects_from_etherwind); \
+    SERIALIZE(30, player_cellaccess_check_flag); \
+    SERIALIZE(31, player_cellaccess_w); \
+    SERIALIZE(32, player_cellaccess_n); \
+    SERIALIZE(33, player_cellaccess_e); \
+    SERIALIZE(34, player_cellaccess_s); \
+    SERIALIZE(35, player_next_move_direction); \
     SERIALIZE(36, played_scene); \
     SERIALIZE(37, torch); \
     SERIALIZE(38, angband_flag); \
     SERIALIZE(39, number_of_learned_skills_by_trainer); \
+    SERIALIZE(60, player_x_on_map_leave); \
+    SERIALIZE(61, player_y_on_map_leave); \
+    SERIALIZE(62, stood_world_map_tile); \
     SERIALIZE(63, is_returning_or_escaping); \
     SERIALIZE(64, destination_map); \
     SERIALIZE(65, destination_dungeon_level); \
@@ -53,30 +62,44 @@ FoobarData foobar_data;
     SERIALIZE(68, previous_x); \
     SERIALIZE(69, previous_y); \
     SERIALIZE(70, executing_immediate_quest_type); \
+    SERIALIZE(71, executing_immediate_quest_show_hunt_remain); \
     SERIALIZE(72, executing_immediate_quest); \
+    SERIALIZE(73, executing_immediate_quest_status); \
+    SERIALIZE(74, executing_immediate_quest_fame_gained); \
     SERIALIZE(75, number_of_existing_quests); \
     SERIALIZE(76, basic_point_of_home_rank); \
+    SERIALIZE(77, total_deco_value); \
+    SERIALIZE(78, total_heirloom_value); \
+    SERIALIZE(79, reset_world_map_in_diastrophism_flag); \
     SERIALIZE(80, cargo_weight); \
     SERIALIZE(81, initial_cart_limit); \
     SERIALIZE(82, current_cart_limit); \
     SERIALIZE(83, protects_from_bad_weather); \
     SERIALIZE(84, left_minutes_of_executing_quest); \
     SERIALIZE(85, ether_disease_stage); \
+    SERIALIZE(87, executing_immediate_quest_time_left_display_period); \
     SERIALIZE(88, time_when_textbook_becomes_available); \
+    SERIALIZE(89, light); \
     SERIALIZE(90, continuous_active_hours); \
+    SERIALIZE(91, continuous_action_about_to_start); \
     SERIALIZE(92, sleep_experience); \
     SERIALIZE(93, acquirable_feat_count); \
+    SERIALIZE(94, chara_last_attacked_by_player); \
     SERIALIZE(95, wish_count); \
     SERIALIZE(96, version); \
     SERIALIZE(97, rights_to_succeed_to); \
+    SERIALIZE(98, character_and_status_for_gene); \
     SERIALIZE(99, next_voting_time); \
     SERIALIZE(170, cost_to_hire); \
+    SERIALIZE(171, rogue_boss_encountered); \
     SERIALIZE(179, left_bill); \
     SERIALIZE(180, distance_between_town); \
     SERIALIZE(181, departure_date); \
     SERIALIZE(182, left_town_map); \
     SERIALIZE(183, mount); \
+    SERIALIZE(184, map_regenerate_count); \
     SERIALIZE(185, catches_god_signal); \
+    SERIALIZE(186, void_next_lord_floor); \
     SERIALIZE(187, reveals_religion); \
     SERIALIZE(250, quest_flags.tutorial); \
     SERIALIZE(252, quest_flags.main_quest); \
@@ -113,31 +136,38 @@ FoobarData foobar_data;
     SERIALIZE(463, quest_flags.red_blossom_in_palmia); \
     SERIALIZE(464, quest_flags.ambitious_scientist); \
     SERIALIZE(465, quest_flags.sewer_sweeping); \
-    SERIALIZE(472, quest_flags.minotaur_king); \
-    SERIALIZE(473, quest_flags.little_sister); \
-    SERIALIZE(474, quest_flags.blue_capsule_drug); \
     SERIALIZE(466, guild.joining_mages_guild); \
     SERIALIZE(467, guild.joining_fighters_guild); \
     SERIALIZE(468, guild.joining_thieves_guild); \
     SERIALIZE(469, guild.mages_guild_quota_recurring); \
     SERIALIZE(470, guild.fighters_guild_quota_recurring); \
     SERIALIZE(471, guild.thieves_guild_quota_recurring); \
+    SERIALIZE(472, quest_flags.minotaur_king); \
+    SERIALIZE(473, quest_flags.little_sister); \
+    SERIALIZE(474, quest_flags.blue_capsule_drug); \
     SERIALIZE(800, ether_disease_speed); \
     SERIALIZE(801, left_turns_of_timestop); \
+    SERIALIZE(802, ex_arena_wins); \
     SERIALIZE(803, ex_arena_level); \
     SERIALIZE(804, time_when_uploding_becomes_available); \
     SERIALIZE(805, play_time); \
     SERIALIZE(806, last_etherwind_month); \
     SERIALIZE(807, god_rank); \
+    SERIALIZE(808, player_is_changing_equipment); \
+    SERIALIZE(809, proc_damage_events_flag); \
     SERIALIZE(810, quest_flags.kill_count_of_little_sister); \
     SERIALIZE(811, quest_flags.save_count_of_little_sister); \
     SERIALIZE(812, quest_flags.gift_count_of_little_sister); \
+    SERIALIZE(813, tcg_used_deck); \
     SERIALIZE(814, number_of_waiting_guests); \
+    SERIALIZE(815, politics_map_id); \
+    SERIALIZE(820, politics_tax_amount); \
     SERIALIZE(825, last_month_when_trainer_visited); \
     SERIALIZE(826, item_turns); \
     SERIALIZE( \
         827, next_level_minus_one_kumiromis_experience_becomes_available); \
     SERIALIZE(828, wizard); \
+    SERIALIZE(850, destination_outer_map); \
     SERIALIZE(851, lost_wallet_count);
 
 

--- a/src/gdata.cpp
+++ b/src/gdata.cpp
@@ -13,6 +13,10 @@ FoobarData foobar_data;
 #define GDATA_PACK(x, ident) gdata(x) = ident;
 #define GDATA_UNPACK(x, ident) ident = gdata(x);
 
+#define SERIALIZE_ARRAY(x, ident) \
+    for (size_t i = 0; i < ident.size(); i++) \
+        SERIALIZE(x + i, ident.at(i));
+
 #define SERIALIZE_ALL() \
     SERIALIZE(0, death_count); \
     SERIALIZE(1, deepest_dungeon_level); \
@@ -51,6 +55,7 @@ FoobarData foobar_data;
     SERIALIZE(37, torch); \
     SERIALIZE(38, angband_flag); \
     SERIALIZE(39, number_of_learned_skills_by_trainer); \
+    SERIALIZE_ARRAY(40, skill_shortcuts); \
     SERIALIZE(60, player_x_on_map_leave); \
     SERIALIZE(61, player_y_on_map_leave); \
     SERIALIZE(62, stood_world_map_tile); \
@@ -90,6 +95,9 @@ FoobarData foobar_data;
     SERIALIZE(97, rights_to_succeed_to); \
     SERIALIZE(98, character_and_status_for_gene); \
     SERIALIZE(99, next_voting_time); \
+    SERIALIZE_ARRAY(120, ranks); \
+    SERIALIZE_ARRAY(140, rank_deadlines); \
+    SERIALIZE_ARRAY(160, taken_quests); \
     SERIALIZE(170, cost_to_hire); \
     SERIALIZE(171, rogue_boss_encountered); \
     SERIALIZE(179, left_bill); \
@@ -101,6 +109,7 @@ FoobarData foobar_data;
     SERIALIZE(185, catches_god_signal); \
     SERIALIZE(186, void_next_lord_floor); \
     SERIALIZE(187, reveals_religion); \
+    SERIALIZE_ARRAY(200, exhelp_flags); \
     SERIALIZE(250, quest_flags.tutorial); \
     SERIALIZE(252, quest_flags.main_quest); \
     SERIALIZE(253, quest_flags.magic_stone_of_fool); \
@@ -145,6 +154,8 @@ FoobarData foobar_data;
     SERIALIZE(472, quest_flags.minotaur_king); \
     SERIALIZE(473, quest_flags.little_sister); \
     SERIALIZE(474, quest_flags.blue_capsule_drug); \
+    SERIALIZE_ARRAY(700, ether_disease_history); \
+    SERIALIZE_ARRAY(750, tracked_skills); \
     SERIALIZE(800, ether_disease_speed); \
     SERIALIZE(801, left_turns_of_timestop); \
     SERIALIZE(802, ex_arena_wins); \
@@ -167,6 +178,7 @@ FoobarData foobar_data;
     SERIALIZE( \
         827, next_level_minus_one_kumiromis_experience_becomes_available); \
     SERIALIZE(828, wizard); \
+    SERIALIZE_ARRAY(830, tcg_decks); \
     SERIALIZE(850, destination_outer_map); \
     SERIALIZE(851, lost_wallet_count);
 

--- a/src/gdata.hpp
+++ b/src/gdata.hpp
@@ -1,6 +1,56 @@
 #pragma once
 #include "version.hpp"
 
+#define gdata_continuous_action_about_to_start gdata(91)
+#define gdata_executing_immediate_quest_show_hunt_remain gdata(71)
+#define gdata_executing_immediate_quest_status gdata(73)
+#define gdata_executing_immediate_quest_fame_gained gdata(74)
+#define gdata_executing_immediate_quest_time_left_display_period gdata(87)
+#define gdata_rogue_boss_encountered gdata(171)
+#define gdata_void_next_lord_floor gdata(186)
+#define gdata_player_next_move_direction gdata(35)
+
+// tc + (0 or 10000)
+#define gdata_character_and_status_for_gene gdata(98)
+
+#define gdata_player_is_changing_equipment gdata(808)
+#define gdata_player_cellaccess_check_flag gdata(30)
+#define gdata_player_cellaccess_w gdata(31)
+#define gdata_player_cellaccess_n gdata(32)
+#define gdata_player_cellaccess_e gdata(33)
+#define gdata_player_cellaccess_s gdata(34)
+#define gdata_player_x_on_map_leave gdata(60)
+#define gdata_player_y_on_map_leave gdata(61)
+#define gdata_stood_world_map_tile gdata(62)
+#define gdata_chara_last_attacked_by_player gdata(94)
+#define gdata_map_regenerate_count gdata(184)
+#define gdata_politics_map_id gdata(815)
+
+// whether or not to proc fury/splitting/active form damage text
+// 1 if not, 2 if yes
+#define gdata_proc_damage_events_flag gdata(809)
+
+#define gdata_destination_outer_map gdata(850)
+#define gdata_reset_world_map_in_diastrophism_flag gdata(79)
+#define gdata_ex_arena_wins gdata(802)
+
+#define gdata_exhelp_flag(n) gdata(200 + n)
+
+// 40-59
+#define gdata_skill_shortcut(n) gdata(40 + n)
+
+// 120-128
+#define gdata_rank(n) gdata(120 + n)
+
+// 140-148
+#define gdata_rank_deadline(n) gdata(140 + n)
+
+// 160-164
+#define gdata_taken_quest(n) gdata(160 + n)
+
+// 750-760
+#define gdata_tracked_skill(n) gdata(750 + n)
+
 namespace elona
 {
 

--- a/src/gdata.hpp
+++ b/src/gdata.hpp
@@ -1,46 +1,6 @@
 #pragma once
 #include "version.hpp"
 
-#define gdata_continuous_action_about_to_start gdata(91)
-#define gdata_executing_immediate_quest_show_hunt_remain gdata(71)
-#define gdata_executing_immediate_quest_status gdata(73)
-#define gdata_executing_immediate_quest_fame_gained gdata(74)
-#define gdata_executing_immediate_quest_time_left_display_period gdata(87)
-#define gdata_rogue_boss_encountered gdata(171)
-#define gdata_void_next_lord_floor gdata(186)
-#define gdata_player_next_move_direction gdata(35)
-
-// tc + (0 or 10000)
-#define gdata_character_and_status_for_gene gdata(98)
-
-#define gdata_player_is_changing_equipment gdata(808)
-#define gdata_player_cellaccess_check_flag gdata(30)
-#define gdata_player_cellaccess_w gdata(31)
-#define gdata_player_cellaccess_n gdata(32)
-#define gdata_player_cellaccess_e gdata(33)
-#define gdata_player_cellaccess_s gdata(34)
-#define gdata_player_x_on_map_leave gdata(60)
-#define gdata_player_y_on_map_leave gdata(61)
-#define gdata_stood_world_map_tile gdata(62)
-#define gdata_total_deco_value gdata(77)
-#define gdata_total_heirloom_value gdata(78)
-#define gdata_light gdata(89)
-#define gdata_chara_last_attacked_by_player gdata(94)
-#define gdata_map_regenerate_count gdata(184)
-#define gdata_tcg_used_deck gdata(813)
-#define gdata_politics_map_id gdata(815)
-#define gdata_politics_tax_amount gdata(820)
-
-// whether or not to proc fury/splitting/active form damage text
-// 1 if not, 2 if yes
-#define gdata_proc_damage_events_flag gdata(809)
-
-#define gdata_destination_outer_map gdata(850)
-#define gdata_reset_world_map_in_diastrophism_flag gdata(79)
-#define gdata_ex_arena_wins gdata(802)
-
-#define gdata_exhelp_flag(n) gdata(200 + n)
-
 // 40-59
 #define gdata_skill_shortcut(n) gdata(40 + n)
 
@@ -52,6 +12,9 @@
 
 // 160-164
 #define gdata_taken_quest(n) gdata(160 + n)
+
+// 200-217
+#define gdata_exhelp_flag(n) gdata(200 + n)
 
 // 700-749?
 #define gdata_ether_disease_history(n) gdata(700 + n)
@@ -162,45 +125,71 @@ struct GameData
     int home_scale;
     int charge_power;
     int entrance_type;
+    int next_shelter_serial_id;
+    int seven_league_boot_effect;
+    int protects_from_etherwind;
+    int player_cellaccess_check_flag;
+    int player_cellaccess_w;
+    int player_cellaccess_n;
+    int player_cellaccess_e;
+    int player_cellaccess_s;
+    int player_next_move_direction;
+    int played_scene;
+    int torch;
+    int angband_flag;
+    int number_of_learned_skills_by_trainer;
+    int player_x_on_map_leave;
+    int player_y_on_map_leave;
+    int stood_world_map_tile;
+    int is_returning_or_escaping;
     int destination_map;
     int destination_dungeon_level;
     int previous_map2;
     int previous_dungeon_level;
     int previous_x;
     int previous_y;
-    int next_shelter_serial_id;
-    int seven_league_boot_effect;
-    int protects_from_etherwind;
-    int played_scene;
-    int torch;
-    int angband_flag;
-    int number_of_learned_skills_by_trainer;
-    int is_returning_or_escaping;
     int executing_immediate_quest_type;
+    int executing_immediate_quest_show_hunt_remain;
     int executing_immediate_quest;
+    int executing_immediate_quest_status;
+    int executing_immediate_quest_fame_gained;
     int number_of_existing_quests;
     int basic_point_of_home_rank;
+    int total_deco_value;
+    int total_heirloom_value;
+    int reset_world_map_in_diastrophism_flag;
     int cargo_weight;
     int initial_cart_limit;
     int current_cart_limit;
     int protects_from_bad_weather;
     int left_minutes_of_executing_quest;
     int ether_disease_stage;
+    int executing_immediate_quest_time_left_display_period;
     int time_when_textbook_becomes_available;
+    int light;
     int continuous_active_hours;
+    int continuous_action_about_to_start;
     int sleep_experience;
     int acquirable_feat_count;
+    int chara_last_attacked_by_player;
     int wish_count;
     int version;
     int rights_to_succeed_to;
+
+    // tc + (0 if continuous action not started, 10000 if so)
+    int character_and_status_for_gene;
+
     int next_voting_time;
     int cost_to_hire;
+    int rogue_boss_encountered;
     int left_bill;
     int distance_between_town;
     int departure_date;
     int left_town_map;
     int mount;
+    int map_regenerate_count;
     int catches_god_signal;
+    int void_next_lord_floor;
     int reveals_religion;
     int used_casino_once;
     int has_not_been_to_vernis;
@@ -210,16 +199,27 @@ struct GameData
     int diastrophism_flag;
     int ether_disease_speed;
     int left_turns_of_timestop;
+    int ex_arena_wins;
     int ex_arena_level;
     int time_when_uploding_becomes_available;
     int play_time;
     int last_etherwind_month;
     int god_rank;
+    int player_is_changing_equipment;
+
+    // proc fury/splitting/active-form damage text from damage_hp?
+    // 1 if not, 2 if yes
+    int proc_damage_events_flag;
+
+    int tcg_used_deck;
     int number_of_waiting_guests;
+    int politics_map_id;
+    int politics_tax_amount;
     int last_month_when_trainer_visited;
     int item_turns;
     int next_level_minus_one_kumiromis_experience_becomes_available;
     int wizard;
+    int destination_outer_map;
     int lost_wallet_count;
 
     QuestFlags quest_flags;

--- a/src/gdata.hpp
+++ b/src/gdata.hpp
@@ -1,29 +1,6 @@
 #pragma once
+#include <array>
 #include "version.hpp"
-
-// 40-59
-#define gdata_skill_shortcut(n) gdata(40 + n)
-
-// 120-128
-#define gdata_rank(n) gdata(120 + n)
-
-// 140-148
-#define gdata_rank_deadline(n) gdata(140 + n)
-
-// 160-164
-#define gdata_taken_quest(n) gdata(160 + n)
-
-// 200-217
-#define gdata_exhelp_flag(n) gdata(200 + n)
-
-// 700-749?
-#define gdata_ether_disease_history(n) gdata(700 + n)
-
-// 750-759
-#define gdata_tracked_skill(n) gdata(750 + n)
-
-// 830-834
-#define gdata_tcg_deck(n) gdata(830 + n)
 
 namespace elona
 {
@@ -106,6 +83,9 @@ struct GuildData
  */
 struct GameData
 {
+    template <size_t N>
+    using ArrayType = std::array<int, N>;
+
     int death_count;
     int deepest_dungeon_level;
     int kill_count;
@@ -138,6 +118,7 @@ struct GameData
     int torch;
     int angband_flag;
     int number_of_learned_skills_by_trainer;
+    ArrayType<20> skill_shortcuts;
     int player_x_on_map_leave;
     int player_y_on_map_leave;
     int stood_world_map_tile;
@@ -175,11 +156,12 @@ struct GameData
     int wish_count;
     int version;
     int rights_to_succeed_to;
-
-    // tc + (0 if continuous action not started, 10000 if so)
-    int character_and_status_for_gene;
-
+    int character_and_status_for_gene; // tc + (0 if continuous action not
+                                       // started, 10000 if so)
     int next_voting_time;
+    ArrayType<20> ranks;
+    ArrayType<9> rank_deadlines;
+    ArrayType<5> taken_quests;
     int cost_to_hire;
     int rogue_boss_encountered;
     int left_bill;
@@ -191,12 +173,15 @@ struct GameData
     int catches_god_signal;
     int void_next_lord_floor;
     int reveals_religion;
+    ArrayType<18> exhelp_flags;
     int used_casino_once;
     int has_not_been_to_vernis;
     int released_fire_giant;
     int fire_giant;
     int holy_well_count;
     int diastrophism_flag;
+    ArrayType<20> ether_disease_history;
+    ArrayType<10> tracked_skills;
     int ether_disease_speed;
     int left_turns_of_timestop;
     int ex_arena_wins;
@@ -206,11 +191,8 @@ struct GameData
     int last_etherwind_month;
     int god_rank;
     int player_is_changing_equipment;
-
-    // proc fury/splitting/active-form damage text from damage_hp?
-    // 1 if not, 2 if yes
-    int proc_damage_events_flag;
-
+    int proc_damage_events_flag; // proc fury/splitting/active-form damage text
+                                 // from damage_hp()? 1 if not, 2 if yes
     int tcg_used_deck;
     int number_of_waiting_guests;
     int politics_map_id;
@@ -219,6 +201,7 @@ struct GameData
     int item_turns;
     int next_level_minus_one_kumiromis_experience_becomes_available;
     int wizard;
+    ArrayType<5> tcg_decks;
     int destination_outer_map;
     int lost_wallet_count;
 

--- a/src/gdata.hpp
+++ b/src/gdata.hpp
@@ -22,9 +22,14 @@
 #define gdata_player_x_on_map_leave gdata(60)
 #define gdata_player_y_on_map_leave gdata(61)
 #define gdata_stood_world_map_tile gdata(62)
+#define gdata_total_deco_value gdata(77)
+#define gdata_total_heirloom_value gdata(78)
+#define gdata_light gdata(89)
 #define gdata_chara_last_attacked_by_player gdata(94)
 #define gdata_map_regenerate_count gdata(184)
+#define gdata_tcg_used_deck gdata(813)
 #define gdata_politics_map_id gdata(815)
+#define gdata_politics_tax_amount gdata(820)
 
 // whether or not to proc fury/splitting/active form damage text
 // 1 if not, 2 if yes
@@ -48,8 +53,14 @@
 // 160-164
 #define gdata_taken_quest(n) gdata(160 + n)
 
-// 750-760
+// 700-749?
+#define gdata_ether_disease_history(n) gdata(700 + n)
+
+// 750-759
 #define gdata_tracked_skill(n) gdata(750 + n)
+
+// 830-834
+#define gdata_tcg_deck(n) gdata(830 + n)
 
 namespace elona
 {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -908,7 +908,7 @@ void initialize_debug_globals()
 {
     for (int cnt = 0; cnt < 9; ++cnt)
     {
-        gdata_rank(cnt) = 5000;
+        game_data.ranks.at(cnt) = 5000;
     }
     game_data.version = 1220;
     game_data.next_inventory_serial_id = 1000;
@@ -993,9 +993,9 @@ void initialize_world()
     initialize_adata();
     game_data.weather = 3;
     game_data.hours_until_weather_changes = 6;
-    for (int cnt = 0; cnt < 20; ++cnt)
+    for (int cnt = 0; cnt < 9; ++cnt)
     {
-        gdata_rank(cnt) = 10000;
+        game_data.ranks.at(cnt) = 10000;
     }
 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -946,7 +946,7 @@ void initialize_debug_globals()
     game_data.played_scene = 50;
     game_data.has_not_been_to_vernis = 1;
     area_data[7].outer_map = 4;
-    gdata(850) = area_data[game_data.current_map].outer_map;
+    gdata_destination_outer_map = area_data[game_data.current_map].outer_map;
     game_data.acquirable_feat_count = 2;
     game_data.quest_flags.save_count_of_little_sister = 1000;
     game_data.rights_to_succeed_to = 1000;
@@ -988,7 +988,7 @@ void initialize_world()
     game_data.pc_x_in_world_map = 22;
     game_data.pc_y_in_world_map = 21;
     game_data.previous_map = -1;
-    gdata(850) = 4;
+    gdata_destination_outer_map = 4;
     ghelp = 1;
     game_data.current_map = static_cast<int>(mdata_t::MapId::your_home);
     game_data.current_dungeon_level = 1;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -910,7 +910,7 @@ void initialize_debug_globals()
 {
     for (int cnt = 0; cnt < 9; ++cnt)
     {
-        gdata(120 + cnt) = 5000;
+        gdata_rank(cnt) = 5000;
     }
     game_data.version = 1220;
     gdata(41) = 424;
@@ -1000,7 +1000,7 @@ void initialize_world()
     game_data.hours_until_weather_changes = 6;
     for (int cnt = 0; cnt < 20; ++cnt)
     {
-        gdata(120 + cnt) = 10000;
+        gdata_rank(cnt) = 10000;
     }
 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -940,7 +940,8 @@ void initialize_debug_globals()
     game_data.played_scene = 50;
     game_data.has_not_been_to_vernis = 1;
     area_data[7].outer_map = 4;
-    gdata_destination_outer_map = area_data[game_data.current_map].outer_map;
+    game_data.destination_outer_map =
+        area_data[game_data.current_map].outer_map;
     game_data.acquirable_feat_count = 2;
     game_data.quest_flags.save_count_of_little_sister = 1000;
     game_data.rights_to_succeed_to = 1000;
@@ -982,7 +983,7 @@ void initialize_world()
     game_data.pc_x_in_world_map = 22;
     game_data.pc_y_in_world_map = 21;
     game_data.previous_map = -1;
-    gdata_destination_outer_map = 4;
+    game_data.destination_outer_map = 4;
     ghelp = 1;
     game_data.current_map = static_cast<int>(mdata_t::MapId::your_home);
     game_data.current_dungeon_level = 1;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -140,7 +140,6 @@ void load_character_sprite()
     DIM3(userdata, 70, 1);
     SDIM4(userdatan, 40, 10, 1);
     SDIM1(untaglist);
-    gdata(86) = 0;
     buffer(5, 1584, (25 + (usernpcmax / 33 + 1) * 2) * 48);
 
     pos(0, 0);
@@ -713,7 +712,6 @@ void initialize_elona()
     load_random_name_table();
     load_random_title_table();
     game_data.random_seed = rnd(800) + 2;
-    gdata(9) = rnd(200) + 2;
     set_item_info();
     clear_trait_data();
     initialize_rankn();
@@ -913,16 +911,12 @@ void initialize_debug_globals()
         gdata_rank(cnt) = 5000;
     }
     game_data.version = 1220;
-    gdata(41) = 424;
-    gdata(42) = 300;
-    gdata(43) = 631;
     game_data.next_inventory_serial_id = 1000;
     game_data.next_shelter_serial_id = 100;
     game_data.pc_x_in_world_map = 22;
     game_data.pc_y_in_world_map = 21;
     game_data.previous_map = -1;
     game_data.random_seed = rnd(800) + 2;
-    gdata(9) = rnd(200) + 2;
     game_data.current_map = static_cast<int>(mdata_t::MapId::north_tyris);
     game_data.current_dungeon_level = 0;
     game_data.entrance_type = 7;

--- a/src/initialize_map.cpp
+++ b/src/initialize_map.cpp
@@ -3448,57 +3448,15 @@ label_1744_internal:
     }
     if (mdata_map_type == mdata_t::MapType::world_map)
     {
-        if (Config::instance().extrahelp)
-        {
-            if (gdata_exhelp_flag(2) == 0)
-            {
-                if (mode == 0)
-                {
-                    if (cdata.player().continuous_action.turn == 0)
-                    {
-                        gdata_exhelp_flag(2) = 1;
-                        ghelp = 2;
-                        show_ex_help();
-                    }
-                }
-            }
-        }
+        maybe_show_ex_help(2);
     }
     if (mdata_map_type == mdata_t::MapType::town)
     {
-        if (Config::instance().extrahelp)
-        {
-            if (gdata_exhelp_flag(3) == 0)
-            {
-                if (mode == 0)
-                {
-                    if (cdata.player().continuous_action.turn == 0)
-                    {
-                        gdata_exhelp_flag(3) = 1;
-                        ghelp = 3;
-                        show_ex_help();
-                    }
-                }
-            }
-        }
+        maybe_show_ex_help(3);
     }
     if (game_data.current_map == mdata_t::MapId::shelter_)
     {
-        if (Config::instance().extrahelp)
-        {
-            if (gdata_exhelp_flag(14) == 0)
-            {
-                if (mode == 0)
-                {
-                    if (cdata.player().continuous_action.turn == 0)
-                    {
-                        gdata_exhelp_flag(14) = 1;
-                        ghelp = 14;
-                        show_ex_help();
-                    }
-                }
-            }
-        }
+        maybe_show_ex_help(14);
     }
     if (mdata_map_type == mdata_t::MapType::town
         || game_data.current_map == mdata_t::MapId::your_home

--- a/src/initialize_map.cpp
+++ b/src/initialize_map.cpp
@@ -115,8 +115,8 @@ label_17401:
         {
             goto label_1741_internal;
         }
-        if (mdata_map_regenerate_count != gdata_map_regenerate_count
-            || (gdata_reset_world_map_in_diastrophism_flag == 1
+        if (mdata_map_regenerate_count != game_data.map_regenerate_count
+            || (game_data.reset_world_map_in_diastrophism_flag == 1
                 && mdata_map_type == mdata_t::MapType::world_map))
         {
             if (mdata_map_type == mdata_t::MapType::town
@@ -2162,7 +2162,8 @@ label_1741_internal:
             }
         }
         mdatan(0) = "";
-        if (4 <= gdata_stood_world_map_tile && gdata_stood_world_map_tile < 9)
+        if (4 <= game_data.stood_world_map_tile
+            && game_data.stood_world_map_tile < 9)
         {
             mdatan(0) = i18n::s.get_enum_property(
                 "core.locale.map.unique", "forest", 2);
@@ -2179,13 +2180,14 @@ label_1741_internal:
                 map(inv[ci].position.x, inv[ci].position.y, 0) = 0;
             }
         }
-        if (264 <= gdata_stood_world_map_tile
-            && gdata_stood_world_map_tile < 363)
+        if (264 <= game_data.stood_world_map_tile
+            && game_data.stood_world_map_tile < 363)
         {
             mdatan(0) =
                 i18n::s.get_enum_property("core.locale.map.unique", "sea", 2);
         }
-        if (9 <= gdata_stood_world_map_tile && gdata_stood_world_map_tile < 13)
+        if (9 <= game_data.stood_world_map_tile
+            && game_data.stood_world_map_tile < 13)
         {
             mdatan(0) = i18n::s.get_enum_property(
                 "core.locale.map.unique", "grassland", 2);
@@ -2205,7 +2207,8 @@ label_1741_internal:
                 inv[ci].own_state = 1;
             }
         }
-        if (13 <= gdata_stood_world_map_tile && gdata_stood_world_map_tile < 17)
+        if (13 <= game_data.stood_world_map_tile
+            && game_data.stood_world_map_tile < 17)
         {
             mdatan(0) = i18n::s.get_enum_property(
                 "core.locale.map.unique", "desert", 2);
@@ -2221,7 +2224,7 @@ label_1741_internal:
                 inv[ci].own_state = 1;
             }
         }
-        if (chipm(0, gdata_stood_world_map_tile) == 4)
+        if (chipm(0, game_data.stood_world_map_tile) == 4)
         {
             mdatan(0) = i18n::s.get_enum_property(
                 "core.locale.map.unique", "snow_field", 2);
@@ -2260,8 +2263,8 @@ label_1741_internal:
             }
         }
         map_placeplayer();
-        if (264 > gdata_stood_world_map_tile
-            || gdata_stood_world_map_tile >= 363)
+        if (264 > game_data.stood_world_map_tile
+            || game_data.stood_world_map_tile >= 363)
         {
             for (int cnt = 0, cnt_end = (4 + rnd(5)); cnt < cnt_end; ++cnt)
             {
@@ -2304,9 +2307,9 @@ label_1741_internal:
             mdata_map_type = static_cast<int>(mdata_t::MapType::temporary);
             rq = encounterref;
             game_data.executing_immediate_quest_type = 1007;
-            gdata_executing_immediate_quest_show_hunt_remain = 1;
+            game_data.executing_immediate_quest_show_hunt_remain = 1;
             game_data.executing_immediate_quest = rq;
-            gdata_executing_immediate_quest_status = 1;
+            game_data.executing_immediate_quest_status = 1;
             p = rnd(3) + 5;
             for (int cnt = 0, cnt_end = (p); cnt < cnt_end; ++cnt)
             {
@@ -2361,8 +2364,8 @@ label_1741_internal:
                 flt(calcobjlv(encounterlv), calcfixlv(Quality::bad));
                 if (game_data.weather == 1)
                 {
-                    if ((33 > gdata_stood_world_map_tile
-                         || gdata_stood_world_map_tile >= 66)
+                    if ((33 > game_data.stood_world_map_tile
+                         || game_data.stood_world_map_tile >= 66)
                         && rnd(3) == 0)
                     {
                         fixlv = Quality::godly;
@@ -2388,12 +2391,12 @@ label_1741_internal:
     if (game_data.current_map == mdata_t::MapId::the_void)
     {
         generate_random_nefia();
-        if (gdata_void_next_lord_floor == 0)
+        if (game_data.void_next_lord_floor == 0)
         {
-            gdata_void_next_lord_floor =
+            game_data.void_next_lord_floor =
                 area_data[game_data.current_map].danger_level + 4;
         }
-        if (gdata_void_next_lord_floor <= game_data.current_dungeon_level)
+        if (game_data.void_next_lord_floor <= game_data.current_dungeon_level)
         {
             event_add(29);
         }
@@ -2747,7 +2750,7 @@ label_1741_internal:
         }
     }
     randomize();
-    mdata_map_regenerate_count = gdata_map_regenerate_count;
+    mdata_map_regenerate_count = game_data.map_regenerate_count;
     mdata_map_mefs_loaded_flag = 1;
     lua::lua->get_event_manager().run_callbacks<lua::EventKind::map_created>();
     loaded_from_file = false;
@@ -2758,8 +2761,8 @@ label_1742_internal:
         {
             cdata.player().position.x = area_data[11].position.x;
             cdata.player().position.y = area_data[11].position.y;
-            gdata_player_next_move_direction = 1;
-            gdata_player_x_on_map_leave = -1;
+            game_data.player_next_move_direction = 1;
+            game_data.player_x_on_map_leave = -1;
             msg_newline();
             msgtemp =
                 "  " + i18n::s.get("core.locale.scenario.three_years_later");
@@ -3347,7 +3350,7 @@ label_1744_internal:
     wake_up();
     pcattacker = 0;
     cdata.player().enemy_id = 0;
-    gdata_chara_last_attacked_by_player = 0;
+    game_data.chara_last_attacked_by_player = 0;
     mode = 0;
     screenupdate = -1;
     update_entire_screen();

--- a/src/initialize_map.cpp
+++ b/src/initialize_map.cpp
@@ -115,8 +115,8 @@ label_17401:
         {
             goto label_1741_internal;
         }
-        if (mdata_map_regenerate_count != gdata(184)
-            || (gdata(79) == 1
+        if (mdata_map_regenerate_count != gdata_map_regenerate_count
+            || (gdata_reset_world_map_in_diastrophism_flag == 1
                 && mdata_map_type == mdata_t::MapType::world_map))
         {
             if (mdata_map_type == mdata_t::MapType::town
@@ -2162,7 +2162,7 @@ label_1741_internal:
             }
         }
         mdatan(0) = "";
-        if (4 <= gdata(62) && gdata(62) < 9)
+        if (4 <= gdata_stood_world_map_tile && gdata_stood_world_map_tile < 9)
         {
             mdatan(0) = i18n::s.get_enum_property(
                 "core.locale.map.unique", "forest", 2);
@@ -2179,12 +2179,13 @@ label_1741_internal:
                 map(inv[ci].position.x, inv[ci].position.y, 0) = 0;
             }
         }
-        if (264 <= gdata(62) && gdata(62) < 363)
+        if (264 <= gdata_stood_world_map_tile
+            && gdata_stood_world_map_tile < 363)
         {
             mdatan(0) =
                 i18n::s.get_enum_property("core.locale.map.unique", "sea", 2);
         }
-        if (9 <= gdata(62) && gdata(62) < 13)
+        if (9 <= gdata_stood_world_map_tile && gdata_stood_world_map_tile < 13)
         {
             mdatan(0) = i18n::s.get_enum_property(
                 "core.locale.map.unique", "grassland", 2);
@@ -2204,7 +2205,7 @@ label_1741_internal:
                 inv[ci].own_state = 1;
             }
         }
-        if (13 <= gdata(62) && gdata(62) < 17)
+        if (13 <= gdata_stood_world_map_tile && gdata_stood_world_map_tile < 17)
         {
             mdatan(0) = i18n::s.get_enum_property(
                 "core.locale.map.unique", "desert", 2);
@@ -2220,7 +2221,7 @@ label_1741_internal:
                 inv[ci].own_state = 1;
             }
         }
-        if (chipm(0, gdata(62)) == 4)
+        if (chipm(0, gdata_stood_world_map_tile) == 4)
         {
             mdatan(0) = i18n::s.get_enum_property(
                 "core.locale.map.unique", "snow_field", 2);
@@ -2259,7 +2260,8 @@ label_1741_internal:
             }
         }
         map_placeplayer();
-        if (264 > gdata(62) || gdata(62) >= 363)
+        if (264 > gdata_stood_world_map_tile
+            || gdata_stood_world_map_tile >= 363)
         {
             for (int cnt = 0, cnt_end = (4 + rnd(5)); cnt < cnt_end; ++cnt)
             {
@@ -2302,9 +2304,9 @@ label_1741_internal:
             mdata_map_type = static_cast<int>(mdata_t::MapType::temporary);
             rq = encounterref;
             game_data.executing_immediate_quest_type = 1007;
-            gdata(71) = 1;
+            gdata_executing_immediate_quest_show_hunt_remain = 1;
             game_data.executing_immediate_quest = rq;
-            gdata(73) = 1;
+            gdata_executing_immediate_quest_status = 1;
             p = rnd(3) + 5;
             for (int cnt = 0, cnt_end = (p); cnt < cnt_end; ++cnt)
             {
@@ -2359,7 +2361,9 @@ label_1741_internal:
                 flt(calcobjlv(encounterlv), calcfixlv(Quality::bad));
                 if (game_data.weather == 1)
                 {
-                    if ((33 > gdata(62) || gdata(62) >= 66) && rnd(3) == 0)
+                    if ((33 > gdata_stood_world_map_tile
+                         || gdata_stood_world_map_tile >= 66)
+                        && rnd(3) == 0)
                     {
                         fixlv = Quality::godly;
                     }
@@ -2384,11 +2388,12 @@ label_1741_internal:
     if (game_data.current_map == mdata_t::MapId::the_void)
     {
         generate_random_nefia();
-        if (gdata(186) == 0)
+        if (gdata_void_next_lord_floor == 0)
         {
-            gdata(186) = area_data[game_data.current_map].danger_level + 4;
+            gdata_void_next_lord_floor =
+                area_data[game_data.current_map].danger_level + 4;
         }
-        if (gdata(186) <= game_data.current_dungeon_level)
+        if (gdata_void_next_lord_floor <= game_data.current_dungeon_level)
         {
             event_add(29);
         }
@@ -2742,7 +2747,7 @@ label_1741_internal:
         }
     }
     randomize();
-    mdata_map_regenerate_count = gdata(184);
+    mdata_map_regenerate_count = gdata_map_regenerate_count;
     mdata_map_mefs_loaded_flag = 1;
     lua::lua->get_event_manager().run_callbacks<lua::EventKind::map_created>();
     loaded_from_file = false;
@@ -2753,8 +2758,8 @@ label_1742_internal:
         {
             cdata.player().position.x = area_data[11].position.x;
             cdata.player().position.y = area_data[11].position.y;
-            gdata(35) = 1;
-            gdata(60) = -1;
+            gdata_player_next_move_direction = 1;
+            gdata_player_x_on_map_leave = -1;
             msg_newline();
             msgtemp =
                 "  " + i18n::s.get("core.locale.scenario.three_years_later");
@@ -3342,7 +3347,7 @@ label_1744_internal:
     wake_up();
     pcattacker = 0;
     cdata.player().enemy_id = 0;
-    gdata(94) = 0;
+    gdata_chara_last_attacked_by_player = 0;
     mode = 0;
     screenupdate = -1;
     update_entire_screen();
@@ -3445,13 +3450,13 @@ label_1744_internal:
     {
         if (Config::instance().extrahelp)
         {
-            if (gdata(202) == 0)
+            if (gdata_exhelp_flag(2) == 0)
             {
                 if (mode == 0)
                 {
                     if (cdata.player().continuous_action.turn == 0)
                     {
-                        gdata(202) = 1;
+                        gdata_exhelp_flag(2) = 1;
                         ghelp = 2;
                         show_ex_help();
                     }
@@ -3463,13 +3468,13 @@ label_1744_internal:
     {
         if (Config::instance().extrahelp)
         {
-            if (gdata(203) == 0)
+            if (gdata_exhelp_flag(3) == 0)
             {
                 if (mode == 0)
                 {
                     if (cdata.player().continuous_action.turn == 0)
                     {
-                        gdata(203) = 1;
+                        gdata_exhelp_flag(3) = 1;
                         ghelp = 3;
                         show_ex_help();
                     }
@@ -3481,13 +3486,13 @@ label_1744_internal:
     {
         if (Config::instance().extrahelp)
         {
-            if (gdata(214) == 0)
+            if (gdata_exhelp_flag(14) == 0)
             {
                 if (mode == 0)
                 {
                     if (cdata.player().continuous_action.turn == 0)
                     {
-                        gdata(214) = 1;
+                        gdata_exhelp_flag(14) = 1;
                         ghelp = 14;
                         show_ex_help();
                     }

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -272,7 +272,7 @@ int magic()
                             {
                                 if (tc >= 16)
                                 {
-                                    gdata(809) = 2;
+                                    gdata_proc_damage_events_flag = 2;
                                     txt3rd = 1;
                                     txt(i18n::s.get(
                                         "core.locale.magic.bolt.other",
@@ -442,7 +442,7 @@ int magic()
                                 {
                                     if (tc >= 16)
                                     {
-                                        gdata(809) = 2;
+                                        gdata_proc_damage_events_flag = 2;
                                         txt3rd = 1;
                                         txt(i18n::s.get(
                                             "core.locale.magic.explosion.other",
@@ -466,7 +466,7 @@ int magic()
                             {
                                 if (tc >= 16)
                                 {
-                                    gdata(809) = 2;
+                                    gdata_proc_damage_events_flag = 2;
                                     txt3rd = 1;
                                     txt(i18n::s.get(
                                         "core.locale.magic.ball.other",
@@ -528,7 +528,7 @@ int magic()
                 {
                     if (tc >= 16)
                     {
-                        gdata(809) = 2;
+                        gdata_proc_damage_events_flag = 2;
                         txt3rd = 1;
                         txt(i18n::s.get(
                             "core.locale.magic.arrow.other", cdata[tc]));
@@ -624,7 +624,7 @@ int magic()
                     {
                         if (tc >= 16)
                         {
-                            gdata(809) = 2;
+                            gdata_proc_damage_events_flag = 2;
                             txt(i18n::s.get(
                                 "core.locale.magic.sucks_blood.other",
                                 cdata[cc],
@@ -650,7 +650,7 @@ int magic()
                 {
                     if (tc >= 16)
                     {
-                        gdata(809) = 2;
+                        gdata_proc_damage_events_flag = 2;
                         txt(i18n::s.get(
                             "core.locale.magic.touch.other",
                             cdata[cc],
@@ -1066,7 +1066,7 @@ int magic()
                             {
                                 if (tc >= 16)
                                 {
-                                    gdata(809) = 2;
+                                    gdata_proc_damage_events_flag = 2;
                                     txt3rd = 1;
                                     txt(i18n::s.get(
                                         "core.locale.magic.breath.other",
@@ -1703,7 +1703,7 @@ label_2181_internal:
         {
             cdata.player().direction = 0;
         }
-        gdata(35) = cdata.player().direction;
+        gdata_player_next_move_direction = cdata.player().direction;
         fishx = x;
         fishy = y;
         addefmap(fishx, fishy, 1, 3);
@@ -2646,7 +2646,7 @@ label_2181_internal:
             txt(i18n::s.get("core.locale.magic.vorpal.sound"));
             if (tc >= 16)
             {
-                gdata(809) = 2;
+                gdata_proc_damage_events_flag = 2;
                 txt3rd = 1;
                 txt(i18n::s.get(
                     "core.locale.magic.vorpal.other", cdata[cc], cdata[tc]));
@@ -2795,7 +2795,7 @@ label_2181_internal:
                     }
                 }
             }
-            game_data.destination_map = gdata(850);
+            game_data.destination_map = gdata_destination_outer_map;
             game_data.destination_dungeon_level = 1;
             if (is_cursed(efstatus))
             {

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -272,7 +272,7 @@ int magic()
                             {
                                 if (tc >= 16)
                                 {
-                                    gdata_proc_damage_events_flag = 2;
+                                    game_data.proc_damage_events_flag = 2;
                                     txt3rd = 1;
                                     txt(i18n::s.get(
                                         "core.locale.magic.bolt.other",
@@ -442,7 +442,7 @@ int magic()
                                 {
                                     if (tc >= 16)
                                     {
-                                        gdata_proc_damage_events_flag = 2;
+                                        game_data.proc_damage_events_flag = 2;
                                         txt3rd = 1;
                                         txt(i18n::s.get(
                                             "core.locale.magic.explosion.other",
@@ -466,7 +466,7 @@ int magic()
                             {
                                 if (tc >= 16)
                                 {
-                                    gdata_proc_damage_events_flag = 2;
+                                    game_data.proc_damage_events_flag = 2;
                                     txt3rd = 1;
                                     txt(i18n::s.get(
                                         "core.locale.magic.ball.other",
@@ -528,7 +528,7 @@ int magic()
                 {
                     if (tc >= 16)
                     {
-                        gdata_proc_damage_events_flag = 2;
+                        game_data.proc_damage_events_flag = 2;
                         txt3rd = 1;
                         txt(i18n::s.get(
                             "core.locale.magic.arrow.other", cdata[tc]));
@@ -624,7 +624,7 @@ int magic()
                     {
                         if (tc >= 16)
                         {
-                            gdata_proc_damage_events_flag = 2;
+                            game_data.proc_damage_events_flag = 2;
                             txt(i18n::s.get(
                                 "core.locale.magic.sucks_blood.other",
                                 cdata[cc],
@@ -650,7 +650,7 @@ int magic()
                 {
                     if (tc >= 16)
                     {
-                        gdata_proc_damage_events_flag = 2;
+                        game_data.proc_damage_events_flag = 2;
                         txt(i18n::s.get(
                             "core.locale.magic.touch.other",
                             cdata[cc],
@@ -1066,7 +1066,7 @@ int magic()
                             {
                                 if (tc >= 16)
                                 {
-                                    gdata_proc_damage_events_flag = 2;
+                                    game_data.proc_damage_events_flag = 2;
                                     txt3rd = 1;
                                     txt(i18n::s.get(
                                         "core.locale.magic.breath.other",
@@ -1703,7 +1703,7 @@ label_2181_internal:
         {
             cdata.player().direction = 0;
         }
-        gdata_player_next_move_direction = cdata.player().direction;
+        game_data.player_next_move_direction = cdata.player().direction;
         fishx = x;
         fishy = y;
         addefmap(fishx, fishy, 1, 3);
@@ -2646,7 +2646,7 @@ label_2181_internal:
             txt(i18n::s.get("core.locale.magic.vorpal.sound"));
             if (tc >= 16)
             {
-                gdata_proc_damage_events_flag = 2;
+                game_data.proc_damage_events_flag = 2;
                 txt3rd = 1;
                 txt(i18n::s.get(
                     "core.locale.magic.vorpal.other", cdata[cc], cdata[tc]));
@@ -2795,7 +2795,7 @@ label_2181_internal:
                     }
                 }
             }
-            game_data.destination_map = gdata_destination_outer_map;
+            game_data.destination_map = game_data.destination_outer_map;
             game_data.destination_dungeon_level = 1;
             if (is_cursed(efstatus))
             {

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -295,7 +295,7 @@ void map_placecharaonentrance(int prm_936, int prm_937, int prm_938)
     }
     if (prm_937 == 3)
     {
-        if (gdata(35) == 1)
+        if (gdata_player_next_move_direction == 1)
         {
             x_at_m167 = mdata_map_width - 2;
             y_at_m167 = mdata_map_height / 2;
@@ -309,7 +309,7 @@ void map_placecharaonentrance(int prm_936, int prm_937, int prm_938)
                 y_at_m167 = 21;
             }
         }
-        if (gdata(35) == 2)
+        if (gdata_player_next_move_direction == 2)
         {
             x_at_m167 = 1;
             y_at_m167 = mdata_map_height / 2;
@@ -323,7 +323,7 @@ void map_placecharaonentrance(int prm_936, int prm_937, int prm_938)
                 y_at_m167 = 1;
             }
         }
-        if (gdata(35) == 3)
+        if (gdata_player_next_move_direction == 3)
         {
             x_at_m167 = mdata_map_width / 2;
             y_at_m167 = mdata_map_height - 2;
@@ -341,7 +341,7 @@ void map_placecharaonentrance(int prm_936, int prm_937, int prm_938)
                 y_at_m167 = 21;
             }
         }
-        if (gdata(35) == 0)
+        if (gdata_player_next_move_direction == 0)
         {
             x_at_m167 = mdata_map_width / 2;
             y_at_m167 = 1;
@@ -360,10 +360,10 @@ void map_placecharaonentrance(int prm_936, int prm_937, int prm_938)
             x_at_m167 = 1;
             y_at_m167 = 14;
         }
-        if (gdata(60) != -1)
+        if (gdata_player_x_on_map_leave != -1)
         {
-            x_at_m167 = gdata(60);
-            y_at_m167 = gdata(61);
+            x_at_m167 = gdata_player_x_on_map_leave;
+            y_at_m167 = gdata_player_y_on_map_leave;
         }
     }
     if (prm_937 == 4)
@@ -2290,7 +2290,7 @@ void initialize_random_nefia_rdtype6()
 int initialize_quest_map_crop()
 {
     game_data.left_minutes_of_executing_quest = 120;
-    gdata(87) = 9999;
+    gdata_executing_immediate_quest_time_left_display_period = 9999;
     mdata_map_indoors_flag = 2;
     mdata_map_tileset = 4;
     mdata_map_width = 58 + rnd(16);
@@ -2726,7 +2726,7 @@ int initialize_quest_map_party()
 {
     int roomdiff = 0;
     game_data.left_minutes_of_executing_quest = 60;
-    gdata(87) = 9999;
+    gdata_executing_immediate_quest_time_left_display_period = 9999;
     rdroomsizemin = 5;
     mdatan(0) = i18n::s.get("core.locale.map.quest.party_room");
     mdata_map_indoors_flag = 1;
@@ -3061,7 +3061,7 @@ void initialize_quest_map_town()
     if (game_data.executing_immediate_quest_type == 1008)
     {
         game_data.left_minutes_of_executing_quest = 720;
-        gdata(87) = 9999;
+        gdata_executing_immediate_quest_time_left_display_period = 9999;
         flt();
         initlv = qdata(5, game_data.executing_immediate_quest);
         fixlv = Quality::godly;
@@ -3782,26 +3782,27 @@ void map_tileset(int prm_933)
     {
         tile_default = 0;
         tile_fog = 528;
-        if (4 <= gdata(62) && gdata(62) < 9)
+        if (4 <= gdata_stood_world_map_tile && gdata_stood_world_map_tile < 9)
         {
             tile_default = 7;
             tile_fog = 528;
         }
-        if (264 <= gdata(62) && gdata(62) < 363)
+        if (264 <= gdata_stood_world_map_tile
+            && gdata_stood_world_map_tile < 363)
         {
             tile_default = 12;
         }
-        if (9 <= gdata(62) && gdata(62) < 13)
+        if (9 <= gdata_stood_world_map_tile && gdata_stood_world_map_tile < 13)
         {
             tile_fog = 528;
             tile_default = 3;
         }
-        if (13 <= gdata(62) && gdata(62) < 17)
+        if (13 <= gdata_stood_world_map_tile && gdata_stood_world_map_tile < 17)
         {
             tile_fog = 531;
             tile_default = 19;
         }
-        if (chipm(0, gdata(62)) == 4)
+        if (chipm(0, gdata_stood_world_map_tile) == 4)
         {
             tile_fog = 532;
             tile_default = 45;

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -295,7 +295,7 @@ void map_placecharaonentrance(int prm_936, int prm_937, int prm_938)
     }
     if (prm_937 == 3)
     {
-        if (gdata_player_next_move_direction == 1)
+        if (game_data.player_next_move_direction == 1)
         {
             x_at_m167 = mdata_map_width - 2;
             y_at_m167 = mdata_map_height / 2;
@@ -309,7 +309,7 @@ void map_placecharaonentrance(int prm_936, int prm_937, int prm_938)
                 y_at_m167 = 21;
             }
         }
-        if (gdata_player_next_move_direction == 2)
+        if (game_data.player_next_move_direction == 2)
         {
             x_at_m167 = 1;
             y_at_m167 = mdata_map_height / 2;
@@ -323,7 +323,7 @@ void map_placecharaonentrance(int prm_936, int prm_937, int prm_938)
                 y_at_m167 = 1;
             }
         }
-        if (gdata_player_next_move_direction == 3)
+        if (game_data.player_next_move_direction == 3)
         {
             x_at_m167 = mdata_map_width / 2;
             y_at_m167 = mdata_map_height - 2;
@@ -341,7 +341,7 @@ void map_placecharaonentrance(int prm_936, int prm_937, int prm_938)
                 y_at_m167 = 21;
             }
         }
-        if (gdata_player_next_move_direction == 0)
+        if (game_data.player_next_move_direction == 0)
         {
             x_at_m167 = mdata_map_width / 2;
             y_at_m167 = 1;
@@ -360,10 +360,10 @@ void map_placecharaonentrance(int prm_936, int prm_937, int prm_938)
             x_at_m167 = 1;
             y_at_m167 = 14;
         }
-        if (gdata_player_x_on_map_leave != -1)
+        if (game_data.player_x_on_map_leave != -1)
         {
-            x_at_m167 = gdata_player_x_on_map_leave;
-            y_at_m167 = gdata_player_y_on_map_leave;
+            x_at_m167 = game_data.player_x_on_map_leave;
+            y_at_m167 = game_data.player_y_on_map_leave;
         }
     }
     if (prm_937 == 4)
@@ -2290,7 +2290,7 @@ void initialize_random_nefia_rdtype6()
 int initialize_quest_map_crop()
 {
     game_data.left_minutes_of_executing_quest = 120;
-    gdata_executing_immediate_quest_time_left_display_period = 9999;
+    game_data.executing_immediate_quest_time_left_display_period = 9999;
     mdata_map_indoors_flag = 2;
     mdata_map_tileset = 4;
     mdata_map_width = 58 + rnd(16);
@@ -2726,7 +2726,7 @@ int initialize_quest_map_party()
 {
     int roomdiff = 0;
     game_data.left_minutes_of_executing_quest = 60;
-    gdata_executing_immediate_quest_time_left_display_period = 9999;
+    game_data.executing_immediate_quest_time_left_display_period = 9999;
     rdroomsizemin = 5;
     mdatan(0) = i18n::s.get("core.locale.map.quest.party_room");
     mdata_map_indoors_flag = 1;
@@ -3061,7 +3061,7 @@ void initialize_quest_map_town()
     if (game_data.executing_immediate_quest_type == 1008)
     {
         game_data.left_minutes_of_executing_quest = 720;
-        gdata_executing_immediate_quest_time_left_display_period = 9999;
+        game_data.executing_immediate_quest_time_left_display_period = 9999;
         flt();
         initlv = qdata(5, game_data.executing_immediate_quest);
         fixlv = Quality::godly;
@@ -3782,27 +3782,30 @@ void map_tileset(int prm_933)
     {
         tile_default = 0;
         tile_fog = 528;
-        if (4 <= gdata_stood_world_map_tile && gdata_stood_world_map_tile < 9)
+        if (4 <= game_data.stood_world_map_tile
+            && game_data.stood_world_map_tile < 9)
         {
             tile_default = 7;
             tile_fog = 528;
         }
-        if (264 <= gdata_stood_world_map_tile
-            && gdata_stood_world_map_tile < 363)
+        if (264 <= game_data.stood_world_map_tile
+            && game_data.stood_world_map_tile < 363)
         {
             tile_default = 12;
         }
-        if (9 <= gdata_stood_world_map_tile && gdata_stood_world_map_tile < 13)
+        if (9 <= game_data.stood_world_map_tile
+            && game_data.stood_world_map_tile < 13)
         {
             tile_fog = 528;
             tile_default = 3;
         }
-        if (13 <= gdata_stood_world_map_tile && gdata_stood_world_map_tile < 17)
+        if (13 <= game_data.stood_world_map_tile
+            && game_data.stood_world_map_tile < 17)
         {
             tile_fog = 531;
             tile_default = 19;
         }
-        if (chipm(0, gdata_stood_world_map_tile) == 4)
+        if (chipm(0, game_data.stood_world_map_tile) == 4)
         {
             tile_fog = 532;
             tile_default = 45;

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -1526,13 +1526,13 @@ TurnResult show_quest_board()
 {
     if (Config::instance().extrahelp)
     {
-        if (gdata(204) == 0)
+        if (gdata_exhelp_flag(4) == 0)
         {
             if (mode == 0)
             {
                 if (cdata.player().continuous_action.turn == 0)
                 {
-                    gdata(204) = 1;
+                    gdata_exhelp_flag(4) = 1;
                     ghelp = 4;
                     show_ex_help();
                     screenupdate = -1;

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -485,6 +485,35 @@ label_2700_internal:
     quickkeywait = 1;
 }
 
+bool maybe_show_ex_help(int id, bool should_update_screen)
+{
+    if (Config::instance().extrahelp)
+    {
+        if (gdata_exhelp_flag(id) == 0)
+        {
+            if (mode == 0)
+            {
+                if (cdata.player().continuous_action.turn == 0)
+                {
+                    gdata_exhelp_flag(id) = 1;
+                    ghelp = id;
+                    show_ex_help();
+
+                    if (should_update_screen)
+                    {
+                        screenupdate = -1;
+                        update_screen();
+                    }
+
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
 void show_ex_help()
 {
     gsel(3);
@@ -1524,23 +1553,7 @@ static TurnResult _visit_quest_giver(int quest_index)
 
 TurnResult show_quest_board()
 {
-    if (Config::instance().extrahelp)
-    {
-        if (gdata_exhelp_flag(4) == 0)
-        {
-            if (mode == 0)
-            {
-                if (cdata.player().continuous_action.turn == 0)
-                {
-                    gdata_exhelp_flag(4) = 1;
-                    ghelp = 4;
-                    show_ex_help();
-                    screenupdate = -1;
-                    update_screen();
-                }
-            }
-        }
-    }
+    maybe_show_ex_help(4, true);
 
     auto result = ui::UIMenuQuestBoard().show();
 

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -489,13 +489,13 @@ bool maybe_show_ex_help(int id, bool should_update_screen)
 {
     if (Config::instance().extrahelp)
     {
-        if (gdata_exhelp_flag(id) == 0)
+        if (game_data.exhelp_flags.at(id) == 0)
         {
             if (mode == 0)
             {
                 if (cdata.player().continuous_action.turn == 0)
                 {
-                    gdata_exhelp_flag(id) = 1;
+                    game_data.exhelp_flags.at(id) = 1;
                     ghelp = id;
                     show_ex_help();
 

--- a/src/menu.hpp
+++ b/src/menu.hpp
@@ -45,6 +45,7 @@ enum class CharacterSheetOperation
 void text_set();
 int cnvjkey(const std::string&);
 void show_quick_menu();
+bool maybe_show_ex_help(int id, bool should_update_screen = false);
 void show_ex_help();
 void show_game_help();
 TurnResult show_chat_history();

--- a/src/proc_event.cpp
+++ b/src/proc_event.cpp
@@ -44,7 +44,7 @@ void proc_event()
             if (qdata(12, game_data.executing_immediate_quest)
                 <= qdata(13, game_data.executing_immediate_quest))
             {
-                gdata(73) = 3;
+                gdata_executing_immediate_quest_status = 3;
                 qdata(8, game_data.executing_immediate_quest) = 3;
                 txtef(2);
                 txt(i18n::s.get("core.locale.quest.party.complete"));
@@ -60,7 +60,7 @@ void proc_event()
             if (qdata(12, game_data.executing_immediate_quest)
                 < qdata(13, game_data.executing_immediate_quest))
             {
-                gdata(73) = 3;
+                gdata_executing_immediate_quest_status = 3;
                 qdata(8, game_data.executing_immediate_quest) = 3;
                 txtef(2);
                 txt(i18n::s.get("core.locale.quest.collect.complete"));
@@ -132,7 +132,7 @@ void proc_event()
     case 23:
         tc = chara_find(302);
         talk_to_npc();
-        gdata(171) = 23;
+        gdata_rogue_boss_encountered = 23;
         break;
     case 12:
         update_screen();
@@ -280,14 +280,17 @@ void proc_event()
         snd(51);
         txt(i18n::s.get("core.locale.common.something_is_put_on_the_ground"));
         modrank(2, 300, 8);
-        gdata(74) = calcfame(0, game_data.current_dungeon_level * 30 + 200);
+        gdata_executing_immediate_quest_fame_gained =
+            calcfame(0, game_data.current_dungeon_level * 30 + 200);
         txtef(2);
-        txt(i18n::s.get("core.locale.quest.gain_fame", gdata(74)));
-        cdata.player().fame += gdata(74);
+        txt(i18n::s.get(
+            "core.locale.quest.gain_fame",
+            gdata_executing_immediate_quest_fame_gained));
+        cdata.player().fame += gdata_executing_immediate_quest_fame_gained;
         if (game_data.current_map == mdata_t::MapId::the_void)
         {
             area_data[game_data.current_map].has_been_conquered = 0;
-            gdata(186) = gdata(186) + 5;
+            gdata_void_next_lord_floor = gdata_void_next_lord_floor + 5;
             txt(i18n::s.get("core.locale.event.seal_broken"));
         }
         else
@@ -580,7 +583,7 @@ void proc_event()
                 cdata[tc].position.y);
             if (c == 0)
             {
-                gdata(35) = cdata[c].direction;
+                gdata_player_next_move_direction = cdata[c].direction;
             }
         }
         talk_to_npc();

--- a/src/proc_event.cpp
+++ b/src/proc_event.cpp
@@ -44,7 +44,7 @@ void proc_event()
             if (qdata(12, game_data.executing_immediate_quest)
                 <= qdata(13, game_data.executing_immediate_quest))
             {
-                gdata_executing_immediate_quest_status = 3;
+                game_data.executing_immediate_quest_status = 3;
                 qdata(8, game_data.executing_immediate_quest) = 3;
                 txtef(2);
                 txt(i18n::s.get("core.locale.quest.party.complete"));
@@ -60,7 +60,7 @@ void proc_event()
             if (qdata(12, game_data.executing_immediate_quest)
                 < qdata(13, game_data.executing_immediate_quest))
             {
-                gdata_executing_immediate_quest_status = 3;
+                game_data.executing_immediate_quest_status = 3;
                 qdata(8, game_data.executing_immediate_quest) = 3;
                 txtef(2);
                 txt(i18n::s.get("core.locale.quest.collect.complete"));
@@ -132,7 +132,7 @@ void proc_event()
     case 23:
         tc = chara_find(302);
         talk_to_npc();
-        gdata_rogue_boss_encountered = 23;
+        game_data.rogue_boss_encountered = 23;
         break;
     case 12:
         update_screen();
@@ -280,17 +280,17 @@ void proc_event()
         snd(51);
         txt(i18n::s.get("core.locale.common.something_is_put_on_the_ground"));
         modrank(2, 300, 8);
-        gdata_executing_immediate_quest_fame_gained =
+        game_data.executing_immediate_quest_fame_gained =
             calcfame(0, game_data.current_dungeon_level * 30 + 200);
         txtef(2);
         txt(i18n::s.get(
             "core.locale.quest.gain_fame",
-            gdata_executing_immediate_quest_fame_gained));
-        cdata.player().fame += gdata_executing_immediate_quest_fame_gained;
+            game_data.executing_immediate_quest_fame_gained));
+        cdata.player().fame += game_data.executing_immediate_quest_fame_gained;
         if (game_data.current_map == mdata_t::MapId::the_void)
         {
             area_data[game_data.current_map].has_been_conquered = 0;
-            gdata_void_next_lord_floor = gdata_void_next_lord_floor + 5;
+            game_data.void_next_lord_floor = game_data.void_next_lord_floor + 5;
             txt(i18n::s.get("core.locale.event.seal_broken"));
         }
         else
@@ -583,7 +583,7 @@ void proc_event()
                 cdata[tc].position.y);
             if (c == 0)
             {
-                gdata_player_next_move_direction = cdata[c].direction;
+                game_data.player_next_move_direction = cdata[c].direction;
             }
         }
         talk_to_npc();

--- a/src/quest.cpp
+++ b/src/quest.cpp
@@ -28,7 +28,7 @@ int quest_is_return_forbidden()
     f = 0;
     for (int cnt = 0; cnt < 5; ++cnt)
     {
-        p = gdata_taken_quest(cnt);
+        p = game_data.taken_quests.at(cnt);
         if (qdata(8, p) == 1)
         {
             if (qdata(3, p) == 1007 || qdata(3, p) == 1002)

--- a/src/quest.cpp
+++ b/src/quest.cpp
@@ -28,7 +28,7 @@ int quest_is_return_forbidden()
     f = 0;
     for (int cnt = 0; cnt < 5; ++cnt)
     {
-        p = gdata(160 + cnt);
+        p = gdata_taken_quest(cnt);
         if (qdata(8, p) == 1)
         {
             if (qdata(3, p) == 1007 || qdata(3, p) == 1002)
@@ -158,9 +158,9 @@ void quest_check()
     {
         return;
     }
-    if (gdata(73) != 3)
+    if (gdata_executing_immediate_quest_status != 3)
     {
-        if (gdata(71) == 1)
+        if (gdata_executing_immediate_quest_show_hunt_remain == 1)
         {
             p_at_m119 = 0;
             for (auto&& cnt : cdata.others())
@@ -969,7 +969,7 @@ void quest_exit_map()
         }
         refresh_burden_state();
     }
-    if (gdata(73) != 3)
+    if (gdata_executing_immediate_quest_status != 3)
     {
         if (game_data.executing_immediate_quest_type >= 1000)
         {
@@ -980,9 +980,9 @@ void quest_exit_map()
             if (qdata(8, rq) == 0)
             {
                 game_data.executing_immediate_quest_type = 0;
-                gdata(71) = 0;
+                gdata_executing_immediate_quest_show_hunt_remain = 0;
                 game_data.executing_immediate_quest = 0;
-                gdata(73) = 0;
+                gdata_executing_immediate_quest_status = 0;
                 return;
             }
             else
@@ -995,9 +995,9 @@ void quest_exit_map()
         msg_halt();
     }
     game_data.executing_immediate_quest_type = 0;
-    gdata(71) = 0;
+    gdata_executing_immediate_quest_show_hunt_remain = 0;
     game_data.executing_immediate_quest = 0;
-    gdata(73) = 0;
+    gdata_executing_immediate_quest_status = 0;
 }
 
 
@@ -1125,8 +1125,10 @@ void quest_team_victorious()
         txtef(2);
         txt(i18n::s.get("core.locale.quest.arena.your_team_is_victorious"));
         txtef(2);
-        txt(i18n::s.get("core.locale.quest.gain_fame", gdata(74)));
-        cdata.player().fame += gdata(74);
+        txt(i18n::s.get(
+            "core.locale.quest.gain_fame",
+            gdata_executing_immediate_quest_fame_gained));
+        cdata.player().fame += gdata_executing_immediate_quest_fame_gained;
         modrank(1, 100, 2);
         ++area_data[game_data.previous_map2].winning_streak_in_pet_arena;
         if (area_data[game_data.previous_map2].winning_streak_in_pet_arena % 20
@@ -1163,16 +1165,18 @@ void quest_all_targets_killed()
 {
     musicloop = 1;
     play_music("core.mcFanfare");
-    gdata(73) = 3;
+    gdata_executing_immediate_quest_status = 3;
     if (game_data.executing_immediate_quest_type == 1)
     {
         snd(69);
         txtef(2);
         txt(i18n::s.get("core.locale.quest.arena.you_are_victorious"));
         txtef(2);
-        txt(i18n::s.get("core.locale.quest.gain_fame", gdata(74)));
+        txt(i18n::s.get(
+            "core.locale.quest.gain_fame",
+            gdata_executing_immediate_quest_fame_gained));
         modrank(0, 100, 2);
-        cdata.player().fame += gdata(74);
+        cdata.player().fame += gdata_executing_immediate_quest_fame_gained;
         txt(i18n::s.get("core.locale.quest.arena.stairs_appear"));
         map_placeupstairs(mdata_map_width / 2, mdata_map_height / 2);
         ++area_data[game_data.previous_map2].winning_streak_in_arena;
@@ -1313,12 +1317,15 @@ void quest_complete()
         }
     }
     modify_karma(cdata.player(), 1);
-    gdata(74) = calcfame(0, qdata(5, rq) * 3 + 10);
+    gdata_executing_immediate_quest_fame_gained =
+        calcfame(0, qdata(5, rq) * 3 + 10);
     txtef(2);
     txt(i18n::s.get("core.locale.quest.completed_taken_from", qname(rq)));
     txtef(2);
-    txt(i18n::s.get("core.locale.quest.gain_fame", gdata(74)));
-    cdata.player().fame += gdata(74);
+    txt(i18n::s.get(
+        "core.locale.quest.gain_fame",
+        gdata_executing_immediate_quest_fame_gained));
+    cdata.player().fame += gdata_executing_immediate_quest_fame_gained;
     txt(i18n::s.get("core.locale.common.something_is_put_on_the_ground"));
     if (qdata(3, rq) == 1002)
     {

--- a/src/quest.cpp
+++ b/src/quest.cpp
@@ -158,9 +158,9 @@ void quest_check()
     {
         return;
     }
-    if (gdata_executing_immediate_quest_status != 3)
+    if (game_data.executing_immediate_quest_status != 3)
     {
-        if (gdata_executing_immediate_quest_show_hunt_remain == 1)
+        if (game_data.executing_immediate_quest_show_hunt_remain == 1)
         {
             p_at_m119 = 0;
             for (auto&& cnt : cdata.others())
@@ -969,7 +969,7 @@ void quest_exit_map()
         }
         refresh_burden_state();
     }
-    if (gdata_executing_immediate_quest_status != 3)
+    if (game_data.executing_immediate_quest_status != 3)
     {
         if (game_data.executing_immediate_quest_type >= 1000)
         {
@@ -980,9 +980,9 @@ void quest_exit_map()
             if (qdata(8, rq) == 0)
             {
                 game_data.executing_immediate_quest_type = 0;
-                gdata_executing_immediate_quest_show_hunt_remain = 0;
+                game_data.executing_immediate_quest_show_hunt_remain = 0;
                 game_data.executing_immediate_quest = 0;
-                gdata_executing_immediate_quest_status = 0;
+                game_data.executing_immediate_quest_status = 0;
                 return;
             }
             else
@@ -995,9 +995,9 @@ void quest_exit_map()
         msg_halt();
     }
     game_data.executing_immediate_quest_type = 0;
-    gdata_executing_immediate_quest_show_hunt_remain = 0;
+    game_data.executing_immediate_quest_show_hunt_remain = 0;
     game_data.executing_immediate_quest = 0;
-    gdata_executing_immediate_quest_status = 0;
+    game_data.executing_immediate_quest_status = 0;
 }
 
 
@@ -1127,8 +1127,8 @@ void quest_team_victorious()
         txtef(2);
         txt(i18n::s.get(
             "core.locale.quest.gain_fame",
-            gdata_executing_immediate_quest_fame_gained));
-        cdata.player().fame += gdata_executing_immediate_quest_fame_gained;
+            game_data.executing_immediate_quest_fame_gained));
+        cdata.player().fame += game_data.executing_immediate_quest_fame_gained;
         modrank(1, 100, 2);
         ++area_data[game_data.previous_map2].winning_streak_in_pet_arena;
         if (area_data[game_data.previous_map2].winning_streak_in_pet_arena % 20
@@ -1165,7 +1165,7 @@ void quest_all_targets_killed()
 {
     musicloop = 1;
     play_music("core.mcFanfare");
-    gdata_executing_immediate_quest_status = 3;
+    game_data.executing_immediate_quest_status = 3;
     if (game_data.executing_immediate_quest_type == 1)
     {
         snd(69);
@@ -1174,9 +1174,9 @@ void quest_all_targets_killed()
         txtef(2);
         txt(i18n::s.get(
             "core.locale.quest.gain_fame",
-            gdata_executing_immediate_quest_fame_gained));
+            game_data.executing_immediate_quest_fame_gained));
         modrank(0, 100, 2);
-        cdata.player().fame += gdata_executing_immediate_quest_fame_gained;
+        cdata.player().fame += game_data.executing_immediate_quest_fame_gained;
         txt(i18n::s.get("core.locale.quest.arena.stairs_appear"));
         map_placeupstairs(mdata_map_width / 2, mdata_map_height / 2);
         ++area_data[game_data.previous_map2].winning_streak_in_arena;
@@ -1317,15 +1317,15 @@ void quest_complete()
         }
     }
     modify_karma(cdata.player(), 1);
-    gdata_executing_immediate_quest_fame_gained =
+    game_data.executing_immediate_quest_fame_gained =
         calcfame(0, qdata(5, rq) * 3 + 10);
     txtef(2);
     txt(i18n::s.get("core.locale.quest.completed_taken_from", qname(rq)));
     txtef(2);
     txt(i18n::s.get(
         "core.locale.quest.gain_fame",
-        gdata_executing_immediate_quest_fame_gained));
-    cdata.player().fame += gdata_executing_immediate_quest_fame_gained;
+        game_data.executing_immediate_quest_fame_gained));
+    cdata.player().fame += game_data.executing_immediate_quest_fame_gained;
     txt(i18n::s.get("core.locale.common.something_is_put_on_the_ground"));
     if (qdata(3, rq) == 1002)
     {

--- a/src/talk.cpp
+++ b/src/talk.cpp
@@ -808,7 +808,7 @@ int talk_guide_quest_client()
 
     for (int i = 0; i < max_quest; ++i)
     {
-        const auto quest_id = gdata_taken_quest(i);
+        const auto quest_id = game_data.taken_quests.at(i);
         if (qdata(8, quest_id) != 1)
             continue;
         if (game_data.current_dungeon_level != 1)
@@ -835,7 +835,7 @@ int talk_guide_quest_client()
             bool duplicated{};
             for (int j = 0; j < i; ++j)
             {
-                if (gdata_taken_quest(j) == quest_id)
+                if (game_data.taken_quests.at(j) == quest_id)
                 {
                     duplicated = true;
                     break;
@@ -859,7 +859,7 @@ int talk_check_trade(int prm_1081)
     j_at_m193 = 0;
     for (int cnt = 0; cnt < 5; ++cnt)
     {
-        p_at_m193 = gdata_taken_quest(cnt);
+        p_at_m193 = game_data.taken_quests.at(cnt);
         if (qdata(8, p_at_m193) == 1)
         {
             if (game_data.current_dungeon_level == 1)

--- a/src/talk.cpp
+++ b/src/talk.cpp
@@ -43,13 +43,13 @@ void talk_to_npc()
     {
         if (Config::instance().extrahelp)
         {
-            if (gdata(207) == 0)
+            if (gdata_exhelp_flag(7) == 0)
             {
                 if (mode == 0)
                 {
                     if (cdata.player().continuous_action.turn == 0)
                     {
-                        gdata(207) = 1;
+                        gdata_exhelp_flag(7) = 1;
                         ghelp = 7;
                         show_ex_help();
                         screenupdate = -1;
@@ -63,13 +63,13 @@ void talk_to_npc()
     {
         if (Config::instance().extrahelp)
         {
-            if (gdata(208) == 0)
+            if (gdata_exhelp_flag(8) == 0)
             {
                 if (mode == 0)
                 {
                     if (cdata.player().continuous_action.turn == 0)
                     {
-                        gdata(208) = 1;
+                        gdata_exhelp_flag(8) = 1;
                         ghelp = 8;
                         show_ex_help();
                         screenupdate = -1;
@@ -837,7 +837,7 @@ int talk_guide_quest_client()
 
     for (int i = 0; i < max_quest; ++i)
     {
-        const auto quest_id = gdata(160 + i);
+        const auto quest_id = gdata_taken_quest(i);
         if (qdata(8, quest_id) != 1)
             continue;
         if (game_data.current_dungeon_level != 1)
@@ -864,7 +864,7 @@ int talk_guide_quest_client()
             bool duplicated{};
             for (int j = 0; j < i; ++j)
             {
-                if (gdata(160 + j) == quest_id)
+                if (gdata_taken_quest(j) == quest_id)
                 {
                     duplicated = true;
                     break;
@@ -888,7 +888,7 @@ int talk_check_trade(int prm_1081)
     j_at_m193 = 0;
     for (int cnt = 0; cnt < 5; ++cnt)
     {
-        p_at_m193 = gdata(160 + cnt);
+        p_at_m193 = gdata_taken_quest(cnt);
         if (qdata(8, p_at_m193) == 1)
         {
             if (game_data.current_dungeon_level == 1)

--- a/src/talk.cpp
+++ b/src/talk.cpp
@@ -43,41 +43,12 @@ void talk_to_npc()
     {
         if (Config::instance().extrahelp)
         {
-            if (gdata_exhelp_flag(7) == 0)
-            {
-                if (mode == 0)
-                {
-                    if (cdata.player().continuous_action.turn == 0)
-                    {
-                        gdata_exhelp_flag(7) = 1;
-                        ghelp = 7;
-                        show_ex_help();
-                        screenupdate = -1;
-                        update_screen();
-                    }
-                }
-            }
+            maybe_show_ex_help(7, true);
         }
     }
     if (cdata[tc].character_role == 7)
     {
-        if (Config::instance().extrahelp)
-        {
-            if (gdata_exhelp_flag(8) == 0)
-            {
-                if (mode == 0)
-                {
-                    if (cdata.player().continuous_action.turn == 0)
-                    {
-                        gdata_exhelp_flag(8) = 1;
-                        ghelp = 8;
-                        show_ex_help();
-                        screenupdate = -1;
-                        update_screen();
-                    }
-                }
-            }
-        }
+        maybe_show_ex_help(8, true);
     }
     set_npc_religion();
     if (scenemode == 0)

--- a/src/talk_npc.cpp
+++ b/src/talk_npc.cpp
@@ -251,7 +251,7 @@ TalkResult talk_arena_master(int chatval_)
             "core.locale.magic.mount.dismount", cdata[game_data.mount]));
         ride_end();
     }
-    gdata_executing_immediate_quest_fame_gained = calcfame(
+    game_data.executing_immediate_quest_fame_gained = calcfame(
         0,
         (220 - gdata_rank(0) / 50)
                 * (100
@@ -357,9 +357,9 @@ TalkResult talk_arena_master(int chatval_)
             game_data.date.hours() + 24;
     }
     game_data.executing_immediate_quest_type = 1;
-    gdata_executing_immediate_quest_show_hunt_remain = 1;
+    game_data.executing_immediate_quest_show_hunt_remain = 1;
     game_data.executing_immediate_quest = 0;
-    gdata_executing_immediate_quest_status = 1;
+    game_data.executing_immediate_quest_status = 1;
     game_data.previous_map2 = game_data.current_map;
     game_data.previous_dungeon_level = game_data.current_dungeon_level;
     game_data.previous_x = cdata.player().position.x;
@@ -373,7 +373,7 @@ TalkResult talk_arena_master(int chatval_)
 
 TalkResult talk_pet_arena_master(int chatval_)
 {
-    gdata_executing_immediate_quest_fame_gained = calcfame(
+    game_data.executing_immediate_quest_fame_gained = calcfame(
         0,
         (220 - gdata_rank(1) / 50)
                 * (50
@@ -438,9 +438,9 @@ TalkResult talk_pet_arena_master(int chatval_)
         return TalkResult::talk_npc;
     }
     game_data.executing_immediate_quest_type = 2;
-    gdata_executing_immediate_quest_show_hunt_remain = 0;
+    game_data.executing_immediate_quest_show_hunt_remain = 0;
     game_data.executing_immediate_quest = 0;
-    gdata_executing_immediate_quest_status = 1;
+    game_data.executing_immediate_quest_status = 1;
     game_data.previous_map2 = game_data.current_map;
     game_data.previous_dungeon_level = game_data.current_dungeon_level;
     game_data.previous_x = cdata.player().position.x;
@@ -824,7 +824,7 @@ TalkResult talk_ally_gene()
     cdata[tc].has_made_gene() = true;
     if (game_data.wizard == 0)
     {
-        gdata_character_and_status_for_gene = tc;
+        game_data.character_and_status_for_gene = tc;
     }
     return TalkResult::talk_end;
 }
@@ -1282,8 +1282,8 @@ TalkResult talk_caravan_master_hire()
     game_data.destination_map = area_data[chatval_].outer_map;
     game_data.destination_dungeon_level = 1;
     levelexitby = 4;
-    gdata_reset_world_map_in_diastrophism_flag = 1;
-    gdata_destination_outer_map = area_data[chatval_].outer_map;
+    game_data.reset_world_map_in_diastrophism_flag = 1;
+    game_data.destination_outer_map = area_data[chatval_].outer_map;
     game_data.pc_x_in_world_map = area_data[chatval_].position.x;
     game_data.pc_y_in_world_map = area_data[chatval_].position.y;
     fixtransfermap = 1;
@@ -1442,9 +1442,9 @@ TalkResult talk_accepted_quest()
         }
     }
     game_data.executing_immediate_quest_type = qdata(3, rq);
-    gdata_executing_immediate_quest_show_hunt_remain = qdata(14, rq);
+    game_data.executing_immediate_quest_show_hunt_remain = qdata(14, rq);
     game_data.executing_immediate_quest = rq;
-    gdata_executing_immediate_quest_status = 1;
+    game_data.executing_immediate_quest_status = 1;
     game_data.previous_map2 = game_data.current_map;
     game_data.previous_dungeon_level = game_data.current_dungeon_level;
     game_data.previous_x = cdata.player().position.x;

--- a/src/talk_npc.cpp
+++ b/src/talk_npc.cpp
@@ -253,7 +253,7 @@ TalkResult talk_arena_master(int chatval_)
     }
     game_data.executing_immediate_quest_fame_gained = calcfame(
         0,
-        (220 - gdata_rank(0) / 50)
+        (220 - game_data.ranks.at(0) / 50)
                 * (100
                    + clamp(
                          area_data[game_data.current_map]
@@ -278,13 +278,13 @@ TalkResult talk_arena_master(int chatval_)
         for (int cnt = 0; cnt < 50; ++cnt)
         {
             arenaop(0) = 0;
-            arenaop(1) = (100 - gdata_rank(0) / 100) / 3 + 1;
+            arenaop(1) = (100 - game_data.ranks.at(0) / 100) / 3 + 1;
             arenaop(2) = 3;
-            if (gdata_rank(0) / 100 < 30)
+            if (game_data.ranks.at(0) / 100 < 30)
             {
                 arenaop(2) = 4;
             }
-            if (gdata_rank(0) / 100 < 10)
+            if (game_data.ranks.at(0) / 100 < 10)
             {
                 arenaop(2) = 5;
             }
@@ -324,7 +324,7 @@ TalkResult talk_arena_master(int chatval_)
             return TalkResult::talk_npc;
         }
         arenaop(0) = 1;
-        arenaop(1) = (100 - gdata_rank(0) / 100) / 2 + 1;
+        arenaop(1) = (100 - game_data.ranks.at(0) / 100) / 2 + 1;
         buff = i18n::s.get(
             "core.locale.talk.npc.arena_master.enter.target_group",
             arenaop(1),
@@ -375,7 +375,7 @@ TalkResult talk_pet_arena_master(int chatval_)
 {
     game_data.executing_immediate_quest_fame_gained = calcfame(
         0,
-        (220 - gdata_rank(1) / 50)
+        (220 - game_data.ranks.at(1) / 50)
                 * (50
                    + clamp(
                          area_data[game_data.current_map]
@@ -389,7 +389,7 @@ TalkResult talk_pet_arena_master(int chatval_)
     {
         arenaop(0) = 0;
         arenaop(1) = 1;
-        arenaop(2) = (100 - gdata_rank(1) / 100) / 3 * 2 + 3;
+        arenaop(2) = (100 - game_data.ranks.at(1) / 100) / 3 * 2 + 3;
         buff = i18n::s.get(
             "core.locale.talk.npc.pet_arena_master.register.target",
             arenaop(2),
@@ -399,7 +399,7 @@ TalkResult talk_pet_arena_master(int chatval_)
     {
         arenaop(0) = 1;
         arenaop(1) = 2;
-        arenaop(2) = (100 - gdata_rank(1) / 100) / 2 + 1;
+        arenaop(2) = (100 - game_data.ranks.at(1) / 100) / 2 + 1;
         arenaop(1) = rnd(7) + 2;
         buff = i18n::s.get(
             "core.locale.talk.npc.pet_arena_master.register.target_group",
@@ -1653,18 +1653,18 @@ TalkResult talk_quest_giver()
         }
         for (int cnt = 0; cnt < 5; ++cnt)
         {
-            p = gdata_taken_quest(cnt);
+            p = game_data.taken_quests.at(cnt);
             f = 0;
             for (int cnt = 0; cnt < 5; ++cnt)
             {
-                if (gdata_taken_quest(cnt) == p)
+                if (game_data.taken_quests.at(cnt) == p)
                 {
                     ++f;
                 }
             }
             if (qdata(8, p) == 0 || f > 1)
             {
-                gdata_taken_quest(cnt) = rq;
+                game_data.taken_quests.at(cnt) = rq;
                 break;
             }
         }

--- a/src/talk_npc.cpp
+++ b/src/talk_npc.cpp
@@ -251,9 +251,9 @@ TalkResult talk_arena_master(int chatval_)
             "core.locale.magic.mount.dismount", cdata[game_data.mount]));
         ride_end();
     }
-    gdata(74) = calcfame(
+    gdata_executing_immediate_quest_fame_gained = calcfame(
         0,
-        (220 - gdata(120) / 50)
+        (220 - gdata_rank(0) / 50)
                 * (100
                    + clamp(
                          area_data[game_data.current_map]
@@ -278,13 +278,13 @@ TalkResult talk_arena_master(int chatval_)
         for (int cnt = 0; cnt < 50; ++cnt)
         {
             arenaop(0) = 0;
-            arenaop(1) = (100 - gdata(120) / 100) / 3 + 1;
+            arenaop(1) = (100 - gdata_rank(0) / 100) / 3 + 1;
             arenaop(2) = 3;
-            if (gdata(120) / 100 < 30)
+            if (gdata_rank(0) / 100 < 30)
             {
                 arenaop(2) = 4;
             }
-            if (gdata(120) / 100 < 10)
+            if (gdata_rank(0) / 100 < 10)
             {
                 arenaop(2) = 5;
             }
@@ -324,7 +324,7 @@ TalkResult talk_arena_master(int chatval_)
             return TalkResult::talk_npc;
         }
         arenaop(0) = 1;
-        arenaop(1) = (100 - gdata(120) / 100) / 2 + 1;
+        arenaop(1) = (100 - gdata_rank(0) / 100) / 2 + 1;
         buff = i18n::s.get(
             "core.locale.talk.npc.arena_master.enter.target_group",
             arenaop(1),
@@ -357,9 +357,9 @@ TalkResult talk_arena_master(int chatval_)
             game_data.date.hours() + 24;
     }
     game_data.executing_immediate_quest_type = 1;
-    gdata(71) = 1;
+    gdata_executing_immediate_quest_show_hunt_remain = 1;
     game_data.executing_immediate_quest = 0;
-    gdata(73) = 1;
+    gdata_executing_immediate_quest_status = 1;
     game_data.previous_map2 = game_data.current_map;
     game_data.previous_dungeon_level = game_data.current_dungeon_level;
     game_data.previous_x = cdata.player().position.x;
@@ -373,9 +373,9 @@ TalkResult talk_arena_master(int chatval_)
 
 TalkResult talk_pet_arena_master(int chatval_)
 {
-    gdata(74) = calcfame(
+    gdata_executing_immediate_quest_fame_gained = calcfame(
         0,
-        (220 - gdata(121) / 50)
+        (220 - gdata_rank(1) / 50)
                 * (50
                    + clamp(
                          area_data[game_data.current_map]
@@ -389,7 +389,7 @@ TalkResult talk_pet_arena_master(int chatval_)
     {
         arenaop(0) = 0;
         arenaop(1) = 1;
-        arenaop(2) = (100 - gdata(121) / 100) / 3 * 2 + 3;
+        arenaop(2) = (100 - gdata_rank(1) / 100) / 3 * 2 + 3;
         buff = i18n::s.get(
             "core.locale.talk.npc.pet_arena_master.register.target",
             arenaop(2),
@@ -399,7 +399,7 @@ TalkResult talk_pet_arena_master(int chatval_)
     {
         arenaop(0) = 1;
         arenaop(1) = 2;
-        arenaop(2) = (100 - gdata(121) / 100) / 2 + 1;
+        arenaop(2) = (100 - gdata_rank(1) / 100) / 2 + 1;
         arenaop(1) = rnd(7) + 2;
         buff = i18n::s.get(
             "core.locale.talk.npc.pet_arena_master.register.target_group",
@@ -438,9 +438,9 @@ TalkResult talk_pet_arena_master(int chatval_)
         return TalkResult::talk_npc;
     }
     game_data.executing_immediate_quest_type = 2;
-    gdata(71) = 0;
+    gdata_executing_immediate_quest_show_hunt_remain = 0;
     game_data.executing_immediate_quest = 0;
-    gdata(73) = 1;
+    gdata_executing_immediate_quest_status = 1;
     game_data.previous_map2 = game_data.current_map;
     game_data.previous_dungeon_level = game_data.current_dungeon_level;
     game_data.previous_x = cdata.player().position.x;
@@ -824,7 +824,7 @@ TalkResult talk_ally_gene()
     cdata[tc].has_made_gene() = true;
     if (game_data.wizard == 0)
     {
-        gdata(98) = tc;
+        gdata_character_and_status_for_gene = tc;
     }
     return TalkResult::talk_end;
 }
@@ -1282,8 +1282,8 @@ TalkResult talk_caravan_master_hire()
     game_data.destination_map = area_data[chatval_].outer_map;
     game_data.destination_dungeon_level = 1;
     levelexitby = 4;
-    gdata(79) = 1;
-    gdata(850) = area_data[chatval_].outer_map;
+    gdata_reset_world_map_in_diastrophism_flag = 1;
+    gdata_destination_outer_map = area_data[chatval_].outer_map;
     game_data.pc_x_in_world_map = area_data[chatval_].position.x;
     game_data.pc_y_in_world_map = area_data[chatval_].position.y;
     fixtransfermap = 1;
@@ -1442,9 +1442,9 @@ TalkResult talk_accepted_quest()
         }
     }
     game_data.executing_immediate_quest_type = qdata(3, rq);
-    gdata(71) = qdata(14, rq);
+    gdata_executing_immediate_quest_show_hunt_remain = qdata(14, rq);
     game_data.executing_immediate_quest = rq;
-    gdata(73) = 1;
+    gdata_executing_immediate_quest_status = 1;
     game_data.previous_map2 = game_data.current_map;
     game_data.previous_dungeon_level = game_data.current_dungeon_level;
     game_data.previous_x = cdata.player().position.x;
@@ -1653,18 +1653,18 @@ TalkResult talk_quest_giver()
         }
         for (int cnt = 0; cnt < 5; ++cnt)
         {
-            p = gdata(160 + cnt);
+            p = gdata_taken_quest(cnt);
             f = 0;
             for (int cnt = 0; cnt < 5; ++cnt)
             {
-                if (gdata(160 + cnt) == p)
+                if (gdata_taken_quest(cnt) == p)
                 {
                     ++f;
                 }
             }
             if (qdata(8, p) == 0 || f > 1)
             {
-                gdata(160 + cnt) = rq;
+                gdata_taken_quest(cnt) = rq;
                 break;
             }
         }

--- a/src/talk_unique.cpp
+++ b/src/talk_unique.cpp
@@ -3636,7 +3636,7 @@ TalkResult talk_unique_balzak()
 
 void _lexus_join_mages_guild()
 {
-    gdata_rank(8) = 10000;
+    game_data.ranks.at(8) = 10000;
     game_data.guild.belongs_to_thieves_guild = 0;
     game_data.guild.belongs_to_fighters_guild = 0;
     game_data.guild.belongs_to_mages_guild = 1;
@@ -3665,7 +3665,7 @@ void _lexus_start_trial()
 void _lexus_update_quota()
 {
     game_data.guild.mages_guild_quota_recurring = 1;
-    game_data.guild.mages_guild_quota = 75 - gdata_rank(8) / 200;
+    game_data.guild.mages_guild_quota = 75 - game_data.ranks.at(8) / 200;
     quest_update_journal_msg();
 }
 
@@ -3679,7 +3679,7 @@ void _lexus_move_self()
 void _lexus_receive_reward()
 {
     game_data.guild.mages_guild_quota_recurring = 0;
-    flt(51 - gdata_rank(8) / 200);
+    flt(51 - game_data.ranks.at(8) / 200);
     flttypemajor = 54000;
     itemcreate(-1, 0, cdata.player().position.x, cdata.player().position.y, 0);
     flt();
@@ -3688,14 +3688,14 @@ void _lexus_receive_reward()
         54,
         cdata.player().position.x,
         cdata.player().position.y,
-        10000 - gdata_rank(8) + 1000);
+        10000 - game_data.ranks.at(8) + 1000);
     flt();
     itemcreate(
         -1,
         55,
         cdata.player().position.x,
         cdata.player().position.y,
-        clamp(4 - gdata_rank(8) / 2500, 1, 4));
+        clamp(4 - game_data.ranks.at(8) / 2500, 1, 4));
     txt(i18n::s.get("core.locale.quest.completed"));
     snd(51);
     txt(i18n::s.get("core.locale.common.something_is_put_on_the_ground"));
@@ -3865,7 +3865,7 @@ void _abyss_start_trial()
 
 void _abyss_join_thieves_guild()
 {
-    gdata_rank(8) = 10000;
+    game_data.ranks.at(8) = 10000;
     game_data.guild.belongs_to_thieves_guild = 1;
     game_data.guild.belongs_to_fighters_guild = 0;
     game_data.guild.belongs_to_mages_guild = 0;
@@ -3894,14 +3894,15 @@ void _abyss_move_self()
 void _abyss_update_quota()
 {
     game_data.guild.thieves_guild_quota_recurring = 1;
-    game_data.guild.thieves_guild_quota = (10000 - gdata_rank(8)) * 6 + 1000;
+    game_data.guild.thieves_guild_quota =
+        (10000 - game_data.ranks.at(8)) * 6 + 1000;
     quest_update_journal_msg();
 }
 
 void _abyss_receive_reward()
 {
     game_data.guild.thieves_guild_quota_recurring = 0;
-    flt(51 - gdata_rank(8) / 200);
+    flt(51 - game_data.ranks.at(8) / 200);
     flttypemajor = 60000;
     itemcreate(-1, 0, cdata.player().position.x, cdata.player().position.y, 0);
     flt();
@@ -3910,14 +3911,14 @@ void _abyss_receive_reward()
         54,
         cdata.player().position.x,
         cdata.player().position.y,
-        10000 - gdata_rank(8) + 1000);
+        10000 - game_data.ranks.at(8) + 1000);
     flt();
     itemcreate(
         -1,
         55,
         cdata.player().position.x,
         cdata.player().position.y,
-        clamp(3 - gdata_rank(8) / 3000, 1, 3));
+        clamp(3 - game_data.ranks.at(8) / 3000, 1, 3));
     txt(i18n::s.get("core.locale.quest.completed"));
     snd(51);
     txt(i18n::s.get("core.locale.common.something_is_put_on_the_ground"));
@@ -4101,7 +4102,7 @@ void _doria_start_trial()
 
 void _doria_join_fighters_guild()
 {
-    gdata_rank(8) = 10000;
+    game_data.ranks.at(8) = 10000;
     game_data.guild.belongs_to_thieves_guild = 0;
     game_data.guild.belongs_to_fighters_guild = 1;
     game_data.guild.belongs_to_mages_guild = 0;
@@ -4157,7 +4158,7 @@ void _doria_update_quota()
 void _doria_receive_reward()
 {
     game_data.guild.fighters_guild_quota_recurring = 0;
-    flt(51 - gdata_rank(8) / 200, calcfixlv(Quality::good));
+    flt(51 - game_data.ranks.at(8) / 200, calcfixlv(Quality::good));
     flttypemajor = 10000;
     itemcreate(-1, 0, cdata.player().position.x, cdata.player().position.y, 0);
     flt();
@@ -4166,14 +4167,14 @@ void _doria_receive_reward()
         54,
         cdata.player().position.x,
         cdata.player().position.y,
-        10000 - gdata_rank(8) + 1000);
+        10000 - game_data.ranks.at(8) + 1000);
     flt();
     itemcreate(
         -1,
         55,
         cdata.player().position.x,
         cdata.player().position.y,
-        clamp(4 - gdata_rank(8) / 2500, 1, 4));
+        clamp(4 - game_data.ranks.at(8) / 2500, 1, 4));
     txt(i18n::s.get("core.locale.quest.completed"));
     snd(51);
     txt(i18n::s.get("core.locale.common.something_is_put_on_the_ground"));

--- a/src/talk_unique.cpp
+++ b/src/talk_unique.cpp
@@ -3636,7 +3636,7 @@ TalkResult talk_unique_balzak()
 
 void _lexus_join_mages_guild()
 {
-    gdata(128) = 10000;
+    gdata_rank(8) = 10000;
     game_data.guild.belongs_to_thieves_guild = 0;
     game_data.guild.belongs_to_fighters_guild = 0;
     game_data.guild.belongs_to_mages_guild = 1;
@@ -3665,7 +3665,7 @@ void _lexus_start_trial()
 void _lexus_update_quota()
 {
     game_data.guild.mages_guild_quota_recurring = 1;
-    game_data.guild.mages_guild_quota = 75 - gdata(128) / 200;
+    game_data.guild.mages_guild_quota = 75 - gdata_rank(8) / 200;
     quest_update_journal_msg();
 }
 
@@ -3679,7 +3679,7 @@ void _lexus_move_self()
 void _lexus_receive_reward()
 {
     game_data.guild.mages_guild_quota_recurring = 0;
-    flt(51 - gdata(128) / 200);
+    flt(51 - gdata_rank(8) / 200);
     flttypemajor = 54000;
     itemcreate(-1, 0, cdata.player().position.x, cdata.player().position.y, 0);
     flt();
@@ -3688,14 +3688,14 @@ void _lexus_receive_reward()
         54,
         cdata.player().position.x,
         cdata.player().position.y,
-        10000 - gdata(128) + 1000);
+        10000 - gdata_rank(8) + 1000);
     flt();
     itemcreate(
         -1,
         55,
         cdata.player().position.x,
         cdata.player().position.y,
-        clamp(4 - gdata(128) / 2500, 1, 4));
+        clamp(4 - gdata_rank(8) / 2500, 1, 4));
     txt(i18n::s.get("core.locale.quest.completed"));
     snd(51);
     txt(i18n::s.get("core.locale.common.something_is_put_on_the_ground"));
@@ -3865,7 +3865,7 @@ void _abyss_start_trial()
 
 void _abyss_join_thieves_guild()
 {
-    gdata(128) = 10000;
+    gdata_rank(8) = 10000;
     game_data.guild.belongs_to_thieves_guild = 1;
     game_data.guild.belongs_to_fighters_guild = 0;
     game_data.guild.belongs_to_mages_guild = 0;
@@ -3894,14 +3894,14 @@ void _abyss_move_self()
 void _abyss_update_quota()
 {
     game_data.guild.thieves_guild_quota_recurring = 1;
-    game_data.guild.thieves_guild_quota = (10000 - gdata(128)) * 6 + 1000;
+    game_data.guild.thieves_guild_quota = (10000 - gdata_rank(8)) * 6 + 1000;
     quest_update_journal_msg();
 }
 
 void _abyss_receive_reward()
 {
     game_data.guild.thieves_guild_quota_recurring = 0;
-    flt(51 - gdata(128) / 200);
+    flt(51 - gdata_rank(8) / 200);
     flttypemajor = 60000;
     itemcreate(-1, 0, cdata.player().position.x, cdata.player().position.y, 0);
     flt();
@@ -3910,14 +3910,14 @@ void _abyss_receive_reward()
         54,
         cdata.player().position.x,
         cdata.player().position.y,
-        10000 - gdata(128) + 1000);
+        10000 - gdata_rank(8) + 1000);
     flt();
     itemcreate(
         -1,
         55,
         cdata.player().position.x,
         cdata.player().position.y,
-        clamp(3 - gdata(128) / 3000, 1, 3));
+        clamp(3 - gdata_rank(8) / 3000, 1, 3));
     txt(i18n::s.get("core.locale.quest.completed"));
     snd(51);
     txt(i18n::s.get("core.locale.common.something_is_put_on_the_ground"));
@@ -4101,7 +4101,7 @@ void _doria_start_trial()
 
 void _doria_join_fighters_guild()
 {
-    gdata(128) = 10000;
+    gdata_rank(8) = 10000;
     game_data.guild.belongs_to_thieves_guild = 0;
     game_data.guild.belongs_to_fighters_guild = 1;
     game_data.guild.belongs_to_mages_guild = 0;
@@ -4157,7 +4157,7 @@ void _doria_update_quota()
 void _doria_receive_reward()
 {
     game_data.guild.fighters_guild_quota_recurring = 0;
-    flt(51 - gdata(128) / 200, calcfixlv(Quality::good));
+    flt(51 - gdata_rank(8) / 200, calcfixlv(Quality::good));
     flttypemajor = 10000;
     itemcreate(-1, 0, cdata.player().position.x, cdata.player().position.y, 0);
     flt();
@@ -4166,14 +4166,14 @@ void _doria_receive_reward()
         54,
         cdata.player().position.x,
         cdata.player().position.y,
-        10000 - gdata(128) + 1000);
+        10000 - gdata_rank(8) + 1000);
     flt();
     itemcreate(
         -1,
         55,
         cdata.player().position.x,
         cdata.player().position.y,
-        clamp(4 - gdata(128) / 2500, 1, 4));
+        clamp(4 - gdata_rank(8) / 2500, 1, 4));
     txt(i18n::s.get("core.locale.quest.completed"));
     snd(51);
     txt(i18n::s.get("core.locale.common.something_is_put_on_the_ground"));

--- a/src/tcg.cpp
+++ b/src/tcg.cpp
@@ -1674,7 +1674,7 @@ void calcdomain()
 void calcdecksize()
 {
     int cardsize_at_tcg = 0;
-    gdata(830 + curdeck) = 0;
+    gdata_tcg_deck(curdeck) = 0;
     cardsize_at_tcg = 0;
     cpdata_at_tcg(9, 0) = 0;
     DIM2(domain_at_tcg, 5);
@@ -1685,7 +1685,7 @@ void calcdecksize()
         {
             continue;
         }
-        gdata(830 + curdeck) += deck(card_at_tcg(18, cnt));
+        gdata_tcg_deck(curdeck) += deck(card_at_tcg(18, cnt));
         domain_at_tcg(card_at_tcg(23, cnt)) = 1;
     }
     for (int cnt = 0; cnt < 5; ++cnt)
@@ -1740,12 +1740,12 @@ void tcgdeck()
             }
             else
             {
-                if (gdata(830 + cnt) != 30)
+                if (gdata_tcg_deck(cnt) != 30)
                 {
                     s_at_tcg(cnt) +=
-                        u8" (NG "s + gdata((830 + cnt)) + u8"/"s + 30 + u8")"s;
+                        u8" (NG "s + gdata_tcg_deck(cnt) + u8"/"s + 30 + u8")"s;
                 }
-                if (gdata(813) == cnt)
+                if (gdata_tcg_used_deck == cnt)
                 {
                     s_at_tcg(cnt) += u8" [Use]"s;
                 }
@@ -1778,7 +1778,7 @@ void tcgdeck()
             }
             if (rtval == 1)
             {
-                gdata(813) = curdeck;
+                gdata_tcg_used_deck = curdeck;
                 continue;
             }
             if (rtval == 0)
@@ -1788,7 +1788,7 @@ void tcgdeck()
                     filesystem::dir::tmp() / (u8"deck_"s + curdeck + u8".s2"));
             }
         }
-        decksizebk_at_tcg = gdata(830 + curdeck);
+        decksizebk_at_tcg = gdata_tcg_deck(curdeck);
         snd(95);
         calcdecksize();
         deckmode_at_tcg(0) = 0;
@@ -2323,7 +2323,7 @@ void tcg_draw_deck_editor()
         pos(basex_at_tcg + 40, basey_at_tcg + 52);
         mes(u8"Deck\n Editor"s);
         color(0, 0, 0);
-        if (gdata(830 + curdeck) != 30)
+        if (gdata_tcg_deck(curdeck) != 30)
         {
             color(255, 100, 100);
         }
@@ -2332,7 +2332,7 @@ void tcg_draw_deck_editor()
             color(100, 255, 100);
         }
         pos(basex_at_tcg + 24, basey_at_tcg + 120);
-        mes(u8"Deck "s + gdata((830 + curdeck)) + u8"/"s + 30);
+        mes(u8"Deck "s + gdata_tcg_deck(curdeck) + u8"/"s + 30);
         color(0, 0, 0);
         color(215, 215, 215);
         pos(basex_at_tcg + 24, basey_at_tcg + 140);
@@ -2657,7 +2657,7 @@ label_1830_internal:
             }
             else
             {
-                gdata(830 + curdeck) = decksizebk_at_tcg;
+                gdata_tcg_deck(curdeck) = decksizebk_at_tcg;
             }
             if (rtval == -1)
             {

--- a/src/tcg.cpp
+++ b/src/tcg.cpp
@@ -1745,7 +1745,7 @@ void tcgdeck()
                     s_at_tcg(cnt) +=
                         u8" (NG "s + gdata_tcg_deck(cnt) + u8"/"s + 30 + u8")"s;
                 }
-                if (gdata_tcg_used_deck == cnt)
+                if (game_data.tcg_used_deck == cnt)
                 {
                     s_at_tcg(cnt) += u8" [Use]"s;
                 }
@@ -1778,7 +1778,7 @@ void tcgdeck()
             }
             if (rtval == 1)
             {
-                gdata_tcg_used_deck = curdeck;
+                game_data.tcg_used_deck = curdeck;
                 continue;
             }
             if (rtval == 0)

--- a/src/tcg.cpp
+++ b/src/tcg.cpp
@@ -1674,7 +1674,7 @@ void calcdomain()
 void calcdecksize()
 {
     int cardsize_at_tcg = 0;
-    gdata_tcg_deck(curdeck) = 0;
+    game_data.tcg_decks.at(curdeck) = 0;
     cardsize_at_tcg = 0;
     cpdata_at_tcg(9, 0) = 0;
     DIM2(domain_at_tcg, 5);
@@ -1685,7 +1685,7 @@ void calcdecksize()
         {
             continue;
         }
-        gdata_tcg_deck(curdeck) += deck(card_at_tcg(18, cnt));
+        game_data.tcg_decks.at(curdeck) += deck(card_at_tcg(18, cnt));
         domain_at_tcg(card_at_tcg(23, cnt)) = 1;
     }
     for (int cnt = 0; cnt < 5; ++cnt)
@@ -1740,10 +1740,10 @@ void tcgdeck()
             }
             else
             {
-                if (gdata_tcg_deck(cnt) != 30)
+                if (game_data.tcg_decks.at(cnt) != 30)
                 {
-                    s_at_tcg(cnt) +=
-                        u8" (NG "s + gdata_tcg_deck(cnt) + u8"/"s + 30 + u8")"s;
+                    s_at_tcg(cnt) += u8" (NG "s + game_data.tcg_decks.at(cnt)
+                        + u8"/"s + 30 + u8")"s;
                 }
                 if (game_data.tcg_used_deck == cnt)
                 {
@@ -1788,7 +1788,7 @@ void tcgdeck()
                     filesystem::dir::tmp() / (u8"deck_"s + curdeck + u8".s2"));
             }
         }
-        decksizebk_at_tcg = gdata_tcg_deck(curdeck);
+        decksizebk_at_tcg = game_data.tcg_decks.at(curdeck);
         snd(95);
         calcdecksize();
         deckmode_at_tcg(0) = 0;
@@ -2323,7 +2323,7 @@ void tcg_draw_deck_editor()
         pos(basex_at_tcg + 40, basey_at_tcg + 52);
         mes(u8"Deck\n Editor"s);
         color(0, 0, 0);
-        if (gdata_tcg_deck(curdeck) != 30)
+        if (game_data.tcg_decks.at(curdeck) != 30)
         {
             color(255, 100, 100);
         }
@@ -2332,7 +2332,7 @@ void tcg_draw_deck_editor()
             color(100, 255, 100);
         }
         pos(basex_at_tcg + 24, basey_at_tcg + 120);
-        mes(u8"Deck "s + gdata_tcg_deck(curdeck) + u8"/"s + 30);
+        mes(u8"Deck "s + game_data.tcg_decks.at(curdeck) + u8"/"s + 30);
         color(0, 0, 0);
         color(215, 215, 215);
         pos(basex_at_tcg + 24, basey_at_tcg + 140);
@@ -2657,7 +2657,7 @@ label_1830_internal:
             }
             else
             {
-                gdata_tcg_deck(curdeck) = decksizebk_at_tcg;
+                game_data.tcg_decks.at(curdeck) = decksizebk_at_tcg;
             }
             if (rtval == -1)
             {

--- a/src/turn_sequence.cpp
+++ b/src/turn_sequence.cpp
@@ -776,13 +776,15 @@ TurnResult turn_begin()
         {
             game_data.left_minutes_of_executing_quest -=
                 game_data.date.second / 60;
-            if (gdata(87) > game_data.left_minutes_of_executing_quest / 10)
+            if (gdata_executing_immediate_quest_time_left_display_period
+                > game_data.left_minutes_of_executing_quest / 10)
             {
                 txtef(9);
                 txt(i18n::s.get(
                     "core.locale.quest.minutes_left",
                     (game_data.left_minutes_of_executing_quest + 1)));
-                gdata(87) = game_data.left_minutes_of_executing_quest / 10;
+                gdata_executing_immediate_quest_time_left_display_period =
+                    game_data.left_minutes_of_executing_quest / 10;
             }
             if (game_data.left_minutes_of_executing_quest <= 0)
             {
@@ -902,9 +904,9 @@ TurnResult pass_one_turn(bool label_2738_flg)
                         "core.locale.magic.return.prevented.overweight"));
                     goto label_2740_internal;
                 }
-                if (game_data.destination_map == gdata(850))
+                if (game_data.destination_map == gdata_destination_outer_map)
                 {
-                    if (game_data.current_map == gdata(850))
+                    if (game_data.current_map == gdata_destination_outer_map)
                     {
                         txt(i18n::s.get("core.locale.common.nothing_happens"));
                         goto label_2740_internal;
@@ -1175,12 +1177,12 @@ TurnResult turn_end()
     if (cc == 0)
     {
         chatturn = 10;
-        if (gdata(98) != 0)
+        if (gdata_character_and_status_for_gene != 0)
         {
-            if (gdata(98) < 10000)
+            if (gdata_character_and_status_for_gene < 10000)
             {
-                gdata(98) += 10000;
-                gdata(91) = 100;
+                gdata_character_and_status_for_gene += 10000;
+                gdata_continuous_action_about_to_start = 100;
                 continuous_action_others();
             }
         }
@@ -1253,7 +1255,7 @@ TurnResult pc_turn(bool advance_time)
                 txtgod(cdata.player().god_id, 12);
             }
         }
-        gdata(808) = 0;
+        gdata_player_is_changing_equipment = 0;
         tgloc = 0;
         if (game_data.mount != 0)
         {
@@ -1271,7 +1273,7 @@ TurnResult pc_turn(bool advance_time)
         {
             return TurnResult::pc_died;
         }
-        if (gdata(30))
+        if (gdata_player_cellaccess_check_flag)
         {
             await(Config::instance().wait1 / 3);
             for (int dy = -1; dy <= 1; ++dy)
@@ -1289,53 +1291,55 @@ TurnResult pc_turn(bool advance_time)
                         p = map(x, y, 1) - 1;
                         if (p != 0 && cdata[p].relationship <= -3)
                         {
-                            gdata(30) = 0;
+                            gdata_player_cellaccess_check_flag = 0;
                         }
                     }
                 }
             }
             x = cdata.player().position.x;
             y = cdata.player().position.y;
-            cdata.player().next_position.x = x + dirxy(0, gdata(35));
-            cdata.player().next_position.y = y + dirxy(1, gdata(35));
+            cdata.player().next_position.x =
+                x + dirxy(0, gdata_player_next_move_direction);
+            cdata.player().next_position.y =
+                y + dirxy(1, gdata_player_next_move_direction);
             if (map(x, y, 5) != 0)
             {
-                gdata(30) = 0;
+                gdata_player_cellaccess_check_flag = 0;
             }
             if (map(x, y, 6) != 0 && map(x, y, 6) != 999)
             {
-                gdata(30) = 0;
+                gdata_player_cellaccess_check_flag = 0;
             }
             cell_check(cdata[cc].position.x + 1, cdata[cc].position.y);
-            if (cellaccess != gdata(33))
+            if (cellaccess != gdata_player_cellaccess_e)
             {
                 if (cellchara >= 16 || cellchara == -1)
                 {
-                    gdata(30) = 0;
+                    gdata_player_cellaccess_check_flag = 0;
                 }
             }
             cell_check(cdata[cc].position.x - 1, cdata[cc].position.y);
-            if (cellaccess != gdata(31))
+            if (cellaccess != gdata_player_cellaccess_w)
             {
                 if (cellchara >= 16 || cellchara == -1)
                 {
-                    gdata(30) = 0;
+                    gdata_player_cellaccess_check_flag = 0;
                 }
             }
             cell_check(cdata[cc].position.x, cdata[cc].position.y + 1);
-            if (cellaccess != gdata(34))
+            if (cellaccess != gdata_player_cellaccess_s)
             {
                 if (cellchara >= 16 || cellchara == -1)
                 {
-                    gdata(30) = 0;
+                    gdata_player_cellaccess_check_flag = 0;
                 }
             }
             cell_check(cdata[cc].position.x, cdata[cc].position.y - 1);
-            if (cellaccess != gdata(32))
+            if (cellaccess != gdata_player_cellaccess_n)
             {
                 if (cellchara >= 16 || cellchara == -1)
                 {
-                    gdata(30) = 0;
+                    gdata_player_cellaccess_check_flag = 0;
                 }
             }
             cell_check(
@@ -1344,7 +1348,7 @@ TurnResult pc_turn(bool advance_time)
             {
                 if (cellchara >= 16 || cellchara == -1)
                 {
-                    gdata(30) = 0;
+                    gdata_player_cellaccess_check_flag = 0;
                 }
             }
         }
@@ -1369,7 +1373,7 @@ TurnResult pc_turn(bool advance_time)
         }
         if (game_data.current_map == mdata_t::MapId::pet_arena)
         {
-            gdata(73) = 3;
+            gdata_executing_immediate_quest_status = 3;
             bool pet_exists = false;
             for (int cc = 1; cc < 16; ++cc)
             {
@@ -1525,7 +1529,7 @@ label_2747:
         firstturn = 0;
     }
 
-    if (gdata(808))
+    if (gdata_player_is_changing_equipment)
     {
         txt(i18n::s.get("core.locale.action.equip.you_change"));
         return TurnResult::turn_end;
@@ -2229,7 +2233,7 @@ label_2747:
         p = 1;
         cdata.player().next_position.x = cdata.player().position.x;
         cdata.player().next_position.y = cdata.player().position.y - 1;
-        gdata(35) = 3;
+        gdata_player_next_move_direction = 3;
         dirsub = 0;
     }
     if (key == key_south)
@@ -2237,7 +2241,7 @@ label_2747:
         p = 1;
         cdata.player().next_position.x = cdata.player().position.x;
         cdata.player().next_position.y = cdata.player().position.y + 1;
-        gdata(35) = 0;
+        gdata_player_next_move_direction = 0;
         dirsub = 4;
     }
     if (key == key_west)
@@ -2245,7 +2249,7 @@ label_2747:
         p = 1;
         cdata.player().next_position.x = cdata.player().position.x - 1;
         cdata.player().next_position.y = cdata.player().position.y;
-        gdata(35) = 1;
+        gdata_player_next_move_direction = 1;
         dirsub = 6;
     }
     if (key == key_east)
@@ -2253,7 +2257,7 @@ label_2747:
         p = 1;
         cdata.player().next_position.x = cdata.player().position.x + 1;
         cdata.player().next_position.y = cdata.player().position.y;
-        gdata(35) = 2;
+        gdata_player_next_move_direction = 2;
         dirsub = 2;
     }
     if (key == key_northwest)
@@ -2261,7 +2265,7 @@ label_2747:
         p = 1;
         cdata.player().next_position.x = cdata.player().position.x - 1;
         cdata.player().next_position.y = cdata.player().position.y - 1;
-        gdata(35) = 3;
+        gdata_player_next_move_direction = 3;
         dirsub = 7;
     }
     if (key == key_northeast)
@@ -2269,7 +2273,7 @@ label_2747:
         p = 1;
         cdata.player().next_position.x = cdata.player().position.x + 1;
         cdata.player().next_position.y = cdata.player().position.y - 1;
-        gdata(35) = 3;
+        gdata_player_next_move_direction = 3;
         dirsub = 1;
     }
     if (key == key_southwest)
@@ -2277,7 +2281,7 @@ label_2747:
         p = 1;
         cdata.player().next_position.x = cdata.player().position.x - 1;
         cdata.player().next_position.y = cdata.player().position.y + 1;
-        gdata(35) = 0;
+        gdata_player_next_move_direction = 0;
         dirsub = 5;
     }
     if (key == key_southeast)
@@ -2285,10 +2289,10 @@ label_2747:
         p = 1;
         cdata.player().next_position.x = cdata.player().position.x + 1;
         cdata.player().next_position.y = cdata.player().position.y + 1;
-        gdata(35) = 0;
+        gdata_player_next_move_direction = 0;
         dirsub = 3;
     }
-    cdata.player().direction = gdata(35);
+    cdata.player().direction = gdata_player_next_move_direction;
     if (p == 1)
     {
         // Autodig

--- a/src/turn_sequence.cpp
+++ b/src/turn_sequence.cpp
@@ -776,14 +776,14 @@ TurnResult turn_begin()
         {
             game_data.left_minutes_of_executing_quest -=
                 game_data.date.second / 60;
-            if (gdata_executing_immediate_quest_time_left_display_period
+            if (game_data.executing_immediate_quest_time_left_display_period
                 > game_data.left_minutes_of_executing_quest / 10)
             {
                 txtef(9);
                 txt(i18n::s.get(
                     "core.locale.quest.minutes_left",
                     (game_data.left_minutes_of_executing_quest + 1)));
-                gdata_executing_immediate_quest_time_left_display_period =
+                game_data.executing_immediate_quest_time_left_display_period =
                     game_data.left_minutes_of_executing_quest / 10;
             }
             if (game_data.left_minutes_of_executing_quest <= 0)
@@ -904,9 +904,11 @@ TurnResult pass_one_turn(bool label_2738_flg)
                         "core.locale.magic.return.prevented.overweight"));
                     goto label_2740_internal;
                 }
-                if (game_data.destination_map == gdata_destination_outer_map)
+                if (game_data.destination_map
+                    == game_data.destination_outer_map)
                 {
-                    if (game_data.current_map == gdata_destination_outer_map)
+                    if (game_data.current_map
+                        == game_data.destination_outer_map)
                     {
                         txt(i18n::s.get("core.locale.common.nothing_happens"));
                         goto label_2740_internal;
@@ -1177,12 +1179,12 @@ TurnResult turn_end()
     if (cc == 0)
     {
         chatturn = 10;
-        if (gdata_character_and_status_for_gene != 0)
+        if (game_data.character_and_status_for_gene != 0)
         {
-            if (gdata_character_and_status_for_gene < 10000)
+            if (game_data.character_and_status_for_gene < 10000)
             {
-                gdata_character_and_status_for_gene += 10000;
-                gdata_continuous_action_about_to_start = 100;
+                game_data.character_and_status_for_gene += 10000;
+                game_data.continuous_action_about_to_start = 100;
                 continuous_action_others();
             }
         }
@@ -1255,7 +1257,7 @@ TurnResult pc_turn(bool advance_time)
                 txtgod(cdata.player().god_id, 12);
             }
         }
-        gdata_player_is_changing_equipment = 0;
+        game_data.player_is_changing_equipment = 0;
         tgloc = 0;
         if (game_data.mount != 0)
         {
@@ -1273,7 +1275,7 @@ TurnResult pc_turn(bool advance_time)
         {
             return TurnResult::pc_died;
         }
-        if (gdata_player_cellaccess_check_flag)
+        if (game_data.player_cellaccess_check_flag)
         {
             await(Config::instance().wait1 / 3);
             for (int dy = -1; dy <= 1; ++dy)
@@ -1291,7 +1293,7 @@ TurnResult pc_turn(bool advance_time)
                         p = map(x, y, 1) - 1;
                         if (p != 0 && cdata[p].relationship <= -3)
                         {
-                            gdata_player_cellaccess_check_flag = 0;
+                            game_data.player_cellaccess_check_flag = 0;
                         }
                     }
                 }
@@ -1299,47 +1301,47 @@ TurnResult pc_turn(bool advance_time)
             x = cdata.player().position.x;
             y = cdata.player().position.y;
             cdata.player().next_position.x =
-                x + dirxy(0, gdata_player_next_move_direction);
+                x + dirxy(0, game_data.player_next_move_direction);
             cdata.player().next_position.y =
-                y + dirxy(1, gdata_player_next_move_direction);
+                y + dirxy(1, game_data.player_next_move_direction);
             if (map(x, y, 5) != 0)
             {
-                gdata_player_cellaccess_check_flag = 0;
+                game_data.player_cellaccess_check_flag = 0;
             }
             if (map(x, y, 6) != 0 && map(x, y, 6) != 999)
             {
-                gdata_player_cellaccess_check_flag = 0;
+                game_data.player_cellaccess_check_flag = 0;
             }
             cell_check(cdata[cc].position.x + 1, cdata[cc].position.y);
-            if (cellaccess != gdata_player_cellaccess_e)
+            if (cellaccess != game_data.player_cellaccess_e)
             {
                 if (cellchara >= 16 || cellchara == -1)
                 {
-                    gdata_player_cellaccess_check_flag = 0;
+                    game_data.player_cellaccess_check_flag = 0;
                 }
             }
             cell_check(cdata[cc].position.x - 1, cdata[cc].position.y);
-            if (cellaccess != gdata_player_cellaccess_w)
+            if (cellaccess != game_data.player_cellaccess_w)
             {
                 if (cellchara >= 16 || cellchara == -1)
                 {
-                    gdata_player_cellaccess_check_flag = 0;
+                    game_data.player_cellaccess_check_flag = 0;
                 }
             }
             cell_check(cdata[cc].position.x, cdata[cc].position.y + 1);
-            if (cellaccess != gdata_player_cellaccess_s)
+            if (cellaccess != game_data.player_cellaccess_s)
             {
                 if (cellchara >= 16 || cellchara == -1)
                 {
-                    gdata_player_cellaccess_check_flag = 0;
+                    game_data.player_cellaccess_check_flag = 0;
                 }
             }
             cell_check(cdata[cc].position.x, cdata[cc].position.y - 1);
-            if (cellaccess != gdata_player_cellaccess_n)
+            if (cellaccess != game_data.player_cellaccess_n)
             {
                 if (cellchara >= 16 || cellchara == -1)
                 {
-                    gdata_player_cellaccess_check_flag = 0;
+                    game_data.player_cellaccess_check_flag = 0;
                 }
             }
             cell_check(
@@ -1348,7 +1350,7 @@ TurnResult pc_turn(bool advance_time)
             {
                 if (cellchara >= 16 || cellchara == -1)
                 {
-                    gdata_player_cellaccess_check_flag = 0;
+                    game_data.player_cellaccess_check_flag = 0;
                 }
             }
         }
@@ -1373,7 +1375,7 @@ TurnResult pc_turn(bool advance_time)
         }
         if (game_data.current_map == mdata_t::MapId::pet_arena)
         {
-            gdata_executing_immediate_quest_status = 3;
+            game_data.executing_immediate_quest_status = 3;
             bool pet_exists = false;
             for (int cc = 1; cc < 16; ++cc)
             {
@@ -1529,7 +1531,7 @@ label_2747:
         firstturn = 0;
     }
 
-    if (gdata_player_is_changing_equipment)
+    if (game_data.player_is_changing_equipment)
     {
         txt(i18n::s.get("core.locale.action.equip.you_change"));
         return TurnResult::turn_end;
@@ -2233,7 +2235,7 @@ label_2747:
         p = 1;
         cdata.player().next_position.x = cdata.player().position.x;
         cdata.player().next_position.y = cdata.player().position.y - 1;
-        gdata_player_next_move_direction = 3;
+        game_data.player_next_move_direction = 3;
         dirsub = 0;
     }
     if (key == key_south)
@@ -2241,7 +2243,7 @@ label_2747:
         p = 1;
         cdata.player().next_position.x = cdata.player().position.x;
         cdata.player().next_position.y = cdata.player().position.y + 1;
-        gdata_player_next_move_direction = 0;
+        game_data.player_next_move_direction = 0;
         dirsub = 4;
     }
     if (key == key_west)
@@ -2249,7 +2251,7 @@ label_2747:
         p = 1;
         cdata.player().next_position.x = cdata.player().position.x - 1;
         cdata.player().next_position.y = cdata.player().position.y;
-        gdata_player_next_move_direction = 1;
+        game_data.player_next_move_direction = 1;
         dirsub = 6;
     }
     if (key == key_east)
@@ -2257,7 +2259,7 @@ label_2747:
         p = 1;
         cdata.player().next_position.x = cdata.player().position.x + 1;
         cdata.player().next_position.y = cdata.player().position.y;
-        gdata_player_next_move_direction = 2;
+        game_data.player_next_move_direction = 2;
         dirsub = 2;
     }
     if (key == key_northwest)
@@ -2265,7 +2267,7 @@ label_2747:
         p = 1;
         cdata.player().next_position.x = cdata.player().position.x - 1;
         cdata.player().next_position.y = cdata.player().position.y - 1;
-        gdata_player_next_move_direction = 3;
+        game_data.player_next_move_direction = 3;
         dirsub = 7;
     }
     if (key == key_northeast)
@@ -2273,7 +2275,7 @@ label_2747:
         p = 1;
         cdata.player().next_position.x = cdata.player().position.x + 1;
         cdata.player().next_position.y = cdata.player().position.y - 1;
-        gdata_player_next_move_direction = 3;
+        game_data.player_next_move_direction = 3;
         dirsub = 1;
     }
     if (key == key_southwest)
@@ -2281,7 +2283,7 @@ label_2747:
         p = 1;
         cdata.player().next_position.x = cdata.player().position.x - 1;
         cdata.player().next_position.y = cdata.player().position.y + 1;
-        gdata_player_next_move_direction = 0;
+        game_data.player_next_move_direction = 0;
         dirsub = 5;
     }
     if (key == key_southeast)
@@ -2289,10 +2291,10 @@ label_2747:
         p = 1;
         cdata.player().next_position.x = cdata.player().position.x + 1;
         cdata.player().next_position.y = cdata.player().position.y + 1;
-        gdata_player_next_move_direction = 0;
+        game_data.player_next_move_direction = 0;
         dirsub = 3;
     }
-    cdata.player().direction = gdata_player_next_move_direction;
+    cdata.player().direction = game_data.player_next_move_direction;
     if (p == 1)
     {
         // Autodig

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -574,15 +574,15 @@ void render_skill_trackers()
     int y{};
     for (int i = 0; i < 10; ++i)
     {
-        const auto skill = gdata(750 + i) % 10000;
+        const auto skill = gdata_tracked_skill(i) % 10000;
         if (skill == 0)
         {
             continue;
         }
-        const auto chara = gdata(750 + i) / 10000;
+        const auto chara = gdata_tracked_skill(i) / 10000;
         if (chara != 0 && cdata[chara].state() != Character::State::alive)
         {
-            gdata(750 + i) = 0;
+            gdata_tracked_skill(i) = 0;
             continue;
         }
         bmes(

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -574,15 +574,15 @@ void render_skill_trackers()
     int y{};
     for (int i = 0; i < 10; ++i)
     {
-        const auto skill = gdata_tracked_skill(i) % 10000;
+        const auto skill = game_data.tracked_skills.at(i) % 10000;
         if (skill == 0)
         {
             continue;
         }
-        const auto chara = gdata_tracked_skill(i) / 10000;
+        const auto chara = game_data.tracked_skills.at(i) / 10000;
         if (chara != 0 && cdata[chara].state() != Character::State::alive)
         {
-            gdata_tracked_skill(i) = 0;
+            game_data.tracked_skills.at(i) = 0;
             continue;
         }
         bmes(

--- a/src/ui/ui_menu_character_sheet.cpp
+++ b/src/ui/ui_menu_character_sheet.cpp
@@ -15,7 +15,8 @@ namespace ui
 {
 
 /*
-        gdata_tracked_skill(0 - 10) => tracked skills (ctrl +f for [TRACKING])
+        game_data.tracked_skills(0 - 10) => tracked skills
+        (ctrl +f for [TRACKING])
 */
 
 static void _trainer_get_gainable_skills()
@@ -1118,7 +1119,7 @@ static void _draw_skill_name(int cnt, int skill_id)
          cnt < (elona::Config::instance().allow_enhanced_skill ? 10 : 3);
          ++cnt)
     {
-        if (gdata_tracked_skill(cnt) == cc * 10000 + skill_id)
+        if (game_data.tracked_skills.at(cnt) == cc * 10000 + skill_id)
         {
             skill_name = u8"*"s + skill_name;
         }
@@ -1286,18 +1287,18 @@ static void _track_skill(int skill_id)
 
     for (int cnt = 0; cnt < max_tracked_skills; ++cnt)
     {
-        if (gdata_tracked_skill(cnt) % 10000 == 0)
+        if (game_data.tracked_skills.at(cnt) % 10000 == 0)
         {
             tracked_skill_index = cnt;
         }
-        if (gdata_tracked_skill(cnt) == cc * 10000 + skill_id)
+        if (game_data.tracked_skills.at(cnt) == cc * 10000 + skill_id)
         {
             tracked_skill_index = cnt;
             skill_id = 0;
             break;
         }
     }
-    gdata_tracked_skill(tracked_skill_index) = cc * 10000 + skill_id;
+    game_data.tracked_skills.at(tracked_skill_index) = cc * 10000 + skill_id;
     snd(20);
 }
 

--- a/src/ui/ui_menu_character_sheet.cpp
+++ b/src/ui/ui_menu_character_sheet.cpp
@@ -15,7 +15,7 @@ namespace ui
 {
 
 /*
-        gdata(750 - 760) => tracked skills (ctrl +f for [TRACKING])
+        gdata_tracked_skill(0 - 10) => tracked skills (ctrl +f for [TRACKING])
 */
 
 static void _trainer_get_gainable_skills()
@@ -1280,7 +1280,7 @@ void UIMenuCharacterSheet::draw()
 
 static void _track_skill(int skill_id)
 {
-    int gdata_index = 750;
+    int tracked_skill_index = 0;
     int max_tracked_skills =
         elona::Config::instance().allow_enhanced_skill ? 10 : 3;
 
@@ -1288,16 +1288,16 @@ static void _track_skill(int skill_id)
     {
         if (gdata_tracked_skill(cnt) % 10000 == 0)
         {
-            gdata_index = cnt;
+            tracked_skill_index = cnt;
         }
         if (gdata_tracked_skill(cnt) == cc * 10000 + skill_id)
         {
-            gdata_index = cnt;
+            tracked_skill_index = cnt;
             skill_id = 0;
             break;
         }
     }
-    gdata_tracked_skill(gdata_index) = cc * 10000 + skill_id;
+    gdata_tracked_skill(tracked_skill_index) = cc * 10000 + skill_id;
     snd(20);
 }
 

--- a/src/ui/ui_menu_character_sheet.cpp
+++ b/src/ui/ui_menu_character_sheet.cpp
@@ -1118,7 +1118,7 @@ static void _draw_skill_name(int cnt, int skill_id)
          cnt < (elona::Config::instance().allow_enhanced_skill ? 10 : 3);
          ++cnt)
     {
-        if (gdata(750 + cnt) == cc * 10000 + skill_id)
+        if (gdata_tracked_skill(cnt) == cc * 10000 + skill_id)
         {
             skill_name = u8"*"s + skill_name;
         }
@@ -1284,20 +1284,20 @@ static void _track_skill(int skill_id)
     int max_tracked_skills =
         elona::Config::instance().allow_enhanced_skill ? 10 : 3;
 
-    for (int cnt = 750; cnt < 750 + max_tracked_skills; ++cnt)
+    for (int cnt = 0; cnt < max_tracked_skills; ++cnt)
     {
-        if (gdata(cnt) % 10000 == 0)
+        if (gdata_tracked_skill(cnt) % 10000 == 0)
         {
             gdata_index = cnt;
         }
-        if (gdata(cnt) == cc * 10000 + skill_id)
+        if (gdata_tracked_skill(cnt) == cc * 10000 + skill_id)
         {
             gdata_index = cnt;
             skill_id = 0;
             break;
         }
     }
-    gdata(gdata_index) = cc * 10000 + skill_id;
+    gdata_tracked_skill(gdata_index) = cc * 10000 + skill_id;
     snd(20);
 }
 

--- a/src/ui/ui_menu_charamake_gender.cpp
+++ b/src/ui/ui_menu_charamake_gender.cpp
@@ -50,7 +50,7 @@ static void _draw_choice(int cnt, const std::string& text)
 {
     pos(wx + 38, wy + 66 + cnt * 19 - 2);
     gcopy(3, cnt * 24 + 72, 30, 24, 18);
-    cs_list(cs == cnt, listn(0, cnt), wx + 64, wy + 66 + cnt * 19 - 1);
+    cs_list(cs == cnt, text, wx + 64, wy + 66 + cnt * 19 - 1);
 }
 
 static void _draw_choices()

--- a/src/ui/ui_menu_equipment.cpp
+++ b/src/ui/ui_menu_equipment.cpp
@@ -280,7 +280,7 @@ void UIMenuEquipment::draw()
 
 static void _unequip_item()
 {
-    gdata_player_is_changing_equipment = 1;
+    game_data.player_is_changing_equipment = 1;
     ci = cdata[cc].body_parts[body - 100] % 10000 - 1;
     if (is_cursed(inv[ci].curse_state))
     {

--- a/src/ui/ui_menu_equipment.cpp
+++ b/src/ui/ui_menu_equipment.cpp
@@ -280,7 +280,7 @@ void UIMenuEquipment::draw()
 
 static void _unequip_item()
 {
-    gdata(808) = 1;
+    gdata_player_is_changing_equipment = 1;
     ci = cdata[cc].body_parts[body - 100] % 10000 - 1;
     if (is_cursed(inv[ci].curse_state))
     {

--- a/src/ui/ui_menu_journal.cpp
+++ b/src/ui/ui_menu_journal.cpp
@@ -89,16 +89,16 @@ bool UIMenuJournal::init()
     noteadd(""s);
     for (int cnt = 0; cnt < 9; ++cnt)
     {
-        if (gdata(120 + cnt) < 10000)
+        if (gdata_rank(cnt) < 10000)
         {
-            noteadd(
-                ""s + ranktitle(cnt) + u8" Rank."s + gdata((120 + cnt)) / 100);
+            noteadd(""s + ranktitle(cnt) + u8" Rank."s + gdata_rank(cnt) / 100);
             s = i18n::s.get("core.locale.ui.journal.rank.pay", calcincome(cnt));
             gold += calcincome(cnt);
             if (cnt != 3 && cnt != 4 && cnt != 5 && cnt != 8)
             {
                 s += i18n::s.get(
-                    "core.locale.ui.journal.rank.deadline", gdata(140 + cnt));
+                    "core.locale.ui.journal.rank.deadline",
+                    gdata_rank_deadline(cnt));
             }
             noteadd(s);
             noteadd(""s);
@@ -106,7 +106,7 @@ bool UIMenuJournal::init()
     }
     noteadd(i18n::s.get(
         "core.locale.ui.journal.rank.arena",
-        gdata(802),
+        gdata_ex_arena_wins,
         cnvrank(game_data.ex_arena_level)));
     noteadd(""s);
     for (int cnt = 0,

--- a/src/ui/ui_menu_journal.cpp
+++ b/src/ui/ui_menu_journal.cpp
@@ -106,7 +106,7 @@ bool UIMenuJournal::init()
     }
     noteadd(i18n::s.get(
         "core.locale.ui.journal.rank.arena",
-        gdata_ex_arena_wins,
+        game_data.ex_arena_wins,
         cnvrank(game_data.ex_arena_level)));
     noteadd(""s);
     for (int cnt = 0,

--- a/src/ui/ui_menu_journal.cpp
+++ b/src/ui/ui_menu_journal.cpp
@@ -89,16 +89,18 @@ bool UIMenuJournal::init()
     noteadd(""s);
     for (int cnt = 0; cnt < 9; ++cnt)
     {
-        if (gdata_rank(cnt) < 10000)
+        if (game_data.ranks.at(cnt) < 10000)
         {
-            noteadd(""s + ranktitle(cnt) + u8" Rank."s + gdata_rank(cnt) / 100);
+            noteadd(
+                ""s + ranktitle(cnt) + u8" Rank."s
+                + game_data.ranks.at(cnt) / 100);
             s = i18n::s.get("core.locale.ui.journal.rank.pay", calcincome(cnt));
             gold += calcincome(cnt);
             if (cnt != 3 && cnt != 4 && cnt != 5 && cnt != 8)
             {
                 s += i18n::s.get(
                     "core.locale.ui.journal.rank.deadline",
-                    gdata_rank_deadline(cnt));
+                    game_data.rank_deadlines.at(cnt));
             }
             noteadd(s);
             noteadd(""s);

--- a/src/ui/ui_menu_skills.cpp
+++ b/src/ui/ui_menu_skills.cpp
@@ -132,7 +132,7 @@ static void _draw_skill_name(int cnt, int skill_id)
     std::string skill_shortcut = "";
     for (int cnt = 0; cnt < 20; ++cnt)
     {
-        if (gdata(40 + cnt) == skill_id)
+        if (gdata_skill_shortcut(cnt) == skill_id)
         {
             skill_shortcut = u8"{"s + cnt + u8"}"s;
         }
@@ -197,19 +197,19 @@ void UIMenuSkills::draw()
 static void _assign_shortcut(int sc_, int skill_id)
 {
     snd(20);
-    if (gdata(40 + sc_) == skill_id)
+    if (gdata_skill_shortcut(sc_) == skill_id)
     {
-        gdata(40 + sc_) = 0;
+        gdata_skill_shortcut(sc_) = 0;
         return;
     }
     for (int cnt = 0; cnt < 20; ++cnt)
     {
-        if (gdata(40 + cnt) == skill_id)
+        if (gdata_skill_shortcut(cnt) == skill_id)
         {
-            gdata(40 + cnt) = 0;
+            gdata_skill_shortcut(cnt) = 0;
         }
     }
-    gdata(40 + sc_) = skill_id;
+    gdata_skill_shortcut(sc_) = skill_id;
     txt(i18n::s.get("core.locale.ui.assign_shortcut", sc_));
     display_msg(inf_screeny + inf_tiles);
 }

--- a/src/ui/ui_menu_skills.cpp
+++ b/src/ui/ui_menu_skills.cpp
@@ -132,7 +132,7 @@ static void _draw_skill_name(int cnt, int skill_id)
     std::string skill_shortcut = "";
     for (int cnt = 0; cnt < 20; ++cnt)
     {
-        if (gdata_skill_shortcut(cnt) == skill_id)
+        if (game_data.skill_shortcuts.at(cnt) == skill_id)
         {
             skill_shortcut = u8"{"s + cnt + u8"}"s;
         }
@@ -197,19 +197,19 @@ void UIMenuSkills::draw()
 static void _assign_shortcut(int sc_, int skill_id)
 {
     snd(20);
-    if (gdata_skill_shortcut(sc_) == skill_id)
+    if (game_data.skill_shortcuts.at(sc_) == skill_id)
     {
-        gdata_skill_shortcut(sc_) = 0;
+        game_data.skill_shortcuts.at(sc_) = 0;
         return;
     }
     for (int cnt = 0; cnt < 20; ++cnt)
     {
-        if (gdata_skill_shortcut(cnt) == skill_id)
+        if (game_data.skill_shortcuts.at(cnt) == skill_id)
         {
-            gdata_skill_shortcut(cnt) = 0;
+            game_data.skill_shortcuts.at(cnt) = 0;
         }
     }
-    gdata_skill_shortcut(sc_) = skill_id;
+    game_data.skill_shortcuts.at(sc_) = skill_id;
     txt(i18n::s.get("core.locale.ui.assign_shortcut", sc_));
     display_msg(inf_screeny + inf_tiles);
 }

--- a/src/ui/ui_menu_spells.cpp
+++ b/src/ui/ui_menu_spells.cpp
@@ -127,7 +127,7 @@ static void _draw_spell_name(int cnt, int spell_id)
     std::string spell_shortcut = "";
     for (int cnt = 0; cnt < 20; ++cnt)
     {
-        if (gdata(40 + cnt) == spell_id)
+        if (gdata_skill_shortcut(cnt) == spell_id)
         {
             spell_shortcut = u8"{"s + cnt + u8"}"s;
         }
@@ -197,19 +197,19 @@ void UIMenuSpells::draw()
 static void _assign_shortcut(int sc_, int spell_id)
 {
     snd(20);
-    if (gdata(40 + sc_) == spell_id)
+    if (gdata_skill_shortcut(sc_) == spell_id)
     {
-        gdata(40 + sc_) = 0;
+        gdata_skill_shortcut(sc_) = 0;
         return;
     }
     for (int cnt = 0; cnt < 20; ++cnt)
     {
-        if (gdata(40 + cnt) == spell_id)
+        if (gdata_skill_shortcut(cnt) == spell_id)
         {
-            gdata(40 + cnt) = 0;
+            gdata_skill_shortcut(cnt) = 0;
         }
     }
-    gdata(40 + sc_) = spell_id;
+    gdata_skill_shortcut(sc_) = spell_id;
     txt(i18n::s.get("core.locale.ui.assign_shortcut", sc_));
     display_msg(inf_screeny + inf_tiles);
 }

--- a/src/ui/ui_menu_spells.cpp
+++ b/src/ui/ui_menu_spells.cpp
@@ -127,7 +127,7 @@ static void _draw_spell_name(int cnt, int spell_id)
     std::string spell_shortcut = "";
     for (int cnt = 0; cnt < 20; ++cnt)
     {
-        if (gdata_skill_shortcut(cnt) == spell_id)
+        if (game_data.skill_shortcuts.at(cnt) == spell_id)
         {
             spell_shortcut = u8"{"s + cnt + u8"}"s;
         }
@@ -197,19 +197,19 @@ void UIMenuSpells::draw()
 static void _assign_shortcut(int sc_, int spell_id)
 {
     snd(20);
-    if (gdata_skill_shortcut(sc_) == spell_id)
+    if (game_data.skill_shortcuts.at(sc_) == spell_id)
     {
-        gdata_skill_shortcut(sc_) = 0;
+        game_data.skill_shortcuts.at(sc_) = 0;
         return;
     }
     for (int cnt = 0; cnt < 20; ++cnt)
     {
-        if (gdata_skill_shortcut(cnt) == spell_id)
+        if (game_data.skill_shortcuts.at(cnt) == spell_id)
         {
-            gdata_skill_shortcut(cnt) = 0;
+            game_data.skill_shortcuts.at(cnt) = 0;
         }
     }
-    gdata_skill_shortcut(sc_) = spell_id;
+    game_data.skill_shortcuts.at(sc_) = spell_id;
     txt(i18n::s.get("core.locale.ui.assign_shortcut", sc_));
     display_msg(inf_screeny + inf_tiles);
 }

--- a/src/ui/ui_menu_town_economy.cpp
+++ b/src/ui/ui_menu_town_economy.cpp
@@ -107,8 +107,8 @@ static void _draw_economy_info(int _city)
     _show_economy_info(
         x,
         y,
-        i18n::s.get("core.locale.ui.economy.basic_tax") + u8" ("s + gdata(820)
-            + u8"%)"s,
+        i18n::s.get("core.locale.ui.economy.basic_tax") + u8" ("s
+            + gdata_politics_tax_amount + u8"%)"s,
         podata(102, _city),
         podata(103, _city));
     _show_economy_info(

--- a/src/ui/ui_menu_town_economy.cpp
+++ b/src/ui/ui_menu_town_economy.cpp
@@ -108,7 +108,7 @@ static void _draw_economy_info(int _city)
         x,
         y,
         i18n::s.get("core.locale.ui.economy.basic_tax") + u8" ("s
-            + gdata_politics_tax_amount + u8"%)"s,
+            + game_data.politics_tax_amount + u8"%)"s,
         podata(102, _city),
         podata(103, _city));
     _show_economy_info(

--- a/src/ui/ui_menu_town_politics.cpp
+++ b/src/ui/ui_menu_town_politics.cpp
@@ -20,8 +20,8 @@ static void _load_politics_list(bool is_town)
     cs_bk = -1;
     curmenu = 2;
     list(0, listmax) = 1;
-    listn(0, listmax) =
-        i18n::s.get("core.locale.ui.politics.name", mapname(gdata(815)));
+    listn(0, listmax) = i18n::s.get(
+        "core.locale.ui.politics.name", mapname(gdata_politics_map_id));
     ++listmax;
 
     if (is_town)

--- a/src/ui/ui_menu_town_politics.cpp
+++ b/src/ui/ui_menu_town_politics.cpp
@@ -21,7 +21,7 @@ static void _load_politics_list(bool is_town)
     curmenu = 2;
     list(0, listmax) = 1;
     listn(0, listmax) = i18n::s.get(
-        "core.locale.ui.politics.name", mapname(gdata_politics_map_id));
+        "core.locale.ui.politics.name", mapname(game_data.politics_map_id));
     ++listmax;
 
     if (is_town)


### PR DESCRIPTION
# Related Issues

Close #851.


# Summary
- Names and moves the remaining raw accesses to `gdata` into `GameData`, and uses `std::array` for array-like `gdata` fields.
- Removes unused `gdata` fields that were accessed in the code.
- Adds `maybe_show_ex_help()`.

At this point there are no raw accesses to `gdata` anywhere in the code.