### PR TITLE
Add #if directive to suppress warnings

### DIFF
--- a/src/defines.hpp
+++ b/src/defines.hpp
@@ -18,6 +18,12 @@
 #endif
 
 
+// Compiler
+#if BOOST_COMP_CLANG
+#define ELONA_COMPILER_CLANG
+#endif
+
+
 // Endianness
 #if BOOST_ENDIAN_BIG_BYTE
 #define ELONA_BIG_ENDIAN

--- a/src/shared_id.hpp
+++ b/src/shared_id.hpp
@@ -1,15 +1,23 @@
 #pragma once
+
 #include <string>
 
-// Assumes that a compiler just ignores unknown pragmas.
-// Supresses "unused variable" warning due to Boost.Flyweight library.
-// This warning is reported only by Clang.
+#include "defines.hpp"
+
+// Supresses "unused variable" warning due to Boost.Flyweight library in Clang
+// compiler.
+#ifdef ELONA_COMPILER_CLANG
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-variable"
+#endif
+
 #include <boost/flyweight.hpp>
 #include <boost/flyweight/no_locking.hpp>
 #include <boost/flyweight/no_tracking.hpp>
+
+#ifdef ELONA_COMPILER_CLANG
 #pragma clang diagnostic pop
+#endif
 
 
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #996 

# Summary

Encloses pragma to suppress "unused variables" warning reported by Clang with `#ifdef` directive in order to suppress "unknown pragma" warnings output by other compilers like GCC or MSVC.