### PR TITLE
Delete src/get_random_item_id.cpp, no longer used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,6 @@ set(CORE_SOURCES
   src/fov.cpp
   src/gdata.cpp
   src/get_card_info.cpp
-  src/get_random_item_id.cpp
   src/get_random_npc_id.cpp
   src/god.cpp
   src/i18n.cpp


### PR DESCRIPTION
# Summary

It's empty and never used.