### PR TITLE
Fix scene fade out

### DIFF
--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -13991,7 +13991,7 @@ label_2682_internal:
     if (s == u8"{fade}"s)
     {
         gsel(4);
-        boxf();
+        boxf(0, 0, windoww, windowh, {0, 0, 0, 255});
         gsel(0);
         animation_fade_in();
         goto label_2682_internal;
@@ -14151,7 +14151,7 @@ label_2684_internal:
 void scene_fade_to_black()
 {
     gsel(4);
-    boxf();
+    boxf(0, 0, windoww, windowh, {0, 0, 0, 255});
     gsel(0);
     animation_fade_in();
     scenemode = 0;


### PR DESCRIPTION
Scenes will currently not fade to black because the default color of `boxf` is transparent instead of opaque.