### PR TITLE
Adjust position of skill tracked potential

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -616,7 +616,7 @@ void render_skill_trackers()
 
             bmes(
                 ""s + sdata.get(skill, chara).potential + u8"%"s,
-                112,
+                128,
                 inf_clocky + 107 + y * 16,
                 col);
         }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #966.


# Summary
Moves the skill tracked potential slightly to the right so it does not overlap in both languages.

Japanese:
![a](https://user-images.githubusercontent.com/6700637/47262284-7acadc80-d499-11e8-8a95-3839c6e97581.png)


English:
![b](https://user-images.githubusercontent.com/6700637/47262285-7dc5cd00-d499-11e8-93ae-7ca6bc7fa984.png)