### PR TITLE
Fix switch_mode_2 action in inventory being duplicated

### DIFF
--- a/src/ctrl_inventory.cpp
+++ b/src/ctrl_inventory.cpp
@@ -2021,7 +2021,7 @@ label_2061_internal:
             goto label_20591;
         }
     }
-    if (action == "switch_mode_2")
+    if (action == "identify")
     {
         if (listmax != 0)
         {


### PR DESCRIPTION
# Summary
`switch_mode_2` mistakenly triggered the behavior of `identify` in the inventory as it is checked for in two places.