### PR TITLE
Add option to skip confirm at shop

### DIFF
--- a/runtime/config.hcl
+++ b/runtime/config.hcl
@@ -181,6 +181,9 @@ config {
 
             # Show damage popups.
             damage_popup = true
+
+            # Skip confirm to buy or sell items at town shop.
+            skip_confirm_at_shop = false
         }
     }
 }

--- a/runtime/locale/en/config.hcl
+++ b/runtime/locale/en/config.hcl
@@ -512,6 +512,11 @@ DOC
                     name = "Show FPS"
                     yes_no = core.locale.config.common.yes_no.show_dont_show
                 }
+
+                skip_confirm_at_shop {
+                    name = "Skip confirm at shop"
+                    doc = "Skip confirm to buy or sell items at town shops."
+                }
             }
 
             android {

--- a/runtime/locale/jp/config.hcl
+++ b/runtime/locale/jp/config.hcl
@@ -401,6 +401,11 @@
                 show_fps {
                     name = "FPSを表示"
                 }
+
+                skip_confirm_at_shop {
+                    name = "売買確認を省略"
+                    doc = "街の店において、売り買いの確認を省略します。"
+                }
             }
 
             android {

--- a/runtime/mods/core/config/config_def.hcl
+++ b/runtime/mods/core/config/config_def.hcl
@@ -342,6 +342,8 @@ config def {
             }
 
             show_fps = false
+
+            skip_confirm_at_shop = false
         }
     }
 

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -309,6 +309,7 @@ void load_config(const fs::path& hcl_file)
     CONFIG_OPTION("foobar.enhanced_skill_tracking_upperbound"s, int, Config::instance().enhanced_skill_upperbound);
     CONFIG_OPTION("foobar.startup_script"s, std::string, Config::instance().startup_script);
     CONFIG_OPTION("foobar.pcc_graphic_scale"s, std::string, Config::instance().pcc_graphic_scale);
+    CONFIG_OPTION("foobar.skip_confirm_at_shop"s, bool, Config::instance().skip_confirm_at_shop);
     CONFIG_OPTION("game.attack_neutral_npcs"s, bool, Config::instance().attack_neutral_npcs);
     CONFIG_OPTION("game.extra_help"s, bool, Config::instance().extrahelp);
     CONFIG_OPTION("game.hide_autoidentify"s, bool, Config::instance().hideautoidentify);

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -87,6 +87,7 @@ public:
     int select_fast_wait;
     bool serverlist;
     bool shadow;
+    bool skip_confirm_at_shop;
     bool skiprandevents;
     bool sound;
     int startrun;

--- a/src/ctrl_inventory.cpp
+++ b/src/ctrl_inventory.cpp
@@ -1267,26 +1267,29 @@ label_2061_internal:
             }
             if (mode == 6 && invctrl != 22 && invctrl != 24)
             {
-                if (invctrl == 11)
+                if (!Config::instance().skip_confirm_at_shop)
                 {
-                    txt(i18n::s.get(
-                        "core.locale.ui.inv.buy.prompt",
-                        itemname(ci, in),
-                        (in * calcitemvalue(ci, 0))));
-                }
-                if (invctrl == 12)
-                {
-                    txt(i18n::s.get(
-                        "core.locale.ui.inv.sell.prompt",
-                        itemname(ci, in),
-                        (in * calcitemvalue(ci, 1))));
-                }
-                rtval = yes_or_no(promptx, prompty, 160);
-                if (rtval != 0)
-                {
-                    screenupdate = -1;
-                    update_screen();
-                    goto label_20591;
+                    if (invctrl == 11)
+                    {
+                        txt(i18n::s.get(
+                            "core.locale.ui.inv.buy.prompt",
+                            itemname(ci, in),
+                            (in * calcitemvalue(ci, 0))));
+                    }
+                    if (invctrl == 12)
+                    {
+                        txt(i18n::s.get(
+                            "core.locale.ui.inv.sell.prompt",
+                            itemname(ci, in),
+                            (in * calcitemvalue(ci, 1))));
+                    }
+                    rtval = yes_or_no(promptx, prompty, 160);
+                    if (rtval != 0)
+                    {
+                        screenupdate = -1;
+                        update_screen();
+                        goto label_20591;
+                    }
                 }
                 if (invctrl == 11)
                 {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #916.


# Summary

Add the option to skip confirm prompt to buy or sell items at town shops, `foobar.skip_confirm_at_shop`(Default: false, as before).