### PR TITLE
Suppress unused variable warning due to Boost.Flyweight

### DIFF
--- a/src/shared_id.hpp
+++ b/src/shared_id.hpp
@@ -1,8 +1,17 @@
 #pragma once
 #include <string>
+
+// Assumes that a compiler just ignores unknown pragmas.
+// Supresses "unused variable" warning due to Boost.Flyweight library.
+// This warning is reported only by Clang.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
 #include <boost/flyweight.hpp>
 #include <boost/flyweight/no_locking.hpp>
 #include <boost/flyweight/no_tracking.hpp>
+#pragma clang diagnostic pop
+
+
 
 namespace elona
 {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #991.

