### PR TITLE
Fix impression modify I18N error

### DIFF
--- a/src/dmgheal.cpp
+++ b/src/dmgheal.cpp
@@ -924,8 +924,8 @@ int damage_hp(
         {
             if (victim.index < 16)
             {
-                chara_modify_impression(victim, -10);
                 victim.set_state(Character::State::pet_dead);
+                chara_modify_impression(victim, -10);
                 victim.current_map = 0;
                 if (victim.is_escorted() == 1)
                 {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

#937.


# Summary
The text was being displayed when the character's state was already `empty`. When the state is set to `empty`, the corresponding Lua reference is removed, but this causes localized text using Lua references in functions to fail since a blank reference was passed. It is done this way since characters with `empty` state can be overwritten by another character at some other time, but there are likely many instances in the code where a character with `empty` state is still passed around when it is known to be referencing the same character as before.

As a workaround, make sure the state is `pet_dead` first, which creates another Lua reference first.