### PR TITLE
Fix trainer_skills_vernis

### DIFF
--- a/src/map_trainer_skills.cpp
+++ b/src/map_trainer_skills.cpp
@@ -216,7 +216,7 @@ void map_get_trainer_skills()
     }
     if (game_data.current_map == mdata_t::MapId::vernis)
     {
-        _trainer_skills_yowyn(dbmax);
+        _trainer_skills_vernis(dbmax);
     }
     if (game_data.current_map == mdata_t::MapId::palmia)
     {


### PR DESCRIPTION
# Summary
It was accidentally set to call `trainer_skills_yowyn()`.
