### PR TITLE
Do not show message "something falls down" if the item is on the ground

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -585,7 +585,10 @@ int item_separate(int ci)
         inv[ti].position = inv[ci].position;
         itemturn(ti);
         cell_refresh(inv[ti].position.x, inv[ti].position.y);
-        txt(i18n::s.get("core.locale.item.something_falls_from_backpack"));
+        if (inv_getowner(ci) != -1)
+        {
+            txt(i18n::s.get("core.locale.item.something_falls_from_backpack"));
+        }
         refresh_burden_state();
     }
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #912.


# Summary

Check if the items is on the ground or in your inventory.