### PR TITLE
Fix forward declaration to fit actual definition: class -> struct

### DIFF
--- a/src/lua_env/data_manager.hpp
+++ b/src/lua_env/data_manager.hpp
@@ -10,7 +10,7 @@ namespace elona
 namespace lua
 {
 
-class ModInfo;
+struct ModInfo;
 
 /***
  * Stores arbitrary data as Lua tables in a naive object database


### PR DESCRIPTION

# Summary

Fixes forward declaration of `class ModInfo` to fit actual definition, `struct ModInfo` in order to suppress warning.