### PR TITLE
Speed up incremental build time on Linux/macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,44 +456,86 @@ else()
   # Compiler options
   target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 
+  set(GENERAL_OPTIONS)
+  set(DEBUG_OPTIONS)
+  set(RELEASE_OPTIONS)
+  set(EXTRA_DEFINES)
+  set(DISABLED_WARNINGS)
+
   if(MSVC)
-    add_definitions("-D_UNICODE")
-    set(CMAKE_CXX_FLAGS "/W4 /source-charset:utf-8 /MT /EHsc")
-  else()
+    list(APPEND EXTRA_DEFINES "_UNICODE")
+    list(APPEND GENERAL_OPTIONS
+      "W4"
+      "source-charset:utf-8"
+      "MT"
+      "EHsc")
+    list(APPEND DEBUG_OPTIONS
+      "MP8"
+      "MTd"
+      "ZI"
+      "Od")
+    list(APPEND RELEASE_OPTIONS
+      "MT")
+    list(APPEND DISABLED_WARNINGS
+      "4459"
+      "4456")
+    list(APPEND EXTRA_DEFINES
+      "BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE")
+
+
+    foreach(opt ${DISABLED_WARNINGS})
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd${opt}")
+    endforeach()
+
+    foreach(opt ${GENERAL_OPTIONS})
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /${opt}")
+    endforeach()
+
+    foreach(opt ${DEBUG_OPTIONS})
+      set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /${opt}")
+    endforeach()
+
+    foreach(opt ${RELEASE_OPTIONS})
+      foreach(flag_var CMAKE_CXX_FLAGS_RELEASE CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+        set(${flag_var} "${${flag_var}} /${opt}")
+      endforeach()
+    endforeach()
+  else() # GCC or Clang
+    list(APPEND GENERAL_OPTIONS
+      "Wall"
+      "Wextra")
+    list(APPEND DEBUG_OPTIONS
+      "g"
+      "O0")
+    list(APPEND EXTRA_DEFINES
+      "DEBUG")
     if(WITH_TESTS STREQUAL "BENCH")
-      set(CMAKE_CXX_FLAGS "-Wall -Wextra -g3")
-    else()
-      set(CMAKE_CXX_FLAGS "-Wall -Wextra")
+      list(APPEND GENERAL_OPTIONS "g")
     endif()
+    list(APPEND DISABLED_WARNINGS
+      "deprecated-declarations")
+
+
+    foreach(opt ${DISABLED_WARNINGS})
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-${opt}")
+    endforeach()
+
+    foreach(opt ${GENERAL_OPTIONS})
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -${opt}")
+    endforeach()
+
+    foreach(opt ${DEBUG_OPTIONS})
+      set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -${opt}")
+    endforeach()
+
+    foreach(opt ${RELEASE_OPTIONS})
+      set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -${opt}")
+    endforeach()
   endif()
 
-  # Compiler options(debug build)
-  if(MSVC)
-    set(CMAKE_CXX_FLAGS_DEBUG "/MP8 /MTd /ZI /Od")
-  else()
-    set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -DDEBUG")
-  endif()
-
-  if(MSVC)
-    set(CMAKE_CXX_FLAGS_RELEASE "/MT")
-  endif()
-
-  if(WITH_TESTS STREQUAL "BENCH")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
-  endif()
-
-  # Warning suppressions
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    # Force GCC to output warnings about undefined symbols
-    string(APPEND CMAKE_CXX_FLAGS " -Wl,--no-undefined")
-    # Disable deprecated declarations, because it causes warnings with boost_locale's use of auto_ptr
-    string(APPEND CMAKE_CXX_FLAGS " -Wno-deprecated-declarations")
-  elseif(MSVC)
-    # Disable warnings about hiding of global/local declarations
-    string(APPEND CMAKE_CXX_FLAGS " /wd4459 /wd4456")
-    # Disable warnings about Boost versions.
-    add_definitions(-DBOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE)
-  endif()
+  foreach(opt ${EXTRA_DEFINES})
+    add_definition("-D${opt}")
+  endforeach()
 
   # My libraries
   add_subdirectory(src/snail)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,13 @@ option(ANDROID_BUNDLE_ASSETS "Bundle assets with Android distribution" OFF)
 option(ANDROID_GENERATE_PROPERTIES "Generate android/app/gradle.properties" OFF)
 
 
+# Platform detection
+set(LINUX FALSE)
+if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+  set(LINUX TRUE)
+endif()
+
+
 # Versioning
 
 # Get commit hash from Git
@@ -477,8 +484,9 @@ else()
     list(APPEND RELEASE_OPTIONS
       "MT")
     list(APPEND DISABLED_WARNINGS
-      "4459"
-      "4456")
+      "4459" # declaration of 'identifier' hides global declaration
+      "4456" # declaration of 'identifier' hides previous local declaration
+      )
     list(APPEND EXTRA_DEFINES
       "BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE")
 
@@ -510,11 +518,43 @@ else()
     list(APPEND EXTRA_DEFINES
       "DEBUG")
     if(WITH_TESTS STREQUAL "BENCH")
-      list(APPEND GENERAL_OPTIONS "g")
+      list(APPEND GENERAL_OPTIONS "g1")
     endif()
     list(APPEND DISABLED_WARNINGS
       "deprecated-declarations")
 
+    # Speed up linking on Linux by using split DWARF
+    if (LINUX)
+      list(APPEND GENERAL_OPTIONS
+        "gsplit-dwarf")
+    endif ()
+
+    # Use gold linker or lld if available
+    set(LINKER)
+
+    option(USE_GOLD_LINKER "Link with GNU gold" ON)
+    if (USE_GOLD_LINKER)
+      execute_process(COMMAND ${CMAKE_CXX_COMPILER} -fuse-ld=gold -Wl,--version ERROR_QUIET OUTPUT_VARIABLE LD_VERSION)
+      if(LD_VERSION MATCHES "GNU gold")
+        set(LINKER "gold")
+      endif()
+    endif()
+
+    option(USE_LLD_LINKER "Link with lld" ON)
+    if (USE_LLD_LINKER)
+      execute_process(COMMAND ${CMAKE_CXX_COMPILER} -fuse-ld=lld -Wl,--version ERROR_QUIET OUTPUT_VARIABLE LD_VERSION)
+      if(LD_VERSION MATCHES "LLD")
+        set(LINKER "lld")
+      endif()
+    endif()
+
+    if (LINKER)
+      list(APPEND GENERAL_OPTIONS
+        "fuse-ld=${LINKER}")
+      message(STATUS "Using linker: ${LINKER}")
+    else()
+      message(STATUS "Using system linker.")
+    endif()
 
     foreach(opt ${DISABLED_WARNINGS})
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-${opt}")
@@ -534,7 +574,7 @@ else()
   endif()
 
   foreach(opt ${EXTRA_DEFINES})
-    add_definition("-D${opt}")
+    add_definitions("-D${opt}")
   endforeach()
 
   # My libraries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,6 +466,7 @@ else()
   set(GENERAL_OPTIONS)
   set(DEBUG_OPTIONS)
   set(RELEASE_OPTIONS)
+  set(LINKER_OPTIONS)
   set(EXTRA_DEFINES)
   set(DISABLED_WARNINGS)
 
@@ -552,12 +553,13 @@ else()
     endif()
 
     if (LINKER)
-      list(APPEND GENERAL_OPTIONS
+      list(APPEND LINKER_OPTIONS
         "fuse-ld=${LINKER}")
       message(STATUS "Using linker: ${LINKER}")
     else()
       message(STATUS "Using system linker.")
     endif()
+
 
     foreach(opt ${DISABLED_WARNINGS})
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-${opt}")
@@ -573,6 +575,10 @@ else()
 
     foreach(opt ${RELEASE_OPTIONS})
       set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -${opt}")
+    endforeach()
+
+    foreach(opt ${LINKER_OPTIONS})
+      set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -${opt}")
     endforeach()
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -484,8 +484,11 @@ else()
     list(APPEND RELEASE_OPTIONS
       "MT")
     list(APPEND DISABLED_WARNINGS
-      "4459" # declaration of 'identifier' hides global declaration
+      "4244" # 'conversion' conversion from 'type1' to 'type2', possible loss of data
+      "4267" # 'var' : conversion from 'size_t' to 'type', possible loss of data
       "4456" # declaration of 'identifier' hides previous local declaration
+      "4459" # declaration of 'identifier' hides global declaration
+      "4996" # Call to 'std::equal' with parameters that may be unsafe
       )
     list(APPEND EXTRA_DEFINES
       "BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE")

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ MKDIR := mkdir
 .PHONY: FORCE
 
 
-all:
+all: $(BIN_DIR)
 	cd $(BIN_DIR); cmake .. $(CMAKE_ARGS); make
 
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -18,7 +18,7 @@ CMAKE_ARGS = \
         -G "Visual Studio 15 2017 Win64"
 
 
-all:
+all: $(BIN_DIR)
 	cd $(BIN_DIR) & cmake .. $(CMAKE_ARGS) & cmake --build .
 
 


### PR DESCRIPTION
# Summary
Adds some options to the build process to speed up the incremental build on Linux and macOS.

- If either of `GNU gold` or `lld` are available, use one as the linker.
- On Linux, enable split DWARF.

Here is a comparison of the time taken for an single-file incremental build. Tested on `linux 4.16.9-1` with `clang 7.0.0`/`lld`.

Before:

```
~/build/elonafoobar % /usr/bin/time -v make
cd bin; cmake .. ; make -j24
...
        User time (seconds): 13.58
        System time (seconds): 1.84
        Percent of CPU this job got: 100%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:15.35
        ...
        Maximum resident set size (kbytes): 618892
```

After:

```
~/build/elonafoobar % /usr/bin/time -v make
cd bin; cmake .. ; make -j24
...
        User time (seconds): 7.53
        System time (seconds): 1.74
        Percent of CPU this job got: 115%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:08.03
        ...
        Maximum resident set size (kbytes): 423712
```