### PR TITLE
Fix inner ID of item chip and character chip

### DIFF
--- a/src/data/types/type_chara_chip.cpp
+++ b/src/data/types/type_chara_chip.cpp
@@ -48,7 +48,7 @@ CharaChipData CharaChipDB::convert(
     return CharaChipData{
         legacy_id,
         Extent{x, y, width, height},
-        CharaChip{SharedId(std::string(Traits::type_id + id_)), offset_y},
+        CharaChip{SharedId(std::string(Traits::type_id) + ":" + id_), offset_y},
         filepath};
 }
 

--- a/src/data/types/type_item_chip.cpp
+++ b/src/data/types/type_item_chip.cpp
@@ -58,14 +58,15 @@ ItemChipData ItemChipDB::convert(
         width = inf_tiles * animation;
     }
 
-    return ItemChipData{id,
-                        Extent{x, y, width, height, frame_width},
-                        ItemChip{SharedId(std::string(Traits::type_id + id_)),
-                                 offset_y,
-                                 stack_height,
-                                 shadow,
-                                 animation},
-                        filepath};
+    return ItemChipData{
+        id,
+        Extent{x, y, width, height, frame_width},
+        ItemChip{SharedId(std::string(Traits::type_id) + ":" + id_),
+                 offset_y,
+                 stack_height,
+                 shadow,
+                 animation},
+        filepath};
 }
 
 } // namespace elona


### PR DESCRIPTION

<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #1025.


# Summary

Insert missing colon separator between data type ID and data ID.

Example:
  `core.chara_chipcore.putit` => `core.chara_chip:core.putit`
