### PR TITLE
Add option "foobar.skip_overcasting_warning"

### DIFF
--- a/runtime/config.hcl
+++ b/runtime/config.hcl
@@ -187,6 +187,9 @@ config {
 
             # Skip confirm to buy or sell items at town shop.
             skip_confirm_at_shop = false
+
+            # Skip confirm to over-cast spells.
+            skip_overcasting_warning = false
         }
     }
 }

--- a/runtime/locale/en/config.hcl
+++ b/runtime/locale/en/config.hcl
@@ -527,6 +527,11 @@ DOC
                     name = "Skip confirm at shop"
                     doc = "Skip confirm to buy or sell items at town shops."
                 }
+
+                skip_overcasting_warning {
+                    name = "Skip over-casting warning"
+                    doc = "Skip warning prompt displayed when you are going to over-cast spells."
+                }
             }
 
             android {

--- a/runtime/locale/jp/config.hcl
+++ b/runtime/locale/jp/config.hcl
@@ -417,6 +417,11 @@ DOC
                     name = "売買確認を省略"
                     doc = "街の店において、売り買いの確認を省略します。"
                 }
+
+                skip_overcasting_warning {
+                    name = "マナ不足の警告を省略"
+                    doc = "マナが足りないときに表示される警告画面を省略します。"
+                }
             }
 
             android {

--- a/runtime/mods/core/config/config_def.hcl
+++ b/runtime/mods/core/config/config_def.hcl
@@ -349,6 +349,8 @@ config def {
             show_fps = false
 
             skip_confirm_at_shop = false
+
+            skip_overcasting_warning = false
         }
     }
 

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -341,6 +341,7 @@ void load_config(const fs::path& hcl_file)
     CONFIG_OPTION("foobar.startup_script"s, std::string, Config::instance().startup_script);
     CONFIG_OPTION("foobar.pcc_graphic_scale"s, std::string, Config::instance().pcc_graphic_scale);
     CONFIG_OPTION("foobar.skip_confirm_at_shop"s, bool, Config::instance().skip_confirm_at_shop);
+    CONFIG_OPTION("foobar.skip_overcasting_warning"s, bool, Config::instance().skip_overcasting_warning);
     CONFIG_OPTION("game.attack_neutral_npcs"s, bool, Config::instance().attack_neutral_npcs);
     CONFIG_OPTION("game.extra_help"s, bool, Config::instance().extrahelp);
     CONFIG_OPTION("game.hide_autoidentify"s, bool, Config::instance().hideautoidentify);

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -88,6 +88,7 @@ public:
     bool serverlist;
     bool shadow;
     bool skip_confirm_at_shop;
+    bool skip_overcasting_warning;
     bool skiprandevents;
     bool sound;
     int startrun;

--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -8755,13 +8755,16 @@ int do_cast_magic_attempt()
     {
         if (calcspellcostmp(efid, cc) > cdata[cc].mp)
         {
-            txt(i18n::s.get("core.locale.action.cast.overcast_warning"));
-            rtval = yes_or_no(promptx, prompty, 160);
-            if (rtval != 0)
+            if (!Config::instance().skip_overcasting_warning)
             {
-                update_screen();
-                efsource = 0;
-                return 0;
+                txt(i18n::s.get("core.locale.action.cast.overcast_warning"));
+                rtval = yes_or_no(promptx, prompty, 160);
+                if (rtval != 0)
+                {
+                    update_screen();
+                    efsource = 0;
+                    return 0;
+                }
             }
         }
         screenupdate = -1;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #1020.


# Summary

Adds new option "foobar.skip_overcasting_warning" to skip the warning prompt saying "You are going to over-cast the spell. Are you sure?"

By default, it is set to false, which is compatible with vanilla's behavior.