### PR TITLE
Remove graphics garbage of selection keys

### DIFF
--- a/src/input_prompt.cpp
+++ b/src/input_prompt.cpp
@@ -125,7 +125,7 @@ void Prompt::_draw_entries()
     for (const auto& entry : _entries)
     {
         pos(sx + 30, cnt * 20 + sy + 22);
-        gcopy(3, cnt * 24 + 624, 30, 24, 24);
+        gcopy(3, cnt * 24 + 624, 30, 24, 18);
 
         auto text = entry.locale_key;
         if (auto text_opt =


### PR DESCRIPTION
# Summary

![image](https://user-images.githubusercontent.com/36858341/47526216-0c8f7b00-d8da-11e8-8ee7-e6fa90fdd489.png)

The size of selection key's image is 24x18, but wrongly drews it in 24x24.