### PR TITLE
Reduce compiler warnings

### DIFF
--- a/src/config/config_menu.hpp
+++ b/src/config/config_menu.hpp
@@ -46,6 +46,7 @@ public:
 };
 
 
+
 class ConfigMenuItemYesNo : public ConfigMenuItemBase
 {
 public:
@@ -88,6 +89,7 @@ public:
 };
 
 
+
 class ConfigMenuItemInfo : public ConfigMenuItemBase
 {
 public:
@@ -109,6 +111,7 @@ public:
         return info;
     }
 };
+
 
 
 class ConfigMenuItemInteger : public ConfigMenuItemBase
@@ -147,6 +150,7 @@ public:
 
     virtual ~ConfigMenuItemInteger() noexcept = default;
 };
+
 
 
 class ConfigMenuItemChoice : public ConfigMenuItemBase
@@ -250,6 +254,8 @@ public:
     virtual ~ConfigMenuItemChoice() noexcept = default;
 };
 
+
+
 class ConfigMenu
 {
 public:
@@ -265,6 +271,8 @@ public:
     {
     }
 
+    virtual ~ConfigMenu() = default;
+
     virtual void draw() const
     {
     }
@@ -276,6 +284,8 @@ public:
     }
 };
 
+
+
 class ConfigMenuSubmenu : public ConfigMenu
 {
 public:
@@ -283,6 +293,8 @@ public:
         : ConfigMenu(title, width, height)
     {
     }
+
+    virtual ~ConfigMenuSubmenu() = default;
 
     void draw() const override
     {
@@ -292,6 +304,8 @@ public:
     }
 };
 
+
+
 class ConfigMenuKeybindings : public ConfigMenu
 {
 public:
@@ -299,6 +313,8 @@ public:
         : ConfigMenu("Keybindings", 100, 100)
     {
     }
+
+    virtual ~ConfigMenuKeybindings() = default;
 
     optional<int> query(int submenu) override
     {

--- a/src/keybind/input_context.hpp
+++ b/src/keybind/input_context.hpp
@@ -81,8 +81,6 @@ private:
     std::set<std::string> _available_actions;
     std::vector<std::string> _available_actions_sorted;
     std::unordered_set<ActionCategory> _excluded_categories;
-    std::string _last_action;
-    int _last_action_held_frames{};
     // Needed to distinguish combining arrow keys to create "northwest" or
     // "northeast" actions and pressing a key bound to "northwest" or
     // "northeast" to cycle between multiple menus, e.g. in the inventory menu.

--- a/src/keybind/keybind.cpp
+++ b/src/keybind/keybind.cpp
@@ -121,6 +121,8 @@ optional<Keybind> Keybind::from_string(std::string str)
 
 bool keybind_is_joystick_key(snail::Key key)
 {
+    // Currently joystick controller is not supported.
+    (void)key;
     return false;
 }
 

--- a/src/snail/application/sdl.cpp
+++ b/src/snail/application/sdl.cpp
@@ -462,11 +462,6 @@ static Rect calculate_android_window_pos_landscape(
 
 Rect Application::calculate_android_window_pos()
 {
-    int x, y, width, height;
-
-    x = 0;
-    y = 0;
-
     if (_orientation == Orientation::portrait)
     {
         return calculate_android_window_pos_portrait(
@@ -477,8 +472,6 @@ Rect Application::calculate_android_window_pos()
         return calculate_android_window_pos_landscape(
             _width, _height, _physical_width, _physical_height);
     }
-
-    return {x, y, width, height};
 }
 
 

--- a/src/snail/touch_input/headless.cpp
+++ b/src/snail/touch_input/headless.cpp
@@ -9,21 +9,32 @@ TouchInput& TouchInput::instance()
     return the_instance;
 }
 
+
+
 void TouchInput::initialize(const fs::path& asset_path)
 {
+    (void)asset_path;
 }
+
+
 
 void TouchInput::initialize_quick_actions()
 {
 }
 
+
+
 void TouchInput::draw_quick_actions()
 {
 }
 
+
+
 void TouchInput::draw_quick_action(const QuickAction&)
 {
 }
+
+
 
 void TouchInput::on_touch_event(::SDL_TouchFingerEvent)
 {

--- a/src/snail/window/headless.cpp
+++ b/src/snail/window/headless.cpp
@@ -3,23 +3,33 @@ namespace elona
 namespace snail
 {
 
-
 void Window::move_to_center()
 {
 }
+
+
 
 std::pair<int, int> Window::get_size()
 {
     return {800, 600};
 }
 
+
+
 void Window::set_size(int width, int height)
 {
+    (void)width;
+    (void)height;
 }
+
+
 
 void Window::set_display_mode(::SDL_DisplayMode display_mode)
 {
+    (void)display_mode;
 }
+
+
 
 ::SDL_DisplayMode Window::get_display_mode()
 {
@@ -27,9 +37,14 @@ void Window::set_display_mode(::SDL_DisplayMode display_mode)
     return mode;
 }
 
+
+
 void Window::set_fullscreen_mode(FullscreenMode fullscreen_mode)
 {
+    (void)fullscreen_mode;
 }
+
+
 
 Window::Window(
     const std::string& title,
@@ -39,9 +54,13 @@ Window::Window(
     int height,
     Flag flag)
 {
+    (void)title;
+    (void)x;
+    (void)y;
+    (void)width;
+    (void)height;
+    (void)flag;
 }
-
-
 
 } // namespace snail
 } // namespace elona

--- a/src/tests/lua_callbacks.cpp
+++ b/src/tests/lua_callbacks.cpp
@@ -34,6 +34,7 @@ Event.register(Event.EventKind.CharaCreated, my_chara_created_handler)
     int idx = elona::rc;
     REQUIRE(idx != -1);
     elona::Character& chara = elona::cdata[idx];
+    (void)chara;
     elona::lua::lua->get_mod_manager()
         .get_mod("test_chara_created")
         ->env.set("idx", idx);
@@ -65,6 +66,7 @@ Event.register(Event.EventKind.CharaDamaged, my_chara_hurt_handler)
     REQUIRE(elona::chara_create(-1, PUTIT_PROTO_ID, 4, 8));
     int idx = elona::rc;
     elona::Character& chara = elona::cdata[idx];
+    (void)chara;
     elona::lua::lua->get_mod_manager()
         .get_mod("test_chara_hurt")
         ->env.set("idx", idx);
@@ -98,6 +100,7 @@ Event.register(Event.EventKind.CharaRemoved, my_chara_removed_handler)
     REQUIRE(elona::chara_create(-1, PUTIT_PROTO_ID, 4, 8));
     int idx = elona::rc;
     elona::Character& chara = elona::cdata[idx];
+    (void)chara;
     elona::lua::lua->get_mod_manager()
         .get_mod("test_chara_removed")
         ->env.set("idx", idx);
@@ -251,6 +254,7 @@ Event.register(Event.EventKind.ItemCreated, my_item_created_handler)
     int idx = elona::ci;
     REQUIRE(idx != -1);
     elona::Item& item = elona::inv[idx];
+    (void)item;
     elona::lua::lua->get_mod_manager()
         .get_mod("test_item_created")
         ->env.set("idx", idx);

--- a/src/tests/lua_handles.cpp
+++ b/src/tests/lua_handles.cpp
@@ -216,6 +216,7 @@ TEST_CASE("Test invalid references to handles from Lua side", "[Lua: Handles]")
     reset_state();
     start_in_debug_map();
     auto& handle_mgr = elona::lua::lua->get_handle_manager();
+    (void)handle_mgr;
     auto& mod_mgr = elona::lua::lua->get_mod_manager();
 
     SECTION("Characters")
@@ -314,6 +315,7 @@ TEST_CASE(
     reset_state();
     start_in_debug_map();
     auto& handle_mgr = elona::lua::lua->get_handle_manager();
+    (void)handle_mgr;
     auto& mod_mgr = elona::lua::lua->get_mod_manager();
 
     {

--- a/src/ui/ui_menu_crafting.cpp
+++ b/src/ui/ui_menu_crafting.cpp
@@ -80,14 +80,14 @@ static bool _should_show_entry(int item_id, int _prodtype)
     return true;
 }
 
-static void _populate_recipe_list(int _invctrl)
+static void _populate_recipe_list(int _invctrl, int _prodtype)
 {
     if (_invctrl == 0)
     {
         for (int item_id = 0, cnt_end = (maxitemid); item_id < cnt_end;
              ++item_id)
         {
-            if (_should_show_entry(item_id, prodtype))
+            if (_should_show_entry(item_id, _prodtype))
             {
                 listn(0, listmax) = ""s + _can_produce_item(item_id);
                 list(0, listmax) = item_id;
@@ -119,7 +119,7 @@ bool UIMenuCrafting::init()
     page_load();
     windowshadow = 1;
 
-    _populate_recipe_list(_invctrl);
+    _populate_recipe_list(_invctrl, _prodtype);
 
     return true;
 }


### PR DESCRIPTION


# Summary

- Unused parameters; add `void` casting.
- Unused variables; delete them.
- No virtual destructor; add it.