### PR TITLE
Fix food not getting rotten sometimes if you believe in Kumiromi

### DIFF
--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -3936,117 +3936,6 @@ void character_drops_item()
 
 
 
-void food_gets_rotten()
-{
-    i = game_data.date.hours();
-    for (int cnt = 0; cnt < 246; ++cnt)
-    {
-        if (cnt == ELONA_MAX_CHARACTERS)
-        {
-            p = -1;
-        }
-        else
-        {
-            p = cnt;
-            if (cdata[p].state() == Character::State::empty)
-            {
-                continue;
-            }
-        }
-        for (const auto& cnt : items(p))
-        {
-            if (inv[cnt].number() == 0)
-            {
-                continue;
-            }
-            if (inv[cnt].material == 35)
-            {
-                if (inv[cnt].param3 > 0)
-                {
-                    if (inv[cnt].param3 <= i)
-                    {
-                        if (inv[cnt].own_state <= 0)
-                        {
-                            if (p == -1)
-                            {
-                                if (inv[cnt].id == 204)
-                                {
-                                    if (chipm(
-                                            0,
-                                            cell_data
-                                                .at(inv[cnt].position.x,
-                                                    inv[cnt].position.y)
-                                                .chip_id_actual)
-                                        == 1)
-                                    {
-                                        if (game_data.weather != 0)
-                                        {
-                                            continue;
-                                        }
-                                        txt(i18n::s.get(
-                                            "core.locale.misc.corpse_is_dried_"
-                                            "up",
-                                            inv[cnt]));
-                                        inv[cnt].param3 =
-                                            game_data.date.hours() + 2160;
-                                        inv[cnt].image = 337;
-                                        inv[cnt].id = 571;
-                                        inv[cnt].param1 = 0;
-                                        inv[cnt].param2 = 5;
-                                        cell_refresh(
-                                            inv[cnt].position.x,
-                                            inv[cnt].position.y);
-                                        continue;
-                                    }
-                                }
-                            }
-                            if (p != -1)
-                            {
-                                if (p < 16)
-                                {
-                                    txt(i18n::s.get(
-                                        "core.locale.misc.get_rotten",
-                                        inv[cnt]));
-                                }
-                            }
-                            inv[cnt].param3 = -1;
-                            inv[cnt].image = 336;
-                            if (p == -1)
-                            {
-                                cell_refresh(
-                                    inv[cnt].position.x, inv[cnt].position.y);
-                            }
-                            if (p == 0)
-                            {
-                                if (cdata.player().god_id == core_god::kumiromi)
-                                {
-                                    i = the_item_db[inv[cnt].id]->subcategory;
-                                    if (rnd(3) == 0)
-                                    {
-                                        txt(i18n::s.get(
-                                            "core.locale.misc.extract_seed",
-                                            inv[cnt]));
-                                        p = rnd(inv[cnt].number()) + 1;
-                                        inv[cnt].modify_number(
-                                            (-inv[cnt].number()));
-                                        flt(calcobjlv(cdata.player().level));
-                                        flttypeminor = 58500;
-                                        itemcreate(0, 0, -1, -1, p);
-                                        p = 0;
-                                        i = game_data.date.hours();
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-
-
 void damage_by_cursed_equipments()
 {
     if (rnd(4) == 0)
@@ -13173,7 +13062,7 @@ void weather_changes()
     }
     map_prepare_tileset_atlas();
     adventurer_update();
-    food_gets_rotten();
+    foods_get_rotten();
     if (map_data.type == mdata_t::MapType::world_map)
     {
         if (rnd(3) == 0)

--- a/src/food.cpp
+++ b/src/food.cpp
@@ -22,6 +22,86 @@
 #include "trait.hpp"
 #include "variables.hpp"
 
+
+
+namespace
+{
+
+void _food_gets_rotten(int chara_idx, int food_idx)
+{
+    auto& food = inv[food_idx];
+
+    if (food.material != 35)
+    {
+        return;
+    }
+    if (food.param3 <= 0)
+    {
+        return; // Has already been rotten.
+    }
+    if (food.param3 > game_data.date.hours())
+    {
+        return; // The expiration date has not come yet.
+    }
+    if (food.own_state > 0)
+    {
+        return; // On the field.
+    }
+
+    // Is it corpse(s) on a dryrock?
+    if (chara_idx == -1 && food.id == 204
+        && chipm(
+               0, cell_data.at(food.position.x, food.position.y).chip_id_actual)
+            == 1)
+    {
+        if (game_data.weather != 0)
+        {
+            return;
+        }
+        txt(i18n::s.get(
+            "core.locale.misc.corpse_is_dried_"
+            "up",
+            food));
+        food.param3 = game_data.date.hours() + 2160;
+        food.image = 337;
+        food.id = 571;
+        food.param1 = 0;
+        food.param2 = 5;
+        cell_refresh(food.position.x, food.position.y);
+        return;
+    }
+
+    if (0 <= chara_idx && chara_idx < 16)
+    {
+        txt(i18n::s.get("core.locale.misc.get_rotten", food));
+    }
+
+    food.param3 = -1;
+    food.image = 336;
+
+    if (chara_idx == -1)
+    {
+        cell_refresh(food.position.x, food.position.y);
+    }
+
+    if (chara_idx == 0 && cdata.player().god_id == core_god::kumiromi)
+    {
+        if (rnd(3) == 0)
+        {
+            txt(i18n::s.get("core.locale.misc.extract_seed", food));
+            const auto seed_num = rnd(food.number()) + 1;
+            food.modify_number(-food.number());
+            flt(calcobjlv(cdata.player().level));
+            flttypeminor = 58500;
+            itemcreate(0, 0, -1, -1, seed_num);
+        }
+    }
+}
+
+} // namespace
+
+
+
 namespace elona
 {
 
@@ -1399,6 +1479,33 @@ foodname(int type, const std::string& ingredient_, int rank, int character_id)
             type,
             "_" + std::to_string(rank),
             ingredient);
+    }
+}
+
+
+
+void foods_get_rotten()
+{
+    for (int j = 0; j < ELONA_MAX_CHARACTERS + 1; ++j)
+    {
+        int chara = j;
+        if (j == ELONA_MAX_CHARACTERS)
+        {
+            chara = -1; // On the ground.
+        }
+        else if (cdata[chara].state() == Character::State::empty)
+        {
+            continue;
+        }
+
+        for (const auto& i : items(chara))
+        {
+            if (inv[i].number() == 0)
+            {
+                continue;
+            }
+            _food_gets_rotten(chara, i);
+        }
     }
 }
 

--- a/src/food.hpp
+++ b/src/food.hpp
@@ -32,6 +32,8 @@ void apply_general_eating_effect(int);
 
 std::string foodname(int, const std::string&, int = 0, int = 0);
 
+void foods_get_rotten();
+
 
 
 } // namespace elona

--- a/src/initialize_map.cpp
+++ b/src/initialize_map.cpp
@@ -11,6 +11,7 @@
 #include "draw.hpp"
 #include "elona.hpp"
 #include "event.hpp"
+#include "food.hpp"
 #include "i18n.hpp"
 #include "item.hpp"
 #include "itemgen.hpp"
@@ -1076,7 +1077,7 @@ static void _proc_map_hooks_2()
     }
     if (map_data.refresh_type == 1)
     {
-        food_gets_rotten();
+        foods_get_rotten();
     }
     if (area_data[game_data.current_map].id == mdata_t::MapId::shop)
     {

--- a/src/variables.hpp
+++ b/src/variables.hpp
@@ -1052,7 +1052,6 @@ void initialize_home_mdata();
 
 //// weather_changes
 void supply_income();
-void food_gets_rotten();
 
 
 //// list/listn


### PR DESCRIPTION

<!-- For bug report -->
# Related Issues

Close #958.


# Summary

This bug also happens in vanilla and there are few variants that have fixed it except for recent MMAh.

## Cause

```
// pseudocode:
i = (The date and time in-game)
for food in items:
    if (the expiration date) < i:                    # (*0)
        The food gets rotten.
        if you believe in Kumiromi:
            i = (The item's subcategory)             # (*1)
            if a third:
                You extract seed(s) from the food.
                i = (The date and time in-game)      # (*2)
```

The variable `i` is modified at line (*1) and restored at line (*2), but (*2) is executed only if you extract seeds. As a result, when a food gets rotten and you don't extract seed from it, the variable `i` become
an invalid value and then, the condition (*0) fails to determine whether a food should get rotten or not.