### PR TITLE
Change clang format setting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -35,7 +35,7 @@ BraceWrapping:
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
-BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBinaryOperators: None
 BreakBeforeInheritanceComma: true
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: true

--- a/src/access_character_info.cpp
+++ b/src/access_character_info.cpp
@@ -136,34 +136,34 @@ int access_character_info()
             {
                 if (jp)
                 {
-                    txt(u8"「"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃんー」",
-                        u8"「"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃん！」",
-                        u8"「"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃ〜ん」",
-                        u8"「"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃんっ」",
-                        u8"「"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃん？」",
-                        u8"「"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"〜ちゃん」",
-                        u8"「"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃん♪」",
+                    txt(u8"「" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃんー」",
+                        u8"「" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃん！」",
+                        u8"「" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃ〜ん」",
+                        u8"「" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃんっ」",
+                        u8"「" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃん？」",
+                        u8"「" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"〜ちゃん」",
+                        u8"「" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃん♪」",
                         Message::color{ColorIndex::cyan});
                     return 1;
                 }
@@ -172,18 +172,18 @@ int access_character_info()
             {
                 if (jp)
                 {
-                    txt(u8"「おかえり、"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃん！」",
-                        u8"「おかえりなさーい、"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃん♪」",
-                        u8"「待ってたよ、"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃん」",
+                    txt(u8"「おかえり、" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃん！」",
+                        u8"「おかえりなさーい、" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃん♪」",
+                        u8"「待ってたよ、" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃん」",
                         Message::color{ColorIndex::cyan});
                     return 1;
                 }
@@ -195,34 +195,34 @@ int access_character_info()
             {
                 if (jp)
                 {
-                    txt(u8"「"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃんー」",
-                        u8"「"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃん！」",
-                        u8"「"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃ〜ん」",
-                        u8"「"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃんっ」",
-                        u8"「"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃん？」",
-                        u8"「"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"〜ちゃん」",
-                        u8"「"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃん♪」",
+                    txt(u8"「" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃんー」",
+                        u8"「" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃん！」",
+                        u8"「" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃ〜ん」",
+                        u8"「" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃんっ」",
+                        u8"「" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃん？」",
+                        u8"「" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"〜ちゃん」",
+                        u8"「" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃん♪」",
                         Message::color{ColorIndex::cyan});
                     return 1;
                 }
@@ -231,18 +231,18 @@ int access_character_info()
             {
                 if (jp)
                 {
-                    txt(u8"「おかえり、"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃん！」",
-                        u8"「おかえりなさーい、"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃん♪」",
-                        u8"「待ってたよ、"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃん」",
+                    txt(u8"「おかえり、" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃん！」",
+                        u8"「おかえりなさーい、" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃん♪」",
+                        u8"「待ってたよ、" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃん」",
                         Message::color{ColorIndex::cyan});
                     return 1;
                 }
@@ -254,34 +254,34 @@ int access_character_info()
             {
                 if (jp)
                 {
-                    txt(u8"「"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃんー」",
-                        u8"「"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃん！」",
-                        u8"「"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃ〜ん」",
-                        u8"「"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃんっ」",
-                        u8"「"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃん？」",
-                        u8"「"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"〜ちゃん」",
-                        u8"「"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃん♪」",
+                    txt(u8"「" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃんー」",
+                        u8"「" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃん！」",
+                        u8"「" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃ〜ん」",
+                        u8"「" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃんっ」",
+                        u8"「" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃん？」",
+                        u8"「" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"〜ちゃん」",
+                        u8"「" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃん♪」",
                         Message::color{ColorIndex::cyan});
                     return 1;
                 }
@@ -290,18 +290,18 @@ int access_character_info()
             {
                 if (jp)
                 {
-                    txt(u8"「おかえりにゃ、"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃん！」",
-                        u8"「おかえりなさいにゃー、"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃん♪」",
-                        u8"「待ってたにゃ、"
-                            + i18n::_(
-                                u8"ui", u8"onii", u8"_"s + cdata.player().sex)
-                            + u8"ちゃん」",
+                    txt(u8"「おかえりにゃ、" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃん！」",
+                        u8"「おかえりなさいにゃー、" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃん♪」",
+                        u8"「待ってたにゃ、" +
+                            i18n::_(
+                                u8"ui", u8"onii", u8"_"s + cdata.player().sex) +
+                            u8"ちゃん」",
                         Message::color{ColorIndex::cyan});
                     return 1;
                 }
@@ -313,12 +313,15 @@ int access_character_info()
             {
                 if (jp)
                 {
-                    txt(u8"「"
-                            + i18n::_(
-                                u8"ui", u8"syujin", u8"_"s + cdata.player().sex)
-                            + u8"〜」",
-                        i18n::_(u8"ui", u8"syujin", u8"_"s + cdata.player().sex)
-                            + u8"〜",
+                    txt(u8"「" +
+                            i18n::_(
+                                u8"ui",
+                                u8"syujin",
+                                u8"_"s + cdata.player().sex) +
+                            u8"〜」",
+                        i18n::_(
+                            u8"ui", u8"syujin", u8"_"s + cdata.player().sex) +
+                            u8"〜",
                         u8"「用事はありませんか♪」",
                         u8"メイドの熱い視線を感じる…",
                         Message::color{ColorIndex::cyan});
@@ -330,10 +333,12 @@ int access_character_info()
                 if (jp)
                 {
                     txt(u8"「ダメぇ！」",
-                        u8"「"
-                            + i18n::_(
-                                u8"ui", u8"syujin", u8"_"s + cdata.player().sex)
-                            + u8"ー！」",
+                        u8"「" +
+                            i18n::_(
+                                u8"ui",
+                                u8"syujin",
+                                u8"_"s + cdata.player().sex) +
+                            u8"ー！」",
                         Message::color{ColorIndex::cyan});
                     return 1;
                 }
@@ -342,10 +347,12 @@ int access_character_info()
             {
                 if (jp)
                 {
-                    txt(u8"「おかえりなさいませ、"
-                            + i18n::_(
-                                u8"ui", u8"syujin", u8"_"s + cdata.player().sex)
-                            + u8"〜」",
+                    txt(u8"「おかえりなさいませ、" +
+                            i18n::_(
+                                u8"ui",
+                                u8"syujin",
+                                u8"_"s + cdata.player().sex) +
+                            u8"〜」",
                         u8"「おかえりなさいまし〜」",
                         Message::color{ColorIndex::cyan});
                     return 1;

--- a/src/access_item_db.cpp
+++ b/src/access_item_db.cpp
@@ -4684,64 +4684,64 @@ int access_item_db(int dbmode)
     case 44:
         if (dbmode == 16 && dbspec == 12)
         {
-            return cdata.player().god_id == core_god::jure
-                || cdata.player().god_id == core_god::opatos;
+            return cdata.player().god_id == core_god::jure ||
+                cdata.player().god_id == core_god::opatos;
         }
         break;
     case 42:
         if (dbmode == 16 && dbspec == 12)
         {
-            return cdata.player().god_id == core_god::jure
-                || cdata.player().god_id == core_god::opatos;
+            return cdata.player().god_id == core_god::jure ||
+                cdata.player().god_id == core_god::opatos;
         }
         break;
     case 41:
         if (dbmode == 16 && dbspec == 12)
         {
-            return cdata.player().god_id == core_god::jure
-                || cdata.player().god_id == core_god::opatos;
+            return cdata.player().god_id == core_god::jure ||
+                cdata.player().god_id == core_god::opatos;
         }
         break;
     case 40:
         if (dbmode == 16 && dbspec == 12)
         {
-            return cdata.player().god_id == core_god::jure
-                || cdata.player().god_id == core_god::opatos;
+            return cdata.player().god_id == core_god::jure ||
+                cdata.player().god_id == core_god::opatos;
         }
         break;
     case 39:
         if (dbmode == 16 && dbspec == 12)
         {
-            return cdata.player().god_id == core_god::jure
-                || cdata.player().god_id == core_god::opatos;
+            return cdata.player().god_id == core_god::jure ||
+                cdata.player().god_id == core_god::opatos;
         }
         break;
     case 38:
         if (dbmode == 16 && dbspec == 12)
         {
-            return cdata.player().god_id == core_god::jure
-                || cdata.player().god_id == core_god::opatos;
+            return cdata.player().god_id == core_god::jure ||
+                cdata.player().god_id == core_god::opatos;
         }
         break;
     case 37:
         if (dbmode == 16 && dbspec == 12)
         {
-            return cdata.player().god_id == core_god::jure
-                || cdata.player().god_id == core_god::opatos;
+            return cdata.player().god_id == core_god::jure ||
+                cdata.player().god_id == core_god::opatos;
         }
         break;
     case 36:
         if (dbmode == 16 && dbspec == 12)
         {
-            return cdata.player().god_id == core_god::jure
-                || cdata.player().god_id == core_god::opatos;
+            return cdata.player().god_id == core_god::jure ||
+                cdata.player().god_id == core_god::opatos;
         }
         break;
     case 35:
         if (dbmode == 16 && dbspec == 12)
         {
-            return cdata.player().god_id == core_god::jure
-                || cdata.player().god_id == core_god::opatos;
+            return cdata.player().god_id == core_god::jure ||
+                cdata.player().god_id == core_god::opatos;
         }
         break;
     case 34:

--- a/src/activity.cpp
+++ b/src/activity.cpp
@@ -34,8 +34,8 @@ void rowact_check(int prm_789)
 {
     if (cdata[prm_789].continuous_action)
     {
-        if (cdata[prm_789].continuous_action.type
-            != ContinuousAction::Type::travel)
+        if (cdata[prm_789].continuous_action.type !=
+            ContinuousAction::Type::travel)
         {
             cdata[prm_789].stops_continuous_action_if_damaged = 1;
         }
@@ -56,8 +56,8 @@ void rowact_item(int prm_790)
         {
             continue;
         }
-        if (cc.continuous_action.type == ContinuousAction::Type::eat
-            || cc.continuous_action.type == ContinuousAction::Type::read)
+        if (cc.continuous_action.type == ContinuousAction::Type::eat ||
+            cc.continuous_action.type == ContinuousAction::Type::read)
         {
             if (cc.continuous_action.item == prm_790)
             {
@@ -74,9 +74,9 @@ void activity_handle_damage(Character& chara)
 {
     if (chara.index == 0)
     {
-        if (chara.continuous_action.type != ContinuousAction::Type::eat
-            && chara.continuous_action.type != ContinuousAction::Type::read
-            && chara.continuous_action.type != ContinuousAction::Type::travel)
+        if (chara.continuous_action.type != ContinuousAction::Type::eat &&
+            chara.continuous_action.type != ContinuousAction::Type::read &&
+            chara.continuous_action.type != ContinuousAction::Type::travel)
         {
             rtval = 0;
         }
@@ -280,8 +280,7 @@ void continuous_action_perform()
                         cdata[cc].position.x,
                         cdata[cc].position.y,
                         audience.position.x,
-                        audience.position.y)
-                    > 3)
+                        audience.position.y) > 3)
                 {
                     continue;
                 }
@@ -364,13 +363,12 @@ void continuous_action_perform()
                 }
                 if (rnd(3) == 0)
                 {
-                    p = cdata[cc].quality_of_performance
-                            * cdata[cc].quality_of_performance
-                            * (100
-                               + inv[cdata[cc].continuous_action.item].param1
-                                   / 5)
-                            / 100 / 1000
-                        + rnd(10);
+                    p = cdata[cc].quality_of_performance *
+                            cdata[cc].quality_of_performance *
+                            (100 +
+                             inv[cdata[cc].continuous_action.item].param1 / 5) /
+                            100 / 1000 +
+                        rnd(10);
                     p = clamp(
                         cdata[tc].gold * clamp(p(0), 1, 100) / 125,
                         0,
@@ -379,9 +377,9 @@ void continuous_action_perform()
                     {
                         p = rnd(clamp(p(0), 1, 100)) + 1;
                     }
-                    if ((cdata[tc].character_role >= 1000
-                         && cdata[tc].character_role < 2000)
-                        || cdata[tc].character_role == 2003)
+                    if ((cdata[tc].character_role >= 1000 &&
+                         cdata[tc].character_role < 2000) ||
+                        cdata[tc].character_role == 2003)
                     {
                         p /= 5;
                     }
@@ -461,8 +459,7 @@ void continuous_action_perform()
                                             cdata[tc].position.x,
                                             cdata[tc].position.y,
                                             x,
-                                            y)
-                                        == 0)
+                                            y) == 0)
                                     {
                                         continue;
                                     }
@@ -471,8 +468,9 @@ void continuous_action_perform()
                                             49))
                                     {
                                         flt(calcobjlv(
-                                                cdata[cc].quality_of_performance
-                                                / 8),
+                                                cdata[cc]
+                                                    .quality_of_performance /
+                                                8),
                                             calcfixlv(
                                                 (rnd(4) == 0)
                                                     ? Quality::miracle
@@ -481,14 +479,16 @@ void continuous_action_perform()
                                     else
                                     {
                                         flt(calcobjlv(
-                                                cdata[cc].quality_of_performance
-                                                / 10),
+                                                cdata[cc]
+                                                    .quality_of_performance /
+                                                10),
                                             calcfixlv(Quality::good));
                                     }
                                     flttypemajor = choice(fsetperform);
                                     dbid = 0;
-                                    if (game_data.executing_immediate_quest_type
-                                        == 1009)
+                                    if (game_data
+                                            .executing_immediate_quest_type ==
+                                        1009)
                                     {
                                         if (rnd(150) == 0)
                                         {
@@ -614,8 +614,8 @@ void continuous_action_perform()
 
     if (cdata[cc].quality_of_performance > 40)
     {
-        cdata[cc].quality_of_performance = cdata[cc].quality_of_performance
-            * (100 + inv[cdata[cc].continuous_action.item].param1 / 5) / 100;
+        cdata[cc].quality_of_performance = cdata[cc].quality_of_performance *
+            (100 + inv[cdata[cc].continuous_action.item].param1 / 5) / 100;
     }
     if (cdata[cc].tip_gold != 0)
     {
@@ -660,8 +660,8 @@ void continuous_action_sex()
         tc -= 10000;
         sexhost = 0;
     }
-    if (cdata[tc].state() != Character::State::alive
-        || cdata[tc].continuous_action.type != ContinuousAction::Type::sex)
+    if (cdata[tc].state() != Character::State::alive ||
+        cdata[tc].continuous_action.type != ContinuousAction::Type::sex)
     {
         if (is_in_fov(cdata[cc]))
         {
@@ -802,8 +802,8 @@ void continuous_action_sex()
     if (!dialog_head.empty() || !dialog_tail.empty() || !dialog_after.empty())
     {
         txt(i18n::s.get(
-                "core.locale.activity.sex.format", dialog_head, dialog_tail)
-            + dialog_after);
+                "core.locale.activity.sex.format", dialog_head, dialog_tail) +
+            dialog_after);
     }
     cdata[cc].continuous_action.finish();
     cdata[tc].continuous_action.finish();
@@ -940,8 +940,8 @@ void continuous_action_others()
         }
         if (game_data.continuous_action_about_to_start == 100)
         {
-            if (map_data.type == mdata_t::MapType::player_owned
-                || map_is_town_or_guild())
+            if (map_data.type == mdata_t::MapType::player_owned ||
+                map_is_town_or_guild())
             {
                 txt(i18n::s.get("core.locale.activity.sleep.start.other"));
                 cdata[cc].continuous_action.turn = 5;
@@ -965,18 +965,18 @@ void continuous_action_others()
         if (game_data.continuous_action_about_to_start == 103)
         {
             txt(i18n::s.get("core.locale.activity.dig", inv[ci]));
-            cdata[cc].continuous_action.turn = 10
-                + clamp(inv[ci].weight
-                            / (1 + sdata(10, 0) * 10 + sdata(180, 0) * 40),
-                        1,
-                        100);
+            cdata[cc].continuous_action.turn = 10 +
+                clamp(inv[ci].weight /
+                          (1 + sdata(10, 0) * 10 + sdata(180, 0) * 40),
+                      1,
+                      100);
         }
         if (game_data.continuous_action_about_to_start == 104)
         {
             if (game_data.weather == 0 || game_data.weather == 3)
             {
-                if (game_data.time_when_textbook_becomes_available
-                    > game_data.date.hours())
+                if (game_data.time_when_textbook_becomes_available >
+                    game_data.date.hours())
                 {
                     txt(i18n::s.get("core.locale.activity.study.start.bored"));
                     cdata[cc].continuous_action.finish();
@@ -1001,8 +1001,8 @@ void continuous_action_others()
             }
             if (game_data.weather != 0 && game_data.weather != 3)
             {
-                if (game_data.current_map == mdata_t::MapId::shelter_
-                    || map_can_use_bad_weather_in_study())
+                if (game_data.current_map == mdata_t::MapId::shelter_ ||
+                    map_can_use_bad_weather_in_study())
                 {
                     txt(i18n::s.get(
                         "core.locale.activity.study.start.weather_is_bad"));
@@ -1137,8 +1137,7 @@ void continuous_action_others()
                         cdata[cnt].position.x,
                         cdata[cnt].position.y,
                         cdata.player().position.x,
-                        cdata.player().position.y)
-                    > 5)
+                        cdata.player().position.y) > 5)
                 {
                     continue;
                 }
@@ -1149,15 +1148,15 @@ void continuous_action_others()
                         continue;
                     }
                 }
-                p = rnd((i + 1))
-                    * (80 + (is_in_fov(cdata[cnt]) == 0) * 50
-                       + dist(
-                             cdata[cnt].position.x,
-                             cdata[cnt].position.y,
-                             cdata.player().position.x,
-                             cdata.player().position.y)
-                           * 20)
-                    / 100;
+                p = rnd((i + 1)) *
+                    (80 + (is_in_fov(cdata[cnt]) == 0) * 50 +
+                     dist(
+                         cdata[cnt].position.x,
+                         cdata[cnt].position.y,
+                         cdata.player().position.x,
+                         cdata.player().position.y) *
+                         20) /
+                    100;
                 if (cnt < 57)
                 {
                     p = p * 2 / 3;
@@ -1236,8 +1235,7 @@ void continuous_action_others()
                         cdata[cc].position.x,
                         cdata[cc].position.y,
                         cdata[tg].position.x,
-                        cdata[tg].position.y)
-                    >= 3)
+                        cdata[tg].position.y) >= 3)
                 {
                     if (f != 1)
                     {
@@ -1289,8 +1287,8 @@ void continuous_action_others()
     if (game_data.continuous_action_about_to_start == 105)
     {
         tg = inv_getowner(ci);
-        if ((tg != -1 && cdata[tg].state() != Character::State::alive)
-            || inv[ci].number() <= 0)
+        if ((tg != -1 && cdata[tg].state() != Character::State::alive) ||
+            inv[ci].number() <= 0)
         {
             txt(i18n::s.get("core.locale.activity.steal.abort"));
             cdata[cc].continuous_action.finish();
@@ -1680,9 +1678,9 @@ void spot_digging()
                             txt(
                                 i18n::s.get("core.locale.common.something_is_"
                                             "put_on_the_ground"));
-                            autosave = 1
-                                * (game_data.current_map
-                                   != mdata_t::MapId::show_house);
+                            autosave = 1 *
+                                (game_data.current_map !=
+                                 mdata_t::MapId::show_house);
                             inv[cnt].modify_number(-1);
                             break;
                         }
@@ -1764,9 +1762,9 @@ void spot_mining_or_wall()
                 }
             }
         }
-        if (f == 1
-            || (game_data.quest_flags.tutorial == 2
-                && game_data.current_map == mdata_t::MapId::your_home))
+        if (f == 1 ||
+            (game_data.quest_flags.tutorial == 2 &&
+             game_data.current_map == mdata_t::MapId::your_home))
         {
             rtval = 0;
             if (rnd(5) == 0)
@@ -1790,8 +1788,8 @@ void spot_mining_or_wall()
             snd("core.crush1");
             BreakingAnimation({refx, refy}).play();
             txt(i18n::s.get("core.locale.activity.dig_mining.finish.wall"));
-            if (game_data.quest_flags.tutorial == 2
-                && game_data.current_map == mdata_t::MapId::your_home)
+            if (game_data.quest_flags.tutorial == 2 &&
+                game_data.current_map == mdata_t::MapId::your_home)
             {
                 flt();
                 itemcreate(-1, 208, digx, digy, 0);
@@ -1847,8 +1845,8 @@ TurnResult do_dig_after_sp_check()
 
 int search_material_spot()
 {
-    if (cell_data.at(cdata.player().position.x, cdata.player().position.y).feats
-        == 0)
+    if (cell_data.at(cdata.player().position.x, cdata.player().position.y)
+            .feats == 0)
     {
         return 0;
     }
@@ -1881,23 +1879,23 @@ int search_material_spot()
         {
             atxlv = 30 + rnd((rnd(atxlv - 30) + 1));
         }
-        if (4 <= game_data.stood_world_map_tile
-            && game_data.stood_world_map_tile < 9)
+        if (4 <= game_data.stood_world_map_tile &&
+            game_data.stood_world_map_tile < 9)
         {
             atxspot = 10;
         }
-        if (264 <= game_data.stood_world_map_tile
-            && game_data.stood_world_map_tile < 363)
+        if (264 <= game_data.stood_world_map_tile &&
+            game_data.stood_world_map_tile < 363)
         {
             atxspot = 11;
         }
-        if (9 <= game_data.stood_world_map_tile
-            && game_data.stood_world_map_tile < 13)
+        if (9 <= game_data.stood_world_map_tile &&
+            game_data.stood_world_map_tile < 13)
         {
             atxspot = 10;
         }
-        if (13 <= game_data.stood_world_map_tile
-            && game_data.stood_world_map_tile < 17)
+        if (13 <= game_data.stood_world_map_tile &&
+            game_data.stood_world_map_tile < 17)
         {
             atxspot = 11;
         }
@@ -2022,8 +2020,8 @@ void matgetmain(int material_id, int amount, int spot_type)
             "core.locale.activity.material.get",
             verb,
             amount,
-            matname(material_id))
-            + u8"("s + mat(material_id) + u8") "s,
+            matname(material_id)) +
+            u8"("s + mat(material_id) + u8") "s,
         Message::color{ColorIndex::blue});
 }
 

--- a/src/adventurer.cpp
+++ b/src/adventurer.cpp
@@ -48,9 +48,9 @@ void create_adventurer()
     cdatan(1, rc) = random_title();
     cdata[rc].character_role = 13;
     p = rnd(450);
-    if (area_data[p].id == mdata_t::MapId::none
-        || area_data[p].id == mdata_t::MapId::your_home
-        || area_data[p].type == mdata_t::MapType::temporary)
+    if (area_data[p].id == mdata_t::MapId::none ||
+        area_data[p].id == mdata_t::MapId::your_home ||
+        area_data[p].type == mdata_t::MapType::temporary)
     {
         p = 4;
     }
@@ -68,8 +68,8 @@ void create_adventurer()
     }
     cdata[rc].current_map = p;
     cdata[rc].current_dungeon_level = 1;
-    cdata[rc].fame = cdata[rc].level * cdata[rc].level * 30
-        + rnd((cdata[rc].level * 200 + 100)) + rnd(500);
+    cdata[rc].fame = cdata[rc].level * cdata[rc].level * 30 +
+        rnd((cdata[rc].level * 200 + 100)) + rnd(500);
 }
 
 
@@ -122,9 +122,9 @@ void addnews2(const std::string& prm_401, int prm_402)
 void addnewstopic(const std::string& prm_403, const std::string& prm_404)
 {
     addnews2(
-        prm_403 + u8" "s + game_data.date.year + u8"/"s + game_data.date.month
-        + u8"/"s + game_data.date.day + u8" h"s + game_data.date.hour + ""s
-        + u8" "s + prm_404);
+        prm_403 + u8" "s + game_data.date.year + u8"/"s + game_data.date.month +
+        u8"/"s + game_data.date.day + u8" h"s + game_data.date.hour + ""s +
+        u8" "s + prm_404);
 }
 
 
@@ -234,9 +234,9 @@ void adventurer_update()
                 }
             }
         }
-        if ((cdata[rc].current_map != game_data.current_map
-             || map_data.type == mdata_t::MapType::world_map)
-            && rnd(60) == 0)
+        if ((cdata[rc].current_map != game_data.current_map ||
+             map_data.type == mdata_t::MapType::world_map) &&
+            rnd(60) == 0)
         {
             for (int cnt = 0; cnt < 10; ++cnt)
             {
@@ -248,9 +248,8 @@ void adventurer_update()
                 {
                     p = rnd(300);
                 }
-                if (area_data[p].id == mdata_t::MapId::none || p == 7
-                    || area_data[p].type == mdata_t::MapType::temporary
-                    || p == 9)
+                if (area_data[p].id == mdata_t::MapId::none || p == 7 ||
+                    area_data[p].type == mdata_t::MapType::temporary || p == 9)
                 {
                     p = 4;
                 }
@@ -283,13 +282,13 @@ void adventurer_update()
         }
         if (rnd(20) == 0)
         {
-            cdata[rc].fame += rnd(cdata[rc].level * cdata[rc].level / 40 + 5)
-                - rnd((cdata[rc].level * cdata[rc].level / 50 + 5));
+            cdata[rc].fame += rnd(cdata[rc].level * cdata[rc].level / 40 + 5) -
+                rnd((cdata[rc].level * cdata[rc].level / 50 + 5));
         }
         if (rnd(2000) == 0)
         {
-            cdata[rc].experience += clamp(cdata[rc].level, 1, 1000)
-                * clamp(cdata[rc].level, 1, 1000) * 100;
+            cdata[rc].experience += clamp(cdata[rc].level, 1, 1000) *
+                clamp(cdata[rc].level, 1, 1000) * 100;
             int fame = rnd(cdata[rc].level * cdata[rc].level / 20 + 10) + 10;
             cdata[rc].fame += fame;
             addnews(4, rc, fame);

--- a/src/ai.cpp
+++ b/src/ai.cpp
@@ -199,8 +199,9 @@ TurnResult ai_proc_basic()
             efid = act;
             if (cdata[cc].mp < cdata[cc].max_mp / 7)
             {
-                if (rnd(3) || cc < 16 || cdata[cc].quality >= Quality::miracle
-                    || cdata[cc].cures_mp_frequently())
+                if (rnd(3) || cc < 16 ||
+                    cdata[cc].quality >= Quality::miracle ||
+                    cdata[cc].cures_mp_frequently())
                 {
                     cdata[cc].mp += cdata[cc].level / 4 + 5;
                     return TurnResult::turn_end;
@@ -372,10 +373,10 @@ TurnResult proc_npc_movement_event(bool retreat)
         cdata[cc]._206 = cdata[tc].position.y;
         if (retreat || cdata[cc].ai_dist > distance)
         {
-            cdata[cc]._205 = cdata[cc].position.x
-                + (cdata[cc].position.x - cdata[tc].position.x);
-            cdata[cc]._206 = cdata[cc].position.y
-                + (cdata[cc].position.y - cdata[tc].position.y);
+            cdata[cc]._205 = cdata[cc].position.x +
+                (cdata[cc].position.x - cdata[tc].position.x);
+            cdata[cc]._206 = cdata[cc].position.y +
+                (cdata[cc].position.y - cdata[tc].position.y);
         }
     }
     else
@@ -383,10 +384,10 @@ TurnResult proc_npc_movement_event(bool retreat)
         --cdata[cc]._203;
     }
     blockedbychara = 0;
-    cdata[cc].next_position.x = (cdata[cc]._205 > cdata[cc].position.x)
-        - (cdata[cc]._205 < cdata[cc].position.x) + cdata[cc].position.x;
-    cdata[cc].next_position.y = (cdata[cc]._206 > cdata[cc].position.y)
-        - (cdata[cc]._206 < cdata[cc].position.y) + cdata[cc].position.y;
+    cdata[cc].next_position.x = (cdata[cc]._205 > cdata[cc].position.x) -
+        (cdata[cc]._205 < cdata[cc].position.x) + cdata[cc].position.x;
+    cdata[cc].next_position.y = (cdata[cc]._206 > cdata[cc].position.y) -
+        (cdata[cc]._206 < cdata[cc].position.y) + cdata[cc].position.y;
     x = cdata[cc].next_position.x;
     y = cdata[cc].next_position.y;
     cell_check(x, y);
@@ -409,9 +410,9 @@ TurnResult proc_npc_movement_event(bool retreat)
             return ai_proc_basic();
         }
         else if (
-            (cdata[cc].quality > Quality::great
-             && cdata[cc].level > cdata[tc].level)
-            || cdata[tc].is_hung_on_sand_bag())
+            (cdata[cc].quality > Quality::great &&
+             cdata[cc].level > cdata[tc].level) ||
+            cdata[tc].is_hung_on_sand_bag())
         {
             if (cdata[cc].enemy_id != tc)
             {
@@ -421,8 +422,8 @@ TurnResult proc_npc_movement_event(bool retreat)
                     txt(i18n::s.get(
                         "core.locale.ai.swap.displace", cdata[cc], cdata[tc]));
                 }
-                if (cdata[tc].continuous_action.type
-                    == ContinuousAction::Type::eat)
+                if (cdata[tc].continuous_action.type ==
+                    ContinuousAction::Type::eat)
                 {
                     if (cdata[tc].continuous_action.turn > 0)
                     {
@@ -454,8 +455,9 @@ TurnResult proc_npc_movement_event(bool retreat)
                         {
                             if (y < map_data.height)
                             {
-                                if (chipm(7, cell_data.at(x, y).chip_id_actual)
-                                    & 4)
+                                if (chipm(
+                                        7, cell_data.at(x, y).chip_id_actual) &
+                                    4)
                                 {
                                     if (rnd(4) == 0)
                                     {
@@ -480,8 +482,8 @@ TurnResult proc_npc_movement_event(bool retreat)
             }
         }
     }
-    if (std::abs(cdata[cc]._205 - cdata[cc].position.x)
-        >= std::abs(cdata[cc]._206 - cdata[cc].position.y))
+    if (std::abs(cdata[cc]._205 - cdata[cc].position.x) >=
+        std::abs(cdata[cc]._206 - cdata[cc].position.y))
     {
         {
             int stat = ai_dir_check_1();
@@ -783,13 +785,12 @@ label_2692_internal:
                                 cell_data
                                     .at(cdata[cc].position.x,
                                         cdata[cc].position.y)
-                                    .chip_id_actual)
-                            == 4)
+                                    .chip_id_actual) == 4)
                         {
                             if (rnd(4) == 0)
                             {
-                                if (cdata[game_data.fire_giant].state()
-                                    == Character::State::alive)
+                                if (cdata[game_data.fire_giant].state() ==
+                                    Character::State::alive)
                                 {
                                     if (is_in_fov(cdata[game_data.fire_giant]))
                                     {
@@ -817,12 +818,11 @@ label_2692_internal:
                                 for (const auto& cnt : itemlist(-1, 541))
                                 {
                                     ti = cnt;
-                                    if (inv[ti].position.x >= scx
-                                        && inv[ti].position.x
-                                            < scx + inf_screenw
-                                        && inv[ti].position.y >= scy
-                                        && inv[ti].position.y
-                                            < scy + inf_screenh)
+                                    if (inv[ti].position.x >= scx &&
+                                        inv[ti].position.x <
+                                            scx + inf_screenw &&
+                                        inv[ti].position.y >= scy &&
+                                        inv[ti].position.y < scy + inf_screenh)
                                     {
                                         found_snowman = true;
                                         break;
@@ -845,8 +845,7 @@ label_2692_internal:
                                 if (cell_data
                                         .at(cdata[cc].position.x,
                                             cdata[cc].position.y)
-                                        .item_appearances_actual
-                                    == 0)
+                                        .item_appearances_actual == 0)
                                 {
                                     flt();
                                     int stat = itemcreate(
@@ -999,8 +998,7 @@ label_2692_internal:
                             cdata[cc].position.x,
                             cdata[cc].position.y,
                             cdata[cnt].position.x,
-                            cdata[cnt].position.y)
-                        < 6)
+                            cdata[cnt].position.y) < 6)
                     {
                         if (fov_los(
                                 cdata[cc].position.x,
@@ -1057,24 +1055,23 @@ label_2692_internal:
     }
     if (cdata[cc].ai_calm == 2)
     {
-        if (map_data.designated_spawns == 1
-            && dist(
-                   cdata[cc].position.x,
-                   cdata[cc].position.y,
-                   cdata[cc].initial_position.x,
-                   cdata[cc].initial_position.y)
-                > 2)
+        if (map_data.designated_spawns == 1 &&
+            dist(
+                cdata[cc].position.x,
+                cdata[cc].position.y,
+                cdata[cc].initial_position.x,
+                cdata[cc].initial_position.y) > 2)
         {
-            cdata[cc].next_position.x = cdata[cc].position.x
-                + rnd(2)
-                    * ((cdata[cc].position.x > cdata[cc].initial_position.x)
-                           * -1
-                       + (cdata[cc].position.x < cdata[cc].initial_position.x));
-            cdata[cc].next_position.y = cdata[cc].position.y
-                + rnd(2)
-                    * ((cdata[cc].position.y > cdata[cc].initial_position.y)
-                           * -1
-                       + (cdata[cc].position.y < cdata[cc].initial_position.y));
+            cdata[cc].next_position.x = cdata[cc].position.x +
+                rnd(2) *
+                    ((cdata[cc].position.x > cdata[cc].initial_position.x) *
+                         -1 +
+                     (cdata[cc].position.x < cdata[cc].initial_position.x));
+            cdata[cc].next_position.y = cdata[cc].position.y +
+                rnd(2) *
+                    ((cdata[cc].position.y > cdata[cc].initial_position.y) *
+                         -1 +
+                     (cdata[cc].position.y < cdata[cc].initial_position.y));
         }
         else
         {

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -148,8 +148,8 @@ void do_particle_animation(
 
 bool is_in_screen(int x, int y)
 {
-    return x < windoww
-        && y < inf_screenh * inf_tiles + inf_screeny - inf_tiles / 2;
+    return x < windoww &&
+        y < inf_screenh * inf_tiles + inf_screeny - inf_tiles / 2;
 }
 
 
@@ -357,8 +357,8 @@ void BreathAnimation::do_play()
             const auto sx =
                 (dx - scx) * inf_tiles + inf_screenx + inf_tiles / 2;
             const auto sy = (dy - scy) * inf_tiles + inf_screeny + 16;
-            if (sx < windoww
-                && sy < inf_screenh * inf_tiles + inf_screeny - inf_tiles / 2)
+            if (sx < windoww &&
+                sy < inf_screenh * inf_tiles + inf_screeny - inf_tiles / 2)
             {
                 pos(sx, sy);
                 gmode(2);
@@ -455,8 +455,8 @@ void BallAnimation::do_play()
                 }
                 if (sx * inf_tiles + inf_screenx < windoww)
                 {
-                    if (sy * inf_tiles + inf_screeny
-                        < inf_screenh * inf_tiles + inf_screeny - inf_tiles / 2)
+                    if (sy * inf_tiles + inf_screeny <
+                        inf_screenh * inf_tiles + inf_screeny - inf_tiles / 2)
                     {
                         pos(sx * inf_tiles + inf_screenx,
                             sy * inf_tiles + inf_screeny);
@@ -823,9 +823,9 @@ void MeleeAttackAnimation::do_play()
         }
         for (int cnt = 0, cnt_end = (damage_percent); cnt < cnt_end; ++cnt)
         {
-            pos(anidx + 24 + sx(cnt)
-                    + (sx(cnt) < 4) * ((1 + (cnt % 2 == 0)) * -1) * cnt2
-                    + (sx(cnt) > -4) * (1 + (cnt % 2 == 0)) * cnt2,
+            pos(anidx + 24 + sx(cnt) +
+                    (sx(cnt) < 4) * ((1 + (cnt % 2 == 0)) * -1) * cnt2 +
+                    (sx(cnt) > -4) * (1 + (cnt % 2 == 0)) * cnt2,
                 anidy + sy(cnt) + cnt2 * cnt2 / 3);
             grotate(1, anix1, 0, inf_tiles, inf_tiles, 6, 6, 0.4 * cnt);
         }
@@ -1214,9 +1214,9 @@ void BreakingAnimation::do_play()
            auto t,
            const auto& particle,
            auto i) {
-            const auto x = center.x + particle.x
-                + (particle.x < 4) * -(1 + (i % 2 == 0)) * t
-                + (particle.x > -4) * (1 + (i % 2 == 0)) * t;
+            const auto x = center.x + particle.x +
+                (particle.x < 4) * -(1 + (i % 2 == 0)) * t +
+                (particle.x > -4) * (1 + (i % 2 == 0)) * t;
             const auto y = center.y - inf_tiles / 4 + particle.y + t * t / 3;
             draw_rotated(key, x, y, 0.5, 23 * i);
         });

--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -68,11 +68,11 @@ SharedId get_default_music()
                                                          "core.mcDungeon6"};
         music_id = choices[game_data.date.hour % 6];
     }
-    if (area_data[game_data.current_map].id == mdata_t::MapId::random_dungeon
-        || area_data[game_data.current_map].id == mdata_t::MapId::the_void)
+    if (area_data[game_data.current_map].id == mdata_t::MapId::random_dungeon ||
+        area_data[game_data.current_map].id == mdata_t::MapId::the_void)
     {
-        if (game_data.current_dungeon_level
-            == area_data[game_data.current_map].deepest_level)
+        if (game_data.current_dungeon_level ==
+            area_data[game_data.current_map].deepest_level)
         {
             if (area_data[game_data.current_map].has_been_conquered != -1)
             {
@@ -140,8 +140,8 @@ SharedId get_default_music()
         music_id = "core.mcTown6"s;
     }
 
-    if (!music_id
-        || area_data[game_data.current_map].type == mdata_t::MapType::world_map)
+    if (!music_id ||
+        area_data[game_data.current_map].type == mdata_t::MapType::world_map)
     {
         static const std::vector<std::string> choices = {
             "core.mcField1", "core.mcField2", "core.mcField3"};
@@ -213,8 +213,8 @@ void snd_inner(
                      i < temporary_channels_head + temporary_channels_size;
                      ++i)
                 {
-                    if (CHECKPLAY(i)
-                        && soundlist[i - temporary_channels_head] == sound.id)
+                    if (CHECKPLAY(i) &&
+                        soundlist[i - temporary_channels_head] == sound.id)
                     {
                         channel = i;
                         found = true;
@@ -442,8 +442,8 @@ void sound_play_environmental()
         DSSETVOLUME(13, max_volume * 0.8);
     }
     else if (
-        game_data.current_dungeon_level == 1
-        || game_data.current_map == mdata_t::MapId::shelter_)
+        game_data.current_dungeon_level == 1 ||
+        game_data.current_map == mdata_t::MapId::shelter_)
     {
         DSSETVOLUME(13, max_volume * 0.2);
     }

--- a/src/autopick.cpp
+++ b/src/autopick.cpp
@@ -59,8 +59,8 @@ bool Autopick::try_load(const fs::path& filepath)
         std::string line_ = line;
         Operation op{Operation::Type::pick_up};
 
-        if (strutil::starts_with(line_, u8"%=")
-            || strutil::starts_with(line_, u8"=%"))
+        if (strutil::starts_with(line_, u8"%=") ||
+            strutil::starts_with(line_, u8"=%"))
         {
             op.type = Operation::Type::save_and_no_drop;
             line_ = line_.substr(2);
@@ -142,8 +142,8 @@ bool Autopick::Matcher::matches(const Item& ci) const
 {
     const auto id = ci.id;
     const auto name = cnvitemname(id);
-    return ci.identification_state != IdentifyState::unidentified
-        && name.find(text) != std::string::npos;
+    return ci.identification_state != IdentifyState::unidentified &&
+        name.find(text) != std::string::npos;
 }
 
 } // namespace elona

--- a/src/blending.cpp
+++ b/src/blending.cpp
@@ -428,8 +428,8 @@ void window_recipe_(
         prm_1052 + prm_1054 - 49 - prm_1054 % 8,
         {234, 220, 188});
     s_at_m184(0) = u8"Page."s + (rppage + 1) + u8"/"s + (rppage(1) + 1);
-    s_at_m184(1) = ""s + key_prev + u8","s + key_next + ""s
-        + i18n::s.get("core.locale.blending.recipe.hint");
+    s_at_m184(1) = ""s + key_prev + u8","s + key_next + ""s +
+        i18n::s.get("core.locale.blending.recipe.hint");
     if (step == -1)
     {
         s_at_m184(1) += strhint3;
@@ -475,14 +475,14 @@ void window_recipe_(
     if (step == -1)
     {
         pos(dx_at_m184, dy_at_m184);
-        mes(""s + i_at_m184 + u8"."s
-            + i18n::s.get("core.locale.blending.window.choose_a_recipe"));
+        mes(""s + i_at_m184 + u8"."s +
+            i18n::s.get("core.locale.blending.window.choose_a_recipe"));
     }
     else
     {
         pos(dx_at_m184, dy_at_m184);
-        mes(""s + i_at_m184 + u8"."s
-            + i18n::s.get(
+        mes(""s + i_at_m184 + u8"."s +
+            i18n::s.get(
                 "core.locale.blending.window.chose_the_recipe_of",
                 rpname(rpid)));
     }
@@ -554,8 +554,8 @@ void window_recipe_(
             {20, 20, 20, 32});
     }
     pos(dx_at_m184, dy_at_m184);
-    mes(""s + i_at_m184 + u8"."s
-        + i18n::s.get("core.locale.blending.window.start"));
+    mes(""s + i_at_m184 + u8"."s +
+        i18n::s.get("core.locale.blending.window.start"));
     dy_at_m184 += 30;
     if (rppage == 0)
     {
@@ -574,8 +574,8 @@ void window_recipe_(
             {
                 break;
             }
-            if (rpdata(11 + cnt * 2, rpid)
-                > sdata(rpdata(10 + cnt * 2, rpid), 0))
+            if (rpdata(11 + cnt * 2, rpid) >
+                sdata(rpdata(10 + cnt * 2, rpid), 0))
             {
                 color(150, 0, 0);
             }
@@ -589,9 +589,9 @@ void window_recipe_(
                     the_ability_db
                         .get_id_from_legacy(rpdata(10 + cnt * 2, rpid))
                         ->get(),
-                    "name")
-                + u8"  "s + rpdata((11 + cnt * 2), rpid) + u8"("s
-                + sdata(rpdata((10 + cnt * 2), rpid), 0) + u8")"s);
+                    "name") +
+                u8"  "s + rpdata((11 + cnt * 2), rpid) + u8"("s +
+                sdata(rpdata((10 + cnt * 2), rpid), 0) + u8")"s);
             color(0, 0, 0);
         }
         dy_at_m184 += 50;
@@ -1200,8 +1200,8 @@ int rpdiff(int, int prm_1042, int prm_1043)
             }
         }
         p_at_m180 =
-            (d_at_m180 * 200 / sdata(rpdata((10 + cnt * 2), rpid), 0) - 200)
-            * -1;
+            (d_at_m180 * 200 / sdata(rpdata((10 + cnt * 2), rpid), 0) - 200) *
+            -1;
         if (p_at_m180 > 0)
         {
             p_at_m180 /= 5;
@@ -1279,8 +1279,8 @@ int blendcheckmat(int prm_1044)
                 {
                     continue;
                 }
-                if ((rpdata(2, rpid) <= 0 || step_at_m181 != 0)
-                    && inv[cnt].own_state > 0)
+                if ((rpdata(2, rpid) <= 0 || step_at_m181 != 0) &&
+                    inv[cnt].own_state > 0)
                 {
                     continue;
                 }
@@ -1290,8 +1290,7 @@ int blendcheckmat(int prm_1044)
                             inv[cnt].position.x,
                             inv[cnt].position.y,
                             cdata.player().position.x,
-                            cdata.player().position.y)
-                        > 4)
+                            cdata.player().position.y) > 4)
                     {
                         continue;
                     }
@@ -1318,9 +1317,9 @@ int blendcheckmat(int prm_1044)
                     if (instr(
                             the_item_db[inv[cnt].id]->rffilter,
                             0,
-                            u8"/"s + rfnameorg(0, (id_at_m181 - 9000)) + u8"/"s)
-                            != -1
-                        || id_at_m181 == 9004)
+                            u8"/"s + rfnameorg(0, (id_at_m181 - 9000)) +
+                                u8"/"s) != -1 ||
+                        id_at_m181 == 9004)
                     {
                         f_at_m181 = 1;
                         break;
@@ -1367,8 +1366,8 @@ int blendmatnum(int prm_1045, int prm_1046)
             {
                 continue;
             }
-            if ((rpdata(2, rpid) <= 0 || prm_1046 != 0)
-                && inv[cnt].own_state > 0)
+            if ((rpdata(2, rpid) <= 0 || prm_1046 != 0) &&
+                inv[cnt].own_state > 0)
             {
                 continue;
             }
@@ -1378,8 +1377,7 @@ int blendmatnum(int prm_1045, int prm_1046)
                         inv[cnt].position.x,
                         inv[cnt].position.y,
                         cdata.player().position.x,
-                        cdata.player().position.y)
-                    > 4)
+                        cdata.player().position.y) > 4)
                 {
                     continue;
                 }
@@ -1405,9 +1403,9 @@ int blendmatnum(int prm_1045, int prm_1046)
                 if (instr(
                         the_item_db[inv[cnt].id]->rffilter,
                         0,
-                        u8"/"s + rfnameorg(0, (prm_1045 - 9000)) + u8"/"s)
-                        != -1
-                    || prm_1045 == 9004)
+                        u8"/"s + rfnameorg(0, (prm_1045 - 9000)) + u8"/"s) !=
+                        -1 ||
+                    prm_1045 == 9004)
                 {
                     m_at_m182 += inv[cnt].number();
                 }
@@ -1462,8 +1460,7 @@ int blendlist(elona_vector2<int>& prm_1047, int prm_1048)
                         inv[cnt].position.x,
                         inv[cnt].position.y,
                         cdata.player().position.x,
-                        cdata.player().position.y)
-                    > 4)
+                        cdata.player().position.y) > 4)
                 {
                     continue;
                 }
@@ -1489,9 +1486,9 @@ int blendlist(elona_vector2<int>& prm_1047, int prm_1048)
                 if (instr(
                         the_item_db[inv[cnt].id]->rffilter,
                         0,
-                        u8"/"s + rfnameorg(0, (id_at_m183 - 9000)) + u8"/"s)
-                        == -1
-                    && id_at_m183 != 9004)
+                        u8"/"s + rfnameorg(0, (id_at_m183 - 9000)) + u8"/"s) ==
+                        -1 &&
+                    id_at_m183 != 9004)
                 {
                     continue;
                 }
@@ -1547,8 +1544,8 @@ int blending_find_required_mat()
             f = 0;
             break;
         }
-        if (inv[rpref(10 + cnt * 2)].number() <= 0
-            || inv[rpref(10 + cnt * 2)].id != rpref(11 + cnt * 2))
+        if (inv[rpref(10 + cnt * 2)].number() <= 0 ||
+            inv[rpref(10 + cnt * 2)].id != rpref(11 + cnt * 2))
         {
             f = 0;
             break;
@@ -1800,8 +1797,8 @@ void blending_proc_on_success_events()
         }
         break;
     case 10008:
-        if (inv[ci].param1 < -5 || inv[ci].param3 >= 20
-            || (inv[ci].id == 602 && game_data.holy_well_count <= 0))
+        if (inv[ci].param1 < -5 || inv[ci].param3 >= 20 ||
+            (inv[ci].id == 602 && game_data.holy_well_count <= 0))
         {
             txt(i18n::s.get(
                 "core.locale.action.dip.result.natural_potion_dry", inv[ci]));

--- a/src/buff.cpp
+++ b/src/buff.cpp
@@ -179,8 +179,8 @@ void buff_add(
         }
         if (const auto& holy_veil = buff_find(cc, 10))
         {
-            if (holy_veil->power + 50 > power * 5 / 2
-                || rnd(holy_veil->power + 50) > rnd(power + 1))
+            if (holy_veil->power + 50 > power * 5 / 2 ||
+                rnd(holy_veil->power + 50) > rnd(power + 1))
             {
                 txt(i18n::s.get("core.locale.magic.buff.holy_veil_repels"));
                 return;

--- a/src/building.cpp
+++ b/src/building.cpp
@@ -100,8 +100,7 @@ void prepare_house_board_tiles()
         if (std::find(
                 std::begin(unavailable_tiles),
                 std::end(unavailable_tiles),
-                p(1))
-            != std::end(unavailable_tiles))
+                p(1)) != std::end(unavailable_tiles))
         {
             continue;
         }
@@ -411,8 +410,8 @@ TurnResult show_house_board()
         p = 0;
         for (auto&& cnt : cdata.others())
         {
-            if (cnt.state() == Character::State::alive
-                || cnt.state() == Character::State::villager_dead)
+            if (cnt.state() == Character::State::alive ||
+                cnt.state() == Character::State::villager_dead)
             {
                 if (cnt.character_role != 0)
                 {
@@ -493,8 +492,8 @@ void prompt_hiring()
     p = 0;
     for (auto&& cnt : cdata.others())
     {
-        if (cnt.state() == Character::State::alive
-            || cnt.state() == Character::State::villager_dead)
+        if (cnt.state() == Character::State::alive ||
+            cnt.state() == Character::State::villager_dead)
         {
             if (cnt.character_role != 0)
             {
@@ -580,8 +579,8 @@ void prompt_hiring()
             {
                 continue;
             }
-            if (cnt.state() != Character::State::empty
-                && cdatan(0, cnt.index) == cdatan(0, rc))
+            if (cnt.state() != Character::State::empty &&
+                cdatan(0, cnt.index) == cdatan(0, rc))
             {
                 chara_vanquish(rc);
             }
@@ -711,8 +710,8 @@ void show_home_value()
     key_list = key_cancel;
 
     s(0) = i18n::s.get("core.locale.building.home.rank.title");
-    s(1) = i18n::s.get("core.locale.building.home.rank.enter_key")
-        + i18n::s.get("core.locale.ui.hint.close");
+    s(1) = i18n::s.get("core.locale.building.home.rank.enter_key") +
+        i18n::s.get("core.locale.ui.hint.close");
     windowshadow = 1;
     display_window((windoww - 440) / 2 + inf_screenx, winposy(360), 440, 360);
     display_topic(
@@ -823,8 +822,8 @@ void prompt_move_ally()
                 continue;
             }
         }
-        if (chipm(7, cell_data.at(tlocx, tlocy).chip_id_actual) & 4
-            || cell_data.at(tlocx, tlocy).chara_index_plus_one != 0)
+        if (chipm(7, cell_data.at(tlocx, tlocy).chip_id_actual) & 4 ||
+            cell_data.at(tlocx, tlocy).chara_index_plus_one != 0)
         {
             txt(i18n::s.get("core.locale.building.home.move.invalid"));
             goto label_1718_internal;
@@ -943,8 +942,8 @@ void show_shop_log()
         u8"["s + i18n::s.get("core.locale.building.shop.info") + u8"]"s;
     if (worker == -1)
     {
-        txt(shop_mark
-            + i18n::s.get("core.locale.building.shop.log.no_shopkeeper"));
+        txt(shop_mark +
+            i18n::s.get("core.locale.building.shop.log.no_shopkeeper"));
         return;
     }
     sold = 0;
@@ -1157,8 +1156,8 @@ void show_shop_log()
     {
         if (!Config::instance().hideshopresult)
         {
-            txt(shop_mark
-                + i18n::s.get(
+            txt(shop_mark +
+                i18n::s.get(
                     "core.locale.building.shop.log.could_not_sell",
                     customer,
                     cdata[worker]));
@@ -1175,8 +1174,8 @@ void show_shop_log()
                     "core.locale.building.shop.log.and_items", income(1));
             }
             snd("core.ding2");
-            txt(shop_mark
-                    + i18n::s.get(
+            txt(shop_mark +
+                    i18n::s.get(
                         "core.locale.building.shop.log.sold_items",
                         customer,
                         cdata[worker],
@@ -1276,8 +1275,7 @@ void update_museum()
         if (wpeek(
                 cell_data.at(inv[cnt].position.x, inv[cnt].position.y)
                     .item_appearances_actual,
-                0)
-            != inv[cnt].image)
+                0) != inv[cnt].image)
         {
             continue;
         }
@@ -1342,8 +1340,7 @@ void calc_home_rank()
         if (wpeek(
                 cell_data.at(inv[cnt].position.x, inv[cnt].position.y)
                     .item_appearances_actual,
-                0)
-            != inv[cnt].image)
+                0) != inv[cnt].image)
         {
             continue;
         }
@@ -1373,10 +1370,10 @@ void calc_home_rank()
     {
         game_data.total_heirloom_value = 10000;
     }
-    rankcur = 10000
-        - (game_data.basic_point_of_home_rank + game_data.total_deco_value
-           + game_data.total_heirloom_value)
-            / 3;
+    rankcur = 10000 -
+        (game_data.basic_point_of_home_rank + game_data.total_deco_value +
+         game_data.total_heirloom_value) /
+            3;
     if (rankcur < 100)
     {
         rankcur = 100;
@@ -1428,9 +1425,9 @@ void update_ranch()
         {
             goto label_1734_internal;
         }
-        if (rnd(5000)
-            > chara_breed_power(cdata[worker]) * 100 / (100 + livestock * 20)
-                - livestock * 2)
+        if (rnd(5000) >
+            chara_breed_power(cdata[worker]) * 100 / (100 + livestock * 20) -
+                livestock * 2)
         {
             if (livestock != 0 || rnd(30) != 0)
             {

--- a/src/calc.cpp
+++ b/src/calc.cpp
@@ -314,8 +314,8 @@ Quality calcfixlv(Quality base_quality)
 
 int calcfame(int cc, int base)
 {
-    int ret = base * 100
-        / (100 + cdata[cc].fame / 100 * (cdata[cc].fame / 100) / 2500);
+    int ret = base * 100 /
+        (100 + cdata[cc].fame / 100 * (cdata[cc].fame / 100) / 2500);
     if (ret < 5)
     {
         ret = rnd(5) + 1;
@@ -440,8 +440,8 @@ int calc_accuracy(bool consider_distance)
     }
     else
     {
-        accuracy = sdata(12, cc) / 4 + sdata(inv[cw].skill, cc) / 3
-            + sdata(attackskill, cc) + 50;
+        accuracy = sdata(12, cc) / 4 + sdata(inv[cw].skill, cc) / 3 +
+            sdata(attackskill, cc) + 50;
         accuracy += cdata[cc].hit_bonus + inv[cw].hit_bonus;
         if (ammo != -1)
         {
@@ -460,8 +460,8 @@ int calc_accuracy(bool consider_distance)
                         cdata[cc].position.x,
                         cdata[cc].position.y,
                         cdata[tc].position.x,
-                        cdata[tc].position.y)
-                        - 1,
+                        cdata[tc].position.y) -
+                        1,
                     0,
                     9);
                 const auto effective_range = calc_effective_range(inv[cw].id);
@@ -484,14 +484,14 @@ int calc_accuracy(bool consider_distance)
                 {
                     if (inv[cw].weight >= 4000)
                     {
-                        accuracy -= (inv[cw].weight - 4000 + 400)
-                            / (10 + sdata(166, cc) / 5);
+                        accuracy -= (inv[cw].weight - 4000 + 400) /
+                            (10 + sdata(166, cc) / 5);
                     }
                 }
                 else if (inv[cw].weight > 1500)
                 {
-                    accuracy -= (inv[cw].weight - 1500 + 100)
-                        / (10 + sdata(166, cc) / 5);
+                    accuracy -= (inv[cw].weight - 1500 + 100) /
+                        (10 + sdata(166, cc) / 5);
                 }
             }
         }
@@ -503,8 +503,8 @@ int calc_accuracy(bool consider_distance)
         {
             accuracy =
                 accuracy * 100 / clamp((150 - sdata(301, cc) / 2), 115, 150);
-            if (attackskill != 106 && attackrange == 0
-                && inv[cw].weight >= 4000)
+            if (attackskill != 106 && attackrange == 0 &&
+                inv[cw].weight >= 4000)
             {
                 accuracy -=
                     (inv[cw].weight - 4000 + 400) / (10 + sdata(301, cc) / 5);
@@ -514,8 +514,8 @@ int calc_accuracy(bool consider_distance)
         {
             accuracy =
                 accuracy * 100 / clamp((150 - sdata(10, cc) / 2), 115, 150);
-            if (attackskill != 106 && attackrange == 0
-                && inv[cw].weight >= 4000)
+            if (attackskill != 106 && attackrange == 0 &&
+                inv[cw].weight >= 4000)
             {
                 accuracy -=
                     (inv[cw].weight - 4000 + 400) / (10 + sdata(10, cc) / 10);
@@ -651,37 +651,36 @@ int calcattackdmg(int prm_894)
             sdata(10, cc) / 8 + sdata(106, cc) / 8 + cdata[cc].damage_bonus;
         dice1 = 2;
         dice2 = sdata(106, cc) / 8 + 5;
-        dmgmulti = 0.5
-            + double(
-                  (sdata(10, cc) + sdata(attackskill, cc) / 5
-                   + sdata(152, cc) * 2))
-                / 40;
+        dmgmulti = 0.5 +
+            double(
+                (sdata(10, cc) + sdata(attackskill, cc) / 5 +
+                 sdata(152, cc) * 2)) /
+                40;
         pierce = clamp(sdata(attackskill, cc) / 5, 5, 50);
     }
     else
     {
-        dmgfix = cdata[cc].damage_bonus + inv[cw].damage_bonus
-            + inv[cw].enhancement
-            + (inv[cw].curse_state == CurseState::blessed);
+        dmgfix = cdata[cc].damage_bonus + inv[cw].damage_bonus +
+            inv[cw].enhancement + (inv[cw].curse_state == CurseState::blessed);
         dice1 = inv[cw].dice_x;
         dice2 = inv[cw].dice_y;
         if (ammo != -1)
         {
-            dmgfix += inv[ammo].damage_bonus
-                + inv[ammo].dice_x * inv[ammo].dice_y / 2;
-            dmgmulti = 0.5
-                + double(
-                      (sdata(13, cc) + sdata(inv[cw].skill, cc) / 5
-                       + sdata(attackskill, cc) / 5 + sdata(189, cc) * 3 / 2))
-                    / 40;
+            dmgfix += inv[ammo].damage_bonus +
+                inv[ammo].dice_x * inv[ammo].dice_y / 2;
+            dmgmulti = 0.5 +
+                double(
+                    (sdata(13, cc) + sdata(inv[cw].skill, cc) / 5 +
+                     sdata(attackskill, cc) / 5 + sdata(189, cc) * 3 / 2)) /
+                    40;
         }
         else
         {
-            dmgmulti = 0.6
-                + double(
-                      (sdata(10, cc) + sdata(inv[cw].skill, cc) / 5
-                       + sdata(attackskill, cc) / 5 + sdata(152, cc) * 2))
-                    / 45;
+            dmgmulti = 0.6 +
+                double(
+                    (sdata(10, cc) + sdata(inv[cw].skill, cc) / 5 +
+                     sdata(attackskill, cc) / 5 + sdata(152, cc) * 2)) /
+                    45;
         }
         pierce = calc_rate_to_pierce(inv[cw].id);
     }
@@ -716,8 +715,8 @@ int calcattackdmg(int prm_894)
     {
         return damage;
     }
-    prot = cdata[tc].pv + sdata(chara_armor_class(cdata[tc]), tc)
-        + sdata(12, tc) / 10;
+    prot = cdata[tc].pv + sdata(chara_armor_class(cdata[tc]), tc) +
+        sdata(12, tc) / 10;
     if (prot > 0)
     {
         prot2 = prot / 4;
@@ -756,8 +755,8 @@ int calcattackdmg(int prm_894)
         }
         else if (ammo != -1)
         {
-            dmgmulti = dmgmulti
-                * clamp((inv[ammo].weight / 100 + 100), 100, 150) / 100;
+            dmgmulti = dmgmulti *
+                clamp((inv[ammo].weight / 100 + 100), 100, 150) / 100;
         }
         else
         {
@@ -827,8 +826,8 @@ int calcattackdmg(int prm_894)
     }
     if (cdata[tc].decrease_physical_damage != 0)
     {
-        damage = damage * 100
-            / clamp((100 + cdata[tc].decrease_physical_damage), 25, 1000);
+        damage = damage * 100 /
+            clamp((100 + cdata[tc].decrease_physical_damage), 25, 1000);
     }
     if (damage < 0)
     {
@@ -880,10 +879,10 @@ int calcitemvalue(int ci, int situation)
         }
         else
         {
-            ret = cdata.player().level / 5
-                    * ((game_data.random_seed + ci * 31) % cdata.player().level
-                       + 4)
-                + 10;
+            ret = cdata.player().level / 5 *
+                    ((game_data.random_seed + ci * 31) % cdata.player().level +
+                     4) +
+                10;
         }
     }
     else if (category >= 50000)
@@ -926,8 +925,8 @@ int calcitemvalue(int ci, int situation)
         if (situation == 0)
         {
             ret += clamp(
-                cdata.player().fame / 40
-                    + ret * (cdata.player().fame / 80) / 100,
+                cdata.player().fame / 40 +
+                    ret * (cdata.player().fame / 80) / 100,
                 0,
                 800);
         }
@@ -1055,8 +1054,8 @@ int calcinvestvalue()
 
 int calcguiltvalue()
 {
-    return -(cdata.player().karma + 30)
-        * (cdata.player().fame / 2 + cdata.player().level * 200);
+    return -(cdata.player().karma + 30) *
+        (cdata.player().fame / 2 + cdata.player().level * 200);
 }
 
 
@@ -1098,8 +1097,8 @@ int calchirecost(int cc)
 void generatemoney(int cc)
 {
     int gold = rnd(100) + rnd(cdata[cc].level * 50 + 1);
-    if ((cdata[cc].character_role >= 1000 && cdata[cc].character_role < 2000)
-        || cdata[cc].character_role == 2003)
+    if ((cdata[cc].character_role >= 1000 && cdata[cc].character_role < 2000) ||
+        cdata[cc].character_role == 2003)
     {
         gold += 2500 + cdata[cc].shop_rank * 250;
     }
@@ -1122,13 +1121,12 @@ void calccosthire()
             continue;
         cost += calchirecost(cnt.index);
     }
-    cost = cost
-        * clamp(
-               100 - clamp(cdata.player().karma / 2, 0, 50) - 7 * trait(38)
-                   - (cdata.player().karma >= 20) * 5,
-               25,
-               200)
-        / 100;
+    cost = cost *
+        clamp(100 - clamp(cdata.player().karma / 2, 0, 50) - 7 * trait(38) -
+                  (cdata.player().karma >= 20) * 5,
+              25,
+              200) /
+        100;
     game_data.cost_to_hire = cost;
 }
 
@@ -1151,13 +1149,12 @@ int calccostbuilding()
         }
     }
 
-    return cost
-        * clamp(
-               100 - clamp(cdata.player().karma / 2, 0, 50) - 7 * trait(38)
-                   - (cdata.player().karma >= 20) * 5,
-               25,
-               200)
-        / 100;
+    return cost *
+        clamp(100 - clamp(cdata.player().karma / 2, 0, 50) - 7 * trait(38) -
+                  (cdata.player().karma >= 20) * 5,
+              25,
+              200) /
+        100;
 }
 
 
@@ -1168,13 +1165,12 @@ int calccosttax()
     cost += cdata.player().gold / 1000;
     cost += cdata.player().fame;
     cost += cdata.player().level * 200;
-    return cost
-        * clamp(
-               100 - clamp(cdata.player().karma / 2, 0, 50) - 7 * trait(38)
-                   - (cdata.player().karma >= 20) * 5,
-               25,
-               200)
-        / 100;
+    return cost *
+        clamp(100 - clamp(cdata.player().karma / 2, 0, 50) - 7 * trait(38) -
+                  (cdata.player().karma >= 20) * 5,
+              25,
+              200) /
+        100;
 }
 
 
@@ -1232,8 +1228,9 @@ int calccargoupdate()
 
 int calccargoupdatecost()
 {
-    return (game_data.current_cart_limit - game_data.initial_cart_limit) / 10000
-        + 1;
+    return (game_data.current_cart_limit - game_data.initial_cart_limit) /
+        10000 +
+        1;
 }
 
 
@@ -1256,8 +1253,8 @@ int calcidentifyvalue(int type)
             {
                 continue;
             }
-            if (inv[cnt].identification_state
-                != IdentifyState::completely_identified)
+            if (inv[cnt].identification_state !=
+                IdentifyState::completely_identified)
             {
                 ++need_to_identify;
             }
@@ -1304,8 +1301,8 @@ int calcresurrectvalue(int pet)
 
 int calcslavevalue(int pet)
 {
-    int value = sdata(10, pet) * sdata(11, pet)
-        + cdata[pet].level * cdata[pet].level + 1000;
+    int value = sdata(10, pet) * sdata(11, pet) +
+        cdata[pet].level * cdata[pet].level + 1000;
     if (value > 50'000)
     {
         value = 50'000;
@@ -1330,10 +1327,10 @@ int calcinitgold(int owner)
 {
     if (owner < 0)
     {
-        return rnd(game_data.current_dungeon_level * 25
-                       * (game_data.current_map != mdata_t::MapId::shelter_)
-                   + 10)
-            + 1;
+        return rnd(game_data.current_dungeon_level * 25 *
+                       (game_data.current_map != mdata_t::MapId::shelter_) +
+                   10) +
+            1;
     }
 
     switch (cdata[owner].id)
@@ -1353,8 +1350,8 @@ int calcspellpower(int id, int cc)
     {
         if (the_ability_db[id]->related_basic_attribute != 0)
         {
-            return sdata(the_ability_db[id]->related_basic_attribute, cc) * 6
-                + 10;
+            return sdata(the_ability_db[id]->related_basic_attribute, cc) * 6 +
+                10;
         }
         return 100;
     }
@@ -1418,8 +1415,8 @@ int calcspellfail(int id, int cc)
         penalty += sdata(id, cc) / 3;
     }
 
-    int percentage = 90 + sdata(id, cc)
-        - the_ability_db[id]->difficulty * penalty / (5 + sdata(172, cc) * 4);
+    int percentage = 90 + sdata(id, cc) -
+        the_ability_db[id]->difficulty * penalty / (5 + sdata(172, cc) * 4);
     if (armor_skill == 169)
     {
         if (percentage > 80)
@@ -1462,15 +1459,15 @@ int calcspellcostmp(int id, int cc)
 
     if (cc == 0)
     {
-        if (id == 413 || id == 461 || id == 457 || id == 438 || id == 409
-            || id == 408 || id == 410 || id == 466)
+        if (id == 413 || id == 461 || id == 457 || id == 438 || id == 409 ||
+            id == 408 || id == 410 || id == 466)
         {
             return the_ability_db[id]->cost;
         }
         else
         {
-            return the_ability_db[id]->cost * (100 + sdata(id, cc) * 3) / 100
-                + sdata(id, cc) / 8;
+            return the_ability_db[id]->cost * (100 + sdata(id, cc) * 3) / 100 +
+                sdata(id, cc) / 8;
         }
     }
     else
@@ -1503,9 +1500,9 @@ int calcspellcoststock(int id, int cc)
 
 int calcscore()
 {
-    int score = cdata.player().level * cdata.player().level
-        + game_data.deepest_dungeon_level * game_data.deepest_dungeon_level
-        + game_data.kill_count;
+    int score = cdata.player().level * cdata.player().level +
+        game_data.deepest_dungeon_level * game_data.deepest_dungeon_level +
+        game_data.kill_count;
     if (game_data.death_count > 1)
     {
         score = score / 10 + 1;
@@ -1655,8 +1652,8 @@ int calc_initial_skill_level_speed(int initial_level, int chara_level)
 
 int calc_initial_skill_level(int initial_level, int chara_level, int potential)
 {
-    return potential * potential * chara_level / 45000 + initial_level
-        + chara_level / 3;
+    return potential * potential * chara_level / 45000 + initial_level +
+        chara_level / 3;
 }
 
 int calc_initial_skill_decayed_potential(int chara_level, int potential)
@@ -1731,10 +1728,10 @@ int calc_chara_exp_from_skill_exp(
     int skill_exp,
     int divisor)
 {
-    return rnd(int(double(chara.required_experience) * skill_exp / 1000
-                   / (chara.level + divisor))
-               + 1)
-        + rnd(2);
+    return rnd(int(double(chara.required_experience) * skill_exp / 1000 /
+                   (chara.level + divisor)) +
+               1) +
+        rnd(2);
 }
 
 int calc_exp_gain_negotiation_gold_threshold(int current_level)

--- a/src/card.cpp
+++ b/src/card.cpp
@@ -152,8 +152,8 @@ reset_page:
                 goto reset_page;
             }
         }
-        if (card(0, list(0, pagesize * page + cs))
-            && (p != -1 || action == "switch_mode_2"))
+        if (card(0, list(0, pagesize * page + cs)) &&
+            (p != -1 || action == "switch_mode_2"))
         {
             const int ci_save = ci;
             Item tmp;

--- a/src/casino.cpp
+++ b/src/casino.cpp
@@ -414,23 +414,23 @@ void casino_random_site()
         if (map_data.type == mdata_t::MapType::world_map)
         {
             atxlv = cdata.player().level;
-            if (4 <= game_data.stood_world_map_tile
-                && game_data.stood_world_map_tile < 9)
+            if (4 <= game_data.stood_world_map_tile &&
+                game_data.stood_world_map_tile < 9)
             {
                 atxid(1) = 2;
             }
-            if (264 <= game_data.stood_world_map_tile
-                && game_data.stood_world_map_tile < 363)
+            if (264 <= game_data.stood_world_map_tile &&
+                game_data.stood_world_map_tile < 363)
             {
                 atxid(1) = 3;
             }
-            if (9 <= game_data.stood_world_map_tile
-                && game_data.stood_world_map_tile < 13)
+            if (9 <= game_data.stood_world_map_tile &&
+                game_data.stood_world_map_tile < 13)
             {
                 atxid(1) = 2;
             }
-            if (13 <= game_data.stood_world_map_tile
-                && game_data.stood_world_map_tile < 17)
+            if (13 <= game_data.stood_world_map_tile &&
+                game_data.stood_world_map_tile < 17)
             {
                 atxid(1) = 3;
             }
@@ -556,12 +556,12 @@ label_1876_internal:
             listn(0, listmax) = u8"調べる"s;
             ++listmax;
             list(0, listmax) = 2;
-            listn(0, listmax) = u8"採取する("s
-                + i18n::s.get_m(
+            listn(0, listmax) = u8"採取する("s +
+                i18n::s.get_m(
                     "locale.ability",
                     the_ability_db.get_id_from_legacy(180)->get(),
-                    "name")
-                + u8": "s + sdata(180, 0) + u8")"s;
+                    "name") +
+                u8": "s + sdata(180, 0) + u8")"s;
             ++listmax;
             atxrefval1 = 7;
         }
@@ -576,12 +576,12 @@ label_1876_internal:
             listn(0, listmax) = u8"調べる"s;
             ++listmax;
             list(0, listmax) = 2;
-            listn(0, listmax) = u8"掘る("s
-                + i18n::s.get_m(
+            listn(0, listmax) = u8"掘る("s +
+                i18n::s.get_m(
                     "locale.ability",
                     the_ability_db.get_id_from_legacy(163)->get(),
-                    "name")
-                + u8": "s + sdata(163, 0) + u8")"s;
+                    "name") +
+                u8": "s + sdata(163, 0) + u8")"s;
             ++listmax;
             atxrefval1 = 7;
         }
@@ -596,12 +596,12 @@ label_1876_internal:
             listn(0, listmax) = u8"飲む"s;
             ++listmax;
             list(0, listmax) = 2;
-            listn(0, listmax) = u8"釣る("s
-                + i18n::s.get_m(
+            listn(0, listmax) = u8"釣る("s +
+                i18n::s.get_m(
                     "locale.ability",
                     the_ability_db.get_id_from_legacy(185)->get(),
-                    "name")
-                + u8": "s + sdata(185, 0) + u8")"s;
+                    "name") +
+                u8": "s + sdata(185, 0) + u8")"s;
             ++listmax;
             atxrefval1 = 7;
         }
@@ -616,12 +616,12 @@ label_1876_internal:
             listn(0, listmax) = u8"あさる"s;
             ++listmax;
             list(0, listmax) = 2;
-            listn(0, listmax) = u8"解剖する("s
-                + i18n::s.get_m(
+            listn(0, listmax) = u8"解剖する("s +
+                i18n::s.get_m(
                     "locale.ability",
                     the_ability_db.get_id_from_legacy(161)->get(),
-                    "name")
-                + u8": "s + sdata(161, 0) + u8")"s;
+                    "name") +
+                u8": "s + sdata(161, 0) + u8")"s;
             ++listmax;
             atxrefval1 = 7;
         }
@@ -653,8 +653,8 @@ label_1876_internal:
                 snd("core.get3");
                 mat(p) += 1;
                 noteadd(
-                    "@BL"
-                    + i18n::s.get(
+                    "@BL" +
+                    i18n::s.get(
                         "core.locale.casino.you_get", 1, matname(p), mat(p)));
             }
             atxthrough = 1;
@@ -798,12 +798,12 @@ label_1876_internal:
         atxpic(3) = 96;
         noteadd(u8"宝箱がある。"s);
         list(0, listmax) = 1;
-        listn(0, listmax) = u8"錠を解体する("s
-            + i18n::s.get_m(
+        listn(0, listmax) = u8"錠を解体する("s +
+            i18n::s.get_m(
                 "locale.ability",
                 the_ability_db.get_id_from_legacy(158)->get(),
-                "name")
-            + u8": "s + sdata(158, 0) + u8")"s;
+                "name") +
+            u8": "s + sdata(158, 0) + u8")"s;
         ++listmax;
         list(0, listmax) = 3;
         listn(0, listmax) = u8"叩き割る(筋力: "s + sdata(10, 0) + u8")"s;
@@ -826,8 +826,8 @@ label_1876_internal:
         snd("core.get3");
         mat(p) += 1;
         noteadd(
-            "@BL"
-            + i18n::s.get("core.locale.casino.you_get", 1, matname(p), mat(p)));
+            "@BL" +
+            i18n::s.get("core.locale.casino.you_get", 1, matname(p), mat(p)));
         atxthrough = 1;
         goto label_1875;
     }
@@ -895,9 +895,8 @@ bool casino_start()
         snd("core.get3");
         mat(1) += 10;
         noteadd(
-            "@BL"
-            + i18n::s.get(
-                "core.locale.casino.you_get", 10, matname(1), mat(1)));
+            "@BL" +
+            i18n::s.get("core.locale.casino.you_get", 10, matname(1), mat(1)));
     }
     atxinfon(1) = i18n::s.get("core.locale.casino.chips_left", mat(1)) + "\n";
     atxinfon(2) = "";
@@ -1076,8 +1075,8 @@ bool casino_blackjack()
         atxinfon(1) =
             i18n::s.get("core.locale.casino.chips_left", mat(1)) + "\n";
         atxinfon(2) =
-            i18n::s.get("core.locale.casino.blackjack.game.bets", stake) + " "
-            + i18n::s.get("core.locale.casino.blackjack.game.wins", winrow);
+            i18n::s.get("core.locale.casino.blackjack.game.bets", stake) + " " +
+            i18n::s.get("core.locale.casino.blackjack.game.wins", winrow);
         if (cardround == -1)
         {
             if (winner == 1)
@@ -1185,9 +1184,10 @@ bool casino_blackjack()
                 atxinfon(1) =
                     i18n::s.get("core.locale.casino.chips_left", mat(1)) + "\n";
                 atxinfon(2) =
-                    i18n::s.get("core.locale.casino.blackjack.game.bets", stake)
-                    + " "
-                    + i18n::s.get(
+                    i18n::s.get(
+                        "core.locale.casino.blackjack.game.bets", stake) +
+                    " " +
+                    i18n::s.get(
                         "core.locale.casino.blackjack.game.wins", winrow);
                 winrow = 0;
                 txt(i18n::s.get(
@@ -1244,8 +1244,8 @@ bool casino_blackjack()
         }
         snd("core.get3");
         noteadd(
-            "@GR"
-            + i18n::s.get("core.locale.casino.blackjack.game.loot", inv[ci]));
+            "@GR" +
+            i18n::s.get("core.locale.casino.blackjack.game.loot", inv[ci]));
         if (winrow > 3)
         {
             // Potion of cure corruption
@@ -1255,8 +1255,8 @@ bool casino_blackjack()
                 itemcreate(-1, 559, -1, -1, 0);
                 snd("core.get3");
                 noteadd(
-                    "@GR"
-                    + i18n::s.get(
+                    "@GR" +
+                    i18n::s.get(
                         "core.locale.casino.blackjack.game.loot", inv[ci]));
             }
         }

--- a/src/casino_card.cpp
+++ b/src/casino_card.cpp
@@ -199,8 +199,8 @@ void showcard()
     showcardpile();
     for (int cnt = 0, cnt_end = (cardmax_at_cardcontrol); cnt < cnt_end; ++cnt)
     {
-        if (card_at_cardcontrol(5, cnt) == -1
-            || card_at_cardcontrol(5, cnt) == -2)
+        if (card_at_cardcontrol(5, cnt) == -1 ||
+            card_at_cardcontrol(5, cnt) == -2)
         {
             continue;
         }
@@ -232,8 +232,8 @@ int servecard(int prm_427)
             break;
         }
     }
-    dx_at_cardcontrol = pilex_at_cardcontrol
-        - cardplayer_at_cardcontrol(1, prm_427) - p_at_cardcontrol * 88;
+    dx_at_cardcontrol = pilex_at_cardcontrol -
+        cardplayer_at_cardcontrol(1, prm_427) - p_at_cardcontrol * 88;
     dy_at_cardcontrol =
         piley_at_cardcontrol - cardplayer_at_cardcontrol(2, prm_427);
     card_at_cardcontrol(5, cardid_at_cardcontrol) = prm_427;
@@ -369,8 +369,8 @@ int trashcard(int prm_430)
              cnt < cnt_end;
              ++cnt)
         {
-            if (cardplayer_at_cardcontrol(10 + cnt, p_at_cardcontrol)
-                == prm_430)
+            if (cardplayer_at_cardcontrol(10 + cnt, p_at_cardcontrol) ==
+                prm_430)
             {
                 cardplayer_at_cardcontrol(10 + cnt, p_at_cardcontrol) = -1;
             }

--- a/src/cell_draw.cpp
+++ b/src/cell_draw.cpp
@@ -504,11 +504,11 @@ void render_cloud()
     for (size_t i = 0; i < clouds.size(); ++i)
     {
         gmode(5, 7 + i * 2);
-        int x = (clouds[i].x0 - cdata.player().position.x * inf_tiles + sxfix)
-                * 100 / (40 + i * 5)
-            + scrturn * 100 / (50 + i * 20);
-        int y = (clouds[i].y0 - cdata.player().position.y * inf_tiles + syfix)
-            * 100 / (40 + i * 5);
+        int x = (clouds[i].x0 - cdata.player().position.x * inf_tiles + sxfix) *
+                100 / (40 + i * 5) +
+            scrturn * 100 / (50 + i * 20);
+        int y = (clouds[i].y0 - cdata.player().position.y * inf_tiles + syfix) *
+            100 / (40 + i * 5);
         x = x % (windoww + clouds[i].width) - clouds[i].width;
         y = y % (inf_very + clouds[i].height) - clouds[i].height;
         int height = clouds[i].height;
@@ -790,16 +790,16 @@ void draw_npc_chara_chip(int c_, int dx, int dy, int ground_)
 
 bool you_can_see(const Character& chara)
 {
-    return is_in_fov(chara)
-        && (!chara.is_invisible() || cdata.player().can_see_invisible()
-            || chara.wet != 0);
+    return is_in_fov(chara) &&
+        (!chara.is_invisible() || cdata.player().can_see_invisible() ||
+         chara.wet != 0);
 }
 
 bool hp_bar_visible(const Character& chara)
 {
-    return chara.has_been_used_stethoscope()
-        || game_data.chara_last_attacked_by_player == chara.index
-        || debug::voldemort;
+    return chara.has_been_used_stethoscope() ||
+        game_data.chara_last_attacked_by_player == chara.index ||
+        debug::voldemort;
 }
 
 bool is_night()
@@ -882,9 +882,8 @@ void draw_efmap(int x, int y, int dx, int dy, bool update_frame)
 
 void draw_nefia_icons(int x, int y, int dx, int dy)
 {
-    if (cell_data.at(x, y).feats != 0
-        && cell_data.at(x, y).chip_id_memory
-            == cell_data.at(x, y).chip_id_actual)
+    if (cell_data.at(x, y).feats != 0 &&
+        cell_data.at(x, y).chip_id_memory == cell_data.at(x, y).chip_id_actual)
     {
         const auto p_ = cell_data.at(x, y).feats % 1000;
         if (p_ != 999 && p_ != 0)
@@ -899,12 +898,12 @@ void draw_nefia_icons(int x, int y, int dx, int dy)
         }
         if (map_data.type == mdata_t::MapType::world_map)
         {
-            const auto q_ = cell_data.at(x, y).feats / 100000 % 100
-                + cell_data.at(x, y).feats / 10000000 * 100;
+            const auto q_ = cell_data.at(x, y).feats / 100000 % 100 +
+                cell_data.at(x, y).feats / 10000000 * 100;
             if (area_data[q_].id == mdata_t::MapId::random_dungeon)
             {
-                if (area_data[q_].visited_deepest_level
-                    == area_data[q_].deepest_level)
+                if (area_data[q_].visited_deepest_level ==
+                    area_data[q_].deepest_level)
                 {
                     draw("conquered_nefia_icon", dx + 16, dy - 16);
                 }
@@ -1076,8 +1075,8 @@ void draw_items(int x, int y, int dx, int dy, int scrturn_)
                 }
                 else
                 {
-                    if (Config::instance().objectshadow
-                        && item_chips[p_].shadow)
+                    if (Config::instance().objectshadow &&
+                        item_chips[p_].shadow)
                     {
                         draw_item_chip_shadow(
                             dx, dy - stack_height, **rect, p_, 70);
@@ -1252,17 +1251,17 @@ void cell_draw()
             int py_ = 0;
 
             // Spot light for PC (bottom a third)
-            if (reph(3) == y && x_ == repw(2)
-                && cdata.player().state() == Character::State::alive)
+            if (reph(3) == y && x_ == repw(2) &&
+                cdata.player().state() == Character::State::alive)
             {
-                px_ = (cdata.player().position.x - scx) * inf_tiles
-                    + inf_screenx - 48;
+                px_ = (cdata.player().position.x - scx) * inf_tiles +
+                    inf_screenx - 48;
                 if (scxbk == scx)
                 {
                     px_ -= sxfix;
                 }
-                py_ = (cdata.player().position.y + 1 - scy) * inf_tiles
-                    + inf_screeny;
+                py_ = (cdata.player().position.y + 1 - scy) * inf_tiles +
+                    inf_screeny;
                 if (scybk == scy)
                 {
                     py_ -= syfix;
@@ -1272,8 +1271,8 @@ void cell_draw()
                 gcopy(3, 800, 208, 144, 48);
             }
 
-            if (reph(2) == y && x_ == repw(2)
-                && cdata.player().state() == Character::State::alive)
+            if (reph(2) == y && x_ == repw(2) &&
+                cdata.player().state() == Character::State::alive)
             {
                 ground_ = cell_data
                               .at(cdata.player().position.x,
@@ -1299,8 +1298,8 @@ void cell_draw()
 
                 if (py_ < windowh - inf_verh - 24)
                 {
-                    if (cdata.player().continuous_action.type
-                        == ContinuousAction::Type::fish)
+                    if (cdata.player().continuous_action.type ==
+                        ContinuousAction::Type::fish)
                     {
                         ani_ = 0;
                     }
@@ -1364,9 +1363,9 @@ void cell_draw()
 
             // Map tile
             ground_ = cell_data.at(x_, y).chip_id_memory;
-            if (chipm(2, ground_) == 2 && y < map_data.height - 1
-                && chipm(2, cell_data.at(x_, y + 1).chip_id_memory) != 2
-                && cell_data.at(x_, y + 1).chip_id_memory != tile_fog)
+            if (chipm(2, ground_) == 2 && y < map_data.height - 1 &&
+                chipm(2, cell_data.at(x_, y + 1).chip_id_memory) != 2 &&
+                cell_data.at(x_, y + 1).chip_id_memory != tile_fog)
             {
                 ground_ += 33;
             }
@@ -1376,10 +1375,10 @@ void cell_draw()
                     dx_,
                     dy_,
                     ground_,
-                    scrturn_ % (chipm(3, ground_) + 1)
-                        - (scrturn_ % (chipm(3, ground_) + 1)
-                           == chipm(3, ground_))
-                            * 2 * (chipm(3, ground_) != 0));
+                    scrturn_ % (chipm(3, ground_) + 1) -
+                        (scrturn_ % (chipm(3, ground_) + 1) ==
+                         chipm(3, ground_)) *
+                            2 * (chipm(3, ground_) != 0));
             }
             else
             {
@@ -1397,19 +1396,19 @@ void cell_draw()
             if (cell_data.at(x_, y).light != 0)
             {
                 const auto& light = lightdata[cell_data.at(x_, y).light];
-                if ((is_night() || light.always_shines)
-                    && mapsync(x_, y) == msync)
+                if ((is_night() || light.always_shines) &&
+                    mapsync(x_, y) == msync)
                 {
-                    light_ -= (6
-                               - clamp(
+                    light_ -= (6 -
+                               clamp(
                                    dist(
                                        cdata.player().position.x,
                                        cdata.player().position.y,
                                        x_,
                                        y),
                                    0,
-                                   6))
-                        * light.brightness;
+                                   6)) *
+                        light.brightness;
                     pos(dx_, dy_ - light.dy);
                     gmode(5, light.alpha_base + rnd(light.alpha_random + 1));
                     gcopy(
@@ -1434,14 +1433,14 @@ void cell_draw()
                             2,
                             ground_ % 33 * inf_tiles,
                             ground_ / 33 * inf_tiles,
-                            inf_tiles - std::max(dx_ + inf_tiles - windoww, 0)
-                                + std::min(dx_, 0),
+                            inf_tiles - std::max(dx_ + inf_tiles - windoww, 0) +
+                                std::min(dx_, 0),
                             12);
                         boxf(
                             std::max(dx_, 0),
                             dy_ - 20,
-                            inf_tiles - std::max(dx_ + inf_tiles - windoww, 0)
-                                + std::min(dx_, 0),
+                            inf_tiles - std::max(dx_ + inf_tiles - windoww, 0) +
+                                std::min(dx_, 0),
                             8,
                             {0, 0, 0, 25});
                     }
@@ -1455,15 +1454,15 @@ void cell_draw()
                     boxf(
                         std::max(dx_, 0),
                         dy_,
-                        inf_tiles - std::max(dx_ + inf_tiles - windoww, 0)
-                            + std::min(dx_, 0),
+                        inf_tiles - std::max(dx_ + inf_tiles - windoww, 0) +
+                            std::min(dx_, 0),
                         24,
                         {0, 0, 0, 16});
                     boxf(
                         std::max(dx_, 0),
                         dy_ + 24,
-                        inf_tiles - std::max(dx_ + inf_tiles - windoww, 0)
-                            + std::min(dx_, 0),
+                        inf_tiles - std::max(dx_ + inf_tiles - windoww, 0) +
+                            std::min(dx_, 0),
                         12,
                         {0, 0, 0, 12});
                 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -228,8 +228,8 @@ int chara_get_free_slot_force()
 bool can_place_character_at(const Position& position, bool allow_stairs)
 {
     // Out of range
-    if (position.x < 0 || map_data.width <= position.x || position.y < 0
-        || map_data.height <= position.y)
+    if (position.x < 0 || map_data.width <= position.x || position.y < 0 ||
+        map_data.height <= position.y)
         return false;
 
     // Wall
@@ -344,8 +344,8 @@ bool chara_place_internal(
             if (enemy_respawn && i < 20)
             {
                 const auto threshold = cdata.player().vision_distance / 2;
-                if (std::abs(cdata.player().position.x - x) <= threshold
-                    && std::abs(cdata.player().position.y - x) <= threshold)
+                if (std::abs(cdata.player().position.x - x) <= threshold &&
+                    std::abs(cdata.player().position.y - x) <= threshold)
                 {
                     // Too close
                     continue;
@@ -878,8 +878,8 @@ void initialize_character()
     {
         cdata[rc].nutrition = 5000 + rnd(4000);
     }
-    cdata[rc].height = cdata[rc].height + rnd((cdata[rc].height / 5 + 1))
-        - rnd((cdata[rc].height / 5 + 1));
+    cdata[rc].height = cdata[rc].height + rnd((cdata[rc].height / 5 + 1)) -
+        rnd((cdata[rc].height / 5 + 1));
     cdata[rc].weight =
         cdata[rc].height * cdata[rc].height * (rnd(6) + 18) / 10000;
     update_required_experience(cdata[rc]);
@@ -1011,8 +1011,8 @@ void chara_refresh(int cc)
         for (size_t i = 0; i < 32 * 30; ++i)
         {
             cdata[cc]._flags[i] =
-                userdata(40 + i / (8 * sizeof(int)), cdata[cc].cnpc_id)
-                & (1 << (i % (8 * sizeof(int))));
+                userdata(40 + i / (8 * sizeof(int)), cdata[cc].cnpc_id) &
+                (1 << (i % (8 * sizeof(int))));
         }
     }
     else
@@ -1062,8 +1062,8 @@ void chara_refresh(int cc)
         {
             cdata[cc].hit_bonus += inv[rp].hit_bonus;
             cdata[cc].damage_bonus += inv[rp].damage_bonus;
-            cdata[cc].pv += inv[rp].enhancement * 2
-                + (inv[rp].curse_state == CurseState::blessed) * 2;
+            cdata[cc].pv += inv[rp].enhancement * 2 +
+                (inv[rp].curse_state == CurseState::blessed) * 2;
         }
         else if (cdata[cc].body_parts[i] / 10000 == 5)
         {
@@ -1290,8 +1290,8 @@ void chara_refresh(int cc)
         {
             if (cdata[cc].quality >= Quality::miracle)
             {
-                if (cdata[cc].attr_adjs[cnt]
-                    < sdata.get(10 + cnt, cc).original_level / 5)
+                if (cdata[cc].attr_adjs[cnt] <
+                    sdata.get(10 + cnt, cc).original_level / 5)
                 {
                     cdata[cc].attr_adjs[cnt] =
                         sdata.get(10 + cnt, cc).original_level / 5;
@@ -1333,21 +1333,21 @@ void chara_refresh(int cc)
     }
     cdata[cc].max_mp =
         clamp(
-            ((sdata(16, cc) * 2 + sdata(15, cc) + sdata(14, cc) / 3)
-                 * cdata[cc].level / 25
-             + sdata(16, cc)),
+            ((sdata(16, cc) * 2 + sdata(15, cc) + sdata(14, cc) / 3) *
+                 cdata[cc].level / 25 +
+             sdata(16, cc)),
             1,
-            1000000)
-        * sdata(3, cc) / 100;
+            1000000) *
+        sdata(3, cc) / 100;
     cdata[cc].max_hp =
         clamp(
-            ((sdata(11, cc) * 2 + sdata(10, cc) + sdata(15, cc) / 3)
-                 * cdata[cc].level / 25
-             + sdata(11, cc)),
+            ((sdata(11, cc) * 2 + sdata(10, cc) + sdata(15, cc) / 3) *
+                 cdata[cc].level / 25 +
+             sdata(11, cc)),
             1,
-            1000000)
-            * sdata(2, cc) / 100
-        + 5;
+            1000000) *
+            sdata(2, cc) / 100 +
+        5;
     cdata[cc].max_sp =
         100 + (sdata(15, cc) + sdata(11, cc)) / 5 + trait(24) * 8;
     if (cdata[cc].max_mp < 1)
@@ -1360,13 +1360,13 @@ void chara_refresh(int cc)
     }
     if (cc >= ELONA_MAX_PARTY_CHARACTERS || false)
     {
-        cdata[cc].dv = cdata[cc].level / 2
-            + cdata[cc].dv * cdata[cc].dv_correction_value / 100
-            + cdata[cc].dv_correction_value - 100;
-        cdata[cc].pv = cdata[cc].level
-            + (cdata[cc].pv + cdata[cc].level / 2
-               + cdata[cc].pv_correction_value / 25)
-                * cdata[cc].pv_correction_value / 100;
+        cdata[cc].dv = cdata[cc].level / 2 +
+            cdata[cc].dv * cdata[cc].dv_correction_value / 100 +
+            cdata[cc].dv_correction_value - 100;
+        cdata[cc].pv = cdata[cc].level +
+            (cdata[cc].pv + cdata[cc].level / 2 +
+             cdata[cc].pv_correction_value / 25) *
+                cdata[cc].pv_correction_value / 100;
         if (cdata[cc].quality == Quality::great)
         {
             cdata[cc].max_hp = cdata[cc].max_hp * 3 / 2;
@@ -1686,8 +1686,8 @@ void chara_vanquish(int cc)
         ride_end();
     }
     else if (
-        cdata[cc].state() == Character::State::alive
-        || cdata[cc].state() == Character::State::servant_being_selected)
+        cdata[cc].state() == Character::State::alive ||
+        cdata[cc].state() == Character::State::servant_being_selected)
     {
         cell_data.at(cdata[cc].position.x, cdata[cc].position.y)
             .chara_index_plus_one = 0;
@@ -1790,9 +1790,9 @@ void chara_killed(Character& chara)
         lua::lua->get_handle_manager().remove_chara_handle_run_callbacks(chara);
     }
     else if (
-        chara.state() == Character::State::villager_dead
-        || chara.state() == Character::State::adventurer_dead
-        || chara.state() == Character::State::pet_dead)
+        chara.state() == Character::State::villager_dead ||
+        chara.state() == Character::State::adventurer_dead ||
+        chara.state() == Character::State::pet_dead)
     {
         // This character revives.
     }
@@ -1962,8 +1962,8 @@ void chara_relocate(
         for (int element = 50; element < 61; ++element)
         {
             auto resistance = 100;
-            if (sdata.get(element, slot).original_level >= 500
-                || sdata.get(element, slot).original_level <= 100)
+            if (sdata.get(element, slot).original_level >= 500 ||
+                sdata.get(element, slot).original_level <= 100)
             {
                 resistance = sdata.get(element, slot).original_level;
             }
@@ -2033,9 +2033,9 @@ int chara_breed_power(const Character& chara)
 
 bool belong_to_same_team(const Character& c1, const Character& c2)
 {
-    return (c1.relationship >= 0 && c2.relationship >= 0)
-        || (c1.relationship == -1 && c2.relationship == -1)
-        || (c1.relationship <= -2 && c2.relationship <= -2);
+    return (c1.relationship >= 0 && c2.relationship >= 0) ||
+        (c1.relationship == -1 && c2.relationship == -1) ||
+        (c1.relationship <= -2 && c2.relationship <= -2);
 }
 
 
@@ -2044,8 +2044,8 @@ void chara_add_quality_parens()
 {
     if (fixlv == Quality::miracle)
     {
-        cdatan(0, rc) = i18n::_(u8"ui", u8"bracket_left") + cdatan(0, rc)
-            + i18n::_(u8"ui", u8"bracket_right");
+        cdatan(0, rc) = i18n::_(u8"ui", u8"bracket_left") + cdatan(0, rc) +
+            i18n::_(u8"ui", u8"bracket_right");
         cdata[rc].level = cdata[rc].level * 10 / 8;
     }
     else if (fixlv == Quality::godly)

--- a/src/character.hpp
+++ b/src/character.hpp
@@ -268,10 +268,10 @@ struct Character
 
     bool is_dead()
     {
-        return state_ == Character::State::empty
-            || state_ == Character::State::pet_dead
-            || state_ == Character::State::villager_dead
-            || state_ == Character::State::adventurer_dead;
+        return state_ == Character::State::empty ||
+            state_ == Character::State::pet_dead ||
+            state_ == Character::State::villager_dead ||
+            state_ == Character::State::adventurer_dead;
     }
 
     Character::State state() const

--- a/src/character_making.cpp
+++ b/src/character_making.cpp
@@ -301,8 +301,8 @@ static bool _validate_save_path(const std::string& playerid)
             filesystem::dir_entries(
                 filesystem::dir::save(), filesystem::DirEntryRange::Type::all),
             [&](const auto& entry) {
-                return filesystem::to_utf8_path(entry.path().filename())
-                    == playerid;
+                return filesystem::to_utf8_path(entry.path().filename()) ==
+                    playerid;
             }))
     {
         return false;
@@ -520,8 +520,8 @@ void draw_race_or_class_info()
                         the_ability_db.get_id_from_legacy(r)->get(),
                         "name"),
                     0,
-                    jp ? 6 : 3)
-                + u8": "s + s(p));
+                    jp ? 6 : 3) +
+                u8": "s + s(p));
             color(0, 0, 0);
         }
         ty += 16;

--- a/src/character_status.cpp
+++ b/src/character_status.cpp
@@ -327,8 +327,8 @@ void modify_height(Character& cc, int delta)
 
 void refresh_speed(Character& cc)
 {
-    cc.current_speed = sdata(18, cc.index)
-        * clamp((100 - cc.speed_correction_value), 0, 100) / 100;
+    cc.current_speed = sdata(18, cc.index) *
+        clamp((100 - cc.speed_correction_value), 0, 100) / 100;
     if (cc.current_speed < 10)
     {
         cc.current_speed = 10;
@@ -340,17 +340,17 @@ void refresh_speed(Character& cc)
 
     if (game_data.mount != 0)
     {
-        const auto mount_speed = sdata(18, game_data.mount)
-            * clamp(100 - cdata[game_data.mount].speed_correction_value, 0, 100)
-            / 100;
+        const auto mount_speed = sdata(18, game_data.mount) *
+            clamp(100 - cdata[game_data.mount].speed_correction_value, 0, 100) /
+            100;
 
-        cdata.player().current_speed = mount_speed * 100
-            / clamp(100 + mount_speed - sdata(10, game_data.mount) * 3 / 2
-                        - sdata(301, 0) * 2
-                        - (cdata[game_data.mount].is_suitable_for_mount() == 1)
-                            * 50,
-                    100,
-                    1000);
+        cdata.player().current_speed = mount_speed * 100 /
+            clamp(100 + mount_speed - sdata(10, game_data.mount) * 3 / 2 -
+                      sdata(301, 0) * 2 -
+                      (cdata[game_data.mount].is_suitable_for_mount() == 1) *
+                          50,
+                  100,
+                  1000);
         if (cdata[game_data.mount].is_unsuitable_for_mount())
         {
             cdata.player().current_speed /= 10;
@@ -401,19 +401,19 @@ void refresh_speed(Character& cc)
     {
         cdata.player().speed_percentage_in_next_turn -= 10;
     }
-    if (map_data.type == mdata_t::MapType::world_map
-        || map_data.type == mdata_t::MapType::field)
+    if (map_data.type == mdata_t::MapType::world_map ||
+        map_data.type == mdata_t::MapType::field)
     {
         if (game_data.cargo_weight > game_data.current_cart_limit)
         {
-            cdata.player().speed_percentage_in_next_turn -= 25
-                + 25
-                    * (game_data.cargo_weight
-                       / (game_data.current_cart_limit + 1));
+            cdata.player().speed_percentage_in_next_turn -= 25 +
+                25 *
+                    (game_data.cargo_weight /
+                     (game_data.current_cart_limit + 1));
         }
     }
-    gspd = cdata.player().current_speed
-        * (100 + cdata.player().speed_percentage) / 100;
+    gspd = cdata.player().current_speed *
+        (100 + cdata.player().speed_percentage) / 100;
     if (gspd < 10)
     {
         gspd = 10;
@@ -506,9 +506,9 @@ void gain_level(Character& cc)
     {
         addnews(2, cc.index);
     }
-    p = 5 * (100 + sdata.get(14, cc.index).original_level * 10)
-            / (300 + cc.level * 15)
-        + 1;
+    p = 5 * (100 + sdata.get(14, cc.index).original_level * 10) /
+            (300 + cc.level * 15) +
+        1;
     if (cc.index == 0)
     {
         if (cc.level % 5 == 0)
@@ -526,8 +526,8 @@ void gain_level(Character& cc)
     }
     cc.skill_bonus += p;
     cc.total_skill_bonus += p;
-    if (cdatan(2, cc.index) == u8"core.mutant"s
-        || (cc.index == 0 && trait(0) == 1))
+    if (cdatan(2, cc.index) == u8"core.mutant"s ||
+        (cc.index == 0 && trait(0) == 1))
     {
         if (cc.level < 37)
         {
@@ -578,10 +578,10 @@ void grow_primary_skills(Character& cc)
 
 void update_required_experience(Character& cc)
 {
-    cc.required_experience = clamp(cc.level, 1, 200)
-            * (clamp(cc.level, 1, 200) + 1) * (clamp(cc.level, 1, 200) + 2)
-            * (clamp(cc.level, 1, 200) + 3)
-        + 3000;
+    cc.required_experience = clamp(cc.level, 1, 200) *
+            (clamp(cc.level, 1, 200) + 1) * (clamp(cc.level, 1, 200) + 2) *
+            (clamp(cc.level, 1, 200) + 3) +
+        3000;
     if (cc.required_experience > 100000000 || cc.required_experience < 0)
     {
         cc.required_experience = 100000000;

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -110,8 +110,8 @@ TurnResult do_give_command()
     {
         if (tc < 16)
         {
-            if (!cdata[tc].is_escorted()
-                && !cdata[tc].is_escorted_in_sub_quest())
+            if (!cdata[tc].is_escorted() &&
+                !cdata[tc].is_escorted_in_sub_quest())
             {
                 return try_interact_with_npc();
             }
@@ -365,9 +365,9 @@ TurnResult do_dig_command()
             return TurnResult::turn_end;
         }
     }
-    if ((chipm(7, cell_data.at(x, y).chip_id_actual) & 4) == 0
-        || chipm(0, cell_data.at(x, y).chip_id_actual) == 3
-        || map_data.type == mdata_t::MapType::world_map)
+    if ((chipm(7, cell_data.at(x, y).chip_id_actual) & 4) == 0 ||
+        chipm(0, cell_data.at(x, y).chip_id_actual) == 3 ||
+        map_data.type == mdata_t::MapType::world_map)
     {
         txt(i18n::s.get("core.locale.common.it_is_impossible"));
         update_screen();
@@ -396,10 +396,10 @@ static void _search_for_crystal()
             continue;
         }
         if (p > dist(
-                inv[cnt].position.x,
-                inv[cnt].position.y,
-                cdata.player().position.x,
-                cdata.player().position.y))
+                    inv[cnt].position.x,
+                    inv[cnt].position.y,
+                    cdata.player().position.x,
+                    cdata.player().position.y))
         {
             p = dist(
                 inv[cnt].position.x,
@@ -464,8 +464,8 @@ static void _search_for_map_feats()
     cell_featread(x, y);
     refx = x;
     refy = y;
-    if (std::abs(cdata[cc].position.y - y) <= 1
-        && std::abs(cdata[cc].position.x - x) <= 1)
+    if (std::abs(cdata[cc].position.y - y) <= 1 &&
+        std::abs(cdata[cc].position.x - x) <= 1)
     {
         if (feat(1) == 14)
         {
@@ -616,9 +616,9 @@ TurnResult do_throw_command()
         txt(i18n::s.get(
             "core.locale.action.throw.execute", cdata[cc], inv[ci]));
     }
-    if (dist(cdata[cc].position.x, cdata[cc].position.y, tlocx, tlocy) * 4
-            > rnd(sdata(111, cc) + 10) + sdata(111, cc) / 4
-        || rnd(10) == 0)
+    if (dist(cdata[cc].position.x, cdata[cc].position.y, tlocx, tlocy) * 4 >
+            rnd(sdata(111, cc) + 10) + sdata(111, cc) / 4 ||
+        rnd(10) == 0)
     {
         x = tlocx + rnd(2) - rnd(2);
         y = tlocy + rnd(2) - rnd(2);
@@ -630,8 +630,8 @@ TurnResult do_throw_command()
                 {
                     if (y < map_data.height)
                     {
-                        if ((chipm(7, cell_data.at(x, y).chip_id_actual) & 4)
-                            == 0)
+                        if ((chipm(7, cell_data.at(x, y).chip_id_actual) & 4) ==
+                            0)
                         {
                             tlocx = x;
                             tlocy = y;
@@ -674,10 +674,10 @@ TurnResult do_throw_command()
             txt(i18n::s.get("core.locale.action.throw.hits", cdata[tc]));
             if (inv[ci].id == 685)
             {
-                if (tc < ELONA_MAX_PARTY_CHARACTERS
-                    || cdata[tc].character_role != 0
-                    || cdata[tc].quality == Quality::special
-                    || cdata[tc].is_lord_of_dungeon() == 1)
+                if (tc < ELONA_MAX_PARTY_CHARACTERS ||
+                    cdata[tc].character_role != 0 ||
+                    cdata[tc].quality == Quality::special ||
+                    cdata[tc].is_lord_of_dungeon() == 1)
                 {
                     txt(
                         i18n::s.get("core.locale.action.throw.monster_ball."
@@ -1230,13 +1230,13 @@ label_1953_internal:
                                 .fill_rect(
                                     sx,
                                     sy * (sy > 0),
-                                    inf_tiles
-                                        - (sx + inf_tiles > windoww)
-                                            * (sx + inf_tiles - windoww),
-                                    inf_tiles + (sy < 0) * inf_screeny
-                                        - (sy + inf_tiles > windowh - inf_verh)
-                                            * (sy + inf_tiles - windowh
-                                               + inf_verh));
+                                    inf_tiles -
+                                        (sx + inf_tiles > windoww) *
+                                            (sx + inf_tiles - windoww),
+                                    inf_tiles + (sy < 0) * inf_screeny -
+                                        (sy + inf_tiles > windowh - inf_verh) *
+                                            (sy + inf_tiles - windowh +
+                                             inf_verh));
                         }
                     }
                 }
@@ -1255,9 +1255,9 @@ label_1953_internal:
                         sx,
                         sy * (sy > 0),
                         inf_tiles,
-                        inf_tiles + (sy < 0) * inf_screeny
-                            - (sy + inf_tiles > windowh - inf_verh)
-                                * (sy + inf_tiles - windowh + inf_verh));
+                        inf_tiles + (sy < 0) * inf_screeny -
+                            (sy + inf_tiles > windowh - inf_verh) *
+                                (sy + inf_tiles - windowh + inf_verh));
                 }
             }
             display_key(
@@ -1371,8 +1371,8 @@ TurnResult do_dip_command()
             }
             else
             {
-                if (inv[ci].param1 < -5 || inv[ci].param3 >= 20
-                    || (inv[ci].id == 602 && game_data.holy_well_count <= 0))
+                if (inv[ci].param1 < -5 || inv[ci].param3 >= 20 ||
+                    (inv[ci].id == 602 && game_data.holy_well_count <= 0))
                 {
                     txt(i18n::s.get(
                         "core.locale.action.dip.result.natural_potion_dry",
@@ -1421,8 +1421,8 @@ TurnResult do_dip_command()
             txt(i18n::s.get(
                     "core.locale.action.dip.result.love_food.made",
                     inv[ci],
-                    inv[cidip])
-                + i18n::s.get("core.locale.action.dip.result.love_food.grin"));
+                    inv[cidip]) +
+                i18n::s.get("core.locale.action.dip.result.love_food.grin"));
             if (is_cursed(inv[cidip].curse_state))
             {
                 dipcursed(ci);
@@ -1440,9 +1440,8 @@ TurnResult do_dip_command()
             txt(i18n::s.get(
                     "core.locale.action.dip.result.love_food.made",
                     inv[ci],
-                    inv[cidip])
-                + i18n::s.get(
-                    "core.locale.action.dip.result.love_food.guilty"));
+                    inv[cidip]) +
+                i18n::s.get("core.locale.action.dip.result.love_food.guilty"));
             if (is_cursed(inv[cidip].curse_state))
             {
                 dipcursed(ci);
@@ -1633,15 +1632,15 @@ TurnResult do_use_command()
     {
         return do_gatcha();
     }
-    if (inv[ci].id == 312 || inv[ci].id == 313 || inv[ci].id == 314
-        || inv[ci].id == 315)
+    if (inv[ci].id == 312 || inv[ci].id == 313 || inv[ci].id == 314 ||
+        inv[ci].id == 315)
     {
         atxid = 1;
         casino_dealer();
         return TurnResult::turn_end;
     }
-    if (inv[ci].function == 1 || inv[ci].function == 2 || inv[ci].function == 3
-        || inv[ci].function == 4)
+    if (inv[ci].function == 1 || inv[ci].function == 2 ||
+        inv[ci].function == 3 || inv[ci].function == 4)
     {
         prodtype = inv[ci].function;
         snd("core.pop2");
@@ -2168,11 +2167,11 @@ TurnResult do_use_command()
             continuous_action_others();
             return TurnResult::turn_end;
         }
-        if (area_data[game_data.current_map].id
-            == mdata_t::MapId::random_dungeon)
+        if (area_data[game_data.current_map].id ==
+            mdata_t::MapId::random_dungeon)
         {
-            if (game_data.current_dungeon_level
-                == area_data[game_data.current_map].deepest_level)
+            if (game_data.current_dungeon_level ==
+                area_data[game_data.current_map].deepest_level)
             {
                 if (area_data[game_data.current_map].has_been_conquered != -1)
                 {
@@ -2220,8 +2219,8 @@ TurnResult do_use_command()
         goto label_2229_internal;
     case 22:
         snd("core.enc");
-        if (map_data.type != mdata_t::MapType::town
-            && map_data.type != mdata_t::MapType::guild)
+        if (map_data.type != mdata_t::MapType::town &&
+            map_data.type != mdata_t::MapType::guild)
         {
             txt(i18n::s.get("core.locale.action.use.rune.only_in_town"));
             goto label_2229_internal;
@@ -2343,8 +2342,8 @@ TurnResult do_use_command()
             cdata[cc].position.x, cdata[cc].position.y, 7, 632, 10, 100, cc);
         goto label_2229_internal;
     case 48:
-        if (game_data.current_map != mdata_t::MapId::show_house
-            || usermapid == 0)
+        if (game_data.current_map != mdata_t::MapId::show_house ||
+            usermapid == 0)
         {
             txt(i18n::s.get("core.locale.action.use.statue.creator.normal"));
             goto label_2229_internal;
@@ -2376,8 +2375,8 @@ TurnResult do_use_command()
         goto label_2229_internal;
     case 41:
         if (game_data
-                .next_level_minus_one_kumiromis_experience_becomes_available
-            > cdata.player().level)
+                .next_level_minus_one_kumiromis_experience_becomes_available >
+            cdata.player().level)
         {
             txt(
                 i18n::s.get("core.locale.action.use.secret_experience.kumiromi."
@@ -2680,8 +2679,8 @@ TurnResult do_open_command()
             {
                 if (game_data.released_fire_giant == 0)
                 {
-                    if (cdata[game_data.fire_giant].state()
-                        == Character::State::alive)
+                    if (cdata[game_data.fire_giant].state() ==
+                        Character::State::alive)
                     {
                         tc = chara_find(203);
                         if (tc != 0)
@@ -2863,11 +2862,11 @@ TurnResult do_use_stairs_command(int val0)
     {
         if (val0 == 1)
         {
-            if (mapitemfind(cdata[cc].position.x, cdata[cc].position.y, 751)
-                != -1)
+            if (mapitemfind(cdata[cc].position.x, cdata[cc].position.y, 751) !=
+                -1)
             {
-                if (game_data.current_dungeon_level
-                    >= area_data[game_data.current_map].deepest_level)
+                if (game_data.current_dungeon_level >=
+                    area_data[game_data.current_map].deepest_level)
                 {
                     txt(i18n::s.get(
                         "core.locale.action.use_stairs.cannot_go.down"));
@@ -2881,11 +2880,11 @@ TurnResult do_use_stairs_command(int val0)
         }
         if (val0 == 2)
         {
-            if (mapitemfind(cdata[cc].position.x, cdata[cc].position.y, 750)
-                != -1)
+            if (mapitemfind(cdata[cc].position.x, cdata[cc].position.y, 750) !=
+                -1)
             {
-                if (game_data.current_dungeon_level
-                    <= area_data[game_data.current_map].danger_level)
+                if (game_data.current_dungeon_level <=
+                    area_data[game_data.current_map].danger_level)
                 {
                     txt(i18n::s.get(
                         "core.locale.action.use_stairs.cannot_go.up"));
@@ -2914,9 +2913,9 @@ TurnResult do_use_stairs_command(int val0)
                 else
                 {
                     movelevelbystairs = 1;
-                    if (game_data.current_map == mdata_t::MapId::the_void
-                        && game_data.current_dungeon_level
-                            >= game_data.void_next_lord_floor)
+                    if (game_data.current_map == mdata_t::MapId::the_void &&
+                        game_data.current_dungeon_level >=
+                            game_data.void_next_lord_floor)
                     {
                         txt(
                             i18n::s.get("core.locale.action.use_stairs.blocked_"
@@ -2996,8 +2995,8 @@ TurnResult do_use_stairs_command(int val0)
     }
     if (area_data[game_data.current_map].id == mdata_t::MapId::random_dungeon)
     {
-        if (game_data.current_dungeon_level
-            == area_data[game_data.current_map].deepest_level)
+        if (game_data.current_dungeon_level ==
+            area_data[game_data.current_map].deepest_level)
         {
             if (area_data[game_data.current_map].has_been_conquered != -1)
             {
@@ -3022,12 +3021,12 @@ TurnResult do_use_stairs_command(int val0)
                 txt(i18n::s.get("core.locale.action.use_stairs.lost_balance"));
                 damage_hp(
                     cdata[cc],
-                    cdata[cc].max_hp
-                            * (cdata.player().inventory_weight * 10
-                                   / cdata.player().max_inventory_weight
-                               + 10)
-                            / 100
-                        + 1,
+                    cdata[cc].max_hp *
+                            (cdata.player().inventory_weight * 10 /
+                                 cdata.player().max_inventory_weight +
+                             10) /
+                            100 +
+                        1,
                     -7);
                 msg_halt();
             }
@@ -3056,11 +3055,9 @@ static TurnResult _pre_proc_movement_event()
     {
         if (264 <= cell_data
                        .at(cdata[cc].next_position.x, cdata[cc].next_position.y)
-                       .chip_id_actual
-            && cell_data
-                    .at(cdata[cc].next_position.x, cdata[cc].next_position.y)
-                    .chip_id_actual
-                < 363)
+                       .chip_id_actual &&
+            cell_data.at(cdata[cc].next_position.x, cdata[cc].next_position.y)
+                    .chip_id_actual < 363)
         {
             return TurnResult::pc_turn_user_error;
         }
@@ -3071,12 +3068,12 @@ static TurnResult _pre_proc_movement_event()
 static TurnResult _bump_into_character()
 {
     tc = cellchara;
-    if (cdata[tc].relationship >= 10
-        || (cdata[tc].relationship == -1
-            && !Config::instance().attack_neutral_npcs)
-        || (cdata[tc].relationship == 0
-            && (area_data[game_data.current_map].is_museum_or_shop()
-                || is_modifier_pressed(snail::ModKey::shift))))
+    if (cdata[tc].relationship >= 10 ||
+        (cdata[tc].relationship == -1 &&
+         !Config::instance().attack_neutral_npcs) ||
+        (cdata[tc].relationship == 0 &&
+         (area_data[game_data.current_map].is_museum_or_shop() ||
+          is_modifier_pressed(snail::ModKey::shift))))
     {
         if (cdata[tc].is_hung_on_sand_bag() == 0)
         {
@@ -3241,15 +3238,15 @@ TurnResult do_movement_command()
     {
         return _pre_proc_movement_event();
     }
-    if (map_data.type == mdata_t::MapType::shelter
-        || (game_data.current_dungeon_level == 1
-            && map_data.type != mdata_t::MapType::world_map
-            && !mdata_t::is_nefia(map_data.type)))
+    if (map_data.type == mdata_t::MapType::shelter ||
+        (game_data.current_dungeon_level == 1 &&
+         map_data.type != mdata_t::MapType::world_map &&
+         !mdata_t::is_nefia(map_data.type)))
     {
-        if (cdata[cc].next_position.x < 0
-            || cdata[cc].next_position.x > map_data.width - 1
-            || cdata[cc].next_position.y < 0
-            || cdata[cc].next_position.y > map_data.height - 1)
+        if (cdata[cc].next_position.x < 0 ||
+            cdata[cc].next_position.x > map_data.width - 1 ||
+            cdata[cc].next_position.y < 0 ||
+            cdata[cc].next_position.y > map_data.height - 1)
         {
             txt(i18n::s.get("core.locale.action.move.leave.prompt", mdatan(0)));
             if (map_data.type == mdata_t::MapType::temporary)
@@ -3439,9 +3436,9 @@ TurnResult do_get_command()
     const auto number = item_info.first;
     const auto item = item_info.second;
 
-    if (cell_data.at(cdata.player().position.x, cdata.player().position.y).feats
-            != 0
-        && game_data.current_map != mdata_t::MapId::show_house && number == 0)
+    if (cell_data.at(cdata.player().position.x, cdata.player().position.y)
+                .feats != 0 &&
+        game_data.current_map != mdata_t::MapId::show_house && number == 0)
     {
         cell_featread(cdata.player().position.x, cdata.player().position.y);
         if (feat(1) == 29)
@@ -3475,8 +3472,7 @@ TurnResult do_get_command()
                     cell_data
                         .at(cdata.player().position.x,
                             cdata.player().position.y)
-                        .chip_id_actual)
-                        == 2
+                        .chip_id_actual) == 2
                     ? 1
                     : 0);
             if (feat(2) == 40)
@@ -3487,8 +3483,8 @@ TurnResult do_get_command()
             refresh_burden_state();
             return TurnResult::turn_end;
         }
-        if (map_data.type == mdata_t::MapType::world_map && feat(1) == 15
-            && feat(2) + feat(3) * 100 >= 300 && feat(2) + feat(3) * 100 < 450)
+        if (map_data.type == mdata_t::MapType::world_map && feat(1) == 15 &&
+            feat(2) + feat(3) * 100 >= 300 && feat(2) + feat(3) * 100 < 450)
         {
             txt(i18n::s.get("core.locale.action.get.building.prompt"));
             rtval = yes_or_no(promptx, prompty, 160);
@@ -3512,13 +3508,12 @@ TurnResult do_get_command()
 
     if (number == 0)
     {
-        if ((map_is_town_or_guild())
-            && chipm(
-                   0,
-                   cell_data
-                       .at(cdata.player().position.x, cdata.player().position.y)
-                       .chip_id_actual)
-                == 4)
+        if ((map_is_town_or_guild()) &&
+            chipm(
+                0,
+                cell_data
+                    .at(cdata.player().position.x, cdata.player().position.y)
+                    .chip_id_actual) == 4)
         {
             snd("core.foot2a");
             txt(i18n::s.get("core.locale.action.get.snow"));
@@ -3555,8 +3550,8 @@ TurnResult do_get_command()
         assert(mr.turn_result != TurnResult::none);
         return mr.turn_result;
     }
-    if ((inv[ci].own_state > 0 && inv[ci].own_state < 3)
-        || inv[ci].own_state == 5)
+    if ((inv[ci].own_state > 0 && inv[ci].own_state < 3) ||
+        inv[ci].own_state == 5)
     {
         snd("core.fail1");
         if (inv[ci].own_state == 2)

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -185,8 +185,8 @@ public:
         if (!storage.at(key).is<T>())
         {
             throw std::runtime_error(
-                "Expected type \"" + def.type_to_string(key) + "\" for key "
-                + key);
+                "Expected type \"" + def.type_to_string(key) + "\" for key " +
+                key);
         }
 
         try

--- a/src/config/config_menu.hpp
+++ b/src/config/config_menu.hpp
@@ -195,14 +195,14 @@ public:
         if (index == -1)
         {
             throw std::runtime_error(
-                "No such enum variant \"" + default_choice + "\" in \"" + key
-                + "\".");
+                "No such enum variant \"" + default_choice + "\" in \"" + key +
+                "\".");
         }
         // If the enum variant is injected, but the selected value is
         // still unknown, try to set its index to the first known
         // value if there is one.
-        if (variants.size() >= 2 && index == 0
-            && variants.at(index).value == spec::unknown_enum_variant)
+        if (variants.size() >= 2 && index == 0 &&
+            variants.at(index).value == spec::unknown_enum_variant)
         {
             index = 1;
             Config::instance().set(key, variants.at(index).value);
@@ -221,8 +221,8 @@ public:
             index = static_cast<int>(variants.size() - 1);
         }
         // See above.
-        if (variants.size() >= 2 && index == 0
-            && variants.at(index).value == spec::unknown_enum_variant)
+        if (variants.size() >= 2 && index == 0 &&
+            variants.at(index).value == spec::unknown_enum_variant)
         {
             index = 1;
         }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -379,13 +379,13 @@ optional<const CraftingRecipe&> crafting_find_recipe(int matid_)
 static Quality _determine_crafted_fixlv(const CraftingRecipe& recipe)
 {
     Quality ret = Quality::good;
-    if (rnd(200 + recipe.required_skill_level * 2)
-        < sdata(recipe.skill_used, 0) + 20)
+    if (rnd(200 + recipe.required_skill_level * 2) <
+        sdata(recipe.skill_used, 0) + 20)
     {
         ret = Quality::miracle;
     }
-    if (rnd(100 + recipe.required_skill_level * 2)
-        < sdata(recipe.skill_used, 0) + 20)
+    if (rnd(100 + recipe.required_skill_level * 2) <
+        sdata(recipe.skill_used, 0) + 20)
     {
         ret = Quality::great;
     }

--- a/src/ctrl_file.cpp
+++ b/src/ctrl_file.cpp
@@ -126,8 +126,8 @@ void arrayfile_write(const std::string& fmode_str, const fs::path& filepath)
     if (!out)
     {
         throw std::runtime_error(
-            u8"Error: fail to write "
-            + filesystem::make_preferred_path_in_utf8(filepath));
+            u8"Error: fail to write " +
+            filesystem::make_preferred_path_in_utf8(filepath));
     }
 
     if (fmode_str == u8"qname"s)

--- a/src/ctrl_inventory.cpp
+++ b/src/ctrl_inventory.cpp
@@ -84,9 +84,10 @@ label_20591:
         if (cnt == 0)
         {
             p = -1;
-            if (invctrl == 2 || invctrl == 6 || invctrl == 10 || invctrl == 12
-                || invctrl == 16 || invctrl == 20 || invctrl == 21
-                || invctrl == 23 || invctrl == 24 || invctrl == 25)
+            if (invctrl == 2 || invctrl == 6 || invctrl == 10 ||
+                invctrl == 12 || invctrl == 16 || invctrl == 20 ||
+                invctrl == 21 || invctrl == 23 || invctrl == 24 ||
+                invctrl == 25)
             {
                 continue;
             }
@@ -112,9 +113,9 @@ label_20591:
             }
         }
         int cnt2 = cnt;
-        if (invctrl != 1 && invctrl != 5 && invctrl != 13 && invctrl != 14
-            && invctrl != 18 && invctrl != 20 && invctrl != 23 && invctrl != 25
-            && invctrl != 27)
+        if (invctrl != 1 && invctrl != 5 && invctrl != 13 && invctrl != 14 &&
+            invctrl != 18 && invctrl != 20 && invctrl != 23 && invctrl != 25 &&
+            invctrl != 27)
         {
             countequip = 0;
         }
@@ -153,8 +154,8 @@ label_20591:
             {
                 if (invctrl == 7)
                 {
-                    if (the_item_db[inv[cnt].id]->subcategory != 53100
-                        && inv[cnt].id != 621)
+                    if (the_item_db[inv[cnt].id]->subcategory != 53100 &&
+                        inv[cnt].id != 621)
                     {
                         continue;
                     }
@@ -164,16 +165,16 @@ label_20591:
             {
                 if (invctrl == 27)
                 {
-                    if (inv[cnt].position.x != tlocx
-                        || inv[cnt].position.y != tlocy)
+                    if (inv[cnt].position.x != tlocx ||
+                        inv[cnt].position.y != tlocy)
                     {
                         continue;
                     }
                 }
                 else if (invctrl != 11 && invctrl != 22 && invctrl != 28)
                 {
-                    if (inv[cnt].position.x != cdata[cc].position.x
-                        || inv[cnt].position.y != cdata[cc].position.y)
+                    if (inv[cnt].position.x != cdata[cc].position.x ||
+                        inv[cnt].position.y != cdata[cc].position.y)
                     {
                         continue;
                     }
@@ -202,8 +203,8 @@ label_20591:
             {
                 if (reftype == 10000)
                 {
-                    if (mainweapon == -1
-                        || inv[cnt].body_part < inv[mainweapon].body_part)
+                    if (mainweapon == -1 ||
+                        inv[cnt].body_part < inv[mainweapon].body_part)
                     {
                         mainweapon = cnt;
                     }
@@ -211,8 +212,8 @@ label_20591:
             }
             if (invctrl == 5)
             {
-                if (reftype != 57000 && reftype != 91000
-                    && inv[cnt].material != 35)
+                if (reftype != 57000 && reftype != 91000 &&
+                    inv[cnt].material != 35)
                 {
                     continue;
                 }
@@ -291,17 +292,16 @@ label_20591:
             }
             if (invctrl == 13)
             {
-                if (inv[cnt].identification_state
-                    == IdentifyState::completely_identified)
+                if (inv[cnt].identification_state ==
+                    IdentifyState::completely_identified)
                 {
                     continue;
                 }
             }
             if (invctrl == 14)
             {
-                if (inv[cnt].function == 0
-                    && !the_item_db[inv[cnt].id]->is_usable
-                    && ibit(10, cnt) == 0)
+                if (inv[cnt].function == 0 &&
+                    !the_item_db[inv[cnt].id]->is_usable && ibit(10, cnt) == 0)
                 {
                     continue;
                 }
@@ -364,8 +364,8 @@ label_20591:
             }
             if (invctrl == 21)
             {
-                if (calcitemvalue(cnt, 0) * inv[cnt].number()
-                    < calcitemvalue(citrade, 0) * inv[citrade].number() / 2 * 3)
+                if (calcitemvalue(cnt, 0) * inv[cnt].number() <
+                    calcitemvalue(citrade, 0) * inv[citrade].number() / 2 * 3)
                 {
                     continue;
                 }
@@ -430,8 +430,8 @@ label_20591:
                 }
                 if (invctrl(1) == 7)
                 {
-                    if (inv[cnt].quality >= Quality::miracle
-                        || reftype >= 50000)
+                    if (inv[cnt].quality >= Quality::miracle ||
+                        reftype >= 50000)
                     {
                         continue;
                     }
@@ -497,16 +497,17 @@ label_20591:
             }
             else if (inv[cnt].own_state == 4)
             {
-                if (invctrl != 1 && invctrl != 2 && invctrl != 3
-                    && invctrl != 5)
+                if (invctrl != 1 && invctrl != 2 && invctrl != 3 &&
+                    invctrl != 5)
                 {
                     continue;
                 }
             }
             if (invctrl == 26)
             {
-                if (reftype != 52000 && inv[cnt].id != 578 && inv[cnt].id != 685
-                    && inv[cnt].id != 699 && inv[cnt].id != 772)
+                if (reftype != 52000 && inv[cnt].id != 578 &&
+                    inv[cnt].id != 685 && inv[cnt].id != 699 &&
+                    inv[cnt].id != 772)
                 {
                     continue;
                 }
@@ -810,10 +811,10 @@ label_2060_internal:
             }
             bmes(
                 i18n::_(u8"ui", u8"inventory_command", u8"_"s + p),
-                x + cnt * 44 + 46
-                    - strlen_u(
-                          i18n::_(u8"ui", u8"inventory_command", u8"_"s + p))
-                        * 3,
+                x + cnt * 44 + 46 -
+                    strlen_u(
+                        i18n::_(u8"ui", u8"inventory_command", u8"_"s + p)) *
+                        3,
                 y + 7,
                 invctrl == p ? snail::Color{255, 255, 255}
                              : snail::Color{165, 165, 165});
@@ -827,8 +828,8 @@ label_2060_internal:
             }
         }
         bmes(
-            ""s + key_prev + u8","s + key_next + u8",Tab,Ctrl+Tab "s + "["
-                + i18n::s.get("core.locale.ui.inv.window.change") + "]",
+            ""s + key_prev + u8","s + key_next + u8",Tab,Ctrl+Tab "s + "[" +
+                i18n::s.get("core.locale.ui.inv.window.change") + "]",
             x + 260,
             y + 32);
     }
@@ -837,22 +838,22 @@ label_2061_internal:
         "core.locale.ui.inv.window.select_item",
         i18n::_(u8"ui", u8"inventory_command", u8"_"s + invctrl));
     s(1) = strhint2 + strhint5 + strhint5b + strhint3;
-    if (invctrl == 5 || invctrl == 7 || invctrl == 8 || invctrl == 9
-        || invctrl == 14 || invctrl == 15 || invctrl == 26)
+    if (invctrl == 5 || invctrl == 7 || invctrl == 8 || invctrl == 9 ||
+        invctrl == 14 || invctrl == 15 || invctrl == 26)
     {
         s(1) += strhint7;
     }
     if (invctrl == 1)
     {
-        s(1) += ""s + key_mode2 + u8" "s + "["
-            + i18n::s.get("core.locale.ui.inv.window.tag.no_drop") + "]";
+        s(1) += ""s + key_mode2 + u8" "s + "[" +
+            i18n::s.get("core.locale.ui.inv.window.tag.no_drop") + "]";
     }
     if (invctrl == 2)
     {
         if (dropcontinue == 0)
         {
-            s(1) += ""s + key_mode2 + u8" "s + "["
-                + i18n::s.get("core.locale.ui.inv.window.tag.multi_drop") + "]";
+            s(1) += ""s + key_mode2 + u8" "s + "[" +
+                i18n::s.get("core.locale.ui.inv.window.tag.multi_drop") + "]";
         }
     }
     display_window((windoww - 640) / 2 + inf_screenx, winposy(432), 640, 432);
@@ -890,13 +891,13 @@ label_2061_internal:
     pos(wx - 6, wy - 6);
     gcopy(3, 960, 216, 48, 72);
     s = ""s + listmax + u8" items"s;
-    s += "  ("s
-        + i18n::s.get(
+    s += "  ("s +
+        i18n::s.get(
             "core.locale.ui.inv.window.total_weight",
             cnvweight(cdata.player().inventory_weight),
             cnvweight(cdata.player().max_inventory_weight),
-            cnvweight(game_data.cargo_weight))
-        + ")"s;
+            cnvweight(game_data.cargo_weight)) +
+        ")"s;
     if (invctrl == 25)
     {
         s = ""s;
@@ -914,9 +915,9 @@ label_2061_internal:
         pos(x + 16, y + 17);
         mes(u8"DV:"s + cdata[tc].dv + u8" PV:"s + cdata[tc].pv);
         pos(x + 16, y + 35);
-        mes(i18n::s.get("core.locale.ui.inv.take_ally.window.equip_weight")
-            + ":" + cnvweight(cdata[tc].sum_of_equipment_weight) + ""s
-            + cnveqweight(tc));
+        mes(i18n::s.get("core.locale.ui.inv.take_ally.window.equip_weight") +
+            ":" + cnvweight(cdata[tc].sum_of_equipment_weight) + ""s +
+            cnveqweight(tc));
         x = wx + 40;
         y = wy + wh - 65 - wh % 8;
         pos(x, y);
@@ -940,9 +941,9 @@ label_2061_internal:
             pos(x, y);
             mes(""s + i18n::_(u8"ui", u8"body_part", u8"_"s + (p / 10000)));
             color(0, 0, 0);
-            x += (i18n::_(u8"ui", u8"body_part", u8"_"s + (p / 10000)).size()
-                  + 1)
-                * 6;
+            x += (i18n::_(u8"ui", u8"body_part", u8"_"s + (p / 10000)).size() +
+                  1) *
+                6;
         }
     }
     keyrange = 0;
@@ -988,19 +989,19 @@ label_2061_internal:
                 "core.locale.ui.inv.trade_medals.medal_value",
                 calcmedalvalue(p));
         }
-        if (invctrl != 3 && invctrl != 11 && invctrl != 22 && invctrl != 27
-            && invctrl != 28)
+        if (invctrl != 3 && invctrl != 11 && invctrl != 22 && invctrl != 27 &&
+            invctrl != 28)
         {
             if (p >= 5080)
             {
-                s += i18n::space_if_needed() + "("
-                    + i18n::s.get("core.locale.ui.inv.window.ground") + ")";
+                s += i18n::space_if_needed() + "(" +
+                    i18n::s.get("core.locale.ui.inv.window.ground") + ")";
             }
         }
         for (int cnt = 0; cnt < 20; ++cnt)
         {
-            if (game_data.skill_shortcuts.at(cnt)
-                == inv[p].id + invctrl * 10000)
+            if (game_data.skill_shortcuts.at(cnt) ==
+                inv[p].id + invctrl * 10000)
             {
                 s +=
                     u8"{"s + get_bound_shortcut_key_name_by_index(cnt) + u8"}"s;
@@ -1016,8 +1017,8 @@ label_2061_internal:
             draw("equipped", wx + 46, wy + 72 + cnt * 18 - 3);
             if (p == mainweapon)
             {
-                s += i18n::space_if_needed() + "("
-                    + i18n::s.get("core.locale.ui.inv.window.main_hand") + ")";
+                s += i18n::space_if_needed() + "(" +
+                    i18n::s.get("core.locale.ui.inv.window.main_hand") + ")";
             }
         }
         if (showresist)
@@ -1140,8 +1141,8 @@ label_2061_internal:
             result.turn_result = TurnResult::turn_end;
             return result;
         }
-        if (invctrl == 3 || invctrl == 11 || invctrl == 12 || invctrl == 22
-            || (invctrl == 24 && (invctrl(1) == 3 || invctrl(1) == 5)))
+        if (invctrl == 3 || invctrl == 11 || invctrl == 12 || invctrl == 22 ||
+            (invctrl == 24 && (invctrl(1) == 3 || invctrl(1) == 5)))
         {
             if (invctrl != 3 && invctrl != 22)
             {
@@ -1485,8 +1486,8 @@ label_2061_internal:
                 return result;
             }
             f = 0;
-            p = sdata(10, tc) * 500 + sdata(11, tc) * 500
-                + sdata(153, tc) * 2500 + 25000;
+            p = sdata(10, tc) * 500 + sdata(11, tc) * 500 +
+                sdata(153, tc) * 2500 + 25000;
             if (cdata[tc].id == 265)
             {
                 p *= 5;
@@ -1524,8 +1525,8 @@ label_2061_internal:
             }
             else
             {
-                if (inv[ci].identification_state
-                    <= IdentifyState::partly_identified)
+                if (inv[ci].identification_state <=
+                    IdentifyState::partly_identified)
                 {
                     snd("core.fail1");
                     txt(i18n::s.get(
@@ -1589,8 +1590,8 @@ label_2061_internal:
                     }
                     if (cdata[tc].is_pregnant())
                     {
-                        if (inv[ci].id == 262 || inv[ci].id == 519
-                            || inv[ci].id == 392)
+                        if (inv[ci].id == 262 || inv[ci].id == 519 ||
+                            inv[ci].id == 392)
                         {
                             f = 1;
                             txt(i18n::s.get(
@@ -1816,9 +1817,10 @@ label_2061_internal:
                         game_data.guild.mages_guild_quota = 0;
                     }
                     txt(i18n::s.get(
-                            "core.locale.ui.inv.put.guild.you_deliver", inv[ci])
-                            + u8"("s + (inv[ci].param1 + 1) * inv[ci].number()
-                            + u8" Guild Point)"s,
+                            "core.locale.ui.inv.put.guild.you_deliver",
+                            inv[ci]) +
+                            u8"("s + (inv[ci].param1 + 1) * inv[ci].number() +
+                            u8" Guild Point)"s,
                         Message::color{ColorIndex::green});
                     if (game_data.guild.mages_guild_quota == 0)
                     {
@@ -2218,8 +2220,8 @@ label_2061_internal:
         result.turn_result = TurnResult::pc_turn_user_error;
         return result;
     }
-    if (invctrl == 5 || invctrl == 7 || invctrl == 8 || invctrl == 9
-        || invctrl == 14 || invctrl == 15 || invctrl == 26)
+    if (invctrl == 5 || invctrl == 7 || invctrl == 8 || invctrl == 9 ||
+        invctrl == 14 || invctrl == 15 || invctrl == 26)
     {
         if (auto shortcut = get_shortcut(action))
         {

--- a/src/data/lua_lazy_cache.hpp
+++ b/src/data/lua_lazy_cache.hpp
@@ -216,8 +216,8 @@ private:
         }
         catch (const std::exception& e)
         {
-            std::string message = "Error initializing "s + Traits::type_id + ":"
-                + id.get() + ": " + e.what();
+            std::string message = "Error initializing "s + Traits::type_id +
+                ":" + id.get() + ": " + e.what();
             ELONA_LOG(message);
             std::cerr << message << std::endl;
 

--- a/src/dialog/dialog_data.cpp
+++ b/src/dialog/dialog_data.cpp
@@ -71,8 +71,8 @@ bool DialogNodeBehaviorRedirector::apply(
     {
         _dialog_error(
             the_dialog_node.id,
-            callback_redirector
-                + ": Redirector callback returned invalid node id");
+            callback_redirector +
+                ": Redirector callback returned invalid node id");
         return false;
     }
 
@@ -136,8 +136,8 @@ bool DialogData::state_is_valid()
     if (current_text_index > text_amount)
     {
         throw std::runtime_error(
-            *current_node_id + ": BUG: Dialog has " + text_amount
-            + " texts, but " + current_text_index + " was requested");
+            *current_node_id + ": BUG: Dialog has " + text_amount +
+            " texts, but " + current_text_index + " was requested");
 
         return false;
     }
@@ -205,8 +205,8 @@ bool DialogData::advance(size_t choice_index)
         {
             _dialog_error(
                 *current_node_id,
-                "Current node should have \"more\" choice only, but choice "s
-                    + choice_index + " was requested"s);
+                "Current node should have \"more\" choice only, but choice "s +
+                    choice_index + " was requested"s);
             return false;
         }
 
@@ -218,8 +218,8 @@ bool DialogData::advance(size_t choice_index)
     {
         _dialog_error(
             *current_node_id,
-            "Current node has "s + choice_amount + " choices, but "s
-                + choice_index + " was requested"s);
+            "Current node has "s + choice_amount + " choices, but "s +
+                choice_index + " was requested"s);
         return false;
     }
 

--- a/src/dialog/dialog_decoder.cpp
+++ b/src/dialog/dialog_decoder.cpp
@@ -37,8 +37,8 @@ static std::pair<std::string, std::string> parse_id(
     if (datatype_mod_name != mod_name || datatype_name != data_name)
     {
         throw std::runtime_error(
-            "Expected id of format \"" + datatype_mod_name + "." + datatype_name
-            + "\", got \"" + mod_name + "." + data_name + "\"");
+            "Expected id of format \"" + datatype_mod_name + "." +
+            datatype_name + "\", got \"" + mod_name + "." + data_name + "\"");
     }
 
     return strutil::split_on_string(datatype_id, ".");
@@ -202,7 +202,9 @@ void DialogDecoderLogic::parse_node_behavior(
     if (behaviors > 1)
     {
         throw std::runtime_error(
-            full_id + ": Only one of \"generator\", \"redirector\", or \"inherit_choices\" can be used at a time");
+            full_id +
+            ": Only one of \"generator\", \"redirector\", or "
+            "\"inherit_choices\" can be used at a time");
     }
 }
 

--- a/src/dmgheal.cpp
+++ b/src/dmgheal.cpp
@@ -262,8 +262,8 @@ int damage_hp(
     {
         if (victim.hp - dmg_at_m141 <= 0)
         {
-            if (clamp(25 + buff_find(victim, 18)->power / 17, 25, 80)
-                >= rnd(100))
+            if (clamp(25 + buff_find(victim, 18)->power / 17, 25, 80) >=
+                rnd(100))
             {
                 dmg_at_m141 *= -1;
             }
@@ -313,8 +313,8 @@ int damage_hp(
                 heal_hp(
                     *attacker,
                     clamp(
-                        rnd(dmg_at_m141 * (150 + element_power * 2) / 1000
-                            + 10),
+                        rnd(dmg_at_m141 * (150 + element_power * 2) / 1000 +
+                            10),
                         1,
                         attacker->max_hp / 10 + rnd(5)));
             }
@@ -718,9 +718,9 @@ int damage_hp(
             {
                 if (rnd(3) == 0)
                 {
-                    if (victim.confused == 0 && victim.dimmed == 0
-                        && victim.poisoned == 0 && victim.paralyzed == 0
-                        && victim.blind == 0)
+                    if (victim.confused == 0 && victim.dimmed == 0 &&
+                        victim.poisoned == 0 && victim.paralyzed == 0 &&
+                        victim.blind == 0)
                     {
                         if (map_data.type != mdata_t::MapType::world_map)
                         {
@@ -817,8 +817,8 @@ int damage_hp(
         {
             if (element)
             {
-                if (victim.index >= 16
-                    && game_data.proc_damage_events_flag == 2)
+                if (victim.index >= 16 &&
+                    game_data.proc_damage_events_flag == 2)
                 {
                     Message::instance().continue_sentence();
                     txteledmg(1, attacker_is_player, victim.index, element);
@@ -833,8 +833,8 @@ int damage_hp(
                 int death_type = rnd(4);
                 if (death_type == 0)
                 {
-                    if (victim.index >= 16
-                        && game_data.proc_damage_events_flag == 2)
+                    if (victim.index >= 16 &&
+                        game_data.proc_damage_events_flag == 2)
                     {
                         Message::instance().continue_sentence();
                         txt(i18n::s.get(
@@ -854,8 +854,8 @@ int damage_hp(
                 }
                 if (death_type == 1)
                 {
-                    if (victim.index >= 16
-                        && game_data.proc_damage_events_flag == 2)
+                    if (victim.index >= 16 &&
+                        game_data.proc_damage_events_flag == 2)
                     {
                         Message::instance().continue_sentence();
                         txt(i18n::s.get(
@@ -873,8 +873,8 @@ int damage_hp(
                 }
                 if (death_type == 2)
                 {
-                    if (victim.index >= 16
-                        && game_data.proc_damage_events_flag == 2)
+                    if (victim.index >= 16 &&
+                        game_data.proc_damage_events_flag == 2)
                     {
                         Message::instance().continue_sentence();
                         txt(i18n::s.get(
@@ -892,8 +892,8 @@ int damage_hp(
                 }
                 if (death_type == 3)
                 {
-                    if (victim.index >= 16
-                        && game_data.proc_damage_events_flag == 2)
+                    if (victim.index >= 16 &&
+                        game_data.proc_damage_events_flag == 2)
                     {
                         Message::instance().continue_sentence();
                         txt(i18n::s.get(
@@ -999,10 +999,10 @@ int damage_hp(
             {
                 chara_custom_talk(attacker->index, 103);
             }
-            gained_exp = clamp(victim.level, 1, 200)
-                    * clamp((victim.level + 1), 1, 200)
-                    * clamp((victim.level + 2), 1, 200) / 20
-                + 8;
+            gained_exp = clamp(victim.level, 1, 200) *
+                    clamp((victim.level + 1), 1, 200) *
+                    clamp((victim.level + 2), 1, 200) / 20 +
+                8;
             if (victim.level > attacker->level)
             {
                 gained_exp /= 4;
@@ -1101,13 +1101,13 @@ int damage_hp(
                                     .kill_count_of_little_sister),
                             Message::color{ColorIndex::red});
                     }
-                    if (game_data.current_dungeon_level
-                            == area_data[game_data.current_map].deepest_level
-                        || game_data.current_map == mdata_t::MapId::the_void)
+                    if (game_data.current_dungeon_level ==
+                            area_data[game_data.current_map].deepest_level ||
+                        game_data.current_map == mdata_t::MapId::the_void)
                     {
-                        if (area_data[game_data.current_map].has_been_conquered
-                                == victim.index
-                            && victim.is_lord_of_dungeon() == 1)
+                        if (area_data[game_data.current_map]
+                                    .has_been_conquered == victim.index &&
+                            victim.is_lord_of_dungeon() == 1)
                         {
                             event_add(5);
                         }
@@ -1123,9 +1123,9 @@ int damage_hp(
                 }
                 else if (game_data.current_map == mdata_t::MapId::the_void)
                 {
-                    if (area_data[game_data.current_map].has_been_conquered
-                            == victim.index
-                        && victim.is_lord_of_dungeon() == 1)
+                    if (area_data[game_data.current_map].has_been_conquered ==
+                            victim.index &&
+                        victim.is_lord_of_dungeon() == 1)
                     {
                         event_add(5);
                     }
@@ -1191,8 +1191,8 @@ int damage_hp(
             {
                 // The victim just died, so the state will not be "alive" when
                 // set below.
-                if (chara_index == victim.index
-                    || cdata[chara_index].state() != Character::State::alive)
+                if (chara_index == victim.index ||
+                    cdata[chara_index].state() != Character::State::alive)
                 {
                     continue;
                 }

--- a/src/draw.cpp
+++ b/src/draw.cpp
@@ -286,9 +286,9 @@ void show_hp_bar(HPBarSide side, int inf_clocky)
     for (int i = 1; i < 16; ++i)
     {
         auto& cc = cdata[i];
-        if ((cc.state() == Character::State::alive
-             || cc.state() == Character::State::pet_dead)
-            && cdata[i].has_been_used_stethoscope())
+        if ((cc.state() == Character::State::alive ||
+             cc.state() == Character::State::pet_dead) &&
+            cdata[i].has_been_used_stethoscope())
         {
             const auto name = cdatan(0, i);
             const int x = 16 + (windoww - strlen_u(name) * 7 - 16) * right;
@@ -443,8 +443,7 @@ void show_damage_popups()
                     cdata.player().position.x,
                     cdata.player().position.y,
                     cc.position.x,
-                    cc.position.y)
-                > cdata.player().vision_distance / 2)
+                    cc.position.y) > cdata.player().vision_distance / 2)
             {
                 ++damage_popup.frame;
                 continue;
@@ -467,11 +466,11 @@ void show_damage_popups()
 
         int cfg_dmgfont = easing(damage_popup.frame / 10.0) * 20 + 12;
 
-        int x = (cc.position.x - scx) * inf_tiles + inf_screenx
-            - strlen_u(damage_popup.text) * (2 + cfg_dmgfont + 1) / 2 / 2
-            + inf_tiles / 2;
-        int y = (cc.position.y - scy) * inf_tiles + inf_screeny
-            - mondmgpos * (2 + cfg_dmgfont + 3) - 2 * damage_popup.frame;
+        int x = (cc.position.x - scx) * inf_tiles + inf_screenx -
+            strlen_u(damage_popup.text) * (2 + cfg_dmgfont + 1) / 2 / 2 +
+            inf_tiles / 2;
+        int y = (cc.position.y - scy) * inf_tiles + inf_screeny -
+            mondmgpos * (2 + cfg_dmgfont + 3) - 2 * damage_popup.frame;
         x += sxfix * (scx != scxbk) * (scrollp >= 3);
         y += syfix * (scy != scybk) * (scrollp >= 3);
 
@@ -507,8 +506,8 @@ void draw_emo(int cc, int x, int y)
 
 void load_pcc_part(int cc, int body_part, const char* body_part_str)
 {
-    const auto filepath = filesystem::dir::graphic()
-        / (u8"pcc_"s + body_part_str + (pcc(body_part, cc) % 1000) + u8".bmp");
+    const auto filepath = filesystem::dir::graphic() /
+        (u8"pcc_"s + body_part_str + (pcc(body_part, cc) % 1000) + u8".bmp");
     if (!fs::exists(filepath))
         return;
 
@@ -648,8 +647,8 @@ void create_pcpic(int cc, bool prm_410)
         {
             load_pcc_part(cc, 2, u8"chest_");
         }
-        if ((cc != 0 || game_data.mount == 0 || pcc(16, cc) == 0)
-            && pcc(21, cc) == 0)
+        if ((cc != 0 || game_data.mount == 0 || pcc(16, cc) == 0) &&
+            pcc(21, cc) == 0)
         {
             load_pcc_part(cc, 3, u8"leg_");
         }
@@ -1001,8 +1000,8 @@ void init_assets()
     if (!in)
     {
         throw std::runtime_error{
-            "Failed to open "
-            + filesystem::make_preferred_path_in_utf8(filepath)};
+            "Failed to open " +
+            filesystem::make_preferred_path_in_utf8(filepath)};
     }
     const auto& result = hcl::parse(in);
     if (!result.valid())

--- a/src/element.cpp
+++ b/src/element.cpp
@@ -28,8 +28,8 @@ int randomele()
              ++cnt)
         {
             i_at_m45 = rnd(11) + 50;
-            if (the_ability_db[i_at_m45]->difficulty
-                < the_ability_db[p_at_m45]->difficulty)
+            if (the_ability_db[i_at_m45]->difficulty <
+                the_ability_db[p_at_m45]->difficulty)
             {
                 if (rnd(2) == 0)
                 {

--- a/src/elona.hpp
+++ b/src/elona.hpp
@@ -89,8 +89,8 @@ struct elona_vector1
     template <
         typename U,
         std::enable_if_t<
-            !std::is_same<T, std::string>::value
-                || !std::is_same<U, int>::value,
+            !std::is_same<T, std::string>::value ||
+                !std::is_same<U, int>::value,
             std::nullptr_t> = nullptr>
     T& operator+=(const U& x)
     {

--- a/src/elonacore.cpp
+++ b/src/elonacore.cpp
@@ -142,8 +142,8 @@ void weather_changes_by_location(bool output_immediately = true)
 {
     if (game_data.weather == 2)
     {
-        if (game_data.pc_x_in_world_map < 65
-            && game_data.pc_y_in_world_map > 10)
+        if (game_data.pc_x_in_world_map < 65 &&
+            game_data.pc_y_in_world_map > 10)
         {
             game_data.weather = 3;
             sound_play_environmental();
@@ -161,8 +161,8 @@ void weather_changes_by_location(bool output_immediately = true)
     }
     if (game_data.weather == 4 || game_data.weather == 3)
     {
-        if (game_data.pc_x_in_world_map > 65
-            || game_data.pc_y_in_world_map < 10)
+        if (game_data.pc_x_in_world_map > 65 ||
+            game_data.pc_y_in_world_map < 10)
         {
             game_data.weather = 2;
             sound_play_environmental();
@@ -1047,12 +1047,12 @@ int cargocheck()
     {
         return 1;
     }
-    if (map_data.type != mdata_t::MapType::world_map
-        && map_data.type != mdata_t::MapType::player_owned
-        && map_data.type != mdata_t::MapType::town
-        && map_data.type != mdata_t::MapType::field
-        && map_data.type != mdata_t::MapType::shelter
-        && map_data.type != mdata_t::MapType::guild)
+    if (map_data.type != mdata_t::MapType::world_map &&
+        map_data.type != mdata_t::MapType::player_owned &&
+        map_data.type != mdata_t::MapType::town &&
+        map_data.type != mdata_t::MapType::field &&
+        map_data.type != mdata_t::MapType::shelter &&
+        map_data.type != mdata_t::MapType::guild)
     {
         txt(i18n::s.get("core.locale.ui.inv.cannot_use_cargo_items"),
             Message::only_once{true});
@@ -1099,8 +1099,8 @@ void go_hostile()
 {
     for (auto&& cc : cdata.others())
     {
-        if (cc.character_role == 14 || cc.character_role == 16
-            || cc.character_role == 1010)
+        if (cc.character_role == 14 || cc.character_role == 16 ||
+            cc.character_role == 1010)
         {
             cc.relationship = -3;
             cc.hate = 80;
@@ -1213,13 +1213,13 @@ int route_info(int& prm_612, int& prm_613, int prm_614)
     }
     if (prm_614 >= maxroute)
     {
-        if (prm_612 < scx || prm_613 < scy || prm_612 >= scx + inf_screenw
-            || prm_613 >= scy + inf_screenh)
+        if (prm_612 < scx || prm_613 < scy || prm_612 >= scx + inf_screenw ||
+            prm_613 >= scy + inf_screenh)
         {
             return 0;
         }
-        if (prm_612 < 0 || prm_613 < 0 || prm_612 >= map_data.width
-            || prm_613 >= map_data.height)
+        if (prm_612 < 0 || prm_613 < 0 || prm_612 >= map_data.width ||
+            prm_613 >= map_data.height)
         {
             return 0;
         }
@@ -1286,13 +1286,13 @@ int breath_list()
             for (int cnt = 0, cnt_end = (breathw); cnt < cnt_end; ++cnt)
             {
                 tx = cnt - breathw / 2 + dx;
-                if (tx < scx || ty < scy || tx >= scx + inf_screenw
-                    || ty >= scy + inf_screenh)
+                if (tx < scx || ty < scy || tx >= scx + inf_screenw ||
+                    ty >= scy + inf_screenh)
                 {
                     continue;
                 }
-                if (tx < 0 || ty < 0 || tx >= map_data.width
-                    || ty >= map_data.height)
+                if (tx < 0 || ty < 0 || tx >= map_data.width ||
+                    ty >= map_data.height)
                 {
                     continue;
                 }
@@ -1527,8 +1527,11 @@ void make_sound(
         {
             continue;
         }
-        if (dist(prm_777, prm_778, cdata[cnt].position.x, cdata[cnt].position.y)
-            < prm_779)
+        if (dist(
+                prm_777,
+                prm_778,
+                cdata[cnt].position.x,
+                cdata[cnt].position.y) < prm_779)
         {
             if (rnd(prm_780) == 0)
             {
@@ -1883,13 +1886,12 @@ void animeblood(int cc, int animation_type, int element)
         }
         for (int cnt = 0; cnt < 20; ++cnt)
         {
-            pos(dx_at_m133 + 24 + x_at_m133(cnt)
-                    + (x_at_m133(cnt) < 3) * ((1 + (cnt % 2 == 0)) * -1)
-                        * cnt2_at_m133
-                    + (x_at_m133(cnt) > -4) * (1 + (cnt % 2 == 0))
-                        * cnt2_at_m133,
-                dy_at_m133 + y_at_m133(cnt) + cnt2_at_m133 * cnt2_at_m133 / 2
-                    - 12 + cnt);
+            pos(dx_at_m133 + 24 + x_at_m133(cnt) +
+                    (x_at_m133(cnt) < 3) * ((1 + (cnt % 2 == 0)) * -1) *
+                        cnt2_at_m133 +
+                    (x_at_m133(cnt) > -4) * (1 + (cnt % 2 == 0)) * cnt2_at_m133,
+                dy_at_m133 + y_at_m133(cnt) + cnt2_at_m133 * cnt2_at_m133 / 2 -
+                    12 + cnt);
             grotate(
                 1,
                 0,
@@ -1926,8 +1928,8 @@ void spillblood(int prm_830, int prm_831, int prm_832)
             dx_at_m136 = prm_830 + rnd(2) - rnd(2);
             dy_at_m136 = prm_831 + rnd(2) - rnd(2);
         }
-        if (dx_at_m136 < 0 || dx_at_m136 >= map_data.width || dy_at_m136 < 0
-            || dy_at_m136 >= map_data.height)
+        if (dx_at_m136 < 0 || dx_at_m136 >= map_data.width || dy_at_m136 < 0 ||
+            dy_at_m136 >= map_data.height)
         {
             continue;
         }
@@ -1958,8 +1960,8 @@ void spillfrag(int prm_833, int prm_834, int prm_835)
             dx_at_m136 = prm_833 + rnd(2) - rnd(2);
             dy_at_m136 = prm_834 + rnd(2) - rnd(2);
         }
-        if (dx_at_m136 < 0 || dx_at_m136 >= map_data.width || dy_at_m136 < 0
-            || dy_at_m136 >= map_data.height)
+        if (dx_at_m136 < 0 || dx_at_m136 >= map_data.width || dy_at_m136 < 0 ||
+            dy_at_m136 >= map_data.height)
         {
             continue;
         }
@@ -1970,10 +1972,10 @@ void spillfrag(int prm_833, int prm_834, int prm_835)
         if (cell_data.at(dx_at_m136, dy_at_m136).blood_and_fragments / 10 < 4)
         {
             cell_data.at(dx_at_m136, dy_at_m136).blood_and_fragments =
-                cell_data.at(dx_at_m136, dy_at_m136).blood_and_fragments % 10
-                + (cell_data.at(dx_at_m136, dy_at_m136).blood_and_fragments / 10
-                   + 1)
-                    * 10;
+                cell_data.at(dx_at_m136, dy_at_m136).blood_and_fragments % 10 +
+                (cell_data.at(dx_at_m136, dy_at_m136).blood_and_fragments / 10 +
+                 1) *
+                    10;
         }
     }
 }
@@ -1983,9 +1985,9 @@ void spillfrag(int prm_833, int prm_834, int prm_835)
 void check_kill(int prm_836, int prm_837)
 {
     int p_at_m137 = 0;
-    if (game_data.current_map == mdata_t::MapId::pet_arena
-        || game_data.current_map == mdata_t::MapId::show_house
-        || game_data.current_map == mdata_t::MapId::arena)
+    if (game_data.current_map == mdata_t::MapId::pet_arena ||
+        game_data.current_map == mdata_t::MapId::show_house ||
+        game_data.current_map == mdata_t::MapId::arena)
     {
         return;
     }
@@ -2020,9 +2022,9 @@ void check_kill(int prm_836, int prm_837)
                 {
                     p_at_m137 = -5;
                 }
-                if ((cdata[prm_837].character_role >= 1000
-                     && cdata[prm_837].character_role < 2000)
-                    || cdata[prm_837].character_role == 2003)
+                if ((cdata[prm_837].character_role >= 1000 &&
+                     cdata[prm_837].character_role < 2000) ||
+                    cdata[prm_837].character_role == 2003)
                 {
                     p_at_m137 = -10;
                 }
@@ -2086,44 +2088,44 @@ void cnvbonus(int prm_895, int prm_896)
     {
         if (prm_896 > 0)
         {
-            buff += u8"　　"s
-                + i18n::s.get_m(
+            buff += u8"　　"s +
+                i18n::s.get_m(
                     "locale.ability",
                     the_ability_db.get_id_from_legacy(prm_895)->get(),
-                    "name")
-                + u8"耐性に <green>クラス"s + prm_896 / 50 + u8"<col>("s
-                + prm_896 + u8") のボーナス\n"s;
+                    "name") +
+                u8"耐性に <green>クラス"s + prm_896 / 50 + u8"<col>("s +
+                prm_896 + u8") のボーナス\n"s;
         }
         if (prm_896 < 0)
         {
-            buff += u8"　　"s
-                + i18n::s.get_m(
+            buff += u8"　　"s +
+                i18n::s.get_m(
                     "locale.ability",
                     the_ability_db.get_id_from_legacy(prm_895)->get(),
-                    "name")
-                + u8"耐性に <red>クラス"s + prm_896 / 50 + u8"<col>("s + prm_896
-                + u8") のマイナス修正\n"s;
+                    "name") +
+                u8"耐性に <red>クラス"s + prm_896 / 50 + u8"<col>("s + prm_896 +
+                u8") のマイナス修正\n"s;
         }
     }
     else
     {
         if (prm_896 > 0)
         {
-            buff += u8"　　"s
-                + i18n::s.get_m(
+            buff += u8"　　"s +
+                i18n::s.get_m(
                     "locale.ability",
                     the_ability_db.get_id_from_legacy(prm_895)->get(),
-                    "name")
-                + u8"に <green>+"s + prm_896 + u8"<col> のボーナス\n"s;
+                    "name") +
+                u8"に <green>+"s + prm_896 + u8"<col> のボーナス\n"s;
         }
         if (prm_896 < 0)
         {
-            buff += u8"　　"s
-                + i18n::s.get_m(
+            buff += u8"　　"s +
+                i18n::s.get_m(
                     "locale.ability",
                     the_ability_db.get_id_from_legacy(prm_895)->get(),
-                    "name")
-                + u8"に <red>"s + prm_896 + u8"<col> のマイナス修正\n"s;
+                    "name") +
+                u8"に <red>"s + prm_896 + u8"<col> のマイナス修正\n"s;
         }
     }
 }
@@ -2278,8 +2280,8 @@ int try_to_cast_spell()
 
 int try_to_reveal()
 {
-    if (rnd(sdata(159, cc) * 15 + 20 + sdata(13, cc))
-        > rnd(game_data.current_dungeon_level * 8 + 60))
+    if (rnd(sdata(159, cc) * 15 + 20 + sdata(13, cc)) >
+        rnd(game_data.current_dungeon_level * 8 + 60))
     {
         gain_detection_experience(cc);
         return 1;
@@ -2313,8 +2315,8 @@ int can_evade_trap()
 
 int try_to_disarm_trap()
 {
-    if (rnd(sdata(175, cc) * 15 + 20 + sdata(12, cc))
-        > rnd(game_data.current_dungeon_level * 12 + 100))
+    if (rnd(sdata(175, cc) * 15 + 20 + sdata(12, cc)) >
+        rnd(game_data.current_dungeon_level * 12 + 100))
     {
         gain_disarm_trap_experience();
         return 1;
@@ -2328,11 +2330,11 @@ int try_to_perceive_npc(int cc)
 {
     int cv = 0;
     cv = 8;
-    if (cdata[cc].position.x > cdata[r2].position.x - cv
-        && cdata[cc].position.x < cdata[r2].position.x + cv)
+    if (cdata[cc].position.x > cdata[r2].position.x - cv &&
+        cdata[cc].position.x < cdata[r2].position.x + cv)
     {
-        if (cdata[cc].position.y > cdata[r2].position.y - cv
-            && cdata[cc].position.y < cdata[r2].position.y + cv)
+        if (cdata[cc].position.y > cdata[r2].position.y - cv &&
+            cdata[cc].position.y < cdata[r2].position.y + cv)
         {
             if (cdata[r2].hate > 0)
             {
@@ -2342,9 +2344,9 @@ int try_to_perceive_npc(int cc)
                     cdata[cc].position.x,
                     cdata[cc].position.y,
                     cdata[r2].position.x,
-                    cdata[r2].position.y)
-                    * 150
-                + (sdata(157, cc) * 100 + 150) + 1;
+                    cdata[r2].position.y) *
+                    150 +
+                (sdata(157, cc) * 100 + 150) + 1;
             if (rnd(p(0)) < rnd(sdata(13, r2) * 60 + 150))
             {
                 return 1;
@@ -2562,8 +2564,8 @@ void proc_turn_end(int cc)
         {
             if (cdata[cc].nutrition < 1000)
             {
-                if (cdata[cc].continuous_action.type
-                    != ContinuousAction::Type::eat)
+                if (cdata[cc].continuous_action.type !=
+                    ContinuousAction::Type::eat)
                 {
                     damage_hp(
                         cdata[cc], rnd(2) + cdata.player().max_hp / 50, -3);
@@ -2642,32 +2644,32 @@ void proc_turn_end(int cc)
 
 void refresh_burden_state()
 {
-    cdata.player().inventory_weight = clamp(inv_weight(0), 0, 20000000)
-        * (100 - trait(201) * 10 + trait(205) * 20) / 100;
+    cdata.player().inventory_weight = clamp(inv_weight(0), 0, 20000000) *
+        (100 - trait(201) * 10 + trait(205) * 20) / 100;
     cdata.player().max_inventory_weight =
         sdata(10, 0) * 500 + sdata(11, 0) * 250 + sdata(153, 0) * 2000 + 45000;
     for (int cnt = 0; cnt < 1; ++cnt)
     {
-        if (cdata.player().inventory_weight
-            > cdata.player().max_inventory_weight * 2)
+        if (cdata.player().inventory_weight >
+            cdata.player().max_inventory_weight * 2)
         {
             cdata.player().inventory_weight_type = 4;
             break;
         }
-        if (cdata.player().inventory_weight
-            > cdata.player().max_inventory_weight)
+        if (cdata.player().inventory_weight >
+            cdata.player().max_inventory_weight)
         {
             cdata.player().inventory_weight_type = 3;
             break;
         }
-        if (cdata.player().inventory_weight
-            > cdata.player().max_inventory_weight / 4 * 3)
+        if (cdata.player().inventory_weight >
+            cdata.player().max_inventory_weight / 4 * 3)
         {
             cdata.player().inventory_weight_type = 2;
             break;
         }
-        if (cdata.player().inventory_weight
-            > cdata.player().max_inventory_weight / 2)
+        if (cdata.player().inventory_weight >
+            cdata.player().max_inventory_weight / 2)
         {
             cdata.player().inventory_weight_type = 1;
             break;
@@ -2841,8 +2843,8 @@ int convertartifact(int prm_930, int prm_931)
         tc_at_m163 = inv_getowner(cnt);
         if (tc_at_m163 != -1)
         {
-            if (cdata[tc_at_m163].state() == Character::State::empty
-                || cdata[tc_at_m163].character_role == 13)
+            if (cdata[tc_at_m163].state() == Character::State::empty ||
+                cdata[tc_at_m163].character_role == 13)
             {
                 continue;
             }
@@ -3184,12 +3186,12 @@ void character_drops_item()
             }
             if (the_item_db[inv[ci].id]->is_cargo)
             {
-                if (map_data.type != mdata_t::MapType::world_map
-                    && map_data.type != mdata_t::MapType::player_owned
-                    && map_data.type != mdata_t::MapType::town
-                    && map_data.type != mdata_t::MapType::field
-                    && map_data.type != mdata_t::MapType::shelter
-                    && map_data.type != mdata_t::MapType::guild)
+                if (map_data.type != mdata_t::MapType::world_map &&
+                    map_data.type != mdata_t::MapType::player_owned &&
+                    map_data.type != mdata_t::MapType::town &&
+                    map_data.type != mdata_t::MapType::field &&
+                    map_data.type != mdata_t::MapType::shelter &&
+                    map_data.type != mdata_t::MapType::guild)
                 {
                     continue;
                 }
@@ -3228,8 +3230,8 @@ void character_drops_item()
                 }
             }
             else if (
-                inv[ci].identification_state
-                == IdentifyState::completely_identified)
+                inv[ci].identification_state ==
+                IdentifyState::completely_identified)
             {
                 if (rnd(4))
                 {
@@ -3243,8 +3245,8 @@ void character_drops_item()
             if (inv[ci].body_part != 0)
             {
                 cdata[rc].body_parts[inv[ci].body_part - 100] =
-                    cdata[rc].body_parts[inv[ci].body_part - 100] / 10000
-                    * 10000;
+                    cdata[rc].body_parts[inv[ci].body_part - 100] / 10000 *
+                    10000;
                 inv[ci].body_part = 0;
             }
             f = 0;
@@ -3438,8 +3440,8 @@ void character_drops_item()
         }
         inv[ci].remove();
     }
-    if (cdata[rc].quality >= Quality::miracle || rnd(20) == 0
-        || cdata[rc].drops_gold() == 1 || rc < 16)
+    if (cdata[rc].quality >= Quality::miracle || rnd(20) == 0 ||
+        cdata[rc].drops_gold() == 1 || rc < 16)
     {
         if (cdata[rc].gold > 0)
         {
@@ -3778,12 +3780,12 @@ void character_drops_item()
         cell_refresh(cdata[rc].position.x, cdata[rc].position.y);
         return;
     }
-    if (game_data.current_map != mdata_t::MapId::arena
-        && cdata[rc].character_role != 20)
+    if (game_data.current_map != mdata_t::MapId::arena &&
+        cdata[rc].character_role != 20)
     {
-        if (rnd(175) == 0 || cdata[rc].quality == Quality::special || 0
-            || (cdata[rc].quality == Quality::miracle && rnd(2) == 0)
-            || (cdata[rc].quality == Quality::godly && rnd(3) == 0))
+        if (rnd(175) == 0 || cdata[rc].quality == Quality::special || 0 ||
+            (cdata[rc].quality == Quality::miracle && rnd(2) == 0) ||
+            (cdata[rc].quality == Quality::godly && rnd(3) == 0))
         {
             flt();
             itemcreate(-1, 504, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3791,9 +3793,9 @@ void character_drops_item()
             inv[ci].subname = cdata[rc].id;
             cell_refresh(inv[ci].position.x, inv[ci].position.y);
         }
-        if (rnd(175) == 0 || cdata[rc].quality == Quality::special || 0
-            || (cdata[rc].quality == Quality::miracle && rnd(2) == 0)
-            || (cdata[rc].quality == Quality::godly && rnd(3) == 0))
+        if (rnd(175) == 0 || cdata[rc].quality == Quality::special || 0 ||
+            (cdata[rc].quality == Quality::miracle && rnd(2) == 0) ||
+            (cdata[rc].quality == Quality::godly && rnd(3) == 0))
         {
             flt();
             itemcreate(-1, 503, cdata[rc].position.x, cdata[rc].position.y, 0);
@@ -3809,8 +3811,8 @@ void character_drops_item()
         inv[ci].param1 = cdata[rc].shop_store_id;
         inv[ci].own_state = 2;
     }
-    if (rollanatomy == 1 || cdata[rc].quality >= Quality::miracle || 0
-        || cdata[rc].is_livestock() == 1 || 0)
+    if (rollanatomy == 1 || cdata[rc].quality >= Quality::miracle || 0 ||
+        cdata[rc].is_livestock() == 1 || 0)
     {
         flt();
         int stat =
@@ -3914,12 +3916,11 @@ void proc_pregnant()
                 -1, 330, cdata[cc].position.x, cdata[cc].position.y);
             if (stat != 0)
             {
-                if (strlen_u(cdatan(0, cc)) > 10
-                    || instr(
-                           cdatan(0, cc),
-                           0,
-                           i18n::s.get("core.locale.chara.job.alien.child"))
-                        != -1)
+                if (strlen_u(cdatan(0, cc)) > 10 ||
+                    instr(
+                        cdatan(0, cc),
+                        0,
+                        i18n::s.get("core.locale.chara.job.alien.child")) != -1)
                 {
                     cdatan(0, rc) =
                         i18n::s.get("core.locale.chara.job.alien.alien_kid");
@@ -3955,7 +3956,8 @@ void proc_negative_equipments()
             {
                 if (map_data.type != mdata_t::MapType::world_map)
                 {
-                    if (rnd(25) < clamp(
+                    if (rnd(25) <
+                        clamp(
                             std::abs(inv[ci].enchantments[cnt].power) / 50,
                             1,
                             25))
@@ -3994,14 +3996,13 @@ void proc_negative_equipments()
                                 cdata[cc]),
                             Message::color{ColorIndex::purple});
                     }
-                    cdata[cc].experience -= cdata[cc].required_experience
-                            / (300
-                               - clamp(
-                                   std::abs(inv[ci].enchantments[cnt].power)
-                                       / 2,
-                                   0,
-                                   50))
-                        + rnd(100);
+                    cdata[cc].experience -= cdata[cc].required_experience /
+                            (300 -
+                             clamp(
+                                 std::abs(inv[ci].enchantments[cnt].power) / 2,
+                                 0,
+                                 50)) +
+                        rnd(100);
                     if (cdata[cc].experience < 0)
                     {
                         cdata[cc].experience = 0;
@@ -4015,7 +4016,8 @@ void proc_negative_equipments()
                 {
                     if (map_data.type != mdata_t::MapType::player_owned)
                     {
-                        if (rnd(50) < clamp(
+                        if (rnd(50) <
+                            clamp(
                                 std::abs(inv[ci].enchantments[cnt].power) / 50,
                                 1,
                                 50))
@@ -4051,16 +4053,16 @@ void proc_negative_equipments()
 
 void auto_identify()
 {
-    if (cdata.player().confused != 0 || cdata.player().sleep != 0
-        || cdata.player().paralyzed != 0 || cdata.player().choked != 0)
+    if (cdata.player().confused != 0 || cdata.player().sleep != 0 ||
+        cdata.player().paralyzed != 0 || cdata.player().choked != 0)
     {
         return;
     }
     for (const auto& cnt : items(0))
     {
-        if (inv[cnt].number() == 0
-            || inv[cnt].identification_state
-                == IdentifyState::completely_identified)
+        if (inv[cnt].number() == 0 ||
+            inv[cnt].identification_state ==
+                IdentifyState::completely_identified)
         {
             continue;
         }
@@ -4244,9 +4246,9 @@ TurnResult exit_map()
         quest_exit_map();
     }
     Message::instance().msg_append_begin("  ");
-    if (game_data.current_map == mdata_t::MapId::show_house
-        || game_data.current_map == mdata_t::MapId::arena
-        || game_data.current_map == mdata_t::MapId::pet_arena)
+    if (game_data.current_map == mdata_t::MapId::show_house ||
+        game_data.current_map == mdata_t::MapId::arena ||
+        game_data.current_map == mdata_t::MapId::pet_arena)
     {
         usermapid = 0;
     }
@@ -4254,8 +4256,8 @@ TurnResult exit_map()
     fixstart = 0;
     if (area_data[game_data.current_map].id == mdata_t::MapId::random_dungeon)
     {
-        if (game_data.current_dungeon_level
-            == area_data[game_data.current_map].deepest_level)
+        if (game_data.current_dungeon_level ==
+            area_data[game_data.current_map].deepest_level)
         {
             if (area_data[game_data.current_map].has_been_conquered > 0)
             {
@@ -4281,14 +4283,14 @@ TurnResult exit_map()
         cell_featread(cdata.player().position.x, cdata.player().position.y);
         if (game_data.current_map == mdata_t::MapId::your_home)
         {
-            if (mapitemfind(cdata[cc].position.x, cdata[cc].position.y, 751)
-                != -1)
+            if (mapitemfind(cdata[cc].position.x, cdata[cc].position.y, 751) !=
+                -1)
             {
                 feat(1) = 11;
                 feat(2) = 0;
             }
-            if (mapitemfind(cdata[cc].position.x, cdata[cc].position.y, 750)
-                != -1)
+            if (mapitemfind(cdata[cc].position.x, cdata[cc].position.y, 750) !=
+                -1)
             {
                 feat(1) = 10;
                 feat(2) = 0;
@@ -4343,8 +4345,8 @@ TurnResult exit_map()
                 if (feat(2) != 0 || feat(3) != 0)
                 {
                     game_data.current_map = feat(2) + feat(3) * 100;
-                    if (area_data[game_data.current_map].id
-                        == mdata_t::MapId::the_void)
+                    if (area_data[game_data.current_map].id ==
+                        mdata_t::MapId::the_void)
                     {
                         if (itemfind(0, 742) == -1)
                         {
@@ -4355,8 +4357,8 @@ TurnResult exit_map()
                                 static_cast<int>(mdata_t::MapId::fields);
                         }
                     }
-                    if (area_data[game_data.current_map].id
-                        == mdata_t::MapId::pyramid)
+                    if (area_data[game_data.current_map].id ==
+                        mdata_t::MapId::pyramid)
                     {
                         if (game_data.quest_flags.pyramid_trial == 0)
                         {
@@ -4368,8 +4370,8 @@ TurnResult exit_map()
                                 static_cast<int>(mdata_t::MapId::fields);
                         }
                     }
-                    if (area_data[game_data.current_map].id
-                        == mdata_t::MapId::jail)
+                    if (area_data[game_data.current_map].id ==
+                        mdata_t::MapId::jail)
                     {
                         txt(i18n::s.get(
                             "core.locale.action.exit_map.cannot_enter_jail"));
@@ -4389,20 +4391,20 @@ TurnResult exit_map()
                         static_cast<int>(mdata_t::MapId::fields);
                 }
             }
-            if (map_data.type == mdata_t::MapType::town
-                || map_data.type == mdata_t::MapType::field
-                || map_data.type == mdata_t::MapType::player_owned
-                || map_data.type == mdata_t::MapType::shelter
-                || map_data.type == mdata_t::MapType::guild)
+            if (map_data.type == mdata_t::MapType::town ||
+                map_data.type == mdata_t::MapType::field ||
+                map_data.type == mdata_t::MapType::player_owned ||
+                map_data.type == mdata_t::MapType::shelter ||
+                map_data.type == mdata_t::MapType::guild)
             {
                 game_data.current_map = game_data.destination_outer_map;
             }
         }
-        if (mdata_t::is_nefia(map_data.type)
-            || map_data.type == static_cast<int>(mdata_t::MapType::shelter))
+        if (mdata_t::is_nefia(map_data.type) ||
+            map_data.type == static_cast<int>(mdata_t::MapType::shelter))
         {
-            if (game_data.current_dungeon_level
-                < area_data[game_data.current_map].danger_level)
+            if (game_data.current_dungeon_level <
+                area_data[game_data.current_map].danger_level)
             {
                 game_data.current_map = game_data.destination_outer_map;
             }
@@ -4472,25 +4474,26 @@ TurnResult exit_map()
     }
     if (game_data.current_map != game_data.previous_map)
     {
-        if (map_is_town_or_guild()
-            || game_data.previous_map == mdata_t::MapId::your_home
-            || game_data.departure_date == 0)
+        if (map_is_town_or_guild() ||
+            game_data.previous_map == mdata_t::MapId::your_home ||
+            game_data.departure_date == 0)
         {
             game_data.departure_date = game_data.date.hours();
             game_data.distance_between_town = 0;
             game_data.left_town_map = game_data.previous_map;
         }
-        if (area_data[game_data.current_map].type != mdata_t::MapType::world_map
-            && area_data[game_data.current_map].type != mdata_t::MapType::field
-            && game_data.current_map != mdata_t::MapId::show_house)
+        if (area_data[game_data.current_map].type !=
+                mdata_t::MapType::world_map &&
+            area_data[game_data.current_map].type != mdata_t::MapType::field &&
+            game_data.current_map != mdata_t::MapId::show_house)
         {
             autosave =
                 1 * (game_data.current_map != mdata_t::MapId::show_house);
         }
         if (map_data.type != mdata_t::MapType::world_map)
         {
-            if (map_data.type != mdata_t::MapType::field
-                || map_data.type == mdata_t::MapType::player_owned)
+            if (map_data.type != mdata_t::MapType::field ||
+                map_data.type == mdata_t::MapType::player_owned)
             {
                 if (fixtransfermap == 0)
                 {
@@ -4516,8 +4519,8 @@ TurnResult exit_map()
             weather_changes_by_location(false);
         }
         else if (
-            area_data[game_data.previous_map].type
-            == mdata_t::MapType::world_map)
+            area_data[game_data.previous_map].type ==
+            mdata_t::MapType::world_map)
         {
             Message::instance().msg_append(i18n::s.get(
                 "core.locale.action.exit_map.entered",
@@ -4537,10 +4540,10 @@ TurnResult exit_map()
         }
         if (game_data.cargo_weight > game_data.current_cart_limit)
         {
-            if (area_data[game_data.current_map].type
-                    == mdata_t::MapType::world_map
-                || area_data[game_data.current_map].type
-                    == mdata_t::MapType::field)
+            if (area_data[game_data.current_map].type ==
+                    mdata_t::MapType::world_map ||
+                area_data[game_data.current_map].type ==
+                    mdata_t::MapType::field)
             {
                 Message::instance().msg_append(i18n::s.get(
                     "core.locale.action.exit_map.burdened_by_cargo"));
@@ -4562,8 +4565,8 @@ TurnResult exit_map()
     }
     if (game_data.current_map == mdata_t::MapId::mountain_pass)
     {
-        if (game_data.current_dungeon_level
-            == area_data[game_data.current_map].deepest_level)
+        if (game_data.current_dungeon_level ==
+            area_data[game_data.current_map].deepest_level)
         {
             game_data.current_map = static_cast<int>(mdata_t::MapId::larna);
             game_data.current_dungeon_level = 1;
@@ -4623,8 +4626,8 @@ TurnResult exit_map()
         }
     }
 
-    bool map_changed = game_data.current_map != previous_map
-        || game_data.current_dungeon_level != previous_dungeon_level;
+    bool map_changed = game_data.current_map != previous_map ||
+        game_data.current_dungeon_level != previous_dungeon_level;
 
     // Only clear map-local data if the map was changed. The map might
     // not change if access to it is refused (jail, pyramid, etc.).
@@ -4693,8 +4696,8 @@ void map_prepare_tileset_atlas()
     {
         pos(0, 0);
         picload(
-            filesystem::dir::graphic()
-                / (u8"map"s + map_data.atlas_number + u8".bmp"),
+            filesystem::dir::graphic() /
+                (u8"map"s + map_data.atlas_number + u8".bmp"),
             1);
         mtilefilecur = map_data.atlas_number;
         initialize_map_chip();
@@ -4708,8 +4711,8 @@ void map_prepare_tileset_atlas()
     int shadow = 5;
     if (map_data.indoors_flag == 2)
     {
-        if (game_data.date.hour >= 24
-            || (game_data.date.hour >= 0 && game_data.date.hour < 4))
+        if (game_data.date.hour >= 24 ||
+            (game_data.date.hour >= 0 && game_data.date.hour < 4))
         {
             shadow = 110;
         }
@@ -4741,8 +4744,8 @@ void map_prepare_tileset_atlas()
         {
             shadow = 65;
         }
-        if (game_data.current_map == mdata_t::MapId::noyel
-            && (game_data.date.hour >= 17 || game_data.date.hour < 7))
+        if (game_data.current_map == mdata_t::MapId::noyel &&
+            (game_data.date.hour >= 17 || game_data.date.hour < 7))
         {
             shadow += 35;
         }
@@ -4832,8 +4835,8 @@ void map_global_proc_diastrophism()
             }
         }
     }
-    if (p <= 25 || rnd(150) == 0 || game_data.diastrophism_flag != 0
-        || game_data.reset_world_map_in_diastrophism_flag)
+    if (p <= 25 || rnd(150) == 0 || game_data.diastrophism_flag != 0 ||
+        game_data.reset_world_map_in_diastrophism_flag)
     {
         game_data.diastrophism_flag = 0;
         Message::instance().msg_append(
@@ -4891,8 +4894,8 @@ void map_global_place_entrances()
     }
     for (int cnt = 0; cnt < 500; ++cnt)
     {
-        if (area_data[cnt].id == mdata_t::MapId::none
-            || area_data[cnt].appearance == 0)
+        if (area_data[cnt].id == mdata_t::MapId::none ||
+            area_data[cnt].appearance == 0)
         {
             continue;
         }
@@ -4910,9 +4913,9 @@ void map_global_place_entrances()
             area_data[cnt].id -= 800;
             continue;
         }
-        if (area_data[cnt].position.x <= 0 || area_data[cnt].position.y <= 0
-            || area_data[cnt].position.x >= map_data.width
-            || area_data[cnt].position.y >= map_data.height)
+        if (area_data[cnt].position.x <= 0 || area_data[cnt].position.y <= 0 ||
+            area_data[cnt].position.x >= map_data.width ||
+            area_data[cnt].position.y >= map_data.height)
         {
             area_data[cnt].position.x = map_data.width / 2;
             area_data[cnt].position.y = map_data.height / 2;
@@ -4922,12 +4925,10 @@ void map_global_place_entrances()
                 7,
                 cell_data
                     .at(area_data[cnt].position.x, area_data[cnt].position.y)
-                    .chip_id_actual)
-                & 4
-            || cell_data
-                    .at(area_data[cnt].position.x, area_data[cnt].position.y)
-                    .feats
-                != 0)
+                    .chip_id_actual) &
+                4 ||
+            cell_data.at(area_data[cnt].position.x, area_data[cnt].position.y)
+                    .feats != 0)
         {
             for (int cnt = 0;; ++cnt)
             {
@@ -4935,13 +4936,13 @@ void map_global_place_entrances()
                 dy = clamp(rnd(cnt / 4 + 1) + 1, 1, map_data.height);
                 x = area_data[p].position.x + rnd(dx(0)) - rnd(dx(0));
                 y = area_data[p].position.y + rnd(dy) - rnd(dy);
-                if (x <= 0 || y <= 0 || x >= map_data.width - 1
-                    || y >= map_data.height - 1)
+                if (x <= 0 || y <= 0 || x >= map_data.width - 1 ||
+                    y >= map_data.height - 1)
                 {
                     continue;
                 }
-                if (33 <= cell_data.at(x, y).chip_id_actual
-                    && cell_data.at(x, y).chip_id_actual < 66)
+                if (33 <= cell_data.at(x, y).chip_id_actual &&
+                    cell_data.at(x, y).chip_id_actual < 66)
                 {
                     continue;
                 }
@@ -4965,8 +4966,8 @@ void map_global_place_entrances()
             15,
             cnt % 100,
             cnt / 100);
-        if (area_data[cnt].type == mdata_t::MapType::town
-            || area_data[cnt].type == mdata_t::MapType::guild)
+        if (area_data[cnt].type == mdata_t::MapType::town ||
+            area_data[cnt].type == mdata_t::MapType::guild)
         {
             cell_data.at(area_data[cnt].position.x, area_data[cnt].position.y)
                 .light = 11;
@@ -5223,8 +5224,8 @@ void supply_income()
         {
             continue;
         }
-        p = calcincome(cnt) + rnd((calcincome(cnt) / 3 + 1))
-            - rnd((calcincome(cnt) / 3 + 1));
+        p = calcincome(cnt) + rnd((calcincome(cnt) / 3 + 1)) -
+            rnd((calcincome(cnt) / 3 + 1));
         income += p;
         flt();
         itemcreate(-1, 54, -1, -1, p);
@@ -5329,11 +5330,11 @@ void supply_income()
                         s(0) = i18n::s.get("core.locale.misc.tax.caution");
                         s(1) = "";
                     }
-                    txt(s
-                            + i18n::s.get(
+                    txt(s +
+                            i18n::s.get(
                                 "core.locale.misc.tax.left_bills",
-                                game_data.left_bill - 1)
-                            + s(1),
+                                game_data.left_bill - 1) +
+                            s(1),
                         Message::color{ColorIndex::red});
                 }
             }
@@ -5438,14 +5439,12 @@ void txttargetnpc(int prm_1057, int prm_1058, int prm_1059)
                 cdata.player().position.x,
                 cdata.player().position.y,
                 prm_1057,
-                prm_1058)
-                == 0
-            || dist(
-                   cdata.player().position.x,
-                   cdata.player().position.y,
-                   prm_1057,
-                   prm_1058)
-                > cdata.player().vision_distance / 2)
+                prm_1058) == 0 ||
+            dist(
+                cdata.player().position.x,
+                cdata.player().position.y,
+                prm_1057,
+                prm_1058) > cdata.player().vision_distance / 2)
         {
             bmes(
                 i18n::s.get("core.locale.action.target.out_of_sight"),
@@ -5459,8 +5458,8 @@ void txttargetnpc(int prm_1057, int prm_1058, int prm_1059)
     if (cell_data.at(prm_1057, prm_1058).chara_index_plus_one != 0)
     {
         i_at_m186 = cell_data.at(prm_1057, prm_1058).chara_index_plus_one - 1;
-        if (cdata[i_at_m186].is_invisible() == 0
-            || cdata.player().can_see_invisible() || cdata[i_at_m186].wet)
+        if (cdata[i_at_m186].is_invisible() == 0 ||
+            cdata.player().can_see_invisible() || cdata[i_at_m186].wet)
         {
             tc = i_at_m186;
             s = txttargetlevel(cc, tc);
@@ -5495,8 +5494,8 @@ void txttargetnpc(int prm_1057, int prm_1058, int prm_1059)
             if (cell_data.at(prm_1057, prm_1058).feats / 1000 % 100 == 15)
             {
                 p_at_m186 =
-                    cell_data.at(prm_1057, prm_1058).feats / 100000 % 100
-                    + cell_data.at(prm_1057, prm_1058).feats / 10000000 * 100;
+                    cell_data.at(prm_1057, prm_1058).feats / 100000 % 100 +
+                    cell_data.at(prm_1057, prm_1058).feats / 10000000 * 100;
                 bmes(
                     mapname(p_at_m186, true),
                     100,
@@ -5653,11 +5652,11 @@ int target_position()
             snail::Application::instance().get_renderer().fill_rect(
                 dx,
                 dy * (dy > 0),
-                inf_tiles
-                    - (dx + inf_tiles > windoww) * (dx + inf_tiles - windoww),
-                inf_tiles + (dy < 0) * inf_screeny
-                    - (dy + inf_tiles > windowh - inf_verh)
-                        * (dy + inf_tiles - windowh + inf_verh));
+                inf_tiles -
+                    (dx + inf_tiles > windoww) * (dx + inf_tiles - windoww),
+                inf_tiles + (dy < 0) * inf_screeny -
+                    (dy + inf_tiles > windowh - inf_verh) *
+                        (dy + inf_tiles - windowh + inf_verh));
         }
         if (homemapmode == 1)
         {
@@ -5687,14 +5686,12 @@ int target_position()
                         cdata[cc].position.x,
                         cdata[cc].position.y,
                         cdata[rc].position.x,
-                        cdata[rc].position.y)
-                    == 0)
+                        cdata[rc].position.y) == 0)
                 {
                     break;
                 }
-                if ((cdata[rc].is_invisible() == 0
-                     || cdata.player().can_see_invisible() || cdata[rc].wet)
-                    == 0)
+                if ((cdata[rc].is_invisible() == 0 ||
+                     cdata.player().can_see_invisible() || cdata[rc].wet) == 0)
                 {
                     break;
                 }
@@ -5736,13 +5733,13 @@ int target_position()
                                 .fill_rect(
                                     sx,
                                     sy * (sy > 0),
-                                    inf_tiles
-                                        - (sx + inf_tiles > windoww)
-                                            * (sx + inf_tiles - windoww),
-                                    inf_tiles + (sy < 0) * inf_screeny
-                                        - (sy + inf_tiles > windowh - inf_verh)
-                                            * (sy + inf_tiles - windowh
-                                               + inf_verh));
+                                    inf_tiles -
+                                        (sx + inf_tiles > windoww) *
+                                            (sx + inf_tiles - windoww),
+                                    inf_tiles + (sy < 0) * inf_screeny -
+                                        (sy + inf_tiles > windowh - inf_verh) *
+                                            (sy + inf_tiles - windowh +
+                                             inf_verh));
                         }
                     }
                 }
@@ -5767,8 +5764,8 @@ int target_position()
             }
             if (input == StickKey::mouse_right)
             {
-                if (chipm(0, cell_data.at(tlocx, tlocy).chip_id_actual) == 2
-                    || chipm(0, cell_data.at(tlocx, tlocy).chip_id_actual) == 1)
+                if (chipm(0, cell_data.at(tlocx, tlocy).chip_id_actual) == 2 ||
+                    chipm(0, cell_data.at(tlocx, tlocy).chip_id_actual) == 1)
                 {
                     snd("core.fail1");
                     wait_key_released();
@@ -5812,8 +5809,8 @@ int target_position()
             {
                 x = tlocx + kdx;
                 y = tlocy + kdy;
-                if (x >= 0 && y >= 0 && x < map_data.width
-                    && y < map_data.height)
+                if (x >= 0 && y >= 0 && x < map_data.width &&
+                    y < map_data.height)
                 {
                     tlocx += kdx;
                     tlocy += kdy;
@@ -5877,8 +5874,8 @@ int target_position()
         {
             if (findlocmode == 1)
             {
-                if (cansee == 0
-                    || chipm(7, cell_data.at(tlocx, tlocy).chip_id_actual) & 4)
+                if (cansee == 0 ||
+                    chipm(7, cell_data.at(tlocx, tlocy).chip_id_actual) & 4)
                 {
                     txt(i18n::s.get(
                         "core.locale.action.which_direction.cannot_see"));
@@ -6398,11 +6395,11 @@ void try_to_return()
         {
             list(0, p) = i;
             list(1, p) = area_data[i].visited_deepest_level;
-            auto text = mapname(i) + u8" "s
-                + cnvrank(
-                            (area_data[i].visited_deepest_level
-                             - area_data[i].danger_level + 1))
-                + i18n::s.get("core.locale.misc.dungeon_level");
+            auto text = mapname(i) + u8" "s +
+                cnvrank(
+                            (area_data[i].visited_deepest_level -
+                             area_data[i].danger_level + 1)) +
+                i18n::s.get("core.locale.misc.dungeon_level");
             prompt.append(text);
             ++p;
         }
@@ -6420,11 +6417,11 @@ void try_to_return()
     if (rtval >= 0)
     {
         txt(i18n::s.get("core.locale.misc.return.air_becomes_charged"));
-        if (area_data[game_data.current_map].id
-            == mdata_t::MapId::random_dungeon)
+        if (area_data[game_data.current_map].id ==
+            mdata_t::MapId::random_dungeon)
         {
-            if (game_data.current_dungeon_level
-                == area_data[game_data.current_map].deepest_level)
+            if (game_data.current_dungeon_level ==
+                area_data[game_data.current_map].deepest_level)
             {
                 if (area_data[game_data.current_map].has_been_conquered != -1)
                 {
@@ -6523,50 +6520,50 @@ void dump_player_info()
     notesel(buff);
     noteadd(latest_version.long_string());
     noteadd(
-        u8"キャラクター情報 "s + game_data.date.year + u8"年"s
-        + game_data.date.month + u8"月"s + game_data.date.day + u8"日 "s
-        + game_data.date.hour + u8"時"s + game_data.date.minute + u8"分  "s
-        + mdatan(0));
+        u8"キャラクター情報 "s + game_data.date.year + u8"年"s +
+        game_data.date.month + u8"月"s + game_data.date.day + u8"日 "s +
+        game_data.date.hour + u8"時"s + game_data.date.minute + u8"分  "s +
+        mdatan(0));
     noteadd(""s);
     noteadd(
-        u8"  "s + fixtxt((""s + cdatan(1, 0) + cdatan(0, 0)), 34)
-        + i18n::_(u8"ui", u8"sex", u8"_"s + cdata.player().sex) + u8" "s
-        + calcage(0) + u8"歳"s + u8"  "s + cdata.player().height + u8"cm"s
-        + u8" "s + cdata.player().weight + u8"kg"s);
+        u8"  "s + fixtxt((""s + cdatan(1, 0) + cdatan(0, 0)), 34) +
+        i18n::_(u8"ui", u8"sex", u8"_"s + cdata.player().sex) + u8" "s +
+        calcage(0) + u8"歳"s + u8"  "s + cdata.player().height + u8"cm"s +
+        u8" "s + cdata.player().weight + u8"kg"s);
     noteadd(""s);
     noteadd(
         fixtxt(
-            u8"種族       : "s
-                + i18n::s.get_m("locale.race", cdatan(2, 0), "name"),
-            30)
-        + fixtxt((u8"信仰      : "s + god_name(cdata.player().god_id)), 32));
+            u8"種族       : "s +
+                i18n::s.get_m("locale.race", cdatan(2, 0), "name"),
+            30) +
+        fixtxt((u8"信仰      : "s + god_name(cdata.player().god_id)), 32));
     noteadd(
-        fixtxt(u8"職業       : "s + classname, 30)
-        + fixtxt((u8"所属      : "s + guildname()), 32));
+        fixtxt(u8"職業       : "s + classname, 30) +
+        fixtxt((u8"所属      : "s + guildname()), 32));
     noteadd(
-        fixtxt(u8"レベル     : "s + cdata.player().level, 30)
-        + fixtxt((u8"経過日数  : "s + game_data.play_days), 32));
+        fixtxt(u8"レベル     : "s + cdata.player().level, 30) +
+        fixtxt((u8"経過日数  : "s + game_data.play_days), 32));
     noteadd(
-        fixtxt(u8"残りBP     : "s + cdata.player().skill_bonus, 30)
-        + fixtxt((u8"経過ターン: "s + game_data.play_turns), 32));
+        fixtxt(u8"残りBP     : "s + cdata.player().skill_bonus, 30) +
+        fixtxt((u8"経過ターン: "s + game_data.play_turns), 32));
     noteadd(
-        fixtxt(u8"金貨       : "s + cdata.player().gold, 30)
-        + fixtxt((u8"殺害数    : "s + game_data.kill_count), 32));
+        fixtxt(u8"金貨       : "s + cdata.player().gold, 30) +
+        fixtxt((u8"殺害数    : "s + game_data.kill_count), 32));
     noteadd(
-        fixtxt(u8"プラチナ   : "s + cdata.player().platinum_coin, 30)
-        + fixtxt(
+        fixtxt(u8"プラチナ   : "s + cdata.player().platinum_coin, 30) +
+        fixtxt(
             (u8"最深到達  : "s + game_data.deepest_dungeon_level + u8"階相当"s),
             32));
     noteadd(fixtxt(
-        u8"プレイ時間 : "s
-            + cnvplaytime(
+        u8"プレイ時間 : "s +
+            cnvplaytime(
                 (game_data.play_time + timeGetTime() / 1000 - time_begin)),
         30));
     noteadd(""s);
-    s(1) = u8"生命力    : "s + sdata(2, 0) + u8"("s
-        + sdata.get(2, 0).original_level + u8")"s;
-    s(2) = u8"マナ      : "s + sdata(3, 0) + u8"("s
-        + sdata.get(3, 0).original_level + u8")"s;
+    s(1) = u8"生命力    : "s + sdata(2, 0) + u8"("s +
+        sdata.get(2, 0).original_level + u8")"s;
+    s(2) = u8"マナ      : "s + sdata(3, 0) + u8"("s +
+        sdata.get(3, 0).original_level + u8")"s;
     s(3) = u8"狂気度    : "s + cdata.player().insanity;
     s(4) = u8"速度      : "s + cdata.player().current_speed;
     s(5) = u8"名声度    : "s + cdata.player().fame;
@@ -6600,11 +6597,11 @@ void dump_player_info()
         }
         s = fixtxt(s, 15);
         s = fixtxt(
-                i18n::_(u8"ui", u8"attribute", u8"_"s + cnt) + u8"    : "s
-                    + sdata((10 + cnt), 0) + u8"("s
-                    + sdata.get(10 + cnt, 0).original_level + u8")"s,
-                24)
-            + s;
+                i18n::_(u8"ui", u8"attribute", u8"_"s + cnt) + u8"    : "s +
+                    sdata((10 + cnt), 0) + u8"("s +
+                    sdata.get(10 + cnt, 0).original_level + u8")"s,
+                24) +
+            s;
         noteadd(s + s((1 + cnt)));
     }
     noteadd(""s);
@@ -6615,13 +6612,13 @@ void dump_player_info()
     prot = calcattackdmg(2);
     noteadd(u8"回避    : "s + evade + u8"%"s);
     noteadd(
-        u8"軽減    : "s + (100 - 10000 / (prot + 100)) + u8"% + "s + protdice1
-        + u8"d"s + protdice2);
+        u8"軽減    : "s + (100 - 10000 / (prot + 100)) + u8"% + "s + protdice1 +
+        u8"d"s + protdice2);
     noteadd(""s);
     noteadd(
-        u8"------------------------------ 装備品 合計重量"s
-        + cnvweight(cdata[cc].sum_of_equipment_weight) + u8" "s
-        + cnveqweight(cc));
+        u8"------------------------------ 装備品 合計重量"s +
+        cnvweight(cdata[cc].sum_of_equipment_weight) + u8" "s +
+        cnveqweight(cc));
     noteadd(""s);
     listmax = 0;
     for (int cnt = 0; cnt < 30; ++cnt)
@@ -6712,12 +6709,12 @@ void dump_player_info()
         }
         access_class_info(2, cdatan(3, cnt));
         noteadd(
-            cdatan(0, cnt) + u8" "s
-            + i18n::s.get_m("locale.race", cdatan(2, cnt), "name") + u8"の"s
-            + classname + u8" "s
-            + i18n::_(u8"ui", u8"sex", u8"_"s + cdata[cnt].sex) + u8" "s
-            + calcage(cnt) + u8"歳"s + u8"  "s + cdata[cnt].height + u8"cm"s
-            + u8" "s + cdata[cnt].weight + u8"kg"s);
+            cdatan(0, cnt) + u8" "s +
+            i18n::s.get_m("locale.race", cdatan(2, cnt), "name") + u8"の"s +
+            classname + u8" "s +
+            i18n::_(u8"ui", u8"sex", u8"_"s + cdata[cnt].sex) + u8" "s +
+            calcage(cnt) + u8"歳"s + u8"  "s + cdata[cnt].height + u8"cm"s +
+            u8" "s + cdata[cnt].weight + u8"kg"s);
         s = u8"レベル "s + cdata[cnt].level + u8" "s;
         if (cdata[cnt].is_married() == 1)
         {
@@ -6733,8 +6730,8 @@ void dump_player_info()
         if (game_data.ranks.at(cnt) < 10000)
         {
             noteadd(
-                ""s + ranktitle(cnt) + u8" Rank."s
-                + game_data.ranks.at(cnt) / 100);
+                ""s + ranktitle(cnt) + u8" Rank."s +
+                game_data.ranks.at(cnt) / 100);
             s = u8"給料: 約 "s + calcincome(cnt) + u8" gold  "s + u8"ノルマ: "s;
             gold += calcincome(cnt);
             if (cnt == 3 || cnt == 4 || cnt == 5 || cnt == 8)
@@ -6853,8 +6850,8 @@ void load_gene_files()
         {
             lomiaseaster = 1;
         }
-        if (inv[cnt].id == 511
-            || the_item_db[inv[cnt].id]->subcategory == 53100)
+        if (inv[cnt].id == 511 ||
+            the_item_db[inv[cnt].id]->subcategory == 53100)
         {
             continue;
         }
@@ -6976,8 +6973,8 @@ void update_save_data(const fs::path& save_dir, int serial_id)
             for (auto&& chara : cdatan_)
             {
                 const auto old_race_id = chara.at(2);
-                if (!old_race_id.empty()
-                    && !strutil::starts_with(old_race_id, "core."))
+                if (!old_race_id.empty() &&
+                    !strutil::starts_with(old_race_id, "core."))
                 {
                     ELONA_LOG(
                         "[Save data] Prepend \"core\" prefix to "
@@ -6990,8 +6987,8 @@ void update_save_data(const fs::path& save_dir, int serial_id)
             if (!out)
             {
                 throw std::runtime_error(
-                    u8"Error: fail to write "
-                    + filesystem::make_preferred_path_in_utf8(entry.path()));
+                    u8"Error: fail to write " +
+                    filesystem::make_preferred_path_in_utf8(entry.path()));
             }
 
             for (const auto& chara : cdatan_)
@@ -7036,8 +7033,8 @@ void update_save_data(const fs::path& save_dir, int serial_id)
             for (auto&& chara : cdatan_)
             {
                 const auto old_class_id = chara.at(3);
-                if (!old_class_id.empty()
-                    && !strutil::starts_with(old_class_id, "core."))
+                if (!old_class_id.empty() &&
+                    !strutil::starts_with(old_class_id, "core."))
                 {
                     ELONA_LOG(
                         "[Save data] Prepend \"core\" prefix to "
@@ -7050,8 +7047,8 @@ void update_save_data(const fs::path& save_dir, int serial_id)
             if (!out)
             {
                 throw std::runtime_error(
-                    u8"Error: fail to write "
-                    + filesystem::make_preferred_path_in_utf8(entry.path()));
+                    u8"Error: fail to write " +
+                    filesystem::make_preferred_path_in_utf8(entry.path()));
             }
 
             for (const auto& chara : cdatan_)
@@ -7084,8 +7081,8 @@ void update_save_data(const fs::path& save_dir, int serial_id)
             std::ostringstream out;
             putit::BinaryOArchive oar{out};
 
-            const auto is_cdatas1 = entry.path().filename() == "cdata.s1"
-                || entry.path().filename() == "g_cdata.s1";
+            const auto is_cdatas1 = entry.path().filename() == "cdata.s1" ||
+                entry.path().filename() == "g_cdata.s1";
             const auto begin = is_cdatas1 ? 0 : ELONA_MAX_PARTY_CHARACTERS;
             const auto end =
                 is_cdatas1 ? ELONA_MAX_PARTY_CHARACTERS : ELONA_MAX_CHARACTERS;
@@ -7360,8 +7357,8 @@ void update_save_data(const fs::path& save_dir, int serial_id)
                     iar(_206);
                 }
                 // Prepend "core" prefix to old god IDs.
-                if (god_id != core_god::eyth
-                    && !strutil::starts_with(god_id, "core."))
+                if (god_id != core_god::eyth &&
+                    !strutil::starts_with(god_id, "core."))
                 {
                     ELONA_LOG(
                         "[Save data] Prepend \"core\" prefix to character("
@@ -7531,8 +7528,8 @@ void update_save_data(const fs::path& save_dir, int serial_id)
             std::ostringstream out;
             putit::BinaryOArchive oar{out};
 
-            const auto is_invs1 = entry.path().filename() == "inv.s1"
-                || entry.path().filename() == "g_inv.s1";
+            const auto is_invs1 = entry.path().filename() == "inv.s1" ||
+                entry.path().filename() == "g_inv.s1";
             const auto begin = is_invs1 ? 0 : 1320;
             const auto end = is_invs1 ? 1320 : 5480;
             for (int idx = begin; idx < end; ++idx)
@@ -8034,8 +8031,8 @@ label_21451_internal:
         {
             if (feat(2) == 7)
             {
-                if ((cdata[cc].is_floating() == 1 && cdata[cc].gravity == 0)
-                    || cdata[cc].is_immune_to_mine() == 1)
+                if ((cdata[cc].is_floating() == 1 && cdata[cc].gravity == 0) ||
+                    cdata[cc].is_immune_to_mine() == 1)
                 {
                     return;
                 }
@@ -8393,8 +8390,8 @@ void sleep_start()
     else
     {
         ci = cdata.player().continuous_action.item;
-        if (inv[ci].param1 == 0 || inv[ci].number() == 0
-            || the_item_db[inv[ci].id]->subcategory != 60004)
+        if (inv[ci].param1 == 0 || inv[ci].number() == 0 ||
+            the_item_db[inv[ci].id]->subcategory != 60004)
         {
             f = 1;
         }
@@ -8515,12 +8512,11 @@ void map_global_proc_travel_events()
             cdata[cc].continuous_action.turn =
                 cdata[cc].continuous_action.turn * 16 / 10;
         }
-        if (game_data.weather == 2
-            || chipm(
-                   0,
-                   cell_data.at(cdata[cc].position.x, cdata[cc].position.y)
-                       .chip_id_actual)
-                == 4)
+        if (game_data.weather == 2 ||
+            chipm(
+                0,
+                cell_data.at(cdata[cc].position.x, cdata[cc].position.y)
+                    .chip_id_actual) == 4)
         {
             cdata[cc].continuous_action.turn =
                 cdata[cc].continuous_action.turn * 22 / 10;
@@ -8530,8 +8526,8 @@ void map_global_proc_travel_events()
             cdata[cc].continuous_action.turn =
                 cdata[cc].continuous_action.turn * 5 / 10;
         }
-        cdata[cc].continuous_action.turn = cdata[cc].continuous_action.turn
-            * 100 / (100 + game_data.seven_league_boot_effect + sdata(182, 0));
+        cdata[cc].continuous_action.turn = cdata[cc].continuous_action.turn *
+            100 / (100 + game_data.seven_league_boot_effect + sdata(182, 0));
         return;
     }
     if (cdata.player().nutrition <= 5000)
@@ -8560,19 +8556,18 @@ void map_global_proc_travel_events()
             continuous_action_eating_finish();
         }
     }
-    if (game_data.weather == 2
-        || chipm(
-               0,
-               cell_data.at(cdata[cc].position.x, cdata[cc].position.y)
-                   .chip_id_actual)
-            == 4)
+    if (game_data.weather == 2 ||
+        chipm(
+            0,
+            cell_data.at(cdata[cc].position.x, cdata[cc].position.y)
+                .chip_id_actual) == 4)
     {
         if (game_data.protects_from_bad_weather == 0)
         {
             if (rnd(100) == 0)
             {
-                if (cdata.player().is_floating() == 0
-                    || cdata.player().gravity > 0)
+                if (cdata.player().is_floating() == 0 ||
+                    cdata.player().gravity > 0)
                 {
                     txt(i18n::s.get("core.locale.action.move.global.weather."
                                     "snow.sound"),
@@ -8607,8 +8602,8 @@ void map_global_proc_travel_events()
         {
             if (rnd(100) == 0)
             {
-                if (cdata.player().is_floating() == 0
-                    || cdata.player().gravity > 0)
+                if (cdata.player().is_floating() == 0 ||
+                    cdata.player().gravity > 0)
                 {
                     txt(i18n::s.get(
                             "core.locale.action.move.global.weather.heavy_rain."
@@ -8782,9 +8777,9 @@ int decode_book()
             cdata[cc],
             efid,
             1,
-            (rnd(51) + 50) * (90 + sdata(165, cc) + (sdata(165, cc) > 0) * 20)
-                    / clamp((100 + spell((efid - 400)) / 2), 50, 1000)
-                + 1);
+            (rnd(51) + 50) * (90 + sdata(165, cc) + (sdata(165, cc) > 0) * 20) /
+                    clamp((100 + spell((efid - 400)) / 2), 50, 1000) +
+                1);
         gain_memorization_experience(0);
         if (itemmemory(2, inv[ci].id) == 0)
         {
@@ -8942,8 +8937,8 @@ int do_cast_magic_attempt()
     {
         if (the_ability_db[efid]->ability_type == 7)
         {
-            if (cdata[cc].relationship == 10
-                || game_data.current_map == mdata_t::MapId::pet_arena)
+            if (cdata[cc].relationship == 10 ||
+                game_data.current_map == mdata_t::MapId::pet_arena)
             {
                 efsource = 0;
                 return 0;
@@ -9053,8 +9048,8 @@ int do_cast_magic_attempt()
         efp = efp * (100 + p / 10) / 100;
     }
     rapidmagic = 0;
-    if (cdata[cc].can_cast_rapid_magic()
-        && the_ability_db[efid]->ability_type == 2)
+    if (cdata[cc].can_cast_rapid_magic() &&
+        the_ability_db[efid]->ability_type == 2)
     {
         rapidmagic = 1 + (rnd(3) != 0) + (rnd(2) != 0);
     }
@@ -9148,8 +9143,8 @@ int drink_potion()
 
 int drink_well()
 {
-    if (inv[ci].param1 < -5 || inv[ci].param3 >= 20
-        || (inv[ci].id == 602 && game_data.holy_well_count <= 0))
+    if (inv[ci].param1 < -5 || inv[ci].param3 >= 20 ||
+        (inv[ci].id == 602 && game_data.holy_well_count <= 0))
     {
         const auto valn = itemname(ci);
         txt(i18n::s.get("core.locale.action.drink.well.is_dry", valn));
@@ -9430,8 +9425,8 @@ int do_zap()
     }
     if (efid >= 400 && efid < 467)
     {
-        if ((stat == 0 && the_ability_db[efid]->range / 1000 * 1000 == 2000)
-            || noeffect == 1)
+        if ((stat == 0 && the_ability_db[efid]->range / 1000 * 1000 == 2000) ||
+            noeffect == 1)
         {
             if (is_in_fov(cdata[cc]))
             {
@@ -9445,9 +9440,9 @@ int do_zap()
     {
         txt(i18n::s.get("core.locale.action.zap.execute", inv[ci]));
     }
-    efp = efp
-        * (100 + sdata(174, cc) * 10 + sdata(16, cc) / 2 + sdata(13, cc) / 2)
-        / 100;
+    efp = efp *
+        (100 + sdata(174, cc) * 10 + sdata(16, cc) / 2 + sdata(13, cc) / 2) /
+        100;
     if (efid >= 400 && efid < 467)
     {
         f = 0;
@@ -9540,8 +9535,8 @@ int do_magic_attempt()
             return 0;
         }
     }
-    if (the_ability_db[efid]->range / 1000 * 1000 != 3000
-        && the_ability_db[efid]->range / 1000 * 1000 != 10000)
+    if (the_ability_db[efid]->range / 1000 * 1000 != 3000 &&
+        the_ability_db[efid]->range / 1000 * 1000 != 10000)
     {
         if (cdata[cc].confused != 0 || cdata[cc].blind != 0)
         {
@@ -9571,8 +9566,8 @@ int do_magic_attempt()
             }
             damage_sp(
                 cdata.player(),
-                rnd(the_ability_db[efid]->cost / 2 + 1)
-                    + the_ability_db[efid]->cost / 2 + 1);
+                rnd(the_ability_db[efid]->cost / 2 + 1) +
+                    the_ability_db[efid]->cost / 2 + 1);
             chara_gain_skill_exp(
                 cdata[cc], the_ability_db[efid]->related_basic_attribute, 25);
         }
@@ -9648,8 +9643,8 @@ int prompt_magic_location()
                     cdata[tc].position.x,
                     cdata[tc].position.y,
                     cdata[cc].position.x,
-                    cdata[cc].position.y)
-                > the_ability_db[efid]->range % 1000 + 1)
+                    cdata[cc].position.y) >
+                the_ability_db[efid]->range % 1000 + 1)
             {
                 return 0;
             }
@@ -9668,8 +9663,7 @@ int prompt_magic_location()
                                    cdata[cc].position.x,
                                    cdata[cc].position.y,
                                    tglocx,
-                                   tglocy)
-                        == 0)
+                                   tglocy) == 0)
                 {
                     if (stat == 0)
                     {
@@ -9707,8 +9701,7 @@ int prompt_magic_location()
                     cdata[tc].position.x,
                     cdata[tc].position.y,
                     cdata[cc].position.x,
-                    cdata[cc].position.y)
-                == 0)
+                    cdata[cc].position.y) == 0)
             {
                 return 0;
             }
@@ -9727,8 +9720,8 @@ int prompt_magic_location()
                         cdata[tc].position.x,
                         cdata[tc].position.y,
                         cdata[cc].position.x,
-                        cdata[cc].position.y)
-                    > the_ability_db[efid]->range % 1000 + 1)
+                        cdata[cc].position.y) >
+                    the_ability_db[efid]->range % 1000 + 1)
                 {
                     return 0;
                 }
@@ -9736,8 +9729,7 @@ int prompt_magic_location()
                         cdata[cc].position.x,
                         cdata[cc].position.y,
                         cdata[tc].position.x,
-                        cdata[tc].position.y)
-                    == 0)
+                        cdata[tc].position.y) == 0)
                 {
                     return 0;
                 }
@@ -9773,8 +9765,7 @@ int prompt_magic_location()
                 cdata[tc].position.x,
                 cdata[tc].position.y,
                 cdata[cc].position.x,
-                cdata[cc].position.y)
-            > the_ability_db[efid]->range % 1000 + 1)
+                cdata[cc].position.y) > the_ability_db[efid]->range % 1000 + 1)
         {
             if (cc == 0)
             {
@@ -9789,8 +9780,7 @@ int prompt_magic_location()
                 cdata[cc].position.x,
                 cdata[cc].position.y,
                 cdata[tc].position.x,
-                cdata[tc].position.y)
-            == 0)
+                cdata[tc].position.y) == 0)
         {
             return 0;
         }
@@ -9957,8 +9947,8 @@ int pick_up_item()
                     mid = ""s + 30 + u8"_"s + (100 + inv[ci].count);
                     tmpload(filesystem::u8path(u8"mdata_"s + mid + u8".s2"));
                     if (fs::exists(
-                            filesystem::dir::tmp()
-                            / (u8"mdata_"s + mid + u8".s2")))
+                            filesystem::dir::tmp() /
+                            (u8"mdata_"s + mid + u8".s2")))
                     {
                         ctrl_file(FileOperation::map_delete);
                     }
@@ -10070,8 +10060,8 @@ int pick_up_item()
                 }
                 else if (inv[ti].param3 != 0 && inv[ti].material == 35)
                 {
-                    inv[ti].param3 = game_data.date.hours()
-                        + the_item_db[inv[ti].id]->expiration_date;
+                    inv[ti].param3 = game_data.date.hours() +
+                        the_item_db[inv[ti].id]->expiration_date;
                     if (inv[ti].param2 != 0)
                     {
                         inv[ti].param3 += 72;
@@ -10389,8 +10379,8 @@ TurnResult do_bash()
             cell_data.at(x, y).feats = 0;
             spillfrag(x, y, 2);
             flt(calcobjlv(
-                    game_data.current_dungeon_level
-                    * (game_data.current_map != mdata_t::MapId::shelter_)),
+                    game_data.current_dungeon_level *
+                    (game_data.current_map != mdata_t::MapId::shelter_)),
                 calcfixlv(Quality::bad));
             flttypemajor = choice(fsetbarrel);
             itemcreate(-1, 0, x, y, 0);
@@ -10446,8 +10436,8 @@ TurnResult do_bash()
                 }
                 if (rnd(3) == 0)
                 {
-                    if (cdata[cc].quality < Quality::miracle
-                        && encfind(cc, 60010) == -1)
+                    if (cdata[cc].quality < Quality::miracle &&
+                        encfind(cc, 60010) == -1)
                     {
                         --cdata[cc].attr_adjs[0];
                         chara_refresh(cc);
@@ -10540,8 +10530,7 @@ TurnResult proc_movement_event()
         }
     }
     if (cell_data.at(cdata[cc].position.x, cdata[cc].position.y)
-            .mef_index_plus_one
-        != 0)
+            .mef_index_plus_one != 0)
     {
         bool turn_ended = mef_proc_from_movement(cc);
         if (turn_ended)
@@ -10588,8 +10577,8 @@ TurnResult proc_movement_event()
             game_data.stood_world_map_tile =
                 cell_data.at(cdata[cc].position.x, cdata[cc].position.y)
                     .chip_id_actual;
-            if (cell_data.at(cdata[cc].position.x, cdata[cc].position.y).feats
-                == 0)
+            if (cell_data.at(cdata[cc].position.x, cdata[cc].position.y)
+                    .feats == 0)
             {
                 p = cell_data.at(cdata[cc].position.x, cdata[cc].position.y)
                         .chip_id_actual;
@@ -10622,13 +10611,12 @@ TurnResult proc_movement_event()
                         encounter = 2;
                     }
                 }
-                if (rnd(220 + cdata.player().level * 10
-                        - clamp(
-                            game_data.cargo_weight * 150
-                                / (game_data.current_cart_limit + 1),
+                if (rnd(220 + cdata.player().level * 10 -
+                        clamp(
+                            game_data.cargo_weight * 150 /
+                                (game_data.current_cart_limit + 1),
                             0,
-                            (210 + cdata.player().level * 10)))
-                    == 0)
+                            (210 + cdata.player().level * 10))) == 0)
                 {
                     encounter = 4;
                 }
@@ -10692,12 +10680,11 @@ TurnResult proc_movement_event()
                 {
                     encounterlv /= 2;
                 }
-                if (33 <= cell_data
-                              .at(cdata[cc].position.x, cdata[cc].position.y)
-                              .chip_id_actual
-                    && cell_data.at(cdata[cc].position.x, cdata[cc].position.y)
-                            .chip_id_actual
-                        < 66)
+                if (33 <=
+                        cell_data.at(cdata[cc].position.x, cdata[cc].position.y)
+                            .chip_id_actual &&
+                    cell_data.at(cdata[cc].position.x, cdata[cc].position.y)
+                            .chip_id_actual < 66)
                 {
                     encounterlv /= 2;
                 }
@@ -10712,9 +10699,9 @@ TurnResult proc_movement_event()
                 auto valn = i18n::s.get(
                                 "core.locale.action.move.global.ambush."
                                 "distance_from_nearest_town",
-                                p(0))
-                    + " "
-                    + i18n::s.get(
+                                p(0)) +
+                    " " +
+                    i18n::s.get(
                         "core.locale.action.move.global.ambush.enemy_"
                         "strength");
                 for (int cnt = 0; cnt < 1; ++cnt)
@@ -10754,8 +10741,8 @@ TurnResult proc_movement_event()
                         "core.locale.action.move.global.ambush.rank.dragon");
                 }
                 valn += u8")"s;
-                txt(i18n::s.get("core.locale.action.move.global.ambush.text")
-                    + valn);
+                txt(i18n::s.get("core.locale.action.move.global.ambush.text") +
+                    valn);
                 msg_halt();
                 levelexitby = 4;
                 return TurnResult::exit_map;
@@ -10774,9 +10761,10 @@ void proc_autopick()
         return;
     if (is_modifier_pressed(snail::ModKey::ctrl))
         return;
-    if (area_data[game_data.current_map].type == mdata_t::MapType::player_owned
-        && area_data[game_data.current_map].id != mdata_t::MapId::shelter_
-        && area_data[game_data.current_map].id != mdata_t::MapId::ranch)
+    if (area_data[game_data.current_map].type ==
+            mdata_t::MapType::player_owned &&
+        area_data[game_data.current_map].id != mdata_t::MapId::shelter_ &&
+        area_data[game_data.current_map].id != mdata_t::MapId::ranch)
         return;
 
 
@@ -10889,9 +10877,9 @@ void sense_map_feats_on_move()
         game_data.player_y_on_map_leave = -1;
         x = cdata.player().position.x;
         y = cdata.player().position.y;
-        if (getkey(snail::Key::shift)
-            && game_data.player_cellaccess_check_flag == 0
-            && cdata.player().confused == 0 && cdata.player().dimmed == 0)
+        if (getkey(snail::Key::shift) &&
+            game_data.player_cellaccess_check_flag == 0 &&
+            cdata.player().confused == 0 && cdata.player().dimmed == 0)
         {
             if (map_data.type != mdata_t::MapType::world_map)
             {
@@ -10938,10 +10926,10 @@ void sense_map_feats_on_move()
                     10,
                     dirsub,
                     rnd(2));
-                if (keybd_wait <= Config::instance().walkwait
-                            * Config::instance().startrun
-                    || cdata.player().turn % 2 == 0
-                    || map_data.type == mdata_t::MapType::world_map)
+                if (keybd_wait <= Config::instance().walkwait *
+                            Config::instance().startrun ||
+                    cdata.player().turn % 2 == 0 ||
+                    map_data.type == mdata_t::MapType::world_map)
                 {
                     sound_footstep2(foot);
                     foot += 1 + rnd(2);
@@ -10965,8 +10953,8 @@ void sense_map_feats_on_move()
             if (feat(1) == 15)
             {
                 txt(mapname(feat(2) + feat(3) * 100, true));
-                if (area_data[feat(2) + feat(3) * 100].id
-                    == mdata_t::MapId::random_dungeon)
+                if (area_data[feat(2) + feat(3) * 100].id ==
+                    mdata_t::MapId::random_dungeon)
                 {
                     maybe_show_ex_help(6);
                 }
@@ -11352,8 +11340,8 @@ void open_new_year_gift()
             {
                 tlocx = cdata.player().position.x + rnd(3) - rnd(3);
                 tlocy = cdata.player().position.y - rnd(3) + rnd(3);
-                if (tlocx < 0 || tlocx >= map_data.width || tlocy < 0
-                    || tlocy >= map_data.height)
+                if (tlocx < 0 || tlocx >= map_data.width || tlocy < 0 ||
+                    tlocy >= map_data.height)
                 {
                     continue;
                 }
@@ -11718,9 +11706,9 @@ void try_to_melee_attack()
     ele = 0;
     if (cdata[cc].equipment_type & 1)
     {
-        if (clamp(int(std::sqrt(sdata(168, cc)) - 3), 1, 5)
-                + cdata[cc].has_power_bash() * 5
-            > rnd(100))
+        if (clamp(int(std::sqrt(sdata(168, cc)) - 3), 1, 5) +
+                cdata[cc].has_power_bash() * 5 >
+            rnd(100))
         {
             if (is_in_fov(cdata[cc]))
             {
@@ -11792,8 +11780,7 @@ label_22191_internal:
         return;
     }
     if (cell_data.at(cdata[tc].position.x, cdata[tc].position.y)
-            .mef_index_plus_one
-        != 0)
+            .mef_index_plus_one != 0)
     {
         bool return_now = mef_proc_from_physical_attack(tc);
         if (return_now)
@@ -11815,9 +11802,9 @@ label_22191_internal:
     if (attacknum > 1 || cc != 0)
     {
     }
-    expmodifer = 1 + cdata[tc].is_hung_on_sand_bag() * 15 + cdata[tc].splits()
-        + cdata[tc].splits2()
-        + (game_data.current_map == mdata_t::MapId::show_house);
+    expmodifer = 1 + cdata[tc].is_hung_on_sand_bag() * 15 + cdata[tc].splits() +
+        cdata[tc].splits2() +
+        (game_data.current_map == mdata_t::MapId::show_house);
     int hit = calcattackhit();
     i = 0;
     if (hit == 1)
@@ -11852,8 +11839,8 @@ label_22191_internal:
             {
                 if (inv[cw].quality == Quality::special)
                 {
-                    s(1) = i18n::s.get("core.locale.misc.wields_proudly.the")
-                        + iknownnameref(inv[cw].id);
+                    s(1) = i18n::s.get("core.locale.misc.wields_proudly.the") +
+                        iknownnameref(inv[cw].id);
                 }
                 else if (inv[cw].subname >= 40000)
                 {
@@ -11863,8 +11850,8 @@ label_22191_internal:
                 }
                 else
                 {
-                    s(1) = i18n::s.get("core.locale.misc.wields_proudly.the")
-                        + iknownnameref(inv[cw].id);
+                    s(1) = i18n::s.get("core.locale.misc.wields_proudly.the") +
+                        iknownnameref(inv[cw].id);
                 }
                 if (inv[cw].quality == Quality::godly)
                 {
@@ -11986,14 +11973,15 @@ label_22191_internal:
             chara_gain_skill_exp(cdata[cc], 186, 60 / expmodifer, 2);
             critical = 0;
         }
-        if (rtdmg > cdata[tc].max_hp / 20 || rtdmg > sdata(154, tc)
-            || rnd(5) == 0)
+        if (rtdmg > cdata[tc].max_hp / 20 || rtdmg > sdata(154, tc) ||
+            rnd(5) == 0)
         {
             chara_gain_skill_exp(
                 cdata[cc],
                 attackskill,
-                clamp((sdata(173, tc) * 2 - sdata(attackskill, cc) + 1), 5, 50)
-                    / expmodifer,
+                clamp(
+                    (sdata(173, tc) * 2 - sdata(attackskill, cc) + 1), 5, 50) /
+                    expmodifer,
                 0,
                 4);
             if (attackrange == 0)
@@ -12029,8 +12017,8 @@ label_22191_internal:
                 chara_gain_skill_exp(
                     cdata[tc],
                     chara_armor_class(cdata[tc]),
-                    clamp((250 * rtdmg / cdata[tc].max_hp + 1), 3, 100)
-                        / expmodifer,
+                    clamp((250 * rtdmg / cdata[tc].max_hp + 1), 3, 100) /
+                        expmodifer,
                     0,
                     5);
                 if (cdata[tc].equipment_type & 1)
@@ -12140,8 +12128,9 @@ label_22191_internal:
         }
         if (sdata(attackskill, cc) > sdata(173, tc) || rnd(5) == 0)
         {
-            p = clamp((sdata(attackskill, cc) - sdata(173, tc) / 2 + 1), 1, 20)
-                / expmodifer;
+            p = clamp(
+                    (sdata(attackskill, cc) - sdata(173, tc) / 2 + 1), 1, 20) /
+                expmodifer;
             chara_gain_skill_exp(cdata[tc], 173, p, 0, 4);
             chara_gain_skill_exp(cdata[tc], 187, p, 0, 4);
         }
@@ -12338,9 +12327,10 @@ void proc_weapon_enchantments()
                 game_data.proc_damage_events_flag = 1;
                 damage_hp(
                     cdata[tc],
-                    rnd(orgdmg * (100 + inv[cw].enchantments[cnt].power) / 1000
-                        + 1)
-                        + 5,
+                    rnd(orgdmg * (100 + inv[cw].enchantments[cnt].power) /
+                            1000 +
+                        1) +
+                        5,
                     cc,
                     ele,
                     inv[cw].enchantments[cnt].power / 2 + 100);
@@ -12369,8 +12359,8 @@ void proc_weapon_enchantments()
                 if (rnd(100) < p)
                 {
                     efid = enc;
-                    efp = inv[cw].enchantments[cnt].power
-                        + sdata(attackskill, cc) * 10;
+                    efp = inv[cw].enchantments[cnt].power +
+                        sdata(attackskill, cc) * 10;
                     magic();
                 }
                 tc = tcbk;
@@ -12614,8 +12604,7 @@ TurnResult do_plant()
     if (chipm(
             0,
             cell_data.at(cdata.player().position.x, cdata.player().position.y)
-                .chip_id_actual)
-        == 2)
+                .chip_id_actual) == 2)
     {
         val0 = 1;
     }
@@ -12838,8 +12827,8 @@ void initialize_economy()
         }
         game_data.current_map = area_data[cnt].id;
         game_data.current_dungeon_level = 1;
-        if (game_data.current_map != bkdata(0)
-            || game_data.current_dungeon_level != bkdata(1))
+        if (game_data.current_map != bkdata(0) ||
+            game_data.current_dungeon_level != bkdata(1))
         {
             initialize_map();
         }
@@ -13258,8 +13247,8 @@ void weather_changes()
                         break;
                     }
                 }
-                if (game_data.pc_x_in_world_map > 65
-                    || game_data.pc_y_in_world_map < 10)
+                if (game_data.pc_x_in_world_map > 65 ||
+                    game_data.pc_y_in_world_map < 10)
                 {
                     if (rnd(2) == 0)
                     {
@@ -13450,11 +13439,11 @@ void weather_changes()
         {
             supply_income();
         }
-        if (game_data.quest_flags.pael_and_her_mom == 1
-            || game_data.quest_flags.pael_and_her_mom == 3
-            || game_data.quest_flags.pael_and_her_mom == 5
-            || game_data.quest_flags.pael_and_her_mom == 7
-            || game_data.quest_flags.pael_and_her_mom == 9)
+        if (game_data.quest_flags.pael_and_her_mom == 1 ||
+            game_data.quest_flags.pael_and_her_mom == 3 ||
+            game_data.quest_flags.pael_and_her_mom == 5 ||
+            game_data.quest_flags.pael_and_her_mom == 7 ||
+            game_data.quest_flags.pael_and_her_mom == 9)
         {
             if (area_data[game_data.current_map].id != mdata_t::MapId::noyel)
             {
@@ -13491,8 +13480,8 @@ void weather_changes()
     }
     if (cdata.player().continuous_action.turn != 0)
     {
-        if (cdata.player().continuous_action.type
-            != ContinuousAction::Type::travel)
+        if (cdata.player().continuous_action.type !=
+            ContinuousAction::Type::travel)
         {
             update_screen();
         }
@@ -13507,8 +13496,8 @@ void weather_changes()
 
 optional<TurnResult> check_angband()
 {
-    if (game_data.angband_flag == -1
-        || map_data.type == mdata_t::MapType::world_map)
+    if (game_data.angband_flag == -1 ||
+        map_data.type == mdata_t::MapType::world_map)
         return none;
 
     switch (game_data.angband_flag)
@@ -13740,8 +13729,8 @@ TurnResult pc_died()
             buff(0) += tmp + '\n';
         }
     }
-    s = cdatan(1, cc) + u8" "s + cdatan(0, cc) + i18n::space_if_needed()
-        + last_words;
+    s = cdatan(1, cc) + u8" "s + cdatan(0, cc) + i18n::space_if_needed() +
+        last_words;
     lenfix(s, 60);
     s += i18n::s.get(
         "core.locale.misc.death.date",
@@ -13829,8 +13818,8 @@ TurnResult pc_died()
         wait_key_pressed();
         return TurnResult::finish_elona;
     }
-    s = u8"dead"s
-        + i18n::s.get(
+    s = u8"dead"s +
+        i18n::s.get(
             "core.locale.misc.death.sent_message",
             cdatan(1, 0),
             cdatan(0, 0),

--- a/src/enchantment.cpp
+++ b/src/enchantment.cpp
@@ -677,11 +677,11 @@ void get_enchantment_description(int val0, int power, int category, bool trait)
             s = i18n::s.get(
                 "core.locale.enchantment.with_parameters.ammo.text",
                 ammoname(sid));
-            s += " ["
-                + i18n::s.get(
+            s += " [" +
+                i18n::s.get(
                     "core.locale.enchantment.with_parameters.ammo.max",
-                    power / 1000)
-                + "]";
+                    power / 1000) +
+                "]";
             break;
         }
         return;
@@ -1066,8 +1066,8 @@ void enchantment_sort(int prm_454)
         for (int cnt = 0; cnt < 14; ++cnt)
         {
             cnt2_at_m47 = cnt + 1;
-            if (inv[prm_454].enchantments[cnt].id
-                < inv[prm_454].enchantments[cnt2_at_m47].id)
+            if (inv[prm_454].enchantments[cnt].id <
+                inv[prm_454].enchantments[cnt2_at_m47].id)
             {
                 p_at_m47(0) = inv[prm_454].enchantments[cnt].id;
                 p_at_m47(1) = inv[prm_454].enchantments[cnt].power;
@@ -1399,11 +1399,11 @@ void add_enchantments()
     {
         egolv = rnd(clamp(rnd(objlv / 10 + 3), 0, 4) + 1);
         inv[ci].value = inv[ci].value * 3;
-        inv[ci].difficulty_of_identification = 50
-            + rnd(std::abs(
-                      static_cast<int>(fixlv) - static_cast<int>(Quality::good))
-                      * 100
-                  + 100);
+        inv[ci].difficulty_of_identification = 50 +
+            rnd(std::abs(
+                    static_cast<int>(fixlv) - static_cast<int>(Quality::good)) *
+                    100 +
+                100);
     }
     if (reftypeminor == 10006)
     {
@@ -1448,8 +1448,8 @@ void add_enchantments()
     if (fixlv == Quality::miracle || fixlv == Quality::godly)
     {
         inv[ci].subname = 40000 + rnd(30000);
-        if (fixlv == Quality::godly
-            || (fixlv == Quality::miracle && rnd(10) == 0))
+        if (fixlv == Quality::godly ||
+            (fixlv == Quality::miracle && rnd(10) == 0))
         {
             enchantment_add(ci, enchantment_generate(99), enchantment_gen_p());
         }
@@ -1488,8 +1488,8 @@ void add_enchantments()
             enchantment_add(
                 ci,
                 enchantment_generate(enchantment_gen_level(egolv)),
-                enchantment_gen_p() + (fixlv == Quality::godly) * 100
-                    + (ibit(15, ci) == 1) * 100,
+                enchantment_gen_p() + (fixlv == Quality::godly) * 100 +
+                    (ibit(15, ci) == 1) * 100,
                 20 - (fixlv == Quality::godly) * 10 - (ibit(15, ci) == 1) * 20);
         }
     }
@@ -1509,12 +1509,11 @@ void add_enchantments()
         enchantment_add(
             ci,
             enchantment_generate(enchantment_gen_level(egolv)),
-            clamp(enchantment_gen_p(), 250, 10000)
-                * (125 + (inv[ci].curse_state == CurseState::doomed) * 25)
-                / 100);
+            clamp(enchantment_gen_p(), 250, 10000) *
+                (125 + (inv[ci].curse_state == CurseState::doomed) * 25) / 100);
         for (int cnt = 0,
-                 cnt_end = cnt
-                 + (1 + (inv[ci].curse_state == CurseState::doomed) + rnd(2));
+                 cnt_end = cnt +
+                 (1 + (inv[ci].curse_state == CurseState::doomed) + rnd(2));
              cnt < cnt_end;
              ++cnt)
         {

--- a/src/equipment.cpp
+++ b/src/equipment.cpp
@@ -19,8 +19,8 @@ void equipinfo(int prm_529, int prm_530, int prm_531)
 {
     int p_at_m66 = 0;
     std::string s_at_m66;
-    if (inv[prm_529].identification_state
-        != IdentifyState::completely_identified)
+    if (inv[prm_529].identification_state !=
+        IdentifyState::completely_identified)
     {
         return;
     }
@@ -187,10 +187,10 @@ void wear_most_valuable_equipment()
                     f = 0;
                 }
                 else if (
-                    inv[i].value
-                    >= inv[cdata[rc].body_parts[bodylist(cnt + 1) - 100] % 10000
-                           - 1]
-                           .value)
+                    inv[i].value >=
+                    inv[cdata[rc].body_parts[bodylist(cnt + 1) - 100] % 10000 -
+                        1]
+                        .value)
                 {
                     f = 0;
                 }
@@ -268,8 +268,7 @@ void supply_new_equipment()
                     {
                         if (the_item_db
                                 [inv[cdata[rc].body_parts[cnt] % 10000 - 1].id]
-                                    ->category
-                            == 10000)
+                                    ->category == 10000)
                         {
                             haveweapon = 1;
                         }

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -177,8 +177,8 @@ fs::path resolve_path_for_mod(const std::string& mod_local_path)
     std::smatch match;
     std::string mod_name, rest;
 
-    if (std::regex_match(mod_local_path, match, mod_name_regex)
-        && match.size() == 3)
+    if (std::regex_match(mod_local_path, match, mod_name_regex) &&
+        match.size() == 3)
     {
         mod_name = match.str(1);
         rest = match.str(2);

--- a/src/food.cpp
+++ b/src/food.cpp
@@ -49,10 +49,10 @@ void _food_gets_rotten(int chara_idx, int food_idx)
     }
 
     // Is it corpse(s) on a dryrock?
-    if (chara_idx == -1 && food.id == 204
-        && chipm(
-               0, cell_data.at(food.position.x, food.position.y).chip_id_actual)
-            == 1)
+    if (chara_idx == -1 && food.id == 204 &&
+        chipm(
+            0, cell_data.at(food.position.x, food.position.y).chip_id_actual) ==
+            1)
     {
         if (game_data.weather != 0)
         {
@@ -298,8 +298,8 @@ void chara_vomit(Character& cc)
     }
     else
     {
-        if ((cc.index < 16 && cc.anorexia_count > 10)
-            || (cc.index >= 16 && rnd(4) == 0))
+        if ((cc.index < 16 && cc.anorexia_count > 10) ||
+            (cc.index >= 16 && rnd(4) == 0))
         {
             if (rnd(5) == 0)
             {
@@ -1172,8 +1172,8 @@ void apply_general_eating_effect(int cieat)
             }
         }
     }
-    if (inv[ci].id == 204
-        || ((inv[ci].id == 571 || inv[ci].id == 573) && rnd(3) == 0))
+    if (inv[ci].id == 204 ||
+        ((inv[ci].id == 571 || inv[ci].id == 573) && rnd(3) == 0))
     {
         dbmode = 12;
         dbid = inv[ci].subname;
@@ -1220,8 +1220,8 @@ void apply_general_eating_effect(int cieat)
             modify_weight(
                 cdata[cc],
                 rnd(3) + 1,
-                cdata[cc].nutrition >= 20000
-                    && rnd(30000 / std::max(1, cdata[cc].nutrition) + 2) == 0);
+                cdata[cc].nutrition >= 20000 &&
+                    rnd(30000 / std::max(1, cdata[cc].nutrition) + 2) == 0);
         }
     }
     if (cdata[cc].id == 261)
@@ -1244,25 +1244,23 @@ void apply_general_eating_effect(int cieat)
         {
             txt(i18n::s.get("core.locale.food.effect.little_sister", cdata[cc]),
                 Message::color{ColorIndex::green});
-            if (rnd(sdata.get(2, cc).original_level
-                        * sdata.get(2, cc).original_level
-                    + 1)
-                < 2000)
+            if (rnd(sdata.get(2, cc).original_level *
+                        sdata.get(2, cc).original_level +
+                    1) < 2000)
             {
                 chara_gain_fixed_skill_exp(cdata[cc], 2, 1000);
             }
-            if (rnd(sdata.get(3, cc).original_level
-                        * sdata.get(3, cc).original_level
-                    + 1)
-                < 2000)
+            if (rnd(sdata.get(3, cc).original_level *
+                        sdata.get(3, cc).original_level +
+                    1) < 2000)
             {
                 chara_gain_fixed_skill_exp(cdata[cc], 3, 1000);
             }
             for (int cnt = 100; cnt < 400; ++cnt)
             {
-                if (!the_ability_db[cnt]
-                    || the_ability_db[cnt]->related_basic_attribute == 0
-                    || sdata.get(cnt, cc).original_level == 0)
+                if (!the_ability_db[cnt] ||
+                    the_ability_db[cnt]->related_basic_attribute == 0 ||
+                    sdata.get(cnt, cc).original_level == 0)
                 {
                     continue;
                 }
@@ -1298,8 +1296,8 @@ void apply_general_eating_effect(int cieat)
             txt(i18n::s.get(
                 "core.locale.food.effect.fortune_cookie", cdata[cc]));
             read_talk_file(u8"%COOKIE2");
-            if (inv[ci].curse_state == CurseState::blessed
-                || (inv[ci].curse_state == CurseState::none && rnd(2)))
+            if (inv[ci].curse_state == CurseState::blessed ||
+                (inv[ci].curse_state == CurseState::none && rnd(2)))
             {
                 read_talk_file(u8"%COOKIE1");
             }
@@ -1419,8 +1417,8 @@ void apply_general_eating_effect(int cieat)
                 chara_gain_skill_exp(
                     cdata[cc],
                     enc,
-                    (inv[ci].enchantments[cnt].power / 50 + 1) * 100
-                        * (1 + (cc != 0) * 5));
+                    (inv[ci].enchantments[cnt].power / 50 + 1) * 100 *
+                        (1 + (cc != 0) * 5));
                 continue;
             }
             if (enc2 == 6)
@@ -1433,8 +1431,8 @@ void apply_general_eating_effect(int cieat)
                 buff_add(
                     cdata[cc],
                     20 + (enc - 10),
-                    (inv[ci].enchantments[cnt].power / 50 + 1) * 5
-                        * (1 + (cc != 0) * 2),
+                    (inv[ci].enchantments[cnt].power / 50 + 1) * 5 *
+                        (1 + (cc != 0) * 2),
                     2000);
                 continue;
             }

--- a/src/fov.cpp
+++ b/src/fov.cpp
@@ -38,10 +38,9 @@ bool is_in_fov(const Character& cc)
 
 int fov_los(int prm_629, int prm_630, int prm_631, int prm_632)
 {
-    if (prm_629 < 0 || map_data.width <= prm_629 || prm_630 < 0
-        || map_data.height <= prm_630 || prm_631 < 0
-        || map_data.width <= prm_631 || prm_632 < 0
-        || map_data.height <= prm_632)
+    if (prm_629 < 0 || map_data.width <= prm_629 || prm_630 < 0 ||
+        map_data.height <= prm_630 || prm_631 < 0 ||
+        map_data.width <= prm_631 || prm_632 < 0 || map_data.height <= prm_632)
     {
         // Out of range
         return 0;
@@ -66,13 +65,14 @@ int fov_los(int prm_629, int prm_630, int prm_631, int prm_632)
                 {
                     break;
                 }
-                if (chipm(7, cell_data.at(prm_629, ty_at_modfov).chip_id_actual)
-                    & 1)
+                if (chipm(
+                        7, cell_data.at(prm_629, ty_at_modfov).chip_id_actual) &
+                    1)
                 {
                     return 0;
                 }
-                if (chipm(7, cell_data.at(prm_629, ty_at_modfov).feats % 1000)
-                    & 1)
+                if (chipm(7, cell_data.at(prm_629, ty_at_modfov).feats % 1000) &
+                    1)
                 {
                     return 0;
                 }
@@ -88,13 +88,14 @@ int fov_los(int prm_629, int prm_630, int prm_631, int prm_632)
                 {
                     break;
                 }
-                if (chipm(7, cell_data.at(prm_629, ty_at_modfov).chip_id_actual)
-                    & 1)
+                if (chipm(
+                        7, cell_data.at(prm_629, ty_at_modfov).chip_id_actual) &
+                    1)
                 {
                     return 0;
                 }
-                if (chipm(7, cell_data.at(prm_629, ty_at_modfov).feats % 1000)
-                    & 1)
+                if (chipm(7, cell_data.at(prm_629, ty_at_modfov).feats % 1000) &
+                    1)
                 {
                     return 0;
                 }
@@ -114,13 +115,14 @@ int fov_los(int prm_629, int prm_630, int prm_631, int prm_632)
                 {
                     break;
                 }
-                if (chipm(7, cell_data.at(tx_at_modfov, prm_630).chip_id_actual)
-                    & 1)
+                if (chipm(
+                        7, cell_data.at(tx_at_modfov, prm_630).chip_id_actual) &
+                    1)
                 {
                     return 0;
                 }
-                if (chipm(7, cell_data.at(tx_at_modfov, prm_630).feats % 1000)
-                    & 1)
+                if (chipm(7, cell_data.at(tx_at_modfov, prm_630).feats % 1000) &
+                    1)
                 {
                     return 0;
                 }
@@ -136,13 +138,14 @@ int fov_los(int prm_629, int prm_630, int prm_631, int prm_632)
                 {
                     break;
                 }
-                if (chipm(7, cell_data.at(tx_at_modfov, prm_630).chip_id_actual)
-                    & 1)
+                if (chipm(
+                        7, cell_data.at(tx_at_modfov, prm_630).chip_id_actual) &
+                    1)
                 {
                     return 0;
                 }
-                if (chipm(7, cell_data.at(tx_at_modfov, prm_630).feats % 1000)
-                    & 1)
+                if (chipm(7, cell_data.at(tx_at_modfov, prm_630).feats % 1000) &
+                    1)
                 {
                     return 0;
                 }
@@ -174,16 +177,14 @@ int fov_los(int prm_629, int prm_630, int prm_631, int prm_632)
             if ((chipm(
                      7,
                      cell_data.at(prm_629, prm_630 + sy_at_modfov)
-                         .chip_id_actual)
-                 & 1)
-                == 0)
+                         .chip_id_actual) &
+                 1) == 0)
             {
                 if ((chipm(
                          7,
-                         cell_data.at(prm_629, (prm_630 + sy_at_modfov)).feats
-                             % 1000)
-                     & 1)
-                    == 0)
+                         cell_data.at(prm_629, (prm_630 + sy_at_modfov)).feats %
+                             1000) &
+                     1) == 0)
                 {
                     return 1;
                 }
@@ -197,16 +198,14 @@ int fov_los(int prm_629, int prm_630, int prm_631, int prm_632)
             if ((chipm(
                      7,
                      cell_data.at(prm_629 + sx_at_modfov, prm_630)
-                         .chip_id_actual)
-                 & 1)
-                == 0)
+                         .chip_id_actual) &
+                 1) == 0)
             {
                 if ((chipm(
                          7,
-                         cell_data.at((prm_629 + sx_at_modfov), prm_630).feats
-                             % 1000)
-                     & 1)
-                    == 0)
+                         cell_data.at((prm_629 + sx_at_modfov), prm_630).feats %
+                             1000) &
+                     1) == 0)
                 {
                     return 1;
                 }
@@ -236,13 +235,15 @@ int fov_los(int prm_629, int prm_630, int prm_631, int prm_632)
                 break;
             }
             if (chipm(
-                    7, cell_data.at(tx_at_modfov, ty_at_modfov).chip_id_actual)
-                & 1)
+                    7,
+                    cell_data.at(tx_at_modfov, ty_at_modfov).chip_id_actual) &
+                1)
             {
                 return 0;
             }
-            if (chipm(7, cell_data.at(tx_at_modfov, ty_at_modfov).feats % 1000)
-                & 1)
+            if (chipm(
+                    7, cell_data.at(tx_at_modfov, ty_at_modfov).feats % 1000) &
+                1)
             {
                 return 0;
             }
@@ -256,15 +257,16 @@ int fov_los(int prm_629, int prm_630, int prm_631, int prm_632)
                 ty_at_modfov += sy_at_modfov;
                 if (chipm(
                         7,
-                        cell_data.at(tx_at_modfov, ty_at_modfov).chip_id_actual)
-                    & 1)
+                        cell_data.at(tx_at_modfov, ty_at_modfov)
+                            .chip_id_actual) &
+                    1)
                 {
                     return 0;
                 }
                 if (chipm(
                         7,
-                        cell_data.at(tx_at_modfov, ty_at_modfov).feats % 1000)
-                    & 1)
+                        cell_data.at(tx_at_modfov, ty_at_modfov).feats % 1000) &
+                    1)
                 {
                     return 0;
                 }
@@ -300,13 +302,15 @@ int fov_los(int prm_629, int prm_630, int prm_631, int prm_632)
                 break;
             }
             if (chipm(
-                    7, cell_data.at(tx_at_modfov, ty_at_modfov).chip_id_actual)
-                & 1)
+                    7,
+                    cell_data.at(tx_at_modfov, ty_at_modfov).chip_id_actual) &
+                1)
             {
                 return 0;
             }
-            if (chipm(7, cell_data.at(tx_at_modfov, ty_at_modfov).feats % 1000)
-                & 1)
+            if (chipm(
+                    7, cell_data.at(tx_at_modfov, ty_at_modfov).feats % 1000) &
+                1)
             {
                 return 0;
             }
@@ -320,15 +324,16 @@ int fov_los(int prm_629, int prm_630, int prm_631, int prm_632)
                 tx_at_modfov += sx_at_modfov;
                 if (chipm(
                         7,
-                        cell_data.at(tx_at_modfov, ty_at_modfov).chip_id_actual)
-                    & 1)
+                        cell_data.at(tx_at_modfov, ty_at_modfov)
+                            .chip_id_actual) &
+                    1)
                 {
                     return 0;
                 }
                 if (chipm(
                         7,
-                        cell_data.at(tx_at_modfov, ty_at_modfov).feats % 1000)
-                    & 1)
+                        cell_data.at(tx_at_modfov, ty_at_modfov).feats % 1000) &
+                    1)
                 {
                     return 0;
                 }
@@ -379,13 +384,14 @@ int get_route(int prm_633, int prm_634, int prm_635, int prm_636)
                 {
                     break;
                 }
-                if (chipm(7, cell_data.at(prm_633, ty_at_modfov).chip_id_actual)
-                    & 1)
+                if (chipm(
+                        7, cell_data.at(prm_633, ty_at_modfov).chip_id_actual) &
+                    1)
                 {
                     return 0;
                 }
-                if (chipm(7, cell_data.at(prm_633, ty_at_modfov).feats % 1000)
-                    & 1)
+                if (chipm(7, cell_data.at(prm_633, ty_at_modfov).feats % 1000) &
+                    1)
                 {
                     return 0;
                 }
@@ -407,13 +413,14 @@ int get_route(int prm_633, int prm_634, int prm_635, int prm_636)
                 {
                     break;
                 }
-                if (chipm(7, cell_data.at(prm_633, ty_at_modfov).chip_id_actual)
-                    & 1)
+                if (chipm(
+                        7, cell_data.at(prm_633, ty_at_modfov).chip_id_actual) &
+                    1)
                 {
                     return 0;
                 }
-                if (chipm(7, cell_data.at(prm_633, ty_at_modfov).feats % 1000)
-                    & 1)
+                if (chipm(7, cell_data.at(prm_633, ty_at_modfov).feats % 1000) &
+                    1)
                 {
                     return 0;
                 }
@@ -440,13 +447,14 @@ int get_route(int prm_633, int prm_634, int prm_635, int prm_636)
                 {
                     break;
                 }
-                if (chipm(7, cell_data.at(tx_at_modfov, prm_634).chip_id_actual)
-                    & 1)
+                if (chipm(
+                        7, cell_data.at(tx_at_modfov, prm_634).chip_id_actual) &
+                    1)
                 {
                     return 0;
                 }
-                if (chipm(7, cell_data.at(tx_at_modfov, prm_634).feats % 1000)
-                    & 1)
+                if (chipm(7, cell_data.at(tx_at_modfov, prm_634).feats % 1000) &
+                    1)
                 {
                     return 0;
                 }
@@ -468,13 +476,14 @@ int get_route(int prm_633, int prm_634, int prm_635, int prm_636)
                 {
                     break;
                 }
-                if (chipm(7, cell_data.at(tx_at_modfov, prm_634).chip_id_actual)
-                    & 1)
+                if (chipm(
+                        7, cell_data.at(tx_at_modfov, prm_634).chip_id_actual) &
+                    1)
                 {
                     return 0;
                 }
-                if (chipm(7, cell_data.at(tx_at_modfov, prm_634).feats % 1000)
-                    & 1)
+                if (chipm(7, cell_data.at(tx_at_modfov, prm_634).feats % 1000) &
+                    1)
                 {
                     return 0;
                 }
@@ -510,16 +519,14 @@ int get_route(int prm_633, int prm_634, int prm_635, int prm_636)
             if ((chipm(
                      7,
                      cell_data.at(prm_633, prm_634 + sy_at_modfov)
-                         .chip_id_actual)
-                 & 1)
-                == 0)
+                         .chip_id_actual) &
+                 1) == 0)
             {
                 if ((chipm(
                          7,
-                         cell_data.at(prm_633, (prm_634 + sy_at_modfov)).feats
-                             % 1000)
-                     & 1)
-                    == 0)
+                         cell_data.at(prm_633, (prm_634 + sy_at_modfov)).feats %
+                             1000) &
+                     1) == 0)
                 {
                     p_at_modfov = 0;
                     route(0, p_at_modfov) = 2;
@@ -544,16 +551,14 @@ int get_route(int prm_633, int prm_634, int prm_635, int prm_636)
             if ((chipm(
                      7,
                      cell_data.at(prm_633 + sx_at_modfov, prm_634)
-                         .chip_id_actual)
-                 & 1)
-                == 0)
+                         .chip_id_actual) &
+                 1) == 0)
             {
                 if ((chipm(
                          7,
-                         cell_data.at((prm_633 + sx_at_modfov), prm_634).feats
-                             % 1000)
-                     & 1)
-                    == 0)
+                         cell_data.at((prm_633 + sx_at_modfov), prm_634).feats %
+                             1000) &
+                     1) == 0)
                 {
                     route(0, p_at_modfov) = 1;
                     route(1, p_at_modfov) = sx_at_modfov;
@@ -599,13 +604,15 @@ int get_route(int prm_633, int prm_634, int prm_635, int prm_636)
                 break;
             }
             if (chipm(
-                    7, cell_data.at(tx_at_modfov, ty_at_modfov).chip_id_actual)
-                & 1)
+                    7,
+                    cell_data.at(tx_at_modfov, ty_at_modfov).chip_id_actual) &
+                1)
             {
                 return 0;
             }
-            if (chipm(7, cell_data.at(tx_at_modfov, ty_at_modfov).feats % 1000)
-                & 1)
+            if (chipm(
+                    7, cell_data.at(tx_at_modfov, ty_at_modfov).feats % 1000) &
+                1)
             {
                 return 0;
             }
@@ -625,15 +632,16 @@ int get_route(int prm_633, int prm_634, int prm_635, int prm_636)
                 ++p_at_modfov;
                 if (chipm(
                         7,
-                        cell_data.at(tx_at_modfov, ty_at_modfov).chip_id_actual)
-                    & 1)
+                        cell_data.at(tx_at_modfov, ty_at_modfov)
+                            .chip_id_actual) &
+                    1)
                 {
                     return 0;
                 }
                 if (chipm(
                         7,
-                        cell_data.at(tx_at_modfov, ty_at_modfov).feats % 1000)
-                    & 1)
+                        cell_data.at(tx_at_modfov, ty_at_modfov).feats % 1000) &
+                    1)
                 {
                     return 0;
                 }
@@ -684,13 +692,15 @@ int get_route(int prm_633, int prm_634, int prm_635, int prm_636)
                 break;
             }
             if (chipm(
-                    7, cell_data.at(tx_at_modfov, ty_at_modfov).chip_id_actual)
-                & 1)
+                    7,
+                    cell_data.at(tx_at_modfov, ty_at_modfov).chip_id_actual) &
+                1)
             {
                 return 0;
             }
-            if (chipm(7, cell_data.at(tx_at_modfov, ty_at_modfov).feats % 1000)
-                & 1)
+            if (chipm(
+                    7, cell_data.at(tx_at_modfov, ty_at_modfov).feats % 1000) &
+                1)
             {
                 return 0;
             }
@@ -710,15 +720,16 @@ int get_route(int prm_633, int prm_634, int prm_635, int prm_636)
                 ++p_at_modfov;
                 if (chipm(
                         7,
-                        cell_data.at(tx_at_modfov, ty_at_modfov).chip_id_actual)
-                    & 1)
+                        cell_data.at(tx_at_modfov, ty_at_modfov)
+                            .chip_id_actual) &
+                    1)
                 {
                     return 0;
                 }
                 if (chipm(
                         7,
-                        cell_data.at(tx_at_modfov, ty_at_modfov).feats % 1000)
-                    & 1)
+                        cell_data.at(tx_at_modfov, ty_at_modfov).feats % 1000) &
+                    1)
                 {
                     return 0;
                 }

--- a/src/get_random_npc_id.cpp
+++ b/src/get_random_npc_id.cpp
@@ -46,8 +46,8 @@ void get_random_npc_id()
             bool ok = true;
             for (int i = 0; i < filtermax; ++i)
             {
-                if (filter_creature(data.id).find(filtern(i))
-                    == std::string::npos)
+                if (filter_creature(data.id).find(filtern(i)) ==
+                    std::string::npos)
                 {
                     ok = false;
                     break;
@@ -58,9 +58,9 @@ void get_random_npc_id()
         }
         sampler.add(
             {data.id, 0},
-            data.rarity
-                    / (500 + std::abs(data.level - objlv) * data.coefficient)
-                + 1);
+            data.rarity /
+                    (500 + std::abs(data.level - objlv) * data.coefficient) +
+                1);
     }
 
     if (!cmshade)
@@ -92,9 +92,9 @@ void get_random_npc_id()
             }
             sampler.add(
                 {343, i},
-                clamp(userdata(6, i), 1'000, 500'000)
-                        / (500 + std::abs(userdata(2, i) - objlv) * 400)
-                    + 1);
+                clamp(userdata(6, i), 1'000, 500'000) /
+                        (500 + std::abs(userdata(2, i) - objlv) * 400) +
+                    1);
         }
     }
 

--- a/src/god.cpp
+++ b/src/god.cpp
@@ -120,8 +120,8 @@ int modpiety(int prm_1035)
         txt(i18n::s.get("core.locale.god.indifferent"));
         return 0;
     }
-    cdata.player().piety_point += prm_1035
-        / (1 + (game_data.current_map == mdata_t::MapId::show_house) * 9);
+    cdata.player().piety_point += prm_1035 /
+        (1 + (game_data.current_map == mdata_t::MapId::show_house) * 9);
     return 1;
 }
 
@@ -129,8 +129,8 @@ int modpiety(int prm_1035)
 
 void set_npc_religion()
 {
-    if (cdata[tc].god_id != core_god::eyth || cdata[tc].has_learned_words()
-        || tc == 0)
+    if (cdata[tc].god_id != core_god::eyth || cdata[tc].has_learned_words() ||
+        tc == 0)
     {
         return;
     }

--- a/src/hcl.hpp
+++ b/src/hcl.hpp
@@ -29,8 +29,8 @@ inline hcl::Value& skip_sections(
         if (!value->is<hcl::Object>() || !value->has(name))
         {
             throw std::runtime_error(
-                hcl_file + ": \"" + sections
-                + "\" object not found at top level"s);
+                hcl_file + ": \"" + sections +
+                "\" object not found at top level"s);
         }
 
         if (sections == "")

--- a/src/i18n.cpp
+++ b/src/i18n.cpp
@@ -41,8 +41,8 @@ void Store::load(const fs::path& path, const std::string& mod_name)
         if (!ifs)
         {
             throw std::runtime_error{
-                "Failed to open "
-                + filesystem::make_preferred_path_in_utf8(entry.path())};
+                "Failed to open " +
+                filesystem::make_preferred_path_in_utf8(entry.path())};
         }
 
         load(ifs, entry.path().string(), mod_name);

--- a/src/i18n.hpp
+++ b/src/i18n.hpp
@@ -353,8 +353,8 @@ inline std::string format_function_call(
                 }
                 else
                 {
-                    return "<unknown parameter "s + call.name + ", _" + *index
-                        + "/"s + args_size + ">"s;
+                    return "<unknown parameter "s + call.name + ", _" + *index +
+                        "/"s + args_size + ">"s;
                 }
             }
             else
@@ -805,8 +805,8 @@ public:
         const I18NKey& property_name)
     {
         const auto pair = strutil::split_on_string(data_key, ".");
-        const auto key = pair.first + "." + data_type_key + "." + pair.second
-            + "." + property_name;
+        const auto key = pair.first + "." + data_type_key + "." + pair.second +
+            "." + property_name;
         return get(key);
     }
 
@@ -822,8 +822,8 @@ public:
         const I18NKey& property_name)
     {
         const auto pair = strutil::split_on_string(data_key, ".");
-        const auto key = pair.first + "." + data_type_key + "." + pair.second
-            + "." + property_name;
+        const auto key = pair.first + "." + data_type_key + "." + pair.second +
+            "." + property_name;
         return get_optional(key);
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -108,8 +108,8 @@ void backup_config_files()
             if (!fs::exists(from_path))
             {
                 throw std::runtime_error(
-                    "Original config file " + from_path.string()
-                    + " didn't exist.");
+                    "Original config file " + from_path.string() +
+                    " didn't exist.");
             }
             fs::copy_file(from_path, to_path);
         }
@@ -172,9 +172,8 @@ void start_elona()
     game_data.date.hour = 16;
     game_data.date.minute = 10;
     quickpage = 1;
-    if (Config::instance().startup_script != ""s
-        && !Config::instance().get<bool>(
-            "core.config.foobar.run_script_in_save"))
+    if (Config::instance().startup_script != ""s &&
+        !Config::instance().get<bool>("core.config.foobar.run_script_in_save"))
     {
         mode = 6;
         initialize_game();

--- a/src/initialize_map.cpp
+++ b/src/initialize_map.cpp
@@ -42,14 +42,14 @@ namespace elona
 
 static void _update_dungeon_level()
 {
-    if (game_data.current_dungeon_level
-        > area_data[game_data.current_map].deepest_level)
+    if (game_data.current_dungeon_level >
+        area_data[game_data.current_map].deepest_level)
     {
         game_data.current_dungeon_level =
             area_data[game_data.current_map].deepest_level;
     }
-    if (game_data.current_dungeon_level
-        < area_data[game_data.current_map].danger_level)
+    if (game_data.current_dungeon_level <
+        area_data[game_data.current_map].danger_level)
     {
         game_data.current_dungeon_level =
             area_data[game_data.current_map].danger_level;
@@ -61,8 +61,8 @@ static void _update_dungeon_level()
             game_data.deepest_dungeon_level = game_data.current_dungeon_level;
         }
     }
-    if (area_data[game_data.current_map].visited_deepest_level
-        < game_data.current_dungeon_level)
+    if (area_data[game_data.current_map].visited_deepest_level <
+        game_data.current_dungeon_level)
     {
         area_data[game_data.current_map].visited_deepest_level =
             game_data.current_dungeon_level;
@@ -166,8 +166,8 @@ static void _relocate_overlapping_area(Area& area)
         {
             continue;
         }
-        if (33 <= cell_data.at(x, y).chip_id_actual
-            && cell_data.at(x, y).chip_id_actual < 66)
+        if (33 <= cell_data.at(x, y).chip_id_actual &&
+            cell_data.at(x, y).chip_id_actual < 66)
         {
             continue;
         }
@@ -178,8 +178,9 @@ static void _relocate_overlapping_area(Area& area)
         i = 1;
         for (int cnt = 0, cnt_end = (300); cnt < cnt_end; ++cnt)
         {
-            if (area_data[cnt].position.x == 0 || area_data[cnt].position.y == 0
-                || area_data[cnt].id == mdata_t::MapId::none)
+            if (area_data[cnt].position.x == 0 ||
+                area_data[cnt].position.y == 0 ||
+                area_data[cnt].id == mdata_t::MapId::none)
             {
                 continue;
             }
@@ -217,15 +218,16 @@ static void _do_mapupdate_world_map()
     for (int cnt = 300; cnt < 500; ++cnt)
     {
         p = cnt;
-        if (area_data[cnt].position.x == 0 || area_data[cnt].position.y == 0
-            || area_data[cnt].id == mdata_t::MapId::none)
+        if (area_data[cnt].position.x == 0 || area_data[cnt].position.y == 0 ||
+            area_data[cnt].id == mdata_t::MapId::none)
         {
             continue;
         }
         for (int cnt = 0; cnt < 300; ++cnt)
         {
-            if (area_data[cnt].position.x == 0 || area_data[cnt].position.y == 0
-                || area_data[cnt].id == mdata_t::MapId::none)
+            if (area_data[cnt].position.x == 0 ||
+                area_data[cnt].position.y == 0 ||
+                area_data[cnt].id == mdata_t::MapId::none)
             {
                 continue;
             }
@@ -251,8 +253,8 @@ static void _prepare_mapupdate()
         {
             continue;
         }
-        if ((cnt.character_role >= 1000 && cnt.character_role < 2000)
-            || cnt.character_role == 2003)
+        if ((cnt.character_role >= 1000 && cnt.character_role < 2000) ||
+            cnt.character_role == 2003)
         {
             rolebk(0, maxnpcbk) = cnt.character_role;
             rolebk(1, maxnpcbk) = cnt.shop_rank;
@@ -293,8 +295,8 @@ static void _do_mapupdate()
         {
             continue;
         }
-        if ((cnt.character_role >= 1000 && cnt.character_role < 2000)
-            || cnt.character_role == 2003)
+        if ((cnt.character_role >= 1000 && cnt.character_role < 2000) ||
+            cnt.character_role == 2003)
         {
             int cnt2 = cnt.index;
             for (int cnt = 0, cnt_end = (maxnpcbk); cnt < cnt_end; ++cnt)
@@ -348,8 +350,8 @@ static void _update_adventurer(int cnt)
         {
             return;
         }
-        if (map_data.type != mdata_t::MapType::town
-            && map_data.type != mdata_t::MapType::guild)
+        if (map_data.type != mdata_t::MapType::town &&
+            map_data.type != mdata_t::MapType::guild)
         {
             return;
         }
@@ -358,8 +360,8 @@ static void _update_adventurer(int cnt)
             return;
         }
     }
-    if (game_data.current_map == mdata_t::MapId::arena
-        || game_data.current_map == mdata_t::MapId::pet_arena)
+    if (game_data.current_map == mdata_t::MapId::arena ||
+        game_data.current_map == mdata_t::MapId::pet_arena)
     {
         return;
     }
@@ -391,9 +393,9 @@ static void _update_adventurers()
 
 static bool _should_regenerate_map()
 {
-    return game_data.date.hours() >= map_data.next_regenerate_date
-        && map_data.should_regenerate == 0 && map_data.next_regenerate_date != 0
-        && game_data.current_dungeon_level == 1;
+    return game_data.date.hours() >= map_data.next_regenerate_date &&
+        map_data.should_regenerate == 0 && map_data.next_regenerate_date != 0 &&
+        game_data.current_dungeon_level == 1;
 }
 
 static void _regenerate_map()
@@ -476,9 +478,9 @@ static void _relocate_character(Character& chara)
 static bool _position_blocked(Character& chara)
 {
     cell_check(chara.position.x, chara.position.y);
-    return cell_data.at(chara.position.x, chara.position.y).chara_index_plus_one
-        != 0
-        || cellaccess != 1;
+    return cell_data.at(chara.position.x, chara.position.y)
+               .chara_index_plus_one != 0 ||
+        cellaccess != 1;
 }
 
 static void _clear_chara_indices_in_map()
@@ -610,8 +612,8 @@ void _adjust_spawns()
     {
         if (cnt.state() == Character::State::alive)
         {
-            if (cnt.position.x < 0 || cnt.position.x >= map_data.width
-                || cnt.position.y < 0 || cnt.position.y >= map_data.height)
+            if (cnt.position.x < 0 || cnt.position.x >= map_data.width ||
+                cnt.position.y < 0 || cnt.position.y >= map_data.height)
             {
                 cnt.position.x = 0;
                 cnt.position.y = 0;
@@ -658,10 +660,10 @@ static void _update_quest_flags_any()
     }
     if (game_data.quest_flags.main_quest == 115)
     {
-        if (game_data.quest_flags.magic_stone_of_fool
-                + game_data.quest_flags.magic_stone_of_king
-                + game_data.quest_flags.magic_stone_of_sage
-            >= 1)
+        if (game_data.quest_flags.magic_stone_of_fool +
+                game_data.quest_flags.magic_stone_of_king +
+                game_data.quest_flags.magic_stone_of_sage >=
+            1)
         {
             sceneid = 28;
             do_play_scene();
@@ -670,10 +672,10 @@ static void _update_quest_flags_any()
     }
     if (game_data.quest_flags.main_quest == 116)
     {
-        if (game_data.quest_flags.magic_stone_of_fool
-                + game_data.quest_flags.magic_stone_of_king
-                + game_data.quest_flags.magic_stone_of_sage
-            >= 2)
+        if (game_data.quest_flags.magic_stone_of_fool +
+                game_data.quest_flags.magic_stone_of_king +
+                game_data.quest_flags.magic_stone_of_sage >=
+            2)
         {
             sceneid = 29;
             do_play_scene();
@@ -682,10 +684,10 @@ static void _update_quest_flags_any()
     }
     if (game_data.quest_flags.main_quest == 117)
     {
-        if (game_data.quest_flags.magic_stone_of_fool
-                + game_data.quest_flags.magic_stone_of_king
-                + game_data.quest_flags.magic_stone_of_sage
-            >= 3)
+        if (game_data.quest_flags.magic_stone_of_fool +
+                game_data.quest_flags.magic_stone_of_king +
+                game_data.quest_flags.magic_stone_of_sage >=
+            3)
         {
             sceneid = 30;
             do_play_scene();
@@ -885,8 +887,8 @@ static void _update_quest_flags_north_tyris()
 
 static void _proc_no_dungeon_master()
 {
-    if (game_data.current_dungeon_level
-        == area_data[game_data.current_map].deepest_level)
+    if (game_data.current_dungeon_level ==
+        area_data[game_data.current_map].deepest_level)
     {
         if (area_data[game_data.current_map].has_been_conquered == -1)
         {
@@ -938,9 +940,9 @@ static void _notify_distance_traveled()
         mapname(game_data.left_town_map),
         cnvdate(game_data.departure_date, false)));
     p = 0;
-    exp = cdata.player().level * game_data.distance_between_town * sdata(182, 0)
-            / 100
-        + 1;
+    exp = cdata.player().level * game_data.distance_between_town *
+            sdata(182, 0) / 100 +
+        1;
     for (int cnt = 0; cnt < 16; ++cnt)
     {
         if (cdata[cnt].state() != Character::State::alive)
@@ -1107,8 +1109,8 @@ static void _proc_map_hooks_2()
     {
         maybe_show_ex_help(14);
     }
-    if (map_is_town_or_guild()
-        || game_data.current_map == mdata_t::MapId::your_home)
+    if (map_is_town_or_guild() ||
+        game_data.current_map == mdata_t::MapId::your_home)
     {
         if (game_data.distance_between_town >= 16)
         {
@@ -1175,8 +1177,8 @@ static void _generate_new_map()
     if (mapupdate)
     {
         randomize(
-            game_data.random_seed + game_data.current_map * 1000
-            + game_data.current_dungeon_level);
+            game_data.random_seed + game_data.current_map * 1000 +
+            game_data.current_dungeon_level);
     }
 
     // Initialize map-specific features.
@@ -1229,8 +1231,8 @@ init_map_begin:
 
     _update_pets_moving_status();
 
-    mid = ""s + game_data.current_map + u8"_"s
-        + (100 + game_data.current_dungeon_level);
+    mid = ""s + game_data.current_map + u8"_"s +
+        (100 + game_data.current_dungeon_level);
 
     if (mode == 3)
     {
@@ -1254,14 +1256,14 @@ init_map_begin:
         {
             goto init_map_before_generate;
         }
-        if (map_data.regenerate_count != game_data.map_regenerate_count
-            || (game_data.reset_world_map_in_diastrophism_flag == 1
-                && map_data.type == mdata_t::MapType::world_map))
+        if (map_data.regenerate_count != game_data.map_regenerate_count ||
+            (game_data.reset_world_map_in_diastrophism_flag == 1 &&
+             map_data.type == mdata_t::MapType::world_map))
         {
-            if (map_data.type == mdata_t::MapType::town
-                || map_data.type == mdata_t::MapType::guild
-                || map_data.type == mdata_t::MapType::shelter
-                || map_data.type == mdata_t::MapType::world_map)
+            if (map_data.type == mdata_t::MapType::town ||
+                map_data.type == mdata_t::MapType::guild ||
+                map_data.type == mdata_t::MapType::shelter ||
+                map_data.type == mdata_t::MapType::world_map)
             {
                 mapupdate = 1;
                 goto init_map_before_generate;

--- a/src/initialize_map_types.cpp
+++ b/src/initialize_map_types.cpp
@@ -38,8 +38,8 @@ static void _init_map_shelter()
 static void _init_map_nefia()
 {
     generate_random_nefia();
-    if (game_data.current_dungeon_level
-        == area_data[game_data.current_map].deepest_level)
+    if (game_data.current_dungeon_level ==
+        area_data[game_data.current_map].deepest_level)
     {
         event_add(4);
     }
@@ -131,8 +131,8 @@ static void _init_map_test_site()
         p = cnt;
         for (int cnt = 0, cnt_end = (map_data.width); cnt < cnt_end; ++cnt)
         {
-            cell_data.at(cnt, p).chip_id_actual = tile_default
-                + (rnd(tile_default(2)) == 0) * rnd(tile_default(1));
+            cell_data.at(cnt, p).chip_id_actual = tile_default +
+                (rnd(tile_default(2)) == 0) * rnd(tile_default(1));
         }
     }
     map_placeplayer();
@@ -2218,9 +2218,9 @@ static void _init_map_fields_maybe_generate_encounter()
             flt(calcobjlv(encounterlv), calcfixlv(Quality::bad));
             if (game_data.weather == 1)
             {
-                if ((33 > game_data.stood_world_map_tile
-                     || game_data.stood_world_map_tile >= 66)
-                    && rnd(3) == 0)
+                if ((33 > game_data.stood_world_map_tile ||
+                     game_data.stood_world_map_tile >= 66) &&
+                    rnd(3) == 0)
                 {
                     fixlv = Quality::godly;
                 }
@@ -2255,29 +2255,29 @@ static void _init_map_fields()
         p = cnt;
         for (int cnt = 0, cnt_end = (map_data.width); cnt < cnt_end; ++cnt)
         {
-            cell_data.at(cnt, p).chip_id_actual = tile_default
-                + (rnd(tile_default(2)) == 0) * rnd(tile_default(1));
+            cell_data.at(cnt, p).chip_id_actual = tile_default +
+                (rnd(tile_default(2)) == 0) * rnd(tile_default(1));
         }
     }
 
     mdatan(0) = "";
-    if (4 <= game_data.stood_world_map_tile
-        && game_data.stood_world_map_tile < 9)
+    if (4 <= game_data.stood_world_map_tile &&
+        game_data.stood_world_map_tile < 9)
     {
         _init_map_fields_forest();
     }
-    if (264 <= game_data.stood_world_map_tile
-        && game_data.stood_world_map_tile < 363)
+    if (264 <= game_data.stood_world_map_tile &&
+        game_data.stood_world_map_tile < 363)
     {
         _init_map_fields_sea();
     }
-    if (9 <= game_data.stood_world_map_tile
-        && game_data.stood_world_map_tile < 13)
+    if (9 <= game_data.stood_world_map_tile &&
+        game_data.stood_world_map_tile < 13)
     {
         _init_map_fields_grassland();
     }
-    if (13 <= game_data.stood_world_map_tile
-        && game_data.stood_world_map_tile < 17)
+    if (13 <= game_data.stood_world_map_tile &&
+        game_data.stood_world_map_tile < 17)
     {
         _init_map_fields_desert();
     }
@@ -2291,8 +2291,8 @@ static void _init_map_fields()
     }
 
     map_placeplayer();
-    if (264 > game_data.stood_world_map_tile
-        || game_data.stood_world_map_tile >= 363)
+    if (264 > game_data.stood_world_map_tile ||
+        game_data.stood_world_map_tile >= 363)
     {
         for (int cnt = 0, cnt_end = (4 + rnd(5)); cnt < cnt_end; ++cnt)
         {
@@ -2328,8 +2328,8 @@ static void _init_map_lesimas()
     map_tileset(map_data.tileset);
     for (int cnt = 0; cnt < 1; ++cnt)
     {
-        if (game_data.current_dungeon_level
-            == area_data[game_data.current_map].deepest_level)
+        if (game_data.current_dungeon_level ==
+            area_data[game_data.current_map].deepest_level)
         {
             map_initcustom(u8"lesimas_1"s);
             map_data.max_crowd_density = 0;
@@ -2379,8 +2379,8 @@ static void _init_map_lesimas()
 
 static void _init_map_tower_of_fire()
 {
-    if (game_data.current_dungeon_level
-        == area_data[game_data.current_map].deepest_level)
+    if (game_data.current_dungeon_level ==
+        area_data[game_data.current_map].deepest_level)
     {
         map_initcustom(u8"firet1"s);
         map_data.max_crowd_density = 0;
@@ -2395,8 +2395,8 @@ static void _init_map_tower_of_fire()
 
 static void _init_map_crypt_of_the_damned()
 {
-    if (game_data.current_dungeon_level
-        == area_data[game_data.current_map].deepest_level)
+    if (game_data.current_dungeon_level ==
+        area_data[game_data.current_map].deepest_level)
     {
         map_initcustom(u8"undeadt1"s);
         map_data.max_crowd_density = 0;
@@ -2411,8 +2411,8 @@ static void _init_map_crypt_of_the_damned()
 
 static void _init_map_ancient_castle()
 {
-    if (game_data.current_dungeon_level
-        == area_data[game_data.current_map].deepest_level)
+    if (game_data.current_dungeon_level ==
+        area_data[game_data.current_map].deepest_level)
     {
         map_initcustom(u8"roguet1"s);
         map_data.max_crowd_density = 0;
@@ -2427,8 +2427,8 @@ static void _init_map_ancient_castle()
 
 static void _init_map_dragons_nest()
 {
-    if (game_data.current_dungeon_level
-        == area_data[game_data.current_map].deepest_level)
+    if (game_data.current_dungeon_level ==
+        area_data[game_data.current_map].deepest_level)
     {
         map_initcustom(u8"d_1"s);
         map_data.max_crowd_density = 0;
@@ -2444,8 +2444,8 @@ static void _init_map_dragons_nest()
 static void _init_map_puppy_cave()
 {
     generate_random_nefia();
-    if (game_data.current_dungeon_level
-        == area_data[game_data.current_map].deepest_level)
+    if (game_data.current_dungeon_level ==
+        area_data[game_data.current_map].deepest_level)
     {
         if (game_data.quest_flags.puppys_cave < 2)
         {
@@ -2462,8 +2462,8 @@ static void _init_map_puppy_cave()
 static void _init_map_minotaurs_nest()
 {
     generate_random_nefia();
-    if (game_data.current_dungeon_level
-        == area_data[game_data.current_map].deepest_level)
+    if (game_data.current_dungeon_level ==
+        area_data[game_data.current_map].deepest_level)
     {
         if (game_data.quest_flags.minotaur_king < 2)
         {
@@ -2476,8 +2476,8 @@ static void _init_map_minotaurs_nest()
 static void _init_map_yeeks_nest()
 {
     generate_random_nefia();
-    if (game_data.current_dungeon_level
-        == area_data[game_data.current_map].deepest_level)
+    if (game_data.current_dungeon_level ==
+        area_data[game_data.current_map].deepest_level)
     {
         if (game_data.quest_flags.novice_knight < 2)
         {
@@ -2542,10 +2542,9 @@ void initialize_map_from_map_type()
     using namespace mdata_t;
     if (game_data.current_map == MapId::your_home)
     {
-        if (mdatan(0) == ""s
-            || mdatan(0)
-                == i18n::s.get_enum_property(
-                    "core.locale.map.unique", "name", 4))
+        if (mdatan(0) == ""s ||
+            mdatan(0) ==
+                i18n::s.get_enum_property("core.locale.map.unique", "name", 4))
         {
             mdatan(0) =
                 i18n::s.get_enum_property("core.locale.map.unique", "name", 7);

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -64,26 +64,26 @@ bool Item::almost_equals(const Item& other, bool ignore_position)
 {
     return true
         // && number == other.number
-        && value == other.value && image == other.image
-        && id == other.id
+        && value == other.value && image == other.image &&
+        id == other.id
         // && quality == other.quality
-        && (ignore_position || position == other.position)
-        && weight == other.weight
-        && identification_state == other.identification_state
-        && count == other.count && dice_x == other.dice_x
-        && dice_y == other.dice_y && damage_bonus == other.damage_bonus
-        && hit_bonus == other.hit_bonus && dv == other.dv && pv == other.pv
-        && skill == other.skill && curse_state == other.curse_state
-        && body_part == other.body_part && function == other.function
-        && enhancement == other.enhancement && own_state == other.own_state
-        && color == other.color && subname == other.subname
-        && material == other.material && param1 == other.param1
-        && param2 == other.param2 && param3 == other.param3
-        && param4 == other.param4
-        && difficulty_of_identification == other.difficulty_of_identification
+        && (ignore_position || position == other.position) &&
+        weight == other.weight &&
+        identification_state == other.identification_state &&
+        count == other.count && dice_x == other.dice_x &&
+        dice_y == other.dice_y && damage_bonus == other.damage_bonus &&
+        hit_bonus == other.hit_bonus && dv == other.dv && pv == other.pv &&
+        skill == other.skill && curse_state == other.curse_state &&
+        body_part == other.body_part && function == other.function &&
+        enhancement == other.enhancement && own_state == other.own_state &&
+        color == other.color && subname == other.subname &&
+        material == other.material && param1 == other.param1 &&
+        param2 == other.param2 && param3 == other.param3 &&
+        param4 == other.param4 &&
+        difficulty_of_identification == other.difficulty_of_identification
         // && turn == other.turn
-        && flags == other.flags
-        && range::equal(enchantments, other.enchantments);
+        && flags == other.flags &&
+        range::equal(enchantments, other.enchantments);
 }
 
 Inventory::Inventory()
@@ -171,8 +171,8 @@ int item_find(int prm_476, int prm_477, int prm_478)
             }
             if (p_at_m52(2) == 0)
             {
-                if (inv[cnt].position.x != cdata.player().position.x
-                    || inv[cnt].position.y != cdata.player().position.y)
+                if (inv[cnt].position.x != cdata.player().position.x ||
+                    inv[cnt].position.y != cdata.player().position.y)
                 {
                     continue;
                 }
@@ -292,10 +292,9 @@ int itemusingfind(int ci, bool disallow_pc)
         {
             continue;
         }
-        if (cnt.continuous_action
-            && cnt.continuous_action.type != ContinuousAction::Type::sex
-            && cnt.continuous_action.turn > 0
-            && cnt.continuous_action.item == ci)
+        if (cnt.continuous_action &&
+            cnt.continuous_action.type != ContinuousAction::Type::sex &&
+            cnt.continuous_action.turn > 0 && cnt.continuous_action.item == ci)
         {
             if (!disallow_pc || cnt.index != 0)
             {
@@ -375,8 +374,8 @@ void cell_refresh(int prm_493, int prm_494)
     {
         return;
     }
-    if (prm_493 < 0 || prm_494 < 0 || prm_493 >= map_data.width
-        || prm_494 >= map_data.height)
+    if (prm_493 < 0 || prm_494 < 0 || prm_493 >= map_data.width ||
+        prm_494 >= map_data.height)
     {
         return;
     }
@@ -388,8 +387,8 @@ void cell_refresh(int prm_493, int prm_494)
     {
         if (inv[cnt].number() > 0)
         {
-            if (inv[cnt].position.x == prm_493
-                && inv[cnt].position.y == prm_494)
+            if (inv[cnt].position.x == prm_493 &&
+                inv[cnt].position.y == prm_494)
             {
                 floorstack(p_at_m55) = cnt;
                 ++p_at_m55;
@@ -634,8 +633,8 @@ bool chara_unequip(int ci)
 
 IdentifyState item_identify(Item& ci, IdentifyState level)
 {
-    if (level == IdentifyState::almost_identified
-        && the_item_db[ci.id]->category >= 50000)
+    if (level == IdentifyState::almost_identified &&
+        the_item_db[ci.id]->category >= 50000)
     {
         level = IdentifyState::completely_identified;
     }
@@ -670,8 +669,8 @@ void item_checkknown(int ci)
     {
         inv[ci].identification_state = IdentifyState::completely_identified;
     }
-    if (itemmemory(0, inv[ci].id)
-        && inv[ci].identification_state == IdentifyState::unidentified)
+    if (itemmemory(0, inv[ci].id) &&
+        inv[ci].identification_state == IdentifyState::unidentified)
     {
         item_identify(inv[ci], IdentifyState::partly_identified);
     }
@@ -689,13 +688,13 @@ void itemname_additional_info()
     if (inv[prm_518].id == 617)
     {
         s_ += lang(
-            ""s
-                + i18n::s.get_enum(
+            ""s +
+                i18n::s.get_enum(
                     "core.locale.item.bait_rank", inv[prm_518].param1),
-            u8" <"s
-                + i18n::s.get_enum(
-                    "core.locale.item.bait_rank", inv[prm_518].param1)
-                + u8">"s);
+            u8" <"s +
+                i18n::s.get_enum(
+                    "core.locale.item.bait_rank", inv[prm_518].param1) +
+                u8">"s);
     }
     if (inv[prm_518].id == 687)
     {
@@ -706,20 +705,20 @@ void itemname_additional_info()
                 s_ += u8"解読済みの"s;
             }
         }
-        if (inv[prm_518].identification_state
-            == IdentifyState::completely_identified)
+        if (inv[prm_518].identification_state ==
+            IdentifyState::completely_identified)
         {
             s_ += lang(
-                u8"《"s
-                    + i18n::s.get_enum(
+                u8"《"s +
+                    i18n::s.get_enum(
                         "core.locale.item.ancient_book_title",
-                        inv[prm_518].param1)
-                    + u8"》という題名の"s,
-                u8" titled <"s
-                    + i18n::s.get_enum(
+                        inv[prm_518].param1) +
+                    u8"》という題名の"s,
+                u8" titled <"s +
+                    i18n::s.get_enum(
                         "core.locale.item.ancient_book_title",
-                        inv[prm_518].param1)
-                    + u8">"s);
+                        inv[prm_518].param1) +
+                    u8">"s);
         }
     }
     if (inv[prm_518].id == 783)
@@ -744,25 +743,25 @@ void itemname_additional_info()
         if (inv[prm_518].id == 563)
         {
             s_ += lang(
-                u8"《"s
-                    + i18n::s.get_m(
+                u8"《"s +
+                    i18n::s.get_m(
                         "locale.ability",
                         the_ability_db.get_id_from_legacy(inv[prm_518].param1)
                             ->get(),
-                        "name")
-                    + u8"》という題名の"s,
-                u8" titled <Art of "s
-                    + i18n::s.get_m(
+                        "name") +
+                    u8"》という題名の"s,
+                u8" titled <Art of "s +
+                    i18n::s.get_m(
                         "locale.ability",
                         the_ability_db.get_id_from_legacy(inv[prm_518].param1)
                             ->get(),
-                        "name")
-                    + u8">"s);
+                        "name") +
+                    u8">"s);
         }
         else if (inv[prm_518].id == 668)
         {
-            s_ += lang(u8"第"s, u8" of Rachel No."s) + inv[prm_518].param2
-                + lang(u8"巻目の"s, ""s);
+            s_ += lang(u8"第"s, u8" of Rachel No."s) + inv[prm_518].param2 +
+                lang(u8"巻目の"s, ""s);
         }
         else if (inv[prm_518].id == 24)
         {
@@ -789,8 +788,8 @@ void itemname_additional_info()
                 skip_ = 1;
                 if (inv[prm_518].id == 618)
                 {
-                    s_ = s_
-                        + foodname(
+                    s_ = s_ +
+                        foodname(
                              inv[prm_518].param1 / 1000,
                              i18n::s.get_m(
                                  "locale.fish",
@@ -803,8 +802,8 @@ void itemname_additional_info()
                 }
                 else
                 {
-                    s_ = s_
-                        + foodname(
+                    s_ = s_ +
+                        foodname(
                              inv[prm_518].param1 / 1000,
                              ioriginalnameref(inv[prm_518].id),
                              inv[prm_518].param2,
@@ -815,9 +814,9 @@ void itemname_additional_info()
         }
         if (inv[prm_518].own_state == 4)
         {
-            s_ += lang(""s, u8" grown "s)
-                + i18n::_(u8"ui", u8"weight", u8"_"s + inv[prm_518].subname)
-                + lang(u8"育った"s, ""s);
+            s_ += lang(""s, u8" grown "s) +
+                i18n::_(u8"ui", u8"weight", u8"_"s + inv[prm_518].subname) +
+                lang(u8"育った"s, ""s);
         }
     }
     if (inv[prm_518].subname != 0)
@@ -835,9 +834,9 @@ void itemname_additional_info()
                 "name");
         }
         else if (
-            a_ == 57000 || a_ == 62000 || inv[prm_518].id == 503
-            || inv[prm_518].id == 504 || inv[prm_518].id == 575
-            || inv[prm_518].id == 574)
+            a_ == 57000 || a_ == 62000 || inv[prm_518].id == 503 ||
+            inv[prm_518].id == 504 || inv[prm_518].id == 575 ||
+            inv[prm_518].id == 574)
         {
             if (inv[prm_518].subname < 0 || inv[prm_518].subname >= 800)
             {
@@ -846,8 +845,8 @@ void itemname_additional_info()
             }
             if (inv[prm_518].own_state != 4)
             {
-                s_ += lang(""s, u8" of "s)
-                    + chara_refstr(inv[prm_518].subname, 2);
+                s_ += lang(""s, u8" of "s) +
+                    chara_refstr(inv[prm_518].subname, 2);
                 if (jp)
                 {
                     s_ += u8"の"s;
@@ -871,9 +870,9 @@ void itemname_additional_info()
         }
         if (inv[prm_518].id == 344)
         {
-            s_ += lang(""s, u8" of "s)
-                + i18n::_(u8"ui", u8"home", u8"_"s + inv[prm_518].param1)
-                + lang(u8"の"s, ""s);
+            s_ += lang(""s, u8" of "s) +
+                i18n::_(u8"ui", u8"home", u8"_"s + inv[prm_518].param1) +
+                lang(u8"の"s, ""s);
         }
         if (inv[prm_518].id == 615)
         {
@@ -934,8 +933,8 @@ std::string itemname(int prm_518, int prm_519, int prm_520)
     std::string s4_;
     elona_vector1<std::string> buf_;
     elona::prm_518 = prm_518;
-    if (inv[prm_518].id >= maxitemid - 2
-        || size_t(inv[prm_518].id) > ioriginalnameref.size())
+    if (inv[prm_518].id >= maxitemid - 2 ||
+        size_t(inv[prm_518].id) > ioriginalnameref.size())
     {
         return i18n::s.get("core.locale.item.unknown_item");
     }
@@ -989,8 +988,8 @@ std::string itemname(int prm_518, int prm_519, int prm_520)
             {
                 s2_ = u8"対の"s;
             }
-            if (a_ == 68000 || a_ == 69000 || inv[prm_518].id == 622
-                || inv[prm_518].id == 724 || inv[prm_518].id == 730)
+            if (a_ == 68000 || a_ == 69000 || inv[prm_518].id == 622 ||
+                inv[prm_518].id == 724 || inv[prm_518].id == 730)
             {
                 s2_ = u8"枚の"s;
             }
@@ -1004,8 +1003,8 @@ std::string itemname(int prm_518, int prm_519, int prm_520)
         {
             s_ = "";
         }
-        if (inv[prm_518].identification_state
-            == IdentifyState::completely_identified)
+        if (inv[prm_518].identification_state ==
+            IdentifyState::completely_identified)
         {
             switch (inv[prm_518].curse_state)
             {
@@ -1019,8 +1018,8 @@ std::string itemname(int prm_518, int prm_519, int prm_520)
     else
     {
         s_ = "";
-        if (inv[prm_518].identification_state
-            == IdentifyState::completely_identified)
+        if (inv[prm_518].identification_state ==
+            IdentifyState::completely_identified)
         {
             switch (inv[prm_518].curse_state)
             {
@@ -1036,8 +1035,8 @@ std::string itemname(int prm_518, int prm_519, int prm_520)
                 break;
             }
         }
-        if (irandomname(inv[prm_518].id) == 1
-            && inv[prm_518].identification_state == IdentifyState::unidentified)
+        if (irandomname(inv[prm_518].id) == 1 &&
+            inv[prm_518].identification_state == IdentifyState::unidentified)
         {
             s2_ = "";
         }
@@ -1052,8 +1051,9 @@ std::string itemname(int prm_518, int prm_519, int prm_520)
             {
                 s3_ = u8"of"s;
             }
-            if (inv[prm_518].identification_state != IdentifyState::unidentified
-                && s2_ == ""s)
+            if (inv[prm_518].identification_state !=
+                    IdentifyState::unidentified &&
+                s2_ == ""s)
             {
                 if (inv[prm_518].weight < 0)
                 {
@@ -1064,8 +1064,8 @@ std::string itemname(int prm_518, int prm_519, int prm_520)
                     s2_ = u8"pair"s;
                 }
             }
-            if (a_ == 57000 && inv[prm_518].param1 != 0
-                && inv[prm_518].param2 != 0)
+            if (a_ == 57000 && inv[prm_518].param1 != 0 &&
+                inv[prm_518].param2 != 0)
             {
                 s2_ = u8"dish"s;
             }
@@ -1111,9 +1111,10 @@ std::string itemname(int prm_518, int prm_519, int prm_520)
             }
             else
             {
-                s_ += i18n::_(
-                          u8"ui", u8"furniture", u8"_"s + inv[prm_518].subname)
-                    + u8" "s;
+                s_ +=
+                    i18n::_(
+                        u8"ui", u8"furniture", u8"_"s + inv[prm_518].subname) +
+                    u8" "s;
             }
         }
         if (inv[prm_518].id == 687 && inv[prm_518].param2 != 0)
@@ -1127,13 +1128,13 @@ std::string itemname(int prm_518, int prm_519, int prm_520)
     }
     if (inv[prm_518].id == 630)
     {
-        s_ += ""s
-            + i18n::s.get_m(
+        s_ += ""s +
+            i18n::s.get_m(
                 "locale.item_material",
                 the_item_material_db.get_id_from_legacy(inv[prm_518].material)
                     ->get(),
-                "name")
-            + lang(u8"製の"s, u8" "s);
+                "name") +
+            lang(u8"製の"s, u8" "s);
     }
     if (jp)
     {
@@ -1143,47 +1144,47 @@ std::string itemname(int prm_518, int prm_519, int prm_520)
     {
         if (jp)
         {
-            s_ += ""s
-                + i18n::s.get_m(
+            s_ += ""s +
+                i18n::s.get_m(
                     "locale.item_material",
                     the_item_material_db
                         .get_id_from_legacy(inv[prm_518].material)
                         ->get(),
-                    "name")
-                + u8"細工の"s;
+                    "name") +
+                u8"細工の"s;
         }
         else
         {
-            s_ += ""s
-                + i18n::s.get_m(
+            s_ += ""s +
+                i18n::s.get_m(
                     "locale.item_material",
                     the_item_material_db
                         .get_id_from_legacy(inv[prm_518].material)
                         ->get(),
-                    "name")
-                + u8"work "s;
+                    "name") +
+                u8"work "s;
         }
     }
     if (inv[prm_518].id == 729)
     {
-        s_ +=
-            i18n::s.get_enum("core.locale.item.gift_rank", inv[prm_518].param4)
-            + i18n::space_if_needed();
+        s_ += i18n::s.get_enum(
+                  "core.locale.item.gift_rank", inv[prm_518].param4) +
+            i18n::space_if_needed();
     }
     if (skip_ == 1)
     {
         goto label_0313_internal;
     }
     alpha_ = 0;
-    if (inv[prm_518].identification_state
-            == IdentifyState::completely_identified
-        && a_ < 50000)
+    if (inv[prm_518].identification_state ==
+            IdentifyState::completely_identified &&
+        a_ < 50000)
     {
         if (ibit(15, prm_518))
         {
             alpha_ = 1;
-            s_ += lang(u8"エターナルフォース"s, u8"eternal force"s)
-                + i18n::space_if_needed();
+            s_ += lang(u8"エターナルフォース"s, u8"eternal force"s) +
+                i18n::space_if_needed();
         }
         else
         {
@@ -1193,14 +1194,14 @@ std::string itemname(int prm_518, int prm_519, int prm_520)
                 {
                     if (jp)
                     {
-                        s_ += egoname(inv[prm_518].subname - 10000)
-                            + i18n::space_if_needed();
+                        s_ += egoname(inv[prm_518].subname - 10000) +
+                            i18n::space_if_needed();
                     }
                 }
                 else if (inv[prm_518].subname < 40000)
                 {
-                    s_ += egominorn(inv[prm_518].subname - 20000)
-                        + i18n::space_if_needed();
+                    s_ += egominorn(inv[prm_518].subname - 20000) +
+                        i18n::space_if_needed();
                 }
             }
             if (inv[prm_518].quality != Quality::special)
@@ -1212,8 +1213,8 @@ std::string itemname(int prm_518, int prm_519, int prm_520)
                               the_item_material_db
                                   .get_id_from_legacy(inv[prm_518].material)
                                   ->get(),
-                              "alias")
-                        + i18n::space_if_needed();
+                              "alias") +
+                        i18n::space_if_needed();
                 }
                 else
                 {
@@ -1222,8 +1223,8 @@ std::string itemname(int prm_518, int prm_519, int prm_520)
                               the_item_material_db
                                   .get_id_from_legacy(inv[prm_518].material)
                                   ->get(),
-                              "name")
-                        + i18n::space_if_needed();
+                              "name") +
+                        i18n::space_if_needed();
                     if (jp)
                     {
                         if (/* TODO is_katakana */ false)
@@ -1244,8 +1245,8 @@ std::string itemname(int prm_518, int prm_519, int prm_520)
         s_ += iknownnameref(inv[prm_518].id);
     }
     else if (
-        inv[prm_518].identification_state
-        != IdentifyState::completely_identified)
+        inv[prm_518].identification_state !=
+        IdentifyState::completely_identified)
     {
         if (inv[prm_518].quality < Quality::miracle || a_ >= 50000)
         {
@@ -1281,8 +1282,8 @@ std::string itemname(int prm_518, int prm_519, int prm_520)
         {
             s_ += ioriginalnameref(inv[prm_518].id);
         }
-        if (en && a_ < 50000 && inv[prm_518].subname >= 10000
-            && inv[prm_518].subname < 20000)
+        if (en && a_ < 50000 && inv[prm_518].subname >= 10000 &&
+            inv[prm_518].subname < 20000)
         {
             s_ += u8" "s + egoname((inv[prm_518].subname - 10000));
         }
@@ -1291,14 +1292,14 @@ std::string itemname(int prm_518, int prm_519, int prm_520)
             randomize(inv[prm_518].subname - 40000);
             if (inv[prm_518].quality == Quality::miracle)
             {
-                s_ += i18n::space_if_needed()
-                    + i18n::s.get(
+                s_ += i18n::space_if_needed() +
+                    i18n::s.get(
                         "core.locale.item.miracle_paren", random_title(1));
             }
             else
             {
-                s_ += i18n::space_if_needed()
-                    + i18n::s.get(
+                s_ += i18n::space_if_needed() +
+                    i18n::s.get(
                         "core.locale.item.godly_paren", random_title(1));
             }
             randomize();
@@ -1309,17 +1310,17 @@ label_0313_internal:
     {
         if (prm_520 == 0)
         {
-            if (inv[prm_518].identification_state
-                    == IdentifyState::completely_identified
-                && (inv[prm_518].quality >= Quality::miracle && a_ < 50000))
+            if (inv[prm_518].identification_state ==
+                    IdentifyState::completely_identified &&
+                (inv[prm_518].quality >= Quality::miracle && a_ < 50000))
             {
                 s_ = u8"the "s + s_;
             }
             else if (num2_ == 1)
             {
                 s4_ = strmid(s_, 0, 1);
-                if (s4_ == u8"a"s || s4_ == u8"o"s || s4_ == u8"i"s
-                    || s4_ == u8"u"s || s4_ == u8"e"s)
+                if (s4_ == u8"a"s || s4_ == u8"o"s || s4_ == u8"i"s ||
+                    s4_ == u8"u"s || s4_ == u8"e"s)
                 {
                     s_ = u8"an "s + s_;
                 }
@@ -1335,8 +1336,8 @@ label_0313_internal:
         }
         itemname_additional_info();
     }
-    if (inv[prm_518].identification_state
-        == IdentifyState::completely_identified)
+    if (inv[prm_518].identification_state ==
+        IdentifyState::completely_identified)
     {
         if (inv[prm_518].enhancement != 0)
         {
@@ -1346,8 +1347,8 @@ label_0313_internal:
         {
             s_ += i18n::s.get("core.locale.item.charges", inv[prm_518].count);
         }
-        if (inv[prm_518].dice_x != 0 || inv[prm_518].hit_bonus != 0
-            || inv[prm_518].damage_bonus != 0)
+        if (inv[prm_518].dice_x != 0 || inv[prm_518].hit_bonus != 0 ||
+            inv[prm_518].damage_bonus != 0)
         {
             s_ += u8" ("s;
             if (inv[prm_518].dice_x != 0)
@@ -1372,8 +1373,8 @@ label_0313_internal:
             }
             else
             {
-                s_ += ""s + inv[prm_518].hit_bonus + u8","s
-                    + inv[prm_518].damage_bonus + u8")"s;
+                s_ += ""s + inv[prm_518].hit_bonus + u8","s +
+                    inv[prm_518].damage_bonus + u8")"s;
             }
         }
         if (inv[prm_518].dv != 0 || inv[prm_518].pv != 0)
@@ -1388,21 +1389,21 @@ label_0313_internal:
     if (inv[prm_518].id == 342 && inv[prm_518].count != 0)
     {
         s_ += lang(
-            u8"("s
-                + i18n::s.get_enum(
-                    "core.locale.item.bait_rank", inv[prm_518].param4)
-                + u8"残り"s + inv[prm_518].count + u8"匹)"s,
-            u8"("s + inv[prm_518].count + u8" "s
-                + i18n::s.get_enum(
-                    "core.locale.item.bait_rank", inv[prm_518].param4)
-                + u8")"s);
+            u8"("s +
+                i18n::s.get_enum(
+                    "core.locale.item.bait_rank", inv[prm_518].param4) +
+                u8"残り"s + inv[prm_518].count + u8"匹)"s,
+            u8"("s + inv[prm_518].count + u8" "s +
+                i18n::s.get_enum(
+                    "core.locale.item.bait_rank", inv[prm_518].param4) +
+                u8")"s);
     }
     if (inv[prm_518].id == 685)
     {
         if (inv[prm_518].subname == 0)
         {
-            s_ += lang(u8" Lv"s, u8" Level "s) + inv[prm_518].param2
-                + lang(u8" (空)"s, u8"(Empty)"s);
+            s_ += lang(u8" Lv"s, u8" Level "s) + inv[prm_518].param2 +
+                lang(u8" (空)"s, u8"(Empty)"s);
         }
         else
         {
@@ -1413,36 +1414,36 @@ label_0313_internal:
     {
         s_ += lang(u8" Lv"s, u8" Level "s) + inv[prm_518].param2;
     }
-    if (inv[prm_518].identification_state == IdentifyState::almost_identified
-        && a_ < 50000)
+    if (inv[prm_518].identification_state == IdentifyState::almost_identified &&
+        a_ < 50000)
     {
-        s_ += u8" ("s
-            + cnven(i18n::_(
+        s_ += u8" ("s +
+            cnven(i18n::_(
                 u8"ui",
                 u8"quality",
-                u8"_"s + static_cast<int>(inv[prm_518].quality)))
-            + u8")"s;
+                u8"_"s + static_cast<int>(inv[prm_518].quality))) +
+            u8")"s;
         if (jp)
         {
-            s_ += u8"["s
-                + i18n::s.get_m(
+            s_ += u8"["s +
+                i18n::s.get_m(
                     "locale.item_material",
                     the_item_material_db
                         .get_id_from_legacy(inv[prm_518].material)
                         ->get(),
-                    "name")
-                + u8"製]"s;
+                    "name") +
+                u8"製]"s;
         }
         else
         {
-            s_ += u8"["s
-                + cnven(i18n::s.get_m(
+            s_ += u8"["s +
+                cnven(i18n::s.get_m(
                     "locale.item_material",
                     the_item_material_db
                         .get_id_from_legacy(inv[prm_518].material)
                         ->get(),
-                    "name"))
-                + u8"]"s;
+                    "name")) +
+                u8"]"s;
         }
         if (inv[prm_518].curse_state == CurseState::cursed)
         {
@@ -1487,8 +1488,8 @@ label_0313_internal:
     {
         s_ += lang(
             u8"("s + (inv[prm_518].count - game_data.date.hours()) + u8"時間)"s,
-            u8"(Next: "s + (inv[prm_518].count - game_data.date.hours())
-                + u8"h.)"s);
+            u8"(Next: "s + (inv[prm_518].count - game_data.date.hours()) +
+                u8"h.)"s);
     }
     if (inv[prm_518].id == 555 && inv[prm_518].count != 0)
     {
@@ -1523,13 +1524,13 @@ void remain_make(int ci, int cc)
     {
         inv[ci].weight = 20 * (inv[ci].weight + 500) / 500;
         inv[ci].value = cdata[cc].level * 40 + 600;
-        if (the_character_db[cdata[cc].id]->rarity / 1000 < 20
-            && cdata[cc].original_relationship < -1)
+        if (the_character_db[cdata[cc].id]->rarity / 1000 < 20 &&
+            cdata[cc].original_relationship < -1)
         {
-            inv[ci].value = inv[ci].value
-                * clamp(4 - the_character_db[cdata[cc].id]->rarity / 1000 / 5,
-                        1,
-                        5);
+            inv[ci].value = inv[ci].value *
+                clamp(4 - the_character_db[cdata[cc].id]->rarity / 1000 / 5,
+                      1,
+                      5);
         }
     }
 }
@@ -1537,8 +1538,8 @@ void remain_make(int ci, int cc)
 
 int item_stack(int inventory_id, int ci, int show_message)
 {
-    if (inv[ci].quality == Quality::special
-        && the_item_db[inv[ci].id]->category < 50000)
+    if (inv[ci].quality == Quality::special &&
+        the_item_db[inv[ci].id]->category < 50000)
     {
         return 0;
     }
@@ -1552,8 +1553,8 @@ int item_stack(int inventory_id, int ci, int show_message)
 
         bool stackable;
         if (inv[i].id == 622)
-            stackable = inventory_id != -1 || mode == 6
-                || inv[i].position == inv[ci].position;
+            stackable = inventory_id != -1 || mode == 6 ||
+                inv[i].position == inv[ci].position;
         else
             stackable =
                 inv[i].almost_equals(inv[ci], inventory_id != -1 || mode == 6);
@@ -1662,8 +1663,8 @@ bool item_fire(int owner, int ci)
 
     if (owner != -1)
     {
-        if (sdata(50, owner) / 50 >= 6
-            || cdata[owner].quality >= Quality::miracle)
+        if (sdata(50, owner) / 50 >= 6 ||
+            cdata[owner].quality >= Quality::miracle)
         {
             return false;
         }
@@ -1739,8 +1740,8 @@ bool item_fire(int owner, int ci)
             continue;
         }
 
-        if (a_ == 72000 || a_ == 59000 || a_ == 68000
-            || inv[ci_].quality >= Quality::miracle)
+        if (a_ == 72000 || a_ == 59000 || a_ == 68000 ||
+            inv[ci_].quality >= Quality::miracle)
         {
             continue;
         }
@@ -1753,8 +1754,8 @@ bool item_fire(int owner, int ci)
             }
         }
 
-        if (a_ != 56000 && a_ != 80000 && a_ != 55000 && a_ != 53000
-            && a_ != 54000)
+        if (a_ != 56000 && a_ != 80000 && a_ != 55000 && a_ != 53000 &&
+            a_ != 54000)
         {
             if (rnd(4))
             {
@@ -1813,8 +1814,8 @@ bool item_fire(int owner, int ci)
                         Message::color{ColorIndex::purple});
                 }
                 cdata[owner].body_parts[inv[ci_].body_part - 100] =
-                    cdata[owner].body_parts[inv[ci_].body_part - 100] / 10000
-                    * 10000;
+                    cdata[owner].body_parts[inv[ci_].body_part - 100] / 10000 *
+                    10000;
                 inv[ci_].body_part = 0;
                 chara_refresh(owner);
             }
@@ -1893,8 +1894,8 @@ bool item_cold(int owner, int ci)
     }
     if (owner != -1)
     {
-        if (sdata(51, owner) / 50 >= 6
-            || cdata[owner].quality >= Quality::miracle)
+        if (sdata(51, owner) / 50 >= 6 ||
+            cdata[owner].quality >= Quality::miracle)
         {
             return false;
         }
@@ -2134,10 +2135,10 @@ int inv_compress(int owner)
                 {
                     inv[cnt].remove();
                     ++number_of_deleted_items;
-                    if (inv[cnt].position.x >= 0
-                        && inv[cnt].position.x < map_data.width
-                        && inv[cnt].position.y >= 0
-                        && inv[cnt].position.y < map_data.height)
+                    if (inv[cnt].position.x >= 0 &&
+                        inv[cnt].position.x < map_data.width &&
+                        inv[cnt].position.y >= 0 &&
+                        inv[cnt].position.y < map_data.height)
                     {
                         cell_refresh(inv[cnt].position.x, inv[cnt].position.y);
                     }
@@ -2171,10 +2172,10 @@ int inv_compress(int owner)
         inv[slot].remove();
         if (mode != 6)
         {
-            if (inv[slot].position.x >= 0
-                && inv[slot].position.x < map_data.width
-                && inv[slot].position.y >= 0
-                && inv[slot].position.y < map_data.height)
+            if (inv[slot].position.x >= 0 &&
+                inv[slot].position.x < map_data.width &&
+                inv[slot].position.y >= 0 &&
+                inv[slot].position.y < map_data.height)
             {
                 cell_refresh(inv[slot].position.x, inv[slot].position.y);
             }

--- a/src/item_load_desc.cpp
+++ b/src/item_load_desc.cpp
@@ -156,10 +156,10 @@ static void _load_item_stat_text(int ci, int& p)
     if (ibit(10, ci))
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::text);
-        listn(0, p) = i18n::s.get("core.locale.item.desc.bit.alive")
-            + u8" [Lv:"s + inv[ci].param1 + u8" Exp:"s
-            + clamp(inv[ci].param2 * 100 / calcexpalive(inv[ci].param1), 0, 100)
-            + u8"%]"s;
+        listn(0, p) = i18n::s.get("core.locale.item.desc.bit.alive") +
+            u8" [Lv:"s + inv[ci].param1 + u8" Exp:"s +
+            clamp(inv[ci].param2 * 100 / calcexpalive(inv[ci].param1), 0, 100) +
+            u8"%]"s;
         ++p;
     }
     if (ibit(16, ci))
@@ -179,10 +179,10 @@ static void _load_item_stat_text(int ci, int& p)
         const auto pierce = calc_rate_to_pierce(inv[ci].id);
         list(0, p) = static_cast<int>(ItemDescriptionType::weapon_info);
         listn(0, p) =
-            i18n::s.get("core.locale.item.desc.weapon.it_can_be_wielded")
-            + u8" ("s + inv[ci].dice_x + u8"d"s + inv[ci].dice_y
-            + i18n::s.get("core.locale.item.desc.weapon.pierce") + pierce
-            + u8"%)"s;
+            i18n::s.get("core.locale.item.desc.weapon.it_can_be_wielded") +
+            u8" ("s + inv[ci].dice_x + u8"d"s + inv[ci].dice_y +
+            i18n::s.get("core.locale.item.desc.weapon.pierce") + pierce +
+            u8"%)"s;
         ++p;
         if (reftype == 10000)
         {
@@ -232,8 +232,8 @@ static void _load_item_stat_text(int ci, int& p)
         }
         const auto percentage = std::min(100 * card_count / npc_count, 100);
         list(0, p) = static_cast<int>(ItemDescriptionType::text);
-        listn(0, p) = i18n::s.get("core.locale.item.desc.deck") + u8": "s
-            + card_count + u8"/" + npc_count + u8"(" + percentage + u8"%)";
+        listn(0, p) = i18n::s.get("core.locale.item.desc.deck") + u8": "s +
+            card_count + u8"/" + npc_count + u8"(" + percentage + u8"%)";
         ++p;
     }
 }

--- a/src/itemgen.cpp
+++ b/src/itemgen.cpp
@@ -23,8 +23,8 @@ int calculate_original_value(const Item& ci)
 {
     if (the_item_db[ci.id]->category == 60000)
     {
-        return ci.value * 100 / (80 + std::max(1, ci.subname) * 20)
-            - the_item_material_db[ci.material]->value * 2;
+        return ci.value * 100 / (80 + std::max(1, ci.subname) * 20) -
+            the_item_material_db[ci.material]->value * 2;
     }
     else
     {
@@ -72,8 +72,8 @@ void get_random_item_id()
             bool ok = true;
             for (int i = 0; i < filtermax; ++i)
             {
-                if (the_item_db[data.id]->filter.find(filtern(i))
-                    == std::string::npos)
+                if (the_item_db[data.id]->filter.find(filtern(i)) ==
+                    std::string::npos)
                 {
                     ok = false;
                     break;
@@ -84,9 +84,9 @@ void get_random_item_id()
         }
         sampler.add(
             data.id,
-            data.rarity
-                    / (1000 + std::abs(data.level - objlv) * data.coefficient)
-                + 1);
+            data.rarity /
+                    (1000 + std::abs(data.level - objlv) * data.coefficient) +
+                1);
     }
 
     dbid = sampler.get().value_or(25);
@@ -135,8 +135,8 @@ int do_create_item(int slot, int x, int y)
                     sx = x + rnd(i + 1) - rnd(i + 1);
                     sy = y + rnd(i + 1) - rnd(i + 1);
                 }
-                if (sx < 0 || sy < 0 || sx > map_data.width - 1
-                    || sy > map_data.height - 1)
+                if (sx < 0 || sy < 0 || sx > map_data.width - 1 ||
+                    sy > map_data.height - 1)
                 {
                     continue;
                 }
@@ -150,9 +150,9 @@ int do_create_item(int slot, int x, int y)
             }
             if (cell_data.at(sx, sy).feats != 0)
             {
-                if (cell_data.at(sx, sy).feats / 1000 % 100 == 22
-                    || cell_data.at(sx, sy).feats / 1000 % 100 == 20
-                    || cell_data.at(sx, sy).feats / 1000 % 100 == 21)
+                if (cell_data.at(sx, sy).feats / 1000 % 100 == 22 ||
+                    cell_data.at(sx, sy).feats / 1000 % 100 == 20 ||
+                    cell_data.at(sx, sy).feats / 1000 % 100 == 21)
                 {
                     continue;
                 }
@@ -278,9 +278,9 @@ int do_create_item(int slot, int x, int y)
             inv[ci].param1 = 2;
         }
         inv[ci].subname = inv[ci].param1;
-        inv[ci].value = 5000
-            + 4500 * inv[ci].param1 * inv[ci].param1 * inv[ci].param1
-            + inv[ci].param1 * 20000;
+        inv[ci].value = 5000 +
+            4500 * inv[ci].param1 * inv[ci].param1 * inv[ci].param1 +
+            inv[ci].param1 * 20000;
         if (inv[ci].param1 == 5)
         {
             inv[ci].value *= 2;
@@ -370,9 +370,9 @@ int do_create_item(int slot, int x, int y)
 
     if (reftype == 72000)
     {
-        inv[ci].param1 = game_data.current_dungeon_level
-                * (game_data.current_map != mdata_t::MapId::shelter_)
-            + 5;
+        inv[ci].param1 = game_data.current_dungeon_level *
+                (game_data.current_map != mdata_t::MapId::shelter_) +
+            5;
         if (inv[ci].id == 283)
         {
             inv[ci].param1 = (rnd(10) + 1) * (cdata.player().level / 10 + 1);
@@ -382,9 +382,9 @@ int do_create_item(int slot, int x, int y)
             inv[ci].param1 = cdata.player().level;
         }
         inv[ci].param2 =
-            rnd(std::abs(game_data.current_dungeon_level)
-                    * (game_data.current_map != mdata_t::MapId::shelter_)
-                + 1);
+            rnd(std::abs(game_data.current_dungeon_level) *
+                    (game_data.current_map != mdata_t::MapId::shelter_) +
+                1);
         if (inv[ci].id == 284 || inv[ci].id == 283)
         {
             inv[ci].param2 = rnd(15);
@@ -438,8 +438,8 @@ int do_create_item(int slot, int x, int y)
     {
         inv[ci].identification_state = IdentifyState::completely_identified;
     }
-    if (reftype == 68000 || reftype == 69000 || inv[ci].id == 622
-        || inv[ci].id == 724 || inv[ci].id == 730 || inv[ci].id == 615)
+    if (reftype == 68000 || reftype == 69000 || inv[ci].id == 622 ||
+        inv[ci].id == 724 || inv[ci].id == 730 || inv[ci].id == 615)
     {
         inv[ci].curse_state = CurseState::none;
         inv[ci].identification_state = IdentifyState::completely_identified;
@@ -703,8 +703,8 @@ void apply_item_material()
 {
     if (reftype == 60000)
     {
-        if (inv[ci].material == 3 || inv[ci].material == 16
-            || inv[ci].material == 21 || inv[ci].material == 2)
+        if (inv[ci].material == 3 || inv[ci].material == 16 ||
+            inv[ci].material == 21 || inv[ci].material == 2)
         {
             inv[ci].material = 43;
         }
@@ -742,13 +742,13 @@ void apply_item_material()
     }
     if (inv[ci].hit_bonus != 0)
     {
-        inv[ci].hit_bonus = the_item_material_db[p]->hit_bonus
-            * inv[ci].hit_bonus * 9 / (p(1) - rnd(30));
+        inv[ci].hit_bonus = the_item_material_db[p]->hit_bonus *
+            inv[ci].hit_bonus * 9 / (p(1) - rnd(30));
     }
     if (inv[ci].damage_bonus != 0)
     {
-        inv[ci].damage_bonus = the_item_material_db[p]->damage_bonus
-            * inv[ci].damage_bonus * 5 / (p(1) - rnd(30));
+        inv[ci].damage_bonus = the_item_material_db[p]->damage_bonus *
+            inv[ci].damage_bonus * 5 / (p(1) - rnd(30));
     }
     if (inv[ci].dv != 0)
     {

--- a/src/keybind/input_context.cpp
+++ b/src/keybind/input_context.cpp
@@ -58,13 +58,13 @@ bool InputContext::_matches(
     {
         return true;
     }
-    if (binding.alternate.main == key
-        && binding.alternate.modifiers == modifiers)
+    if (binding.alternate.main == key &&
+        binding.alternate.modifiers == modifiers)
     {
         return true;
     }
-    if (binding.permanent.main == key
-        && binding.permanent.modifiers == modifiers)
+    if (binding.permanent.main == key &&
+        binding.permanent.modifiers == modifiers)
     {
         return true;
     }
@@ -81,9 +81,9 @@ optional<std::string> InputContext::_action_for_key(const Keybind& keybind)
     for (const auto& action_id : _available_actions_sorted)
     {
         const auto& binding = KeybindManager::instance().binding(action_id);
-        bool excluded =
-            _excluded_categories.find(keybind::actions.at(action_id).category)
-            != _excluded_categories.end();
+        bool excluded = _excluded_categories.find(
+                            keybind::actions.at(action_id).category) !=
+            _excluded_categories.end();
 
         if (!excluded && binding.matches(keybind))
         {
@@ -308,8 +308,8 @@ std::string InputContext::_delay_movement_action(
         }
         else if (Config::instance().scroll == 0)
         {
-            if (keybd_wait
-                < Config::instance().walkwait * Config::instance().startrun)
+            if (keybd_wait <
+                Config::instance().walkwait * Config::instance().startrun)
             {
                 if (keybd_wait % Config::instance().walkwait != 0)
                 {
@@ -352,8 +352,8 @@ std::string InputContext::_delay_movement_action(
         }
     }
     else if (
-        keybd_wait
-        < Config::instance().select_fast_start * Config::instance().select_wait)
+        keybd_wait <
+        Config::instance().select_fast_start * Config::instance().select_wait)
     {
         if (keybd_wait % Config::instance().select_wait != 0)
         {
@@ -578,8 +578,8 @@ std::unordered_set<ActionCategory> keybind_conflicting_action_categories(
     {
         const auto& categories = pair.second;
         bool is_in_context =
-            std::find(categories.begin(), categories.end(), action_category)
-            != categories.end();
+            std::find(categories.begin(), categories.end(), action_category) !=
+            categories.end();
 
         // If the action can be returned from input in this category, the
         // keybinding for it cannot confict with other actions in other

--- a/src/keybind/key_names.cpp
+++ b/src/keybind/key_names.cpp
@@ -197,8 +197,8 @@ optional<snail::Key> keybind_key_code(const std::string& name, bool shift)
 {
     for (const auto& it : key_names)
     {
-        if ((shift && it.second.shift && *it.second.shift == name)
-            || (!shift && it.second.normal == name))
+        if ((shift && it.second.shift && *it.second.shift == name) ||
+            (!shift && it.second.normal == name))
         {
             return it.first;
         }

--- a/src/keybind/keybind.cpp
+++ b/src/keybind/keybind.cpp
@@ -22,8 +22,8 @@ bool is_number_key(snail::Key k)
     constexpr auto numpad_0_ = static_cast<int>(snail::Key::keypad_0);
     constexpr auto numpad_9_ = static_cast<int>(snail::Key::keypad_9);
 
-    return (key_0_ <= k_ && k_ <= key_9_)
-        || (numpad_0_ <= k_ && k_ <= numpad_9_);
+    return (key_0_ <= k_ && k_ <= key_9_) ||
+        (numpad_0_ <= k_ && k_ <= numpad_9_);
 }
 
 } // namespace
@@ -182,8 +182,8 @@ void keybind_regenerate_key_select()
 
 int keybind_index_number(const std::string& action_id)
 {
-    if (!(keybind_action_has_category(action_id, ActionCategory::selection)
-          || keybind_action_has_category(action_id, ActionCategory::shortcut)))
+    if (!(keybind_action_has_category(action_id, ActionCategory::selection) ||
+          keybind_action_has_category(action_id, ActionCategory::shortcut)))
     {
         return 0;
     }
@@ -222,9 +222,9 @@ std::string get_bound_shortcut_key_name_by_action_id(
 {
     const auto& keybind = KeybindManager::instance().binding(action_id).primary;
 
-    if (is_number_key(keybind.main)
-        && (keybind.modifiers & (snail::ModKey::ctrl | snail::ModKey::shift))
-            != snail::ModKey::none)
+    if (is_number_key(keybind.main) &&
+        (keybind.modifiers & (snail::ModKey::ctrl | snail::ModKey::shift)) !=
+            snail::ModKey::none)
     {
         return "1" + *keybind_key_name(keybind.main);
     }

--- a/src/keybind/keybind_manager.cpp
+++ b/src/keybind/keybind_manager.cpp
@@ -35,9 +35,8 @@ void KeybindManager::save()
     std::ofstream file{path.native(), std::ios::binary};
     if (!file)
     {
-        throw std::runtime_error{
-            u8"Failed to open: "s
-            + filesystem::make_preferred_path_in_utf8(path)};
+        throw std::runtime_error{u8"Failed to open: "s +
+                                 filesystem::make_preferred_path_in_utf8(path)};
     }
 
     KeybindSerializer(*this).save(file);

--- a/src/keybind/keybind_manager.hpp
+++ b/src/keybind/keybind_manager.hpp
@@ -18,8 +18,8 @@ public:
 
         bool matches(const Keybind& keybind) const
         {
-            return primary == keybind || alternate == keybind
-                || joystick == keybind.main || permanent == keybind;
+            return primary == keybind || alternate == keybind ||
+                joystick == keybind.main || permanent == keybind;
         }
 
         void clear()

--- a/src/lua_env/api_manager.cpp
+++ b/src/lua_env/api_manager.cpp
@@ -69,8 +69,8 @@ void APIManager::add_api(
         if (!pair.first.is<std::string>())
         {
             throw sol::error(
-                "Error loading mod " + module_namespace
-                + ": Mod API tables must only have string keys.");
+                "Error loading mod " + module_namespace +
+                ": Mod API tables must only have string keys.");
         }
         api_table[pair.first.as<std::string>()] = pair.second;
     }

--- a/src/lua_env/export_manager.hpp
+++ b/src/lua_env/export_manager.hpp
@@ -60,8 +60,8 @@ public:
         else
         {
             throw std::runtime_error(
-                "Script callback error (" + name
-                + "): no such exported function was found");
+                "Script callback error (" + name +
+                "): no such exported function was found");
         }
     }
 
@@ -94,9 +94,9 @@ public:
         }
         else
         {
-            std::string message =
-                "Script callback error (" + name + "): no such exported function was "
-                  "found";
+            std::string message = "Script callback error (" + name +
+                "): no such exported function was "
+                "found";
 
             txt(message, Message::color{ColorIndex::red});
             std::cerr << message << std::endl;

--- a/src/lua_env/lua_api/lua_api_trait.cpp
+++ b/src/lua_env/lua_api/lua_api_trait.cpp
@@ -41,15 +41,15 @@ void Trait::set(int trait_id, int level)
     {
         return;
     }
-    if (elona::trait(trait_id) < level
-        && elona::trait(trait_id) < elona::traitref(2) && traitrefn(0) != "")
+    if (elona::trait(trait_id) < level &&
+        elona::trait(trait_id) < elona::traitref(2) && traitrefn(0) != "")
     {
         snd("core.ding3");
         elona::txt(traitrefn(0), elona::Message::color{ColorIndex::green});
     }
     else if (
-        elona::trait(trait_id) > level
-        && elona::trait(trait_id) > elona::traitref(1) && traitrefn(1) != "")
+        elona::trait(trait_id) > level &&
+        elona::trait(trait_id) > elona::traitref(1) && traitrefn(1) != "")
     {
         snd("core.ding3");
         elona::txt(traitrefn(1), elona::Message::color{ColorIndex::red});
@@ -65,15 +65,15 @@ void Trait::modify(int trait_id, int delta)
     {
         return;
     }
-    if (delta > 0 && elona::trait(trait_id) < elona::traitref(2)
-        && traitrefn(0) != "")
+    if (delta > 0 && elona::trait(trait_id) < elona::traitref(2) &&
+        traitrefn(0) != "")
     {
         snd("core.ding3");
         elona::txt(traitrefn(0), elona::Message::color{ColorIndex::green});
     }
     else if (
-        delta < 0 && elona::trait(trait_id) > elona::traitref(1)
-        && traitrefn(1) != "")
+        delta < 0 && elona::trait(trait_id) > elona::traitref(1) &&
+        traitrefn(1) != "")
     {
         snd("core.ding3");
         elona::txt(traitrefn(1), elona::Message::color{ColorIndex::red});

--- a/src/lua_env/lua_class/lua_class_character.cpp
+++ b/src/lua_env/lua_class/lua_class_character.cpp
@@ -50,8 +50,8 @@ void LuaCharacter::apply_ailment(
 
 bool LuaCharacter::recruit_as_ally(Character& self)
 {
-    if (self.state() == Character::State::empty
-        || (self.index != 0 && self.index <= 16) || self.index == 0)
+    if (self.state() == Character::State::empty ||
+        (self.index != 0 && self.index <= 16) || self.index == 0)
     {
         return false;
     }

--- a/src/lua_env/lua_console.cpp
+++ b/src/lua_env/lua_console.cpp
@@ -33,9 +33,9 @@ LuaConsole::LuaConsole(LuaEnv* lua)
 
 static std::string _version_string()
 {
-    return u8"ver."s + latest_version.short_string() + " ("
-        + latest_version.revision + ") OS: " + latest_version.platform
-        + ", timestamp: " + latest_version.timestamp;
+    return u8"ver."s + latest_version.short_string() + " (" +
+        latest_version.revision + ") OS: " + latest_version.platform +
+        ", timestamp: " + latest_version.timestamp;
 }
 
 void LuaConsole::init_constants()
@@ -182,15 +182,15 @@ void LuaConsole::draw()
     {
         elona::pos(4, _char_height * (_max_lines - 1));
         font(inf_mesfont - en * 2);
-        mes((_is_multiline ? prompt_secondary : prompt_primary) + u8" "s
-            + _input + (_cursor_visible ? u8"|" : ""));
+        mes((_is_multiline ? prompt_secondary : prompt_primary) + u8" "s +
+            _input + (_cursor_visible ? u8"|" : ""));
     }
 
     // Scrollback counter
     if (_pos > 0)
     {
-        std::string line_count = std::to_string(_pos + _max_lines) + "/"
-            + std::to_string(_buf.size());
+        std::string line_count = std::to_string(_pos + _max_lines) + "/" +
+            std::to_string(_buf.size());
         elona::pos(windoww - (line_count.size() * _char_width), 0);
         font(inf_mesfont - en * 2);
         mes(line_count);
@@ -231,8 +231,8 @@ bool LuaConsole::lua_error_handler(
     else
     {
         sol::error error = pfr;
-        std::string mes = "Error: "s
-            + error.what(); // lang(u8"エラー: ", u8"Error: ") + error.what();
+        std::string mes = "Error: "s +
+            error.what(); // lang(u8"エラー: ", u8"Error: ") + error.what();
         print(mes);
     }
 
@@ -333,16 +333,17 @@ void LuaConsole::grab_input()
         }
         else
         {
-            return Input::instance().is_pressed(key, Config::instance().keywait)
-                && (Input::instance().modifiers() & modifiers) != ModKey::none;
+            return Input::instance().is_pressed(
+                       key, Config::instance().keywait) &&
+                (Input::instance().modifiers() & modifiers) != ModKey::none;
         }
     };
 
     while (_focused)
     {
         ++frame;
-        if (Config::instance().scrsync > 0
-            && frame % Config::instance().scrsync == 0)
+        if (Config::instance().scrsync > 0 &&
+            frame % Config::instance().scrsync == 0)
         {
             ++scrturn;
             ui_render_from_screensync();
@@ -374,9 +375,9 @@ void LuaConsole::grab_input()
         {
             if (_input_history.size() > 0)
             {
-                if (history_index == -1
-                    || static_cast<size_t>(history_index)
-                        < _input_history.size() - 1)
+                if (history_index == -1 ||
+                    static_cast<size_t>(history_index) <
+                        _input_history.size() - 1)
                 {
                     ++history_index;
                     _input = _input_history.at(
@@ -430,8 +431,8 @@ void LuaConsole::grab_input()
         else if (pressed(Key::key_c, ModKey::ctrl))
         {
             print(
-                (_is_multiline ? prompt_secondary : prompt_primary) + u8" "s
-                + _input);
+                (_is_multiline ? prompt_secondary : prompt_primary) + u8" "s +
+                _input);
             _multiline_input = "";
             _is_multiline = false;
             inputlog = "";
@@ -445,8 +446,8 @@ void LuaConsole::grab_input()
             if (_input != "")
             {
                 print(
-                    (_is_multiline ? prompt_secondary : prompt_primary) + u8" "s
-                    + _input);
+                    (_is_multiline ? prompt_secondary : prompt_primary) +
+                    u8" "s + _input);
                 if (interpret_lua(_multiline_input))
                 {
                     _multiline_input = "";

--- a/src/lua_env/mod_manager.cpp
+++ b/src/lua_env/mod_manager.cpp
@@ -21,11 +21,9 @@ namespace
 
 bool is_alnum_only(const std::string& str)
 {
-    return find_if(
-               str.begin(),
-               str.end(),
-               [](char c) { return !(isalnum(c) || (c == '_')); })
-        == str.end();
+    return find_if(str.begin(), str.end(), [](char c) {
+               return !(isalnum(c) || (c == '_'));
+           }) == str.end();
 }
 
 } // namespace
@@ -136,8 +134,8 @@ void ModManager::scan_mod(const fs::path& mod_dir)
     if (!is_alnum_only(mod_name))
     {
         throw std::runtime_error(
-            "Mod name \"" + mod_name
-            + "\" must contain alphanumeric characters only.");
+            "Mod name \"" + mod_name +
+            "\" must contain alphanumeric characters only.");
     }
     if (mod_name == "script" || mod_name == "console")
     {
@@ -150,8 +148,8 @@ void ModManager::scan_mod(const fs::path& mod_dir)
 
 void ModManager::scan_all_mods(const fs::path& mods_dir)
 {
-    if (stage != ModLoadingStage::not_started
-        && stage != ModLoadingStage::scan_finished)
+    if (stage != ModLoadingStage::not_started &&
+        stage != ModLoadingStage::scan_finished)
     {
         throw std::runtime_error("Mods have already been scanned!");
     }

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -230,13 +230,17 @@ int magic()
                     {
                         continue;
                     }
-                    if (dist(dx, dy, cdata[cc].position.x, cdata[cc].position.y)
-                        > the_ability_db[efid]->range % 1000 + 1)
+                    if (dist(
+                            dx,
+                            dy,
+                            cdata[cc].position.x,
+                            cdata[cc].position.y) >
+                        the_ability_db[efid]->range % 1000 + 1)
                     {
                         break;
                     }
-                    if (dx == cdata[cc].position.x
-                        && dy == cdata[cc].position.y)
+                    if (dx == cdata[cc].position.x &&
+                        dy == cdata[cc].position.y)
                     {
                         continue;
                     }
@@ -406,8 +410,8 @@ int magic()
                             }
                             continue;
                         }
-                        if (dx == cdata[cc].position.x
-                            && dy == cdata[cc].position.y)
+                        if (dx == cdata[cc].position.x &&
+                            dy == cdata[cc].position.y)
                         {
                             continue;
                         }
@@ -431,8 +435,8 @@ int magic()
                         }
                         if (cc != tc)
                         {
-                            dmg = roll(dice1, dice2, bonus) * 100
-                                / (75 + dist(tlocx, tlocy, dx, dy) * 25);
+                            dmg = roll(dice1, dice2, bonus) * 100 /
+                                (75 + dist(tlocx, tlocy, dx, dy) * 25);
                             int stat = calcmagiccontrol(cc, tc);
                             if (stat == 1)
                             {
@@ -701,15 +705,15 @@ int magic()
                 if (efid == 613)
                 {
                     p = rnd(10);
-                    if ((cdata[tc].quality >= Quality::miracle && rnd(4))
-                        || encfind(tc, 60010 + p) != -1)
+                    if ((cdata[tc].quality >= Quality::miracle && rnd(4)) ||
+                        encfind(tc, 60010 + p) != -1)
                     {
                         p = -1;
                     }
                     if (p != -1)
                     {
-                        i = sdata.get(10 + p, tc).original_level
-                            + cdata[tc].attr_adjs[p];
+                        i = sdata.get(10 + p, tc).original_level +
+                            cdata[tc].attr_adjs[p];
                         if (i > 0)
                         {
                             i = i * efp / 2000 + 1;
@@ -728,8 +732,8 @@ int magic()
             case 7:
                 if (cc == 0)
                 {
-                    if (game_data.crowd_density + 100
-                        >= ELONA_MAX_OTHER_CHARACTERS)
+                    if (game_data.crowd_density + 100 >=
+                        ELONA_MAX_OTHER_CHARACTERS)
                     {
                         txt(i18n::s.get("core.locale.common.nothing_happens"));
                         obvious = 0;
@@ -876,8 +880,8 @@ int magic()
                         goto the_end;
                     }
                     p = rnd(cdata[tc].gold / 10 + 1);
-                    if (rnd(sdata(13, tc)) > rnd(sdata(12, cc) * 4)
-                        || cdata[tc].is_protected_from_thieves() == 1)
+                    if (rnd(sdata(13, tc)) > rnd(sdata(12, cc) * 4) ||
+                        cdata[tc].is_protected_from_thieves() == 1)
                     {
                         txt(i18n::s.get(
                             "core.locale.magic.teleport.suspicious_hand."
@@ -919,10 +923,10 @@ int magic()
                     {
                         p(0) = -1;
                         p(1) = 1;
-                        cdata[tc].next_position.x = cdata[tc].position.x
-                            + (3 - cnt / 70 + rnd(5)) * p(rnd(2));
-                        cdata[tc].next_position.y = cdata[tc].position.y
-                            + (3 - cnt / 70 + rnd(5)) * p(rnd(2));
+                        cdata[tc].next_position.x = cdata[tc].position.x +
+                            (3 - cnt / 70 + rnd(5)) * p(rnd(2));
+                        cdata[tc].next_position.y = cdata[tc].position.y +
+                            (3 - cnt / 70 + rnd(5)) * p(rnd(2));
                     }
                     else if (efidprev == 619)
                     {
@@ -1031,13 +1035,15 @@ int magic()
                     dx = breathlist(0, cnt);
                     dy = breathlist(1, cnt);
                     if (fov_los(
-                            cdata[cc].position.x, cdata[cc].position.y, dx, dy)
-                        == 0)
+                            cdata[cc].position.x,
+                            cdata[cc].position.y,
+                            dx,
+                            dy) == 0)
                     {
                         continue;
                     }
-                    if (dx == cdata[cc].position.x
-                        && dy == cdata[cc].position.y)
+                    if (dx == cdata[cc].position.x &&
+                        dy == cdata[cc].position.y)
                     {
                         continue;
                     }
@@ -1431,8 +1437,8 @@ label_2181_internal:
         get_sick_if_cursed(efstatus, cdata[tc]);
         break;
     case 300:
-        if (game_data.executing_immediate_quest_type == 1008
-            || game_data.executing_immediate_quest_type == 1010)
+        if (game_data.executing_immediate_quest_type == 1008 ||
+            game_data.executing_immediate_quest_type == 1010)
         {
             txt(i18n::s.get("core.locale.magic.steal.in_quest"));
             return 0;
@@ -1451,8 +1457,8 @@ label_2181_internal:
             }
             damage_sp(
                 cdata.player(),
-                rnd(the_ability_db[efid]->cost / 2 + 1)
-                    + the_ability_db[efid]->cost / 2 + 1);
+                rnd(the_ability_db[efid]->cost / 2 + 1) +
+                    the_ability_db[efid]->cost / 2 + 1);
         }
         invsubroutine = 1;
         invctrl(0) = 27;
@@ -1475,8 +1481,8 @@ label_2181_internal:
             }
             damage_sp(
                 cdata.player(),
-                rnd(the_ability_db[efid]->cost / 2 + 1)
-                    + the_ability_db[efid]->cost / 2 + 1);
+                rnd(the_ability_db[efid]->cost / 2 + 1) +
+                    the_ability_db[efid]->cost / 2 + 1);
         }
         if (game_data.mount != 0)
         {
@@ -1494,9 +1500,8 @@ label_2181_internal:
                 txt(i18n::s.get(
                     "core.locale.magic.mount.dismount",
                     cdata[game_data.mount]));
-                txt(name(game_data.mount)
-                        + i18n::s.get(
-                            "core.locale.magic.mount.dismount_dialog"),
+                txt(name(game_data.mount) +
+                        i18n::s.get("core.locale.magic.mount.dismount_dialog"),
                     Message::color{ColorIndex::cyan});
                 ride_end();
                 break;
@@ -1507,8 +1512,8 @@ label_2181_internal:
             txt(i18n::s.get("core.locale.magic.mount.only_ally"));
             break;
         }
-        if (cdata[tc].is_escorted() == 1
-            || cdata[tc].is_escorted_in_sub_quest() == 1)
+        if (cdata[tc].is_escorted() == 1 ||
+            cdata[tc].is_escorted_in_sub_quest() == 1)
         {
             txt(i18n::s.get("core.locale.magic.mount.not_client"));
             break;
@@ -1537,8 +1542,8 @@ label_2181_internal:
         else
         {
             ride_begin(tc);
-            txt(name(game_data.mount)
-                    + i18n::s.get("core.locale.magic.mount.mount.dialog"),
+            txt(name(game_data.mount) +
+                    i18n::s.get("core.locale.magic.mount.mount.dialog"),
                 Message::color{ColorIndex::cyan});
         }
         break;
@@ -1587,8 +1592,8 @@ label_2181_internal:
             }
             damage_sp(
                 cdata.player(),
-                rnd(the_ability_db[efid]->cost / 2 + 1)
-                    + the_ability_db[efid]->cost / 2 + 1);
+                rnd(the_ability_db[efid]->cost / 2 + 1) +
+                    the_ability_db[efid]->cost / 2 + 1);
         }
         continuous_action_perform();
         break;
@@ -1623,8 +1628,8 @@ label_2181_internal:
             }
             damage_sp(
                 cdata.player(),
-                rnd(the_ability_db[efid]->cost / 2 + 1)
-                    + the_ability_db[efid]->cost / 2 + 1);
+                rnd(the_ability_db[efid]->cost / 2 + 1) +
+                    the_ability_db[efid]->cost / 2 + 1);
         }
         cook();
         break;
@@ -1665,8 +1670,8 @@ label_2181_internal:
             {
                 y = cdata[cc].position.y;
                 x = cdata[cc].position.x + cnt - 1;
-                if (x < 0 || y < 0 || x >= map_data.width
-                    || y >= map_data.height)
+                if (x < 0 || y < 0 || x >= map_data.width ||
+                    y >= map_data.height)
                 {
                     continue;
                 }
@@ -1688,8 +1693,7 @@ label_2181_internal:
                 0,
                 cell_data
                     .at(cdata.player().position.x, cdata.player().position.y)
-                    .chip_id_actual)
-            == 3)
+                    .chip_id_actual) == 3)
         {
             txt(i18n::s.get("core.locale.magic.fish.cannot_during_swim"));
             update_screen();
@@ -1729,8 +1733,8 @@ label_2181_internal:
             }
             damage_sp(
                 cdata.player(),
-                rnd(the_ability_db[efid]->cost / 2 + 1)
-                    + the_ability_db[efid]->cost / 2 + 1);
+                rnd(the_ability_db[efid]->cost / 2 + 1) +
+                    the_ability_db[efid]->cost / 2 + 1);
         }
         item_separate(ci);
         --inv[ci].count;
@@ -1945,9 +1949,9 @@ label_2181_internal:
         }
         f = 0;
         for (int cnt = 0,
-                 cnt_end = cnt
-                 + (1 + (efstatus == CurseState::blessed)
-                    + (!is_cursed(efstatus)) + rnd(2));
+                 cnt_end = cnt +
+                 (1 + (efstatus == CurseState::blessed) +
+                  (!is_cursed(efstatus)) + rnd(2));
              cnt < cnt_end;
              ++cnt)
         {
@@ -2236,8 +2240,8 @@ label_2181_internal:
                                 "core.locale.magic.gain_knowledge.furthermore");
                         }
                         chara_gain_skill(cdata.player(), p, 1, 200);
-                        txt(s
-                                + i18n::s.get(
+                        txt(s +
+                                i18n::s.get(
                                     "core.locale.magic.gain_knowledge.gain",
                                     i18n::s.get_m(
                                         "locale.ability",
@@ -2452,8 +2456,8 @@ label_2181_internal:
                         if (is_in_fov(cdata[tc]))
                         {
                             snd("core.ding2");
-                            txt(s
-                                    + i18n::s.get(
+                            txt(s +
+                                    i18n::s.get(
                                         "core.locale.magic.gain_skill_"
                                         "potential."
                                         "increases",
@@ -2605,8 +2609,8 @@ label_2181_internal:
                         }
                         continue;
                     }
-                    if (p < 7 || rnd(efp + 1) > rnd(p * 8 + 1)
-                        || efstatus == CurseState::blessed)
+                    if (p < 7 || rnd(efp + 1) > rnd(p * 8 + 1) ||
+                        efstatus == CurseState::blessed)
                     {
                         if (efid == 429)
                         {
@@ -2615,9 +2619,8 @@ label_2181_internal:
                         }
                         if (efid == 430)
                         {
-                            if (cell_data.at(x, y).feats != 0
-                                || cell_data.at(x, y).item_appearances_memory
-                                    != 0)
+                            if (cell_data.at(x, y).feats != 0 ||
+                                cell_data.at(x, y).item_appearances_memory != 0)
                             {
                                 cell_data.at(x, y).chip_id_memory =
                                     cell_data.at(x, y).chip_id_actual;
@@ -2794,14 +2797,14 @@ label_2181_internal:
                 }
             }
             txt(i18n::s.get("core.locale.magic.escape.begin"));
-            if (area_data[game_data.current_map].id
-                == mdata_t::MapId::random_dungeon)
+            if (area_data[game_data.current_map].id ==
+                mdata_t::MapId::random_dungeon)
             {
-                if (game_data.current_dungeon_level
-                    == area_data[game_data.current_map].deepest_level)
+                if (game_data.current_dungeon_level ==
+                    area_data[game_data.current_map].deepest_level)
                 {
-                    if (area_data[game_data.current_map].has_been_conquered
-                        != -1)
+                    if (area_data[game_data.current_map].has_been_conquered !=
+                        -1)
                     {
                         txt(i18n::s.get(
                             "core.locale.magic.escape.lord_may_disappear"));
@@ -3095,9 +3098,9 @@ label_2181_internal:
         {
             f = 0;
         }
-        if (cdata[tc].quality >= Quality::miracle
-            || cdata[tc].character_role != 0
-            || cdata[tc].is_lord_of_dungeon() == 1)
+        if (cdata[tc].quality >= Quality::miracle ||
+            cdata[tc].character_role != 0 ||
+            cdata[tc].is_lord_of_dungeon() == 1)
         {
             f = -1;
         }
@@ -3217,8 +3220,8 @@ label_2181_internal:
         invctrl(1) = 0;
         snd("core.inv");
         ctrl_inventory();
-        if (inv[ci].quality < Quality::miracle
-            || inv[ci].quality == Quality::special)
+        if (inv[ci].quality < Quality::miracle ||
+            inv[ci].quality == Quality::special)
         {
             txt(i18n::s.get("core.locale.common.it_is_impossible"));
             obvious = 0;
@@ -3280,8 +3283,8 @@ label_2181_internal:
             enchantment_add(
                 ci,
                 enchantment_generate(enchantment_gen_level(egolv)),
-                enchantment_gen_p() + (fixlv == Quality::godly) * 100
-                    + (ibit(15, ci) == 1) * 100,
+                enchantment_gen_p() + (fixlv == Quality::godly) * 100 +
+                    (ibit(15, ci) == 1) * 100,
                 20 - (fixlv == Quality::godly) * 10 - (ibit(15, ci) == 1) * 20);
         }
         randomize();
@@ -3468,9 +3471,10 @@ label_2181_internal:
             {
                 dbid = inv[ci].id;
                 access_item_db(2);
-                if (ichargelevel < 1 || inv[ci].id == 290 || inv[ci].id == 480
-                    || inv[ci].id == 289 || inv[ci].id == 732
-                    || (inv[ci].id == 687 && inv[ci].param2 != 0))
+                if (ichargelevel < 1 || inv[ci].id == 290 ||
+                    inv[ci].id == 480 || inv[ci].id == 289 ||
+                    inv[ci].id == 732 ||
+                    (inv[ci].id == 687 && inv[ci].param2 != 0))
                 {
                     txt(i18n::s.get(
                         "core.locale.magic.fill_charge.cannot_recharge"));
@@ -3606,9 +3610,9 @@ label_2181_internal:
         {
             f = 0;
         }
-        if (cdata[tc].quality >= Quality::miracle
-            || cdata[tc].character_role != 0 || cdata[tc].is_escorted() == 1
-            || cdata[tc].is_lord_of_dungeon() == 1)
+        if (cdata[tc].quality >= Quality::miracle ||
+            cdata[tc].character_role != 0 || cdata[tc].is_escorted() == 1 ||
+            cdata[tc].is_lord_of_dungeon() == 1)
         {
             f = -1;
         }
@@ -3665,13 +3669,13 @@ label_2181_internal:
                             inv[ci].weight);
                         if (inv[ci].pv > 0)
                         {
-                            inv[ci].pv -= inv[ci].pv / 10 + 1
-                                + (efstatus != CurseState::blessed);
+                            inv[ci].pv -= inv[ci].pv / 10 + 1 +
+                                (efstatus != CurseState::blessed);
                         }
                         if (inv[ci].damage_bonus > 0)
                         {
-                            inv[ci].damage_bonus -= inv[ci].damage_bonus / 10
-                                + 1 + (efstatus != CurseState::blessed);
+                            inv[ci].damage_bonus -= inv[ci].damage_bonus / 10 +
+                                1 + (efstatus != CurseState::blessed);
                         }
                     }
                     txt(i18n::s.get("core.locale.magic.flying.apply", inv[ci]));
@@ -3787,8 +3791,8 @@ label_2181_internal:
                     }
                 }
             }
-            if (cell_data.at(x, y).chara_index_plus_one != 0
-                || cell_data.at(x, y).feats != 0)
+            if (cell_data.at(x, y).chara_index_plus_one != 0 ||
+                cell_data.at(x, y).feats != 0)
             {
                 f = 0;
             }
@@ -3862,13 +3866,13 @@ label_2181_internal:
             tc = cnt.index;
             dx = cdata[tc].position.x;
             dy = cdata[tc].position.y;
-            if (dist(cdata[cc].position.x, cdata[cc].position.y, dx, dy)
-                > the_ability_db[631]->range % 1000 + 1)
+            if (dist(cdata[cc].position.x, cdata[cc].position.y, dx, dy) >
+                the_ability_db[631]->range % 1000 + 1)
             {
                 continue;
             }
-            if (fov_los(cdata[cc].position.x, cdata[cc].position.y, dx, dy)
-                == 0)
+            if (fov_los(cdata[cc].position.x, cdata[cc].position.y, dx, dy) ==
+                0)
             {
                 continue;
             }
@@ -3999,13 +4003,13 @@ label_2181_internal:
             tc = cnt.index;
             dx = cdata[tc].position.x;
             dy = cdata[tc].position.y;
-            if (dist(cdata[cc].position.x, cdata[cc].position.y, dx, dy)
-                > the_ability_db[656]->range % 1000 + 1)
+            if (dist(cdata[cc].position.x, cdata[cc].position.y, dx, dy) >
+                the_ability_db[656]->range % 1000 + 1)
             {
                 continue;
             }
-            if (fov_los(cdata[cc].position.x, cdata[cc].position.y, dx, dy)
-                == 0)
+            if (fov_los(cdata[cc].position.x, cdata[cc].position.y, dx, dy) ==
+                0)
             {
                 continue;
             }

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -40,8 +40,8 @@ MainMenuResult main_title_menu()
     color(0, 0, 0);
     color(255, 255, 255);
     pos(20, 38);
-    mes(u8"  Variant foobar version "s + latest_version.short_string()
-        + u8"  Developed by KI");
+    mes(u8"  Variant foobar version "s + latest_version.short_string() +
+        u8"  Developed by KI");
     color(0, 0, 0);
     if (jp)
     {
@@ -427,13 +427,13 @@ MainMenuResult main_menu_continue()
                     playerid = listn(0, p);
                     if (jp)
                     {
-                        s = u8"本当に"s + playerid
-                            + u8"を削除していいのかい？"s;
+                        s = u8"本当に"s + playerid +
+                            u8"を削除していいのかい？"s;
                     }
                     else
                     {
-                        s = u8"Do you really want to delete "s + playerid
-                            + u8" ?"s;
+                        s = u8"Do you really want to delete "s + playerid +
+                            u8" ?"s;
                     }
                     draw_caption();
                     rtval = yes_or_no(promptx, prompty, 200);
@@ -443,13 +443,13 @@ MainMenuResult main_menu_continue()
                     }
                     if (jp)
                     {
-                        s = u8"本当の本当に"s + playerid
-                            + u8"を削除していいのかい？"s;
+                        s = u8"本当の本当に"s + playerid +
+                            u8"を削除していいのかい？"s;
                     }
                     else
                     {
-                        s = u8"Are you sure you really want to delete "s
-                            + playerid + u8" ?"s;
+                        s = u8"Are you sure you really want to delete "s +
+                            playerid + u8" ?"s;
                     }
                     draw_caption();
                     rtval = yes_or_no(promptx, prompty, 200);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -263,8 +263,8 @@ std::string map_get_custom_map_name(int map_id)
 
 bool map_is_town_or_guild()
 {
-    return map_data.type == mdata_t::MapType::town
-        || map_data.type == mdata_t::MapType::guild;
+    return map_data.type == mdata_t::MapType::town ||
+        map_data.type == mdata_t::MapType::guild;
 }
 
 
@@ -282,10 +282,10 @@ bool map_should_reveal_fog()
         result |= map->reveals_fog;
     }
 
-    return result || dbg_revealmap || map_data.type == mdata_t::MapType::town
-        || map_data.type == mdata_t::MapType::world_map
-        || map_data.type == mdata_t::MapType::player_owned
-        || map_data.type == mdata_t::MapType::guild;
+    return result || dbg_revealmap || map_data.type == mdata_t::MapType::town ||
+        map_data.type == mdata_t::MapType::world_map ||
+        map_data.type == mdata_t::MapType::player_owned ||
+        map_data.type == mdata_t::MapType::guild;
 }
 
 
@@ -298,11 +298,11 @@ bool map_shows_floor_count_in_name()
         result |= map->shows_floor_count_in_name;
     }
 
-    return area_data[game_data.current_map].type != mdata_t::MapType::town
-        && (result
-            || area_data[game_data.current_map].id
-                == mdata_t::MapId::random_dungeon
-            || mdata_t::is_nefia(map_data.type));
+    return area_data[game_data.current_map].type != mdata_t::MapType::town &&
+        (result ||
+         area_data[game_data.current_map].id ==
+             mdata_t::MapId::random_dungeon ||
+         mdata_t::is_nefia(map_data.type));
 }
 
 
@@ -520,10 +520,10 @@ bool map_villagers_make_snowmen()
 
 bool map_can_use_bad_weather_in_study()
 {
-    return game_data.current_map != mdata_t::MapId::shelter_
-        && map_data.indoors_flag == 1
-        && (map_data.type == mdata_t::MapType::player_owned
-            || map_is_town_or_guild());
+    return game_data.current_map != mdata_t::MapId::shelter_ &&
+        map_data.indoors_flag == 1 &&
+        (map_data.type == mdata_t::MapType::player_owned ||
+         map_is_town_or_guild());
 }
 
 
@@ -548,8 +548,8 @@ void map_randsite(int prm_971, int prm_972)
         }
         if ((chipm(7, cell_data.at(found_x, found_y).chip_id_actual) & 4) == 0)
         {
-            if (cell_data.at(found_x, found_y).feats == 0
-                && cell_data.at(found_x, found_y).item_appearances_actual == 0)
+            if (cell_data.at(found_x, found_y).feats == 0 &&
+                cell_data.at(found_x, found_y).item_appearances_actual == 0)
             {
                 f_at_m169 = 1;
                 break;
@@ -558,10 +558,10 @@ void map_randsite(int prm_971, int prm_972)
     }
     if (map_data.type == mdata_t::MapType::world_map)
     {
-        if ((264 <= cell_data.at(found_x, found_y).chip_id_actual
-             && cell_data.at(found_x, found_y).chip_id_actual < 363)
-            || (33 <= cell_data.at(found_x, found_y).chip_id_actual
-                && cell_data.at(found_x, found_y).chip_id_actual < 66))
+        if ((264 <= cell_data.at(found_x, found_y).chip_id_actual &&
+             cell_data.at(found_x, found_y).chip_id_actual < 363) ||
+            (33 <= cell_data.at(found_x, found_y).chip_id_actual &&
+             cell_data.at(found_x, found_y).chip_id_actual < 66))
         {
             f_at_m169 = 0;
         }
@@ -871,8 +871,8 @@ static void _map_restock_regenerate()
 {
     _grow_plants();
 
-    if (map_is_town_or_guild()
-        || game_data.current_map == mdata_t::MapId::your_home)
+    if (map_is_town_or_guild() ||
+        game_data.current_map == mdata_t::MapId::your_home)
     {
         _restock_character_inventories();
     }
@@ -1303,13 +1303,13 @@ int map_global_place_random_nefias()
         {
             x = cxinit + rnd((cnt + 1)) - rnd((cnt + 1));
             y = cyinit + rnd((cnt + 1)) - rnd((cnt + 1));
-            if (x <= 5 || y <= 5 || x >= map_data.width - 6
-                || y >= map_data.height - 6)
+            if (x <= 5 || y <= 5 || x >= map_data.width - 6 ||
+                y >= map_data.height - 6)
             {
                 continue;
             }
-            if (33 <= cell_data.at(x, y).chip_id_actual
-                && cell_data.at(x, y).chip_id_actual < 66)
+            if (33 <= cell_data.at(x, y).chip_id_actual &&
+                cell_data.at(x, y).chip_id_actual < 66)
             {
                 continue;
             }
@@ -1328,11 +1328,11 @@ int map_global_place_random_nefias()
                 {
                     continue;
                 }
-                if (x >= area_data[cnt].position.x - 2
-                    && x <= area_data[cnt].position.x + 2)
+                if (x >= area_data[cnt].position.x - 2 &&
+                    x <= area_data[cnt].position.x + 2)
                 {
-                    if (y >= area_data[cnt].position.y - 2
-                        && y <= area_data[cnt].position.y + 2)
+                    if (y >= area_data[cnt].position.y - 2 &&
+                        y <= area_data[cnt].position.y + 2)
                     {
                         p = 0;
                         break;

--- a/src/map_cell.cpp
+++ b/src/map_cell.cpp
@@ -51,8 +51,8 @@ void cell_featset(
     {
         feat_at_m80(3) = cell_data.at(prm_592, prm_593).feats / 10000000;
     }
-    cell_data.at(prm_592, prm_593).feats = feat_at_m80 + feat_at_m80(1) * 1000
-        + feat_at_m80(2) * 100000 + feat_at_m80(3) * 10000000;
+    cell_data.at(prm_592, prm_593).feats = feat_at_m80 + feat_at_m80(1) * 1000 +
+        feat_at_m80(2) * 100000 + feat_at_m80(3) * 10000000;
 }
 
 
@@ -80,8 +80,8 @@ void cell_check(int prm_603, int prm_604)
     cellaccess = 1;
     cellchara = -1;
     cellfeat = -1;
-    if (prm_603 < 0 || prm_603 >= map_data.width || prm_604 < 0
-        || prm_604 >= map_data.height)
+    if (prm_603 < 0 || prm_603 >= map_data.width || prm_604 < 0 ||
+        prm_604 >= map_data.height)
     {
         cellaccess = 0;
         return;
@@ -184,8 +184,8 @@ int cell_itemlist(int prm_625, int prm_626)
     {
         if (inv[cnt].number() > 0)
         {
-            if (inv[cnt].position.x == prm_625
-                && inv[cnt].position.y == prm_626)
+            if (inv[cnt].position.x == prm_625 &&
+                inv[cnt].position.y == prm_626)
             {
                 list(0, listmax) = cnt;
                 ++listmax;
@@ -252,8 +252,8 @@ int cell_findspace(int prm_796, int prm_797, int prm_798)
             {
                 continue;
             }
-            if (chipm(7, cell_data.at(dx_at_m130, dy_at_m130).chip_id_actual)
-                & 4)
+            if (chipm(7, cell_data.at(dx_at_m130, dy_at_m130).chip_id_actual) &
+                4)
             {
                 continue;
             }

--- a/src/map_chara_filter.cpp
+++ b/src/map_chara_filter.cpp
@@ -330,8 +330,8 @@ void map_set_chara_generation_filter()
         _chara_filter_pyramid();
         return;
     }
-    if (game_data.current_map == mdata_t::MapId::lumiest_graveyard
-        || game_data.current_map == mdata_t::MapId::truce_ground)
+    if (game_data.current_map == mdata_t::MapId::lumiest_graveyard ||
+        game_data.current_map == mdata_t::MapId::truce_ground)
     {
         _chara_filter_lumiest_graveyard();
         return;

--- a/src/map_special_events.cpp
+++ b/src/map_special_events.cpp
@@ -45,8 +45,8 @@ static void _map_events_quest_party()
 {
     if (quest_data.immediate().progress != 3)
     {
-        if (game_data.crowd_density
-            < game_data.left_minutes_of_executing_quest / 60)
+        if (game_data.crowd_density <
+            game_data.left_minutes_of_executing_quest / 60)
         {
             dbid = 0;
             if (rnd(4) == 0)
@@ -185,8 +185,8 @@ static void _map_events_jail()
 
 static void _map_events_shelter()
 {
-    if (game_data.weather == 2 || game_data.weather == 4
-        || game_data.weather == 1)
+    if (game_data.weather == 2 || game_data.weather == 4 ||
+        game_data.weather == 1)
     {
         if (cdata.player().nutrition < 5000)
         {

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -197,14 +197,14 @@ void map_converttile()
             x = cnt;
             if (cell_data.at(x, y).chip_id_actual == 0)
             {
-                cell_data.at(x, y).chip_id_actual = tile_default
-                    + (rnd(tile_default(2)) == 0) * rnd(tile_default(1));
+                cell_data.at(x, y).chip_id_actual = tile_default +
+                    (rnd(tile_default(2)) == 0) * rnd(tile_default(1));
                 continue;
             }
             if (cell_data.at(x, y).chip_id_actual >= 100)
             {
-                cell_data.at(x, y).chip_id_actual = tile_tunnel
-                    + (rnd(tile_tunnel(2)) == 0) * rnd(tile_tunnel(1));
+                cell_data.at(x, y).chip_id_actual = tile_tunnel +
+                    (rnd(tile_tunnel(2)) == 0) * rnd(tile_tunnel(1));
                 continue;
             }
             if (cell_data.at(x, y).chip_id_actual == 1)
@@ -221,8 +221,8 @@ void map_converttile()
             }
             if (cell_data.at(x, y).chip_id_actual == 4)
             {
-                cell_data.at(x, y).chip_id_actual = tile_default
-                    + (rnd(tile_default(2)) == 0) * rnd(tile_default(1));
+                cell_data.at(x, y).chip_id_actual = tile_default +
+                    (rnd(tile_default(2)) == 0) * rnd(tile_default(1));
                 continue;
             }
         }
@@ -415,17 +415,17 @@ void map_placearena(int prm_939, int prm_940)
         chara_place();
         if (prm_940 == 0)
         {
-            if (cdata[prm_939].position.x >= 13
-                && cdata[prm_939].position.y >= 6
-                && cdata[prm_939].position.x < 20
-                && cdata[prm_939].position.y < 12)
+            if (cdata[prm_939].position.x >= 13 &&
+                cdata[prm_939].position.y >= 6 &&
+                cdata[prm_939].position.x < 20 &&
+                cdata[prm_939].position.y < 12)
             {
                 break;
             }
         }
         else if (
-            cdata[prm_939].position.x >= 5 && cdata[prm_939].position.y >= 6
-            && cdata[prm_939].position.x < 12 && cdata[prm_939].position.y < 12)
+            cdata[prm_939].position.x >= 5 && cdata[prm_939].position.y >= 6 &&
+            cdata[prm_939].position.x < 12 && cdata[prm_939].position.y < 12)
         {
             break;
         }
@@ -503,8 +503,8 @@ void map_randomtile(int prm_941, int prm_942)
 
 int map_digcheck(int prm_953, int prm_954)
 {
-    if (prm_953 < 1 || prm_954 < 1 || prm_953 > map_data.width - 2
-        || prm_954 > map_data.height - 2)
+    if (prm_953 < 1 || prm_954 < 1 || prm_953 > map_data.width - 2 ||
+        prm_954 > map_data.height - 2)
     {
         return 0;
     }
@@ -962,9 +962,8 @@ void map_createroomdoor()
         {
             dx = x + p(cnt);
             dy = y + p((cnt + 2));
-            if ((dx >= 0 && dy >= 0 && dx < map_data.width
-                 && dy < map_data.height)
-                == 0)
+            if ((dx >= 0 && dy >= 0 && dx < map_data.width &&
+                 dy < map_data.height) == 0)
             {
                 f = 0;
                 break;
@@ -1055,8 +1054,8 @@ int map_createroom(int prm_966)
             rdpos = rnd(4);
             if (rdpos == 3 || rdpos == 0)
             {
-                roomx(cr) = rnd(map_data.width - rdroomsizemin * 3 / 2 - 2)
-                    + rdroomsizemin / 2;
+                roomx(cr) = rnd(map_data.width - rdroomsizemin * 3 / 2 - 2) +
+                    rdroomsizemin / 2;
                 roomwidth(cr) = rnd(rdroomsizemin) + rdroomsizemin / 2 + 3;
                 roomheight(cr) = rdroomsizemin;
                 if (rdpos == 3)
@@ -1070,8 +1069,8 @@ int map_createroom(int prm_966)
             }
             if (rdpos == 1 || rdpos == 2)
             {
-                roomy(cr) = rnd(map_data.height - rdroomsizemin * 3 / 2 - 2)
-                    + rdroomsizemin / 2;
+                roomy(cr) = rnd(map_data.height - rdroomsizemin * 3 / 2 - 2) +
+                    rdroomsizemin / 2;
                 roomwidth(cr) = rdroomsizemin;
                 roomheight(cr) = rnd(rdroomsizemin) + rdroomsizemin / 2 + 3;
                 if (rdpos == 1)
@@ -1191,8 +1190,8 @@ int map_createroom(int prm_966)
             tile = 3;
             if (roomwall != 0)
             {
-                if (cnt == 0 || cnt2 == 0 || cnt == roomwidth(cr) - 1
-                    || cnt2 == roomheight(cr) - 1)
+                if (cnt == 0 || cnt2 == 0 || cnt == roomwidth(cr) - 1 ||
+                    cnt2 == roomheight(cr) - 1)
                 {
                     if (roomwall == 1)
                     {
@@ -1314,8 +1313,8 @@ int map_placedownstairs(int prm_969, int prm_970)
     int found_x;
     int found_y;
 
-    if (game_data.current_dungeon_level
-        >= area_data[game_data.current_map].deepest_level)
+    if (game_data.current_dungeon_level >=
+        area_data[game_data.current_map].deepest_level)
     {
         return 0;
     }
@@ -1359,8 +1358,8 @@ int map_trap(int prm_973, int prm_974, int, int prm_976)
             dx_at_m170 = prm_973;
             dy_at_m170 = prm_974;
         }
-        if ((chipm(7, cell_data.at(dx_at_m170, dy_at_m170).chip_id_actual) & 4)
-            == 0)
+        if ((chipm(7, cell_data.at(dx_at_m170, dy_at_m170).chip_id_actual) &
+             4) == 0)
         {
             if (cell_data.at(dx_at_m170, dy_at_m170).feats == 0)
             {
@@ -1426,8 +1425,8 @@ int map_web(int prm_977, int prm_978, int prm_979)
             dx_at_m170 = prm_977;
             dy_at_m170 = prm_978;
         }
-        if ((chipm(7, cell_data.at(dx_at_m170, dy_at_m170).chip_id_actual) & 4)
-            == 0)
+        if ((chipm(7, cell_data.at(dx_at_m170, dy_at_m170).chip_id_actual) &
+             4) == 0)
         {
             if (cell_data.at(dx_at_m170, dy_at_m170).feats == 0)
             {
@@ -1463,8 +1462,8 @@ int map_barrel(int prm_980, int prm_981)
             dx_at_m170 = prm_980;
             dy_at_m170 = prm_981;
         }
-        if ((chipm(7, cell_data.at(dx_at_m170, dy_at_m170).chip_id_actual) & 4)
-            == 0)
+        if ((chipm(7, cell_data.at(dx_at_m170, dy_at_m170).chip_id_actual) &
+             4) == 0)
         {
             if (cell_data.at(dx_at_m170, dy_at_m170).feats == 0)
             {
@@ -1515,16 +1514,16 @@ int map_connectroom()
                     }
                     if (x != 0)
                     {
-                        if (cell_data.at(dx, dy - 1).chip_id_actual == 3
-                            || cell_data.at(dx, dy + 1).chip_id_actual == 3)
+                        if (cell_data.at(dx, dy - 1).chip_id_actual == 3 ||
+                            cell_data.at(dx, dy + 1).chip_id_actual == 3)
                         {
                             continue;
                         }
                     }
                     if (y != 0)
                     {
-                        if (cell_data.at(dx - 1, dy).chip_id_actual == 3
-                            || cell_data.at(dx + 1, dy).chip_id_actual == 3)
+                        if (cell_data.at(dx - 1, dy).chip_id_actual == 3 ||
+                            cell_data.at(dx + 1, dy).chip_id_actual == 3)
                         {
                             continue;
                         }
@@ -1663,8 +1662,8 @@ static optional<int> _setup_map_generation_parameters()
             map_data.tileset = 10;
         }
     }
-    if (area_data[game_data.current_map].type
-        == mdata_t::MapType::dungeon_forest)
+    if (area_data[game_data.current_map].type ==
+        mdata_t::MapType::dungeon_forest)
     {
         rdtype = 2;
         if (rnd(6) == 0)
@@ -1684,8 +1683,8 @@ static optional<int> _setup_map_generation_parameters()
             rdtype = 4;
         }
     }
-    if (area_data[game_data.current_map].type
-        == mdata_t::MapType::dungeon_tower)
+    if (area_data[game_data.current_map].type ==
+        mdata_t::MapType::dungeon_tower)
     {
         rdtype = 1;
         if (rnd(5) == 0)
@@ -1705,8 +1704,8 @@ static optional<int> _setup_map_generation_parameters()
             map_data.tileset = 10;
         }
     }
-    if (area_data[game_data.current_map].type
-        == mdata_t::MapType::dungeon_castle)
+    if (area_data[game_data.current_map].type ==
+        mdata_t::MapType::dungeon_castle)
     {
         rdtype = 1;
         if (rnd(5) == 0)
@@ -1815,8 +1814,8 @@ static optional<int> _setup_map_generation_parameters()
         map_data.tileset = 7;
         rdtype = 1;
     }
-    if (area_data[game_data.current_map].id
-        == mdata_t::MapId::crypt_of_the_damned)
+    if (area_data[game_data.current_map].id ==
+        mdata_t::MapId::crypt_of_the_damned)
     {
         map_data.max_crowd_density += game_data.current_dungeon_level / 2;
         map_data.tileset = 0;
@@ -2111,8 +2110,8 @@ void generate_random_nefia()
     }
     if (map_data.refresh_type == 1)
     {
-        if (rnd(15 + game_data.quest_flags.kill_count_of_little_sister * 2)
-            == 0)
+        if (rnd(15 + game_data.quest_flags.kill_count_of_little_sister * 2) ==
+            0)
         {
             flt();
             chara_create(-1, 318, -3, 0);
@@ -2120,10 +2119,10 @@ void generate_random_nefia()
     }
     if (area_data[game_data.current_map].id == mdata_t::MapId::lesimas)
     {
-        if (game_data.current_dungeon_level == 3
-            || game_data.current_dungeon_level == 17
-            || game_data.current_dungeon_level == 25
-            || game_data.current_dungeon_level == 44)
+        if (game_data.current_dungeon_level == 3 ||
+            game_data.current_dungeon_level == 17 ||
+            game_data.current_dungeon_level == 25 ||
+            game_data.current_dungeon_level == 44)
         {
             x = map_data.stair_down_pos % 1000;
             y = map_data.stair_down_pos / 1000;
@@ -2196,8 +2195,8 @@ int initialize_quest_map_crop()
         p = cnt;
         for (int cnt = 0, cnt_end = (map_data.width); cnt < cnt_end; ++cnt)
         {
-            cell_data.at(cnt, p).chip_id_actual = tile_default
-                + (rnd(tile_default(2)) == 0) * rnd(tile_default(1));
+            cell_data.at(cnt, p).chip_id_actual = tile_default +
+                (rnd(tile_default(2)) == 0) * rnd(tile_default(1));
         }
     }
     mdatan(0) = i18n::s.get("core.locale.map.quest.field");
@@ -2241,8 +2240,8 @@ int initialize_quest_map_crop()
                     break;
                 }
                 cell_data.at(x, y).chip_id_actual = tile;
-                if (rnd(10) != 0
-                    || cell_data.at(x, y).item_appearances_actual != 0)
+                if (rnd(10) != 0 ||
+                    cell_data.at(x, y).item_appearances_actual != 0)
                 {
                     continue;
                 }
@@ -2275,8 +2274,8 @@ int initialize_quest_map_crop()
     {
         x = rnd(map_data.width);
         y = rnd(map_data.height);
-        if (cell_data.at(x, y).chip_id_actual != 30
-            && cell_data.at(x, y).chip_id_actual != 31)
+        if (cell_data.at(x, y).chip_id_actual != 30 &&
+            cell_data.at(x, y).chip_id_actual != 31)
         {
             if (cell_data.at(x, y).item_appearances_actual == 0)
             {
@@ -2351,8 +2350,8 @@ int initialize_random_nefia_rdtype4()
         {
             x = cnt;
             cell_data.at(x, y).chip_id_actual = 1;
-            if (x > p && y > p && x + 1 < map_data.width - p
-                && y + 1 < map_data.height - p)
+            if (x > p && y > p && x + 1 < map_data.width - p &&
+                y + 1 < map_data.height - p)
             {
                 cell_data.at(x, y).chip_id_actual = 100;
             }
@@ -2418,8 +2417,8 @@ int initialize_random_nefia_rdtype5()
         {
             x = cnt;
             cell_data.at(x, y).chip_id_actual = 1;
-            if (x > p && y > p && x + 1 < map_data.width - p
-                && y + 1 < map_data.height - p)
+            if (x > p && y > p && x + 1 < map_data.width - p &&
+                y + 1 < map_data.height - p)
             {
                 cell_data.at(x, y).chip_id_actual = 100;
             }
@@ -2553,8 +2552,8 @@ int initialize_random_nefia_rdtype2()
                 dy = rnd(rdroomsizemax) + rdroomsizemin;
                 rx = rnd(dx(0));
                 ry = rnd(dy);
-                if (x > 1 && y > 1 && x + dx < map_data.width - 2
-                    && y + dy < map_data.height - 2)
+                if (x > 1 && y > 1 && x + dx < map_data.width - 2 &&
+                    y + dy < map_data.height - 2)
                 {
                     p = 1;
                     break;
@@ -2594,8 +2593,8 @@ int initialize_random_nefia_rdtype3()
         for (int cnt = 0, cnt_end = (map_data.width); cnt < cnt_end; ++cnt)
         {
             x = cnt;
-            if (x == 0 || y == 0 || x + 1 == map_data.width
-                || y + 1 == map_data.height)
+            if (x == 0 || y == 0 || x + 1 == map_data.width ||
+                y + 1 == map_data.height)
             {
                 continue;
             }
@@ -2636,8 +2635,8 @@ int initialize_quest_map_party()
         for (int cnt = 0, cnt_end = (map_data.width); cnt < cnt_end; ++cnt)
         {
             x = cnt;
-            if (x == 0 || y == 0 || x + 1 == map_data.width
-                || y + 1 == map_data.height)
+            if (x == 0 || y == 0 || x + 1 == map_data.width ||
+                y + 1 == map_data.height)
             {
                 continue;
             }
@@ -2661,13 +2660,13 @@ int initialize_quest_map_party()
             for (int cnt = 0; cnt < 4; ++cnt)
             {
                 x = dx + cnt;
-                if (cell_data.at(x, y).chip_id_actual != tile_tunnel
-                    || cell_data.at(x, y).item_appearances_actual != 0)
+                if (cell_data.at(x, y).chip_id_actual != tile_tunnel ||
+                    cell_data.at(x, y).item_appearances_actual != 0)
                 {
                     p(0) = 0;
                 }
-                if (cell_data.at(x, y).chip_id_actual != tile_room
-                    || cell_data.at(x, y).item_appearances_actual != 0)
+                if (cell_data.at(x, y).chip_id_actual != tile_room ||
+                    cell_data.at(x, y).item_appearances_actual != 0)
                 {
                     p(1) = 0;
                 }
@@ -2856,8 +2855,8 @@ int initialize_quest_map_party()
     {
         x = rnd(map_data.width);
         y = rnd(map_data.height);
-        if (cell_data.at(x, y).item_appearances_actual != 0
-            || chipm(7, cell_data.at(x, y).chip_id_actual) & 4)
+        if (cell_data.at(x, y).item_appearances_actual != 0 ||
+            chipm(7, cell_data.at(x, y).chip_id_actual) & 4)
         {
             continue;
         }
@@ -3353,8 +3352,8 @@ void initialize_random_nefia_rdtype10()
                 for (int cnt = 0, cnt_end = (w); cnt < cnt_end; ++cnt)
                 {
                     dx = cnt + x - w / 2;
-                    if (dx < 1 || dy < 1 || dx >= map_data.width - 1
-                        || dy >= map_data.height - 1)
+                    if (dx < 1 || dy < 1 || dx >= map_data.width - 1 ||
+                        dy >= map_data.height - 1)
                     {
                         continue;
                     }
@@ -3493,8 +3492,9 @@ void initialize_random_nefia_rdtype10()
                                 tile_doorclosed,
                                 21,
                                 rnd(std::abs(
-                                        game_data.current_dungeon_level * 3 / 2)
-                                    + 1));
+                                        game_data.current_dungeon_level * 3 /
+                                        2) +
+                                    1));
                         }
                     }
                     continue;
@@ -3514,8 +3514,9 @@ void initialize_random_nefia_rdtype10()
                                 tile_doorclosed,
                                 21,
                                 rnd(std::abs(
-                                        game_data.current_dungeon_level * 3 / 2)
-                                    + 1));
+                                        game_data.current_dungeon_level * 3 /
+                                        2) +
+                                    1));
                         }
                     }
                     continue;
@@ -3677,25 +3678,25 @@ void map_tileset(int prm_933)
     {
         tile_default = 0;
         tile_fog = 528;
-        if (4 <= game_data.stood_world_map_tile
-            && game_data.stood_world_map_tile < 9)
+        if (4 <= game_data.stood_world_map_tile &&
+            game_data.stood_world_map_tile < 9)
         {
             tile_default = 7;
             tile_fog = 528;
         }
-        if (264 <= game_data.stood_world_map_tile
-            && game_data.stood_world_map_tile < 363)
+        if (264 <= game_data.stood_world_map_tile &&
+            game_data.stood_world_map_tile < 363)
         {
             tile_default = 12;
         }
-        if (9 <= game_data.stood_world_map_tile
-            && game_data.stood_world_map_tile < 13)
+        if (9 <= game_data.stood_world_map_tile &&
+            game_data.stood_world_map_tile < 13)
         {
             tile_fog = 528;
             tile_default = 3;
         }
-        if (13 <= game_data.stood_world_map_tile
-            && game_data.stood_world_map_tile < 17)
+        if (13 <= game_data.stood_world_map_tile &&
+            game_data.stood_world_map_tile < 17)
         {
             tile_fog = 531;
             tile_default = 19;

--- a/src/mef.cpp
+++ b/src/mef.cpp
@@ -149,8 +149,7 @@ void mef_update()
                                 dx,
                                 dy,
                                 cdata.player().position.x,
-                                cdata.player().position.y)
-                            < 6)
+                                cdata.player().position.y) < 6)
                         {
                             sound = "core.fire1";
                         }
@@ -159,8 +158,8 @@ void mef_update()
                     {
                         x = rnd(2) + dx - rnd(2);
                         y = rnd(2) + dy - rnd(2);
-                        if (x < 0 || y < 0 || x >= map_data.width
-                            || y >= map_data.height)
+                        if (x < 0 || y < 0 || x >= map_data.width ||
+                            y >= map_data.height)
                         {
                             f = 0;
                             continue;
@@ -200,8 +199,8 @@ void mef_update()
 void mef_proc(int tc)
 {
     int ef = cell_data.at(cdata[tc].position.x, cdata[tc].position.y)
-                 .mef_index_plus_one
-        - 1;
+                 .mef_index_plus_one -
+        1;
     if (mef(0, ef) == 0)
     {
         return;
@@ -292,8 +291,8 @@ void mef_proc(int tc)
 bool mef_proc_from_movement(int cc)
 {
     int i = cell_data.at(cdata[cc].position.x, cdata[cc].position.y)
-                .mef_index_plus_one
-        - 1;
+                .mef_index_plus_one -
+        1;
     if (mef(0, i) == 0)
     {
         return false;
@@ -302,8 +301,8 @@ bool mef_proc_from_movement(int cc)
     {
         if (cdatan(2, cc) != u8"core.spider"s)
         {
-            if (rnd(mef(5, i) + 25) < rnd(sdata(10, cc) + sdata(12, cc) + 1)
-                || cdata[cc].weight > 100)
+            if (rnd(mef(5, i) + 25) < rnd(sdata(10, cc) + sdata(12, cc) + 1) ||
+                cdata[cc].weight > 100)
             {
                 if (is_in_fov(cdata[cc]))
                 {
@@ -331,8 +330,8 @@ bool mef_proc_from_movement(int cc)
 bool mef_proc_from_physical_attack(int tc)
 {
     int i = cell_data.at(cdata[tc].position.x, cdata[tc].position.y)
-                .mef_index_plus_one
-        - 1;
+                .mef_index_plus_one -
+        1;
     if (mef(0, i) == 0)
     {
         return false;

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -55,8 +55,8 @@ namespace elona
 void text_set()
 {
     strhint1 = i18n::s.get("core.locale.ui.hint.cursor");
-    strhint2 = ""s + key_pageup + u8","s + key_pagedown
-        + i18n::s.get("core.locale.ui.hint.page");
+    strhint2 = ""s + key_pageup + u8","s + key_pagedown +
+        i18n::s.get("core.locale.ui.hint.page");
     strhint3 = i18n::s.get("core.locale.ui.hint.close");
     strhint3b = i18n::s.get("core.locale.ui.hint.back");
     strhint4 = i18n::s.get("core.locale.ui.hint.enter");
@@ -205,8 +205,8 @@ void show_ex_help()
     if (p == -1)
     {
         dialog(
-            u8"help index not found %"s + ghelp + u8","s
-            + i18n::s.get("core.locale.meta.tag"));
+            u8"help index not found %"s + ghelp + u8","s +
+            i18n::s.get("core.locale.meta.tag"));
         return;
     }
     buff = strmid(buff, p, instr(buff, p, u8"%END"s));
@@ -374,8 +374,8 @@ void draw_spell_power_entry(int skill_id)
             calc_buff_duration(p, calcspellpower(skill_id, cc));
         const auto description =
             get_buff_description(p, calcspellpower(skill_id, cc));
-        s = ""s + duration + i18n::s.get("core.locale.ui.spell.turn_counter")
-            + description;
+        s = ""s + duration + i18n::s.get("core.locale.ui.spell.turn_counter") +
+            description;
         return;
     }
     const auto damage =
@@ -690,8 +690,8 @@ int change_appearance()
     boxf();
     for (int cnt = 0; cnt < 10; ++cnt)
     {
-        const auto filepath = filesystem::dir::user() / u8"graphic"
-            / (u8"face"s + (cnt + 1) + u8".bmp");
+        const auto filepath = filesystem::dir::user() / u8"graphic" /
+            (u8"face"s + (cnt + 1) + u8".bmp");
         if (fs::exists(filepath))
         {
             pos(cnt * 80, 0);
@@ -912,9 +912,9 @@ label_2041_internal:
         if (rtval(1) == 0)
         {
             if (fs::exists(
-                    filesystem::dir::graphic()
-                    / (u8"pcc_"s + rtvaln + u8"_" + (pcc(rtval, cc) % 1000 + 1)
-                       + u8".bmp")))
+                    filesystem::dir::graphic() /
+                    (u8"pcc_"s + rtvaln + u8"_" + (pcc(rtval, cc) % 1000 + 1) +
+                     u8".bmp")))
             {
                 ++pcc(rtval, cc);
                 p = 1;
@@ -944,11 +944,11 @@ label_2041_internal:
         }
         if (rtval(1) == 0)
         {
-            if ((pcc(rtval, cc) % 1000 == 1 && rtval != 15)
-                || fs::exists(
-                    filesystem::dir::graphic()
-                    / (u8"pcc_"s + rtvaln + u8"_"s + (pcc(rtval, cc) % 1000 - 1)
-                       + u8".bmp"s)))
+            if ((pcc(rtval, cc) % 1000 == 1 && rtval != 15) ||
+                fs::exists(
+                    filesystem::dir::graphic() /
+                    (u8"pcc_"s + rtvaln + u8"_"s + (pcc(rtval, cc) % 1000 - 1) +
+                     u8".bmp"s)))
             {
                 --pcc(rtval, cc);
                 p = 1;
@@ -1177,8 +1177,8 @@ void show_weapon_dice(int val0)
     {
         s(3) = s;
     }
-    s = ""s + dice1 + u8"d"s + dice2 + cnvfix(dmgfix) + u8" x"s
-        + strmid(
+    s = ""s + dice1 + u8"d"s + dice2 + cnvfix(dmgfix) + u8" x"s +
+        strmid(
             s(2),
             0,
             3 + (elona::stoi(s(2)) >= 10) + (elona::stoi(s(2)) >= 100));
@@ -1355,8 +1355,8 @@ void screen_analyze_self()
     apply_god_blessing(56);
     if (cdata.player().god_id != core_god::eyth)
     {
-        buff += u8"<title1>◆ "s + god_name(cdata.player().god_id)
-            + u8"による能力の恩恵<def>\n"s;
+        buff += u8"<title1>◆ "s + god_name(cdata.player().god_id) +
+            u8"による能力の恩恵<def>\n"s;
         for (int cnt = 0; cnt < 600; ++cnt)
         {
             p = sdata(cnt, rc) - 1;

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -185,12 +185,12 @@ void Message::_msg_write(std::string& message)
         {
             break;
         }
-        message = message.substr(0, bytewise_pos) + u8"  "
-            + message.substr(
+        message = message.substr(0, bytewise_pos) + u8"  " +
+            message.substr(
                 bytewise_pos + std::strlen(musical_note) + (symbol_type != 0));
         elona::pos(
-            (message_width + widthwise_pos) * inf_mesfont / 2 + inf_msgx + 7
-                + en * 3,
+            (message_width + widthwise_pos) * inf_mesfont / 2 + inf_msgx + 7 +
+                en * 3,
             (inf_msgline - 1) * inf_msgspace + inf_msgy + 5);
         gmode(2);
         gcopy(3, 600 + symbol_type * 24, 360, 16, 16);
@@ -360,15 +360,15 @@ void Message::_txt_conv()
                         {
                             break;
                         }
-                        if (!strutil::starts_with(msgtemp, u8"。", len)
-                            && !strutil::starts_with(msgtemp, u8"、", len)
-                            && !strutil::starts_with(msgtemp, u8"」", len)
-                            && !strutil::starts_with(msgtemp, u8"』", len)
-                            && !strutil::starts_with(msgtemp, u8"！", len)
-                            && !strutil::starts_with(msgtemp, u8"？", len)
-                            && !strutil::starts_with(msgtemp, u8"…", len)
-                            && !strutil::starts_with(msgtemp, u8"♪", len)
-                            && !strutil::starts_with(msgtemp, u8"♪1", len))
+                        if (!strutil::starts_with(msgtemp, u8"。", len) &&
+                            !strutil::starts_with(msgtemp, u8"、", len) &&
+                            !strutil::starts_with(msgtemp, u8"」", len) &&
+                            !strutil::starts_with(msgtemp, u8"』", len) &&
+                            !strutil::starts_with(msgtemp, u8"！", len) &&
+                            !strutil::starts_with(msgtemp, u8"？", len) &&
+                            !strutil::starts_with(msgtemp, u8"…", len) &&
+                            !strutil::starts_with(msgtemp, u8"♪", len) &&
+                            !strutil::starts_with(msgtemp, u8"♪1", len))
                         {
                             break;
                         }

--- a/src/pic_loader/pic_loader.hpp
+++ b/src/pic_loader/pic_loader.hpp
@@ -148,8 +148,8 @@ public:
                 if (auto e = fits(w, h, i))
                 {
                     Skyline& skyline = skylines[i];
-                    if (e->bottom() < bottom
-                        || (e->bottom() == bottom && skyline.width < width))
+                    if (e->bottom() < bottom ||
+                        (e->bottom() == bottom && skyline.width < width))
                     {
                         bottom = e->bottom();
                         width = skyline.width;

--- a/src/proc_event.cpp
+++ b/src/proc_event.cpp
@@ -43,8 +43,8 @@ void proc_event()
             txt(i18n::s.get(
                 "core.locale.quest.party.final_score",
                 quest_data.immediate().extra_info_2));
-            if (quest_data.immediate().extra_info_1
-                <= quest_data.immediate().extra_info_2)
+            if (quest_data.immediate().extra_info_1 <=
+                quest_data.immediate().extra_info_2)
             {
                 game_data.executing_immediate_quest_status = 3;
                 quest_data.immediate().progress = 3;
@@ -59,8 +59,8 @@ void proc_event()
             }
             break;
         case 1006:
-            if (quest_data.immediate().extra_info_1
-                < quest_data.immediate().extra_info_2)
+            if (quest_data.immediate().extra_info_1 <
+                quest_data.immediate().extra_info_2)
             {
                 game_data.executing_immediate_quest_status = 3;
                 quest_data.immediate().progress = 3;
@@ -311,9 +311,8 @@ void proc_event()
     case 15:
         for (int i = 0; i < game_data.number_of_existing_quests; ++i)
         {
-            if (quest_data[i].id == 1007 && quest_data[i].progress == 1
-                && quest_data[i].extra_info_2
-                    == evdata1(evnum - (evnum != 0) * 1))
+            if (quest_data[i].id == 1007 && quest_data[i].progress == 1 &&
+                quest_data[i].extra_info_2 == evdata1(evnum - (evnum != 0) * 1))
             {
                 rq = i;
                 quest_failed(quest_data[rq].id);
@@ -396,9 +395,9 @@ void proc_event()
             flt(0, Quality::good);
             for (int i = 0; i < 1; ++i)
             {
-                if (game_data.last_month_when_trainer_visited
-                        != game_data.date.month
-                    || rnd(5) == 0)
+                if (game_data.last_month_when_trainer_visited !=
+                        game_data.date.month ||
+                    rnd(5) == 0)
                 {
                     if (rnd(3))
                     {
@@ -449,11 +448,11 @@ void proc_event()
             for (int j = 0; j < 100; ++j)
             {
                 i = rnd(39) + 16;
-                if (cdata[i].state()
-                        == Character::State::adventurer_in_other_map
-                    && cdata[i].is_contracting() == 0
-                    && cdata[i].current_map != game_data.current_map
-                    && cdata[i].relationship >= 0)
+                if (cdata[i].state() ==
+                        Character::State::adventurer_in_other_map &&
+                    cdata[i].is_contracting() == 0 &&
+                    cdata[i].current_map != game_data.current_map &&
+                    cdata[i].relationship >= 0)
                 {
                     if (rnd(25) < p)
                     {
@@ -560,9 +559,8 @@ void proc_event()
                 if (p(2) < p(1))
                 {
                     if (cell_data.at(inv[ci].position.x, inv[ci].position.y)
-                                .chara_index_plus_one
-                            == 0
-                        || c == 0 || c == tc)
+                                .chara_index_plus_one == 0 ||
+                        c == 0 || c == tc)
                     {
                         p(0) = ci;
                         p(1) = p(2);
@@ -611,8 +609,9 @@ void proc_event()
                 continue;
             if (cdata[cc].character_role != 13 && cdata[cc].character_role != 3)
             {
-                if (cdata[cc].character_role != 0 || cdata[cc].relationship == 0
-                    || cdata[cc].current_map == game_data.current_map)
+                if (cdata[cc].character_role != 0 ||
+                    cdata[cc].relationship == 0 ||
+                    cdata[cc].current_map == game_data.current_map)
                 {
                     cdata[cc].emotion_icon = 2006;
                     int stat = chara_custom_talk(cc, 104);
@@ -813,10 +812,10 @@ void proc_event()
                 }
             }
         }
-        if (evdata1(evnum - (evnum != 0) * 1) == 33
-            && evdata2(evnum - (evnum != 0) * 1) == 16
-            && game_data.current_map == mdata_t::MapId::palmia
-            && game_data.quest_flags.red_blossom_in_palmia == 1)
+        if (evdata1(evnum - (evnum != 0) * 1) == 33 &&
+            evdata2(evnum - (evnum != 0) * 1) == 16 &&
+            game_data.current_map == mdata_t::MapId::palmia &&
+            game_data.quest_flags.red_blossom_in_palmia == 1)
         {
             game_data.quest_flags.red_blossom_in_palmia = 2;
             quest_update_journal_msg();
@@ -848,8 +847,8 @@ void proc_event()
             }
             x = rnd(inf_screenw) + scx;
             y = rnd(inf_screenh) + scy;
-            if (x < 0 || y < 0 || x >= map_data.width || y >= map_data.height
-                || rnd(5) == 0)
+            if (x < 0 || y < 0 || x >= map_data.width || y >= map_data.height ||
+                rnd(5) == 0)
             {
                 x = rnd(map_data.width);
                 y = rnd(map_data.height);

--- a/src/quest.cpp
+++ b/src/quest.cpp
@@ -299,14 +299,14 @@ void quest_set_data(int val0)
         if (quest_data[rq].reward_item_id < 10000)
         {
             s(5) +=
-                i18n::s.get("core.locale.quest.info.and")
-                + i18n::_(
+                i18n::s.get("core.locale.quest.info.and") +
+                i18n::_(
                     u8"ui", u8"reward", u8"_"s + quest_data[rq].reward_item_id);
         }
         else
         {
-            s(5) += i18n::s.get("core.locale.quest.info.and")
-                + fltname(quest_data[rq].reward_item_id);
+            s(5) += i18n::s.get("core.locale.quest.info.and") +
+                fltname(quest_data[rq].reward_item_id);
         }
     }
     if (quest_data[rq].deadline_days == -1)
@@ -375,9 +375,9 @@ void quest_set_data(int val0)
         s = u8"%DELIVER,"s + quest_data[rq].extra_info_1;
         parse_quest_board_text(val0);
         s(10) = cnvarticle(cnvitemname(quest_data[rq].target_item_id));
-        s(11) = ""s
-            + mapname(quest_data[quest_data[rq].target_chara_index]
-                          .originating_map_id);
+        s(11) = ""s +
+            mapname(quest_data[quest_data[rq].target_chara_index]
+                        .originating_map_id);
         s(12) = ""s + qname(quest_data[rq].target_chara_index);
         if (iorgweight(quest_data[rq].target_item_id) > 50000)
         {
@@ -426,8 +426,8 @@ void quest_set_data(int val0)
         parse_quest_board_text(val0);
         s(10) = cnvarticle(cnvitemname(quest_data[rq].target_item_id));
         s(11) = ""s + mapname(quest_data[rq].originating_map_id);
-        if (game_data.current_map == quest_data[rq].originating_map_id
-            && game_data.current_dungeon_level == 1)
+        if (game_data.current_map == quest_data[rq].originating_map_id &&
+            game_data.current_dungeon_level == 1)
         {
             s(12) = ""s + cdatan(0, quest_data[rq].target_chara_index);
         }
@@ -446,8 +446,8 @@ void quest_set_data(int val0)
     if (val0 == 1)
     {
         buff = i18n::s.get(
-                   "core.locale.quest.giver.have_something_to_ask", cdata[tc])
-            + buff;
+                   "core.locale.quest.giver.have_something_to_ask", cdata[tc]) +
+            buff;
         if (quest_data[rq].deadline_days != -1)
         {
             buff += i18n::s.get(
@@ -461,19 +461,19 @@ void quest_set_data(int val0)
     {
         if (quest_data[rq].progress == 3)
         {
-            buff += u8"@QC["s
-                + i18n::s.get("core.locale.quest.journal.complete") + u8"]"s
-                + s(3) + u8"\n"s;
+            buff += u8"@QC["s +
+                i18n::s.get("core.locale.quest.journal.complete") + u8"]"s +
+                s(3) + u8"\n"s;
         }
         else
         {
-            buff += u8"@QL["s + i18n::s.get("core.locale.quest.journal.job")
-                + u8"] "s + s(3) + u8"\n"s;
+            buff += u8"@QL["s + i18n::s.get("core.locale.quest.journal.job") +
+                u8"] "s + s(3) + u8"\n"s;
         }
-        buff += i18n::s.get("core.locale.quest.journal.client") + qname(rq)
-            + u8"\n"s;
-        buff += i18n::s.get("core.locale.quest.journal.location")
-            + mapname(quest_data[rq].originating_map_id) + u8"\n"s;
+        buff += i18n::s.get("core.locale.quest.journal.client") + qname(rq) +
+            u8"\n"s;
+        buff += i18n::s.get("core.locale.quest.journal.location") +
+            mapname(quest_data[rq].originating_map_id) + u8"\n"s;
         buff += i18n::s.get("core.locale.quest.journal.deadline");
         if (quest_data[rq].deadline_days != -1)
         {
@@ -509,8 +509,8 @@ void quest_set_data(int val0)
         }
         if (quest_data[rq].id == 1006)
         {
-            if (quest_data[rq].extra_info_1 * 125 / 100
-                < quest_data[rq].extra_info_2)
+            if (quest_data[rq].extra_info_1 * 125 / 100 <
+                quest_data[rq].extra_info_2)
             {
                 buff += i18n::s.get(
                     "core.locale.quest.giver.complete.extra_coins", cdata[tc]);
@@ -518,8 +518,8 @@ void quest_set_data(int val0)
         }
         if (quest_data[rq].id == 1009)
         {
-            if (quest_data[rq].extra_info_1 * 150 / 100
-                < quest_data[rq].extra_info_2)
+            if (quest_data[rq].extra_info_1 * 150 / 100 <
+                quest_data[rq].extra_info_2)
             {
                 buff += i18n::s.get(
                     "core.locale.quest.giver.complete.music_tickets",
@@ -647,9 +647,8 @@ int quest_generate()
             {
                 continue;
             }
-            if (cdata[n].relationship != 0
-                || (cdata[n].character_role != 4
-                    && cdata[n].character_role != 14))
+            if (cdata[n].relationship != 0 ||
+                (cdata[n].character_role != 4 && cdata[n].character_role != 14))
             {
                 continue;
             }
@@ -689,8 +688,8 @@ int quest_generate()
     {
         if (rnd(13) == 0)
         {
-            quest_data[rq].difficulty = rnd(cdata.player().level + 10)
-                + rnd((cdata.player().fame / 2500 + 1));
+            quest_data[rq].difficulty = rnd(cdata.player().level + 10) +
+                rnd((cdata.player().fame / 2500 + 1));
             quest_data[rq].difficulty =
                 roundmargin(quest_data[rq].difficulty, cdata.player().level);
             minlevel = clamp(quest_data[rq].difficulty / 7, 5, 30);
@@ -725,8 +724,8 @@ int quest_generate()
     {
         if (rnd(20) == 0)
         {
-            quest_data[rq].difficulty = rnd(cdata.player().level + 10)
-                + rnd((cdata.player().fame / 2500 + 1));
+            quest_data[rq].difficulty = rnd(cdata.player().level + 10) +
+                rnd((cdata.player().fame / 2500 + 1));
             quest_data[rq].difficulty =
                 roundmargin(quest_data[rq].difficulty, cdata.player().level);
             minlevel = clamp(quest_data[rq].difficulty / 4, 5, 30);
@@ -777,53 +776,53 @@ int quest_generate()
         p = quest_data[rq].extra_info_1;
         if (quest_data[rq].escort_difficulty == 0)
         {
-            rewardfix = 140
-                + dist(
-                      area_data[game_data.current_map].position.x,
-                      area_data[game_data.current_map].position.y,
-                      area_data[p].position.x,
-                      area_data[p].position.y)
-                    * 2;
+            rewardfix = 140 +
+                dist(
+                    area_data[game_data.current_map].position.x,
+                    area_data[game_data.current_map].position.y,
+                    area_data[p].position.x,
+                    area_data[p].position.y) *
+                    2;
             quest_data[rq].deadline_days = rnd(8) + 6;
             quest_data[rq].difficulty = clamp(
-                rnd(cdata.player().level + 10)
-                    + rnd((cdata.player().fame / 500 + 1)) + 1,
+                rnd(cdata.player().level + 10) +
+                    rnd((cdata.player().fame / 500 + 1)) + 1,
                 1,
                 80);
         }
         if (quest_data[rq].escort_difficulty == 1)
         {
-            rewardfix = 130
-                + dist(
-                      area_data[game_data.current_map].position.x,
-                      area_data[game_data.current_map].position.y,
-                      area_data[p].position.x,
-                      area_data[p].position.y)
-                    * 2;
+            rewardfix = 130 +
+                dist(
+                    area_data[game_data.current_map].position.x,
+                    area_data[game_data.current_map].position.y,
+                    area_data[p].position.x,
+                    area_data[p].position.y) *
+                    2;
             quest_data[rq].deadline_days = rnd(5) + 2;
             quest_data[rq].difficulty = clamp(rewardfix / 10 + 1, 1, 40);
         }
         if (quest_data[rq].escort_difficulty == 2)
         {
-            rewardfix = 80
-                + dist(
-                      area_data[game_data.current_map].position.x,
-                      area_data[game_data.current_map].position.y,
-                      area_data[p].position.x,
-                      area_data[p].position.y)
-                    * 2;
+            rewardfix = 80 +
+                dist(
+                    area_data[game_data.current_map].position.x,
+                    area_data[game_data.current_map].position.y,
+                    area_data[p].position.x,
+                    area_data[p].position.y) *
+                    2;
             quest_data[rq].deadline_days = rnd(8) + 6;
             quest_data[rq].difficulty = clamp(rewardfix / 20 + 1, 1, 40);
         }
-        if (quest_data[rq].extra_info_1 == 33
-            || game_data.current_map == mdata_t::MapId::noyel)
+        if (quest_data[rq].extra_info_1 == 33 ||
+            game_data.current_map == mdata_t::MapId::noyel)
         {
             rewardfix = rewardfix * 180 / 100;
         }
         return 0;
     }
-    if (rnd(23) == 0
-        || (game_data.current_map == mdata_t::MapId::palmia && rnd(8) == 0))
+    if (rnd(23) == 0 ||
+        (game_data.current_map == mdata_t::MapId::palmia && rnd(8) == 0))
     {
         quest_data[rq].difficulty = clamp(
             rnd(sdata(183, 0) + 10),
@@ -842,12 +841,12 @@ int quest_generate()
         rewardfix = 0;
         return 0;
     }
-    if (rnd(30) == 0
-        || (game_data.current_map == mdata_t::MapId::yowyn && rnd(2) == 0))
+    if (rnd(30) == 0 ||
+        (game_data.current_map == mdata_t::MapId::yowyn && rnd(2) == 0))
     {
         quest_data[rq].difficulty = clamp(
-            rnd(cdata.player().level + 5) + rnd((cdata.player().fame / 800 + 1))
-                + 1,
+            rnd(cdata.player().level + 5) +
+                rnd((cdata.player().fame / 800 + 1)) + 1,
             1,
             50);
         quest_data[rq].deadline_hours =
@@ -865,8 +864,8 @@ int quest_generate()
     if (rnd(8) == 0)
     {
         quest_data[rq].difficulty = clamp(
-            rnd(cdata.player().level + 10)
-                + rnd((cdata.player().fame / 500 + 1)) + 1,
+            rnd(cdata.player().level + 10) +
+                rnd((cdata.player().fame / 500 + 1)) + 1,
             1,
             80);
         quest_data[rq].difficulty =
@@ -909,8 +908,8 @@ int quest_generate()
             }
             if (quest_data[p].client_chara_index != 0)
             {
-                if (quest_data[p].originating_map_id != game_data.current_map
-                    || 0)
+                if (quest_data[p].originating_map_id != game_data.current_map ||
+                    0)
                 {
                     i = p;
                     break;
@@ -920,13 +919,13 @@ int quest_generate()
         if (i != -1)
         {
             p = quest_data[i].originating_map_id;
-            rewardfix = 70
-                + dist(
-                      area_data[game_data.current_map].position.x,
-                      area_data[game_data.current_map].position.y,
-                      area_data[p].position.x,
-                      area_data[p].position.y)
-                    * 2;
+            rewardfix = 70 +
+                dist(
+                    area_data[game_data.current_map].position.x,
+                    area_data[game_data.current_map].position.y,
+                    area_data[p].position.x,
+                    area_data[p].position.y) *
+                    2;
             if (p == 33 || game_data.current_map == mdata_t::MapId::noyel)
             {
                 rewardfix = rewardfix * 175 / 100;
@@ -1025,30 +1024,30 @@ int quest_generate()
 void quest_gen_scale_by_level()
 {
     quest_data[rq].reward_gold =
-        ((quest_data[rq].difficulty + 3) * 100
-         + rnd((quest_data[rq].difficulty * 30 + 200)) + 400)
-        * rewardfix / 100;
-    quest_data[rq].reward_gold = quest_data[rq].reward_gold * 100
-        / (100 + quest_data[rq].difficulty * 2 / 3);
-    if (quest_data[rq].client_chara_type == 3
-        || quest_data[rq].client_chara_type == 2)
+        ((quest_data[rq].difficulty + 3) * 100 +
+         rnd((quest_data[rq].difficulty * 30 + 200)) + 400) *
+        rewardfix / 100;
+    quest_data[rq].reward_gold = quest_data[rq].reward_gold * 100 /
+        (100 + quest_data[rq].difficulty * 2 / 3);
+    if (quest_data[rq].client_chara_type == 3 ||
+        quest_data[rq].client_chara_type == 2)
     {
         return;
     }
     if (cdata.player().level >= quest_data[rq].difficulty)
     {
-        quest_data[rq].reward_gold = quest_data[rq].reward_gold * 100
-            / (100 + (cdata.player().level - quest_data[rq].difficulty) * 10);
+        quest_data[rq].reward_gold = quest_data[rq].reward_gold * 100 /
+            (100 + (cdata.player().level - quest_data[rq].difficulty) * 10);
     }
     else
     {
-        quest_data[rq].reward_gold = quest_data[rq].reward_gold
-            * (100
-               + clamp(
-                   (quest_data[rq].difficulty - cdata.player().level) / 5 * 25,
-                   0,
-                   200))
-            / 100;
+        quest_data[rq].reward_gold = quest_data[rq].reward_gold *
+            (100 +
+             clamp(
+                 (quest_data[rq].difficulty - cdata.player().level) / 5 * 25,
+                 0,
+                 200)) /
+            100;
     }
 }
 
@@ -1291,14 +1290,16 @@ void quest_team_victorious()
         cdata.player().fame += game_data.executing_immediate_quest_fame_gained;
         modrank(1, 100, 2);
         ++area_data[game_data.previous_map2].winning_streak_in_pet_arena;
-        if (area_data[game_data.previous_map2].winning_streak_in_pet_arena % 20
-            == 0)
+        if (area_data[game_data.previous_map2].winning_streak_in_pet_arena %
+                20 ==
+            0)
         {
             matgetmain(41, 1);
         }
         else if (
-            area_data[game_data.previous_map2].winning_streak_in_pet_arena % 5
-            == 0)
+            area_data[game_data.previous_map2].winning_streak_in_pet_arena %
+                5 ==
+            0)
         {
             matgetmain(40, 1);
         }
@@ -1340,8 +1341,8 @@ void quest_all_targets_killed()
         txt(i18n::s.get("core.locale.quest.arena.stairs_appear"));
         map_placeupstairs(map_data.width / 2, map_data.height / 2);
         ++area_data[game_data.previous_map2].winning_streak_in_arena;
-        if (area_data[game_data.previous_map2].winning_streak_in_arena % 20
-            == 0)
+        if (area_data[game_data.previous_map2].winning_streak_in_arena % 20 ==
+            0)
         {
             matgetmain(41, 1);
         }
@@ -1351,8 +1352,8 @@ void quest_all_targets_killed()
             matgetmain(40, 1);
         }
     }
-    if (game_data.executing_immediate_quest_type == 1001
-        || game_data.executing_immediate_quest_type == 1010)
+    if (game_data.executing_immediate_quest_type == 1001 ||
+        game_data.executing_immediate_quest_type == 1010)
     {
         quest_data.immediate().progress = 3;
         txt(i18n::s.get("core.locale.quest.hunt.complete"),
@@ -1380,14 +1381,14 @@ void quest_complete()
     {
         if (quest_data[rq].extra_info_1 != 0)
         {
-            if (quest_data[rq].extra_info_1 * 125 / 100
-                < quest_data[rq].extra_info_2)
+            if (quest_data[rq].extra_info_1 * 125 / 100 <
+                quest_data[rq].extra_info_2)
             {
                 p = clamp(
-                    p
-                        * static_cast<int>(
-                            static_cast<double>(quest_data[rq].extra_info_2)
-                            / quest_data[rq].extra_info_1),
+                    p *
+                        static_cast<int>(
+                            static_cast<double>(quest_data[rq].extra_info_2) /
+                            quest_data[rq].extra_info_1),
                     p(0),
                     p * 3);
             }
@@ -1415,8 +1416,8 @@ void quest_complete()
     itemcreate(-1, 55, cdata.player().position.x, cdata.player().position.y, p);
     if (quest_data[rq].id == 1009)
     {
-        if (quest_data[rq].extra_info_1 * 150 / 100
-            < quest_data[rq].extra_info_2)
+        if (quest_data[rq].extra_info_1 * 150 / 100 <
+            quest_data[rq].extra_info_2)
         {
             flt();
             itemcreate(

--- a/src/race.cpp
+++ b/src/race.cpp
@@ -57,8 +57,8 @@ int access_race_info(int dbmode, const std::string& race_id)
     cdata[rc].dv_correction_value = data->dv_multiplier;
     cdata[rc].pv_correction_value = data->pv_multiplier;
 
-    cdata[rc].birth_year = game_data.date.year
-        - (rnd(data->max_age - data->min_age + 1) + data->min_age);
+    cdata[rc].birth_year = game_data.date.year -
+        (rnd(data->max_age - data->min_age + 1) + data->min_age);
     cdata[rc].height = data->height;
     if (mode == 1)
     {

--- a/src/set_item_info.cpp
+++ b/src/set_item_info.cpp
@@ -53,9 +53,10 @@ void set_item_info()
             // random seed of the current save data.
             int p = (data.id % game_data.random_seed) % 6;
             iknownnameref(data.id) =
-                i18n::_(u8"ui", u8"random_" + data.originalnameref2, u8"_"s + p)
-                + i18n::space_if_needed()
-                + i18n::_(u8"ui", data.originalnameref2);
+                i18n::_(
+                    u8"ui", u8"random_" + data.originalnameref2, u8"_"s + p) +
+                i18n::space_if_needed() +
+                i18n::_(u8"ui", data.originalnameref2);
         }
         else
         {

--- a/src/snail/hsp/sdl.cpp
+++ b/src/snail/hsp/sdl.cpp
@@ -227,8 +227,8 @@ struct MessageBox
         {
             if (!input.is_ime_active())
             {
-                if (input.was_pressed_just_now(Key::enter)
-                    || input.was_pressed_just_now(Key::keypad_enter))
+                if (input.was_pressed_just_now(Key::enter) ||
+                    input.was_pressed_just_now(Key::keypad_enter))
                 {
                     // New line.
                     buffer += '\n';
@@ -240,9 +240,9 @@ struct MessageBox
                 }
                 else if (input.is_pressed(Key::backspace) && !buffer.empty())
                 {
-                    if (backspace_held_frames == 0
-                        || (backspace_held_frames > 15
-                            && backspace_held_frames % 2 == 0))
+                    if (backspace_held_frames == 0 ||
+                        (backspace_held_frames > 15 &&
+                         backspace_held_frames % 2 == 0))
                     {
                         // Delete the last character.
                         size_t last_byte_count{};
@@ -258,8 +258,8 @@ struct MessageBox
                     backspace_held_frames++;
                 }
                 else if (
-                    input.was_pressed_just_now(Key::key_v)
-                    && input.is_pressed(Key::ctrl))
+                    input.was_pressed_just_now(Key::key_v) &&
+                    input.is_pressed(Key::ctrl))
                 {
                     // Paste.
                     std::unique_ptr<char, decltype(&::SDL_free)> text_ptr{
@@ -276,8 +276,8 @@ struct MessageBox
         }
         else
         {
-            if (input.is_pressed(Key::enter, keywait)
-                || input.is_pressed(Key::keypad_enter, keywait))
+            if (input.is_pressed(Key::enter, keywait) ||
+                input.is_pressed(Key::keypad_enter, keywait))
             {
                 // New line.
                 buffer += '\n';

--- a/src/snail/input.cpp
+++ b/src/snail/input.cpp
@@ -354,8 +354,8 @@ void Input::_update_modifier_keys()
              {Key::shift, Key::shift_l, Key::shift_r, ModKey::shift},
          })
     {
-        if (_keys[static_cast<size_t>(std::get<1>(tuple))].is_pressed()
-            || _keys[static_cast<int>(std::get<2>(tuple))].is_pressed())
+        if (_keys[static_cast<size_t>(std::get<1>(tuple))].is_pressed() ||
+            _keys[static_cast<int>(std::get<2>(tuple))].is_pressed())
         {
             _keys[static_cast<size_t>(std::get<0>(tuple))]._press();
             _modifiers |= std::get<3>(tuple);

--- a/src/snail/touch_input/sdl.cpp
+++ b/src/snail/touch_input/sdl.cpp
@@ -126,8 +126,8 @@ bool TouchInput::is_touched(int x, int y, const QuickAction& action)
     int size = quick_action_size() / 2;
     int deadzone = ((float)size * 0.75);
 
-    return x > action.center_x - deadzone && y > action.center_y - deadzone
-        && x <= action.center_x + deadzone && y <= action.center_y + deadzone;
+    return x > action.center_x - deadzone && y > action.center_y - deadzone &&
+        x <= action.center_x + deadzone && y <= action.center_y + deadzone;
 }
 
 void TouchInput::draw_quick_action(const QuickAction& action)
@@ -170,9 +170,9 @@ void TouchInput::on_touch_event(::SDL_TouchFingerEvent event)
     {
         QuickAction& action = *it;
 
-        if (_last_touched_quick_action_idx == none
-            && event.type != static_cast<decltype(event.type)>(EventType::up)
-            && is_touched(norm_x, norm_y, action))
+        if (_last_touched_quick_action_idx == none &&
+            event.type != static_cast<decltype(event.type)>(EventType::up) &&
+            is_touched(norm_x, norm_y, action))
         {
             action.touched = true;
             _last_touched_quick_action_idx = it - _quick_actions.begin();

--- a/src/snail/window/headless.hpp
+++ b/src/snail/window/headless.hpp
@@ -114,12 +114,12 @@ public:
         int height,
         Flag flag)
         : Window(
-            title,
-            static_cast<int>(x),
-            static_cast<int>(y),
-            width,
-            height,
-            flag)
+              title,
+              static_cast<int>(x),
+              static_cast<int>(y),
+              width,
+              height,
+              flag)
     {
     }
 

--- a/src/snail/window/sdl.cpp
+++ b/src/snail/window/sdl.cpp
@@ -54,14 +54,14 @@ Window::Window(
     int height,
     Flag flag)
     : _ptr(
-        detail::enforce_sdl(::SDL_CreateWindow(
-            title.c_str(),
-            x,
-            y,
-            width,
-            height,
-            static_cast<SDL_WindowFlags>(flag))),
-        ::SDL_DestroyWindow)
+          detail::enforce_sdl(::SDL_CreateWindow(
+              title.c_str(),
+              x,
+              y,
+              width,
+              height,
+              static_cast<SDL_WindowFlags>(flag))),
+          ::SDL_DestroyWindow)
 {
 }
 

--- a/src/snail/window/sdl.hpp
+++ b/src/snail/window/sdl.hpp
@@ -114,12 +114,12 @@ public:
         int height,
         Flag flag)
         : Window(
-            title,
-            static_cast<int>(x),
-            static_cast<int>(y),
-            width,
-            height,
-            flag)
+              title,
+              static_cast<int>(x),
+              static_cast<int>(y),
+              width,
+              height,
+              flag)
     {
     }
 

--- a/src/spec.cpp
+++ b/src/spec.cpp
@@ -263,8 +263,8 @@ EnumDef Object::visit_enum(
         throw SpecError(
             hcl_file,
             current_key,
-            "Default enum value " + default_value
-                + " not provided in enum variant list.");
+            "Default enum value " + default_value +
+                " not provided in enum variant list.");
     }
 
     def.variants = variants;

--- a/src/spec.hpp
+++ b/src/spec.hpp
@@ -184,8 +184,8 @@ public:
             throw SpecError(
                 key,
                 "Attempted to inject an enum, but it was not of type "
-                "runtime_enum: "
-                    + key);
+                "runtime_enum: " +
+                    key);
         }
 
 
@@ -201,8 +201,8 @@ public:
             def.variants = std::vector<std::string>();
             throw SpecError(
                 key,
-                "Default variant \"" + default_variant
-                    + "\" not found: " + key);
+                "Default variant \"" + default_variant +
+                    "\" not found: " + key);
         }
 
         def.default_index = *index;

--- a/src/spec_load.cpp
+++ b/src/spec_load.cpp
@@ -263,8 +263,8 @@ EnumDef Object::visit_enum(
         throw SpecError(
             hcl_file,
             current_key,
-            "Default enum value " + default_value
-                + " not provided in enum variant list.");
+            "Default enum value " + default_value +
+                " not provided in enum variant list.");
     }
 
     def.variants = variants;

--- a/src/status_ailment.cpp
+++ b/src/status_ailment.cpp
@@ -312,8 +312,8 @@ void dmgcon(int cc, StatusAilment status_ailment, int power)
         }
         return;
     default:
-        throw std::runtime_error{u8"Unknown status ailment: "s
-                                 + int(status_ailment)};
+        throw std::runtime_error{u8"Unknown status ailment: "s +
+                                 int(status_ailment)};
     }
 }
 

--- a/src/std.cpp
+++ b/src/std.cpp
@@ -110,12 +110,12 @@ void await(int msec)
     // On Android, potentially quicksave if SDL detects that the app's
     // focus was lost and the player is being queried for input in
     // pc_turn().
-    if (defines::is_android
-        && snail::Application::instance().was_focus_lost_just_now())
+    if (defines::is_android &&
+        snail::Application::instance().was_focus_lost_just_now())
     {
-        if (player_queried_for_input
-            && Config::instance().get<bool>("core.config.android.quicksave")
-            && !std::uncaught_exception())
+        if (player_queried_for_input &&
+            Config::instance().get<bool>("core.config.android.quicksave") &&
+            !std::uncaught_exception())
         {
             ELONA_LOG("Focus lost, quicksaving game.");
             snail::android::toast(
@@ -164,8 +164,8 @@ void bload(const fs::path& filename, std::string& data, int size, int)
     if (!in)
     {
         throw std::runtime_error(
-            u8"Error: fail to read "
-            + filesystem::make_preferred_path_in_utf8(filename));
+            u8"Error: fail to read " +
+            filesystem::make_preferred_path_in_utf8(filename));
     }
     auto buf = read_binary(in, size).first;
     data = std::string{buf.get(), static_cast<size_t>(size)};
@@ -182,8 +182,8 @@ void bload(const fs::path& filename, int& data, int size, int)
     if (!in)
     {
         throw std::runtime_error(
-            u8"Error: fail to read "
-            + filesystem::make_preferred_path_in_utf8(filename));
+            u8"Error: fail to read " +
+            filesystem::make_preferred_path_in_utf8(filename));
     }
     auto buf = read_binary(in, size).first;
     data = *reinterpret_cast<int*>(buf.get());
@@ -201,8 +201,8 @@ void bload(const fs::path& filename, elona_vector1<int>& data, int size, int)
     if (!in)
     {
         throw std::runtime_error(
-            u8"Error: fail to read "
-            + filesystem::make_preferred_path_in_utf8(filename));
+            u8"Error: fail to read " +
+            filesystem::make_preferred_path_in_utf8(filename));
     }
     auto buf = read_binary(in, size).first;
     for (size_t i = 0; i < data.size(); ++i)
@@ -222,8 +222,8 @@ void bsave(const fs::path& filename, const std::string& data)
     if (!out)
     {
         throw std::runtime_error(
-            u8"Error: fail to write "
-            + filesystem::make_preferred_path_in_utf8(filename));
+            u8"Error: fail to write " +
+            filesystem::make_preferred_path_in_utf8(filename));
     }
     out.write(reinterpret_cast<const char*>(data.c_str()), data.size());
 }
@@ -343,8 +343,8 @@ void font(int size, snail::Font::Style style)
     snail::hsp::font(
         size,
         style,
-        filesystem::path(u8"font")
-            / filesystem::u8path(Config::instance().font_filename));
+        filesystem::path(u8"font") /
+            filesystem::u8path(Config::instance().font_filename));
 }
 
 
@@ -833,19 +833,19 @@ StickKey stick(StickKey allow_repeat_keys)
         check_key_pressed(StickKey::mouse_right, snail::Mouse::Button::right);
     ret |= check_key_pressed(StickKey::tab, snail::Key::tab);
 
-    if (allow_repeat_keys
-        == (StickKey::left | StickKey::up | StickKey::right | StickKey::down))
+    if (allow_repeat_keys ==
+        (StickKey::left | StickKey::up | StickKey::right | StickKey::down))
     {
-        if (is_enabled(allow_repeat_keys, StickKey::left)
-            || is_enabled(allow_repeat_keys, StickKey::right))
+        if (is_enabled(allow_repeat_keys, StickKey::left) ||
+            is_enabled(allow_repeat_keys, StickKey::right))
         {
             ret |= input.is_pressed(snail::Key::up) ? StickKey::up
                                                     : StickKey::none;
             ret |= input.is_pressed(snail::Key::down) ? StickKey::down
                                                       : StickKey::none;
         }
-        if (is_enabled(allow_repeat_keys, StickKey::up)
-            || is_enabled(allow_repeat_keys, StickKey::down))
+        if (is_enabled(allow_repeat_keys, StickKey::up) ||
+            is_enabled(allow_repeat_keys, StickKey::down))
         {
             ret |= input.is_pressed(snail::Key::left) ? StickKey::left
                                                       : StickKey::none;

--- a/src/talk.cpp
+++ b/src/talk.cpp
@@ -75,8 +75,8 @@ void talk_to_npc()
     {
         cdata[tc].interest = 100;
     }
-    if ((cdata[tc].character_role >= 1000 && cdata[tc].character_role < 2000)
-        || cdata[tc].character_role == 2003)
+    if ((cdata[tc].character_role >= 1000 && cdata[tc].character_role < 2000) ||
+        cdata[tc].character_role == 2003)
     {
         invfile = cdata[tc].shop_store_id;
         shop_refresh_on_talk();
@@ -125,8 +125,8 @@ void talk_to_npc()
         talk_wrapper(TalkResult::talk_house_visitor);
     }
 
-    if (chatval_unique_chara_id
-        && game_data.current_map != mdata_t::MapId::show_house && tc >= 16)
+    if (chatval_unique_chara_id &&
+        game_data.current_map != mdata_t::MapId::show_house && tc >= 16)
     {
         const auto& dialog_id = the_character_db[cdata[tc].id]->dialog_id;
 
@@ -179,8 +179,8 @@ TalkResult talk_more()
 TalkResult talk_sleeping()
 {
     listmax = 0;
-    buff = u8"("s + i18n::s.get("core.locale.talk.is_sleeping", cdata[tc])
-        + u8")"s;
+    buff = u8"("s + i18n::s.get("core.locale.talk.is_sleeping", cdata[tc]) +
+        u8")"s;
     tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::_(u8"ui", u8"bye");
@@ -674,8 +674,8 @@ void talk_window_show()
     }
     else
     {
-        const auto portrait_filepath = filesystem::dir::user()
-            / (u8"graphic/face"s + std::abs(cdata[tc].portrait + 1) + u8".bmp");
+        const auto portrait_filepath = filesystem::dir::user() /
+            (u8"graphic/face"s + std::abs(cdata[tc].portrait + 1) + u8".bmp");
         if (!fs::exists(portrait_filepath) || cdata[tc].portrait == -1)
         {
             int chara_chip_id = cdata[tc].image % 1000;
@@ -713,8 +713,8 @@ void talk_window_show()
     else
     {
         s = i18n::s.get(
-                "core.locale.talk.window.of", cdatan(0, tc), cdatan(1, tc))
-            + " ";
+                "core.locale.talk.window.of", cdatan(0, tc), cdatan(1, tc)) +
+            " ";
     }
     if (cdata[tc].sex == 0)
     {
@@ -728,11 +728,11 @@ void talk_window_show()
     {
         s += " " + i18n::s.get("core.locale.talk.window.fame", cdata[tc].fame);
     }
-    if ((cdata[tc].character_role >= 1000 && cdata[tc].character_role < 2000)
-        || cdata[tc].character_role == 2003)
+    if ((cdata[tc].character_role >= 1000 && cdata[tc].character_role < 2000) ||
+        cdata[tc].character_role == 2003)
     {
-        s += " "
-            + i18n::s.get(
+        s += " " +
+            i18n::s.get(
                 "core.locale.talk.window.shop_rank", cdata[tc].shop_rank);
     }
     if (game_data.reveals_religion)
@@ -817,8 +817,8 @@ int talk_guide_quest_client()
         auto client = -1;
         if (quest_data[quest_id].id == 1011)
         {
-            if (quest_data[quest_id].originating_map_id
-                == game_data.current_map)
+            if (quest_data[quest_id].originating_map_id ==
+                game_data.current_map)
             {
                 client = quest_data[quest_id].target_chara_index;
             }
@@ -826,8 +826,7 @@ int talk_guide_quest_client()
         if (quest_data[quest_id].id == 1002)
         {
             if (quest_data[quest_data[quest_id].target_chara_index]
-                    .originating_map_id
-                == game_data.current_map)
+                    .originating_map_id == game_data.current_map)
             {
                 client = quest_data[quest_data[quest_id].target_chara_index]
                              .client_chara_index;
@@ -868,8 +867,8 @@ int talk_check_trade(int prm_1081)
         {
             if (game_data.current_dungeon_level == 1)
             {
-                if (quest_data[p_at_m193].originating_map_id
-                    == game_data.current_map)
+                if (quest_data[p_at_m193].originating_map_id ==
+                    game_data.current_map)
                 {
                     if (prm_1081 == quest_data[p_at_m193].target_chara_index)
                     {

--- a/src/talk_house_visitor.cpp
+++ b/src/talk_house_visitor.cpp
@@ -112,8 +112,8 @@ void _adventurer_hate_action()
         {
             tlocx = cdata[tc].position.x + rnd(3) - rnd(3);
             tlocy = cdata[tc].position.y - rnd(3) + rnd(3);
-            if (tlocx < 0 || tlocy < 0 || tlocx >= map_data.width
-                || tlocy >= map_data.height)
+            if (tlocx < 0 || tlocy < 0 || tlocx >= map_data.width ||
+                tlocy >= map_data.height)
             {
                 continue;
             }
@@ -253,8 +253,8 @@ TalkResult _talk_hv_adventurer_train()
                 "locale.ability",
                 the_ability_db.get_id_from_legacy(skill_id)->get(),
                 "name"),
-            std::to_string(calclearncost(skill_id, cc, true))
-                + i18n::_(u8"ui", u8"platinum"),
+            std::to_string(calclearncost(skill_id, cc, true)) +
+                i18n::_(u8"ui", u8"platinum"),
             cdata[tc]);
         if (cdata.player().platinum_coin >= calclearncost(skill_id, cc, true))
         {
@@ -274,8 +274,8 @@ TalkResult _talk_hv_adventurer_train()
                 "locale.ability",
                 the_ability_db.get_id_from_legacy(skill_id)->get(),
                 "name"),
-            std::to_string(calclearncost(skill_id, cc, true))
-                + i18n::_(u8"ui", u8"platinum"),
+            std::to_string(calclearncost(skill_id, cc, true)) +
+                i18n::_(u8"ui", u8"platinum"),
             cdata[tc]);
         if (cdata.player().platinum_coin >= calctraincost(skill_id, cc, true))
         {
@@ -614,8 +614,8 @@ TalkResult _talk_hv_adventurer()
     {
         return _talk_hv_adventurer_hate();
     }
-    if (cdata[tc].impression >= 100 && !cdata[tc].is_best_friend()
-        && inv_getfreeid(-1) != -1)
+    if (cdata[tc].impression >= 100 && !cdata[tc].is_best_friend() &&
+        inv_getfreeid(-1) != -1)
     {
         // NOTE: this dialog falls through.
         _talk_hv_adventurer_best_friend();

--- a/src/talk_npc.cpp
+++ b/src/talk_npc.cpp
@@ -97,8 +97,8 @@ TalkResult talk_wizard_identify(int chatval_)
         {
             continue;
         }
-        if (inv[cnt].identification_state
-            != IdentifyState::completely_identified)
+        if (inv[cnt].identification_state !=
+            IdentifyState::completely_identified)
         {
             ++p;
         }
@@ -122,8 +122,8 @@ TalkResult talk_wizard_identify(int chatval_)
             {
                 continue;
             }
-            if (inv[cnt].identification_state
-                != IdentifyState::completely_identified)
+            if (inv[cnt].identification_state !=
+                IdentifyState::completely_identified)
             {
                 const auto result = item_identify(inv[cnt], 250);
                 item_stack(0, cnt, 1);
@@ -255,20 +255,20 @@ TalkResult talk_arena_master(int chatval_)
     }
     game_data.executing_immediate_quest_fame_gained = calcfame(
         0,
-        (220 - game_data.ranks.at(0) / 50)
-                * (100
-                   + clamp(
-                       area_data[game_data.current_map].winning_streak_in_arena,
-                       0,
-                       50))
-                / 100
-            + 2);
+        (220 - game_data.ranks.at(0) / 50) *
+                (100 +
+                 clamp(
+                     area_data[game_data.current_map].winning_streak_in_arena,
+                     0,
+                     50)) /
+                100 +
+            2);
     listmax = 0;
     randomize(area_data[game_data.current_map].time_of_next_arena);
     if (chatval_ == 21)
     {
-        if (area_data[game_data.current_map].time_of_next_arena
-            > game_data.date.hours())
+        if (area_data[game_data.current_map].time_of_next_arena >
+            game_data.date.hours())
         {
             buff = i18n::s.get(
                 "core.locale.talk.npc.arena_master.enter.game_is_over",
@@ -316,8 +316,8 @@ TalkResult talk_arena_master(int chatval_)
     }
     else
     {
-        if (area_data[game_data.current_map].time_of_next_rumble
-            > game_data.date.hours())
+        if (area_data[game_data.current_map].time_of_next_rumble >
+            game_data.date.hours())
         {
             buff = i18n::s.get(
                 "core.locale.talk.npc.arena_master.enter.game_is_over",
@@ -376,15 +376,15 @@ TalkResult talk_pet_arena_master(int chatval_)
 {
     game_data.executing_immediate_quest_fame_gained = calcfame(
         0,
-        (220 - game_data.ranks.at(1) / 50)
-                * (50
-                   + clamp(
-                       area_data[game_data.current_map]
-                           .winning_streak_in_pet_arena,
-                       0,
-                       50))
-                / 100
-            + 2);
+        (220 - game_data.ranks.at(1) / 50) *
+                (50 +
+                 clamp(
+                     area_data[game_data.current_map]
+                         .winning_streak_in_pet_arena,
+                     0,
+                     50)) /
+                100 +
+            2);
     listmax = 0;
     if (chatval_ == 40)
     {
@@ -989,15 +989,15 @@ TalkResult talk_ally_silence()
     if (cdata[tc].is_silent() == 0)
     {
         cdata[tc].is_silent() = true;
-        buff = u8"("s
-            + i18n::s.get("core.locale.talk.npc.ally.silence.start", cdata[tc])
-            + u8")"s;
+        buff = u8"("s +
+            i18n::s.get("core.locale.talk.npc.ally.silence.start", cdata[tc]) +
+            u8")"s;
     }
     else
     {
-        buff = u8"("s
-            + i18n::s.get("core.locale.talk.npc.ally.silence.stop", cdata[tc])
-            + u8")"s;
+        buff = u8"("s +
+            i18n::s.get("core.locale.talk.npc.ally.silence.stop", cdata[tc]) +
+            u8")"s;
         cdata[tc].is_silent() = false;
     }
     return TalkResult::talk_npc;
@@ -1849,8 +1849,8 @@ TalkResult talk_npc()
         ELONA_APPEND_RESPONSE(
             1, i18n::s.get("core.locale.talk.npc.common.choices.talk"));
     }
-    if ((cdata[tc].character_role >= 1000 && cdata[tc].character_role < 2000)
-        || cdata[tc].character_role == 2003)
+    if ((cdata[tc].character_role >= 1000 && cdata[tc].character_role < 2000) ||
+        cdata[tc].character_role == 2003)
     {
         ELONA_APPEND_RESPONSE(
             10, i18n::s.get("core.locale.talk.npc.shop.choices.buy"));
@@ -1861,8 +1861,8 @@ TalkResult talk_npc()
             ELONA_APPEND_RESPONSE(
                 31, i18n::s.get("core.locale.talk.npc.shop.choices.attack"));
         }
-        if (cdata[tc].character_role != 1010
-            && cdata[tc].character_role != 1009)
+        if (cdata[tc].character_role != 1010 &&
+            cdata[tc].character_role != 1009)
         {
             ELONA_APPEND_RESPONSE(
                 12, i18n::s.get("core.locale.talk.npc.shop.choices.invest"));
@@ -1950,10 +1950,10 @@ TalkResult talk_npc()
     {
         ELONA_APPEND_RESPONSE(
             13,
-            i18n::s.get("core.locale.talk.npc.innkeeper.choices.eat") + u8" ("s
-                + calcmealvalue() + i18n::_(u8"ui", u8"gold") + u8")"s);
-        if (game_data.weather == 1 || game_data.weather == 4
-            || game_data.weather == 2)
+            i18n::s.get("core.locale.talk.npc.innkeeper.choices.eat") +
+                u8" ("s + calcmealvalue() + i18n::_(u8"ui", u8"gold") + u8")"s);
+        if (game_data.weather == 1 || game_data.weather == 4 ||
+            game_data.weather == 2)
         {
             ELONA_APPEND_RESPONSE(
                 43,
@@ -1965,19 +1965,19 @@ TalkResult talk_npc()
     {
         ELONA_APPEND_RESPONSE(
             14,
-            i18n::s.get("core.locale.talk.npc.wizard.choices.identify")
-                + u8" ("s + calcidentifyvalue(0) + i18n::_(u8"ui", u8"gold")
-                + u8")"s);
+            i18n::s.get("core.locale.talk.npc.wizard.choices.identify") +
+                u8" ("s + calcidentifyvalue(0) + i18n::_(u8"ui", u8"gold") +
+                u8")"s);
         ELONA_APPEND_RESPONSE(
             15,
-            i18n::s.get("core.locale.talk.npc.wizard.choices.identify_all")
-                + u8" ("s + calcidentifyvalue(1) + i18n::_(u8"ui", u8"gold")
-                + u8")"s);
+            i18n::s.get("core.locale.talk.npc.wizard.choices.identify_all") +
+                u8" ("s + calcidentifyvalue(1) + i18n::_(u8"ui", u8"gold") +
+                u8")"s);
         ELONA_APPEND_RESPONSE(
             16,
-            i18n::s.get("core.locale.talk.npc.wizard.choices.investigate")
-                + u8" ("s + calcidentifyvalue(2) + i18n::_(u8"ui", u8"gold")
-                + u8")"s);
+            i18n::s.get("core.locale.talk.npc.wizard.choices.investigate") +
+                u8" ("s + calcidentifyvalue(2) + i18n::_(u8"ui", u8"gold") +
+                u8")"s);
     }
     if (cdata[tc].character_role == 7)
     {
@@ -2002,9 +2002,9 @@ TalkResult talk_npc()
         ELONA_APPEND_RESPONSE(
             19,
             i18n::s.get(
-                "core.locale.talk.npc.healer.choices.restore_attributes")
-                + u8"("s + calcrestorecost() + i18n::_(u8"ui", u8"gold")
-                + u8")"s);
+                "core.locale.talk.npc.healer.choices.restore_attributes") +
+                u8"("s + calcrestorecost() + i18n::_(u8"ui", u8"gold") +
+                u8")"s);
     }
     if (cdata[tc].character_role == 13)
     {
@@ -2198,8 +2198,8 @@ TalkResult talk_npc()
             quest_complete();
         }
         else if (
-            quest_data[rq].client_chara_type == 3
-            && quest_data[rq].progress == 1)
+            quest_data[rq].client_chara_type == 3 &&
+            quest_data[rq].progress == 1)
         {
             supply = -1;
             for (const auto& cnt : items(0))
@@ -2216,8 +2216,8 @@ TalkResult talk_npc()
                 {
                     if (the_item_db[inv[cnt].id]->category == 57000)
                     {
-                        if (inv[cnt].param1 / 1000
-                            == quest_data[rq].extra_info_1)
+                        if (inv[cnt].param1 / 1000 ==
+                            quest_data[rq].extra_info_1)
                         {
                             if (inv[cnt].param2 == quest_data[rq].extra_info_2)
                             {
@@ -2273,9 +2273,9 @@ TalkResult talk_npc()
         {
             if (cdata[tc].character_role != 0)
             {
-                if ((cdata[tc].character_role < 2000
-                     || cdata[tc].character_role >= 3000)
-                    && event_id() == -1)
+                if ((cdata[tc].character_role < 2000 ||
+                     cdata[tc].character_role >= 3000) &&
+                    event_id() == -1)
                 {
                     ELONA_APPEND_RESPONSE(
                         44,
@@ -2309,15 +2309,15 @@ TalkResult talk_npc()
 
     if (chatval_ == 10 || chatval_ == 11)
     {
-        if ((cdata[tc].character_role >= 1000
-             && cdata[tc].character_role < 2000)
-            || cdata[tc].character_role == 2003)
+        if ((cdata[tc].character_role >= 1000 &&
+             cdata[tc].character_role < 2000) ||
+            cdata[tc].character_role == 2003)
         {
-            if (cdata.player().karma < -30
-                && cdata.player().is_incognito() == 0)
+            if (cdata.player().karma < -30 &&
+                cdata.player().is_incognito() == 0)
             {
-                if (game_data.current_map != mdata_t::MapId::derphy
-                    && game_data.current_map != mdata_t::MapId::your_home)
+                if (game_data.current_map != mdata_t::MapId::derphy &&
+                    game_data.current_map != mdata_t::MapId::your_home)
                 {
                     listmax = 0;
                     if (chatval_ == 10)

--- a/src/talk_unique.cpp
+++ b/src/talk_unique.cpp
@@ -186,8 +186,8 @@ TalkResult talk_unique_loyter()
 
         return TalkResult::talk_end;
     }
-    if (game_data.quest_flags.nightmare == 1
-        || game_data.quest_flags.nightmare == 2)
+    if (game_data.quest_flags.nightmare == 1 ||
+        game_data.quest_flags.nightmare == 2)
     {
         ELONA_APPEND_RESPONSE(
             1,
@@ -861,8 +861,8 @@ TalkResult talk_unique_lomias()
                 i18n::s.get(
                     "core.locale.talk.unique.lomias.after.choices.nothing"));
         }
-        if (game_data.quest_flags.tutorial == 0
-            || game_data.quest_flags.tutorial == -1)
+        if (game_data.quest_flags.tutorial == 0 ||
+            game_data.quest_flags.tutorial == -1)
         {
             ELONA_APPEND_RESPONSE(
                 2,
@@ -1340,8 +1340,8 @@ TalkResult talk_unique_erystia()
             5,
             i18n::s.get("core.locale.talk.unique.erystia.investigation.choices."
                         "mission"));
-        if (game_data.quest_flags.main_quest >= 100
-            && game_data.quest_flags.main_quest <= 120)
+        if (game_data.quest_flags.main_quest >= 100 &&
+            game_data.quest_flags.main_quest <= 120)
         {
             ELONA_APPEND_RESPONSE(
                 3,
@@ -1784,8 +1784,8 @@ TalkResult talk_unique_pael()
 {
     if (game_data.quest_flags.pael_and_her_mom == 1000)
     {
-        if (game_data.current_map == mdata_t::MapId::noyel
-            && area_data[game_data.current_map].christmas_festival)
+        if (game_data.current_map == mdata_t::MapId::noyel &&
+            area_data[game_data.current_map].christmas_festival)
         {
             listmax = 0;
             buff = i18n::s.get("core.locale.talk.unique.pael.festival");
@@ -1835,8 +1835,8 @@ TalkResult talk_unique_pael()
         game_data.quest_flags.pael_and_her_mom = 1;
         return TalkResult::talk_end;
     }
-    if (game_data.quest_flags.pael_and_her_mom == 1
-        || game_data.quest_flags.pael_and_her_mom == 3)
+    if (game_data.quest_flags.pael_and_her_mom == 1 ||
+        game_data.quest_flags.pael_and_her_mom == 3)
     {
         listmax = 0;
         buff = i18n::s.get_enum("core.locale.talk.unique.pael.progress", 0);
@@ -1846,8 +1846,8 @@ TalkResult talk_unique_pael()
         ELONA_TALK_SCENE_CUT();
         return TalkResult::talk_end;
     }
-    if (game_data.quest_flags.pael_and_her_mom == 5
-        || game_data.quest_flags.pael_and_her_mom == 7)
+    if (game_data.quest_flags.pael_and_her_mom == 5 ||
+        game_data.quest_flags.pael_and_her_mom == 7)
     {
         listmax = 0;
         buff = i18n::s.get_enum(
@@ -1858,8 +1858,8 @@ TalkResult talk_unique_pael()
         ELONA_TALK_SCENE_CUT();
         return TalkResult::talk_end;
     }
-    if (game_data.quest_flags.pael_and_her_mom == 2
-        || game_data.quest_flags.pael_and_her_mom == 4)
+    if (game_data.quest_flags.pael_and_her_mom == 2 ||
+        game_data.quest_flags.pael_and_her_mom == 4)
     {
         buff = i18n::s.get_enum(
             "core.locale.talk.unique.pael.progress", 2, cdatan(0, 0));
@@ -1995,8 +1995,8 @@ TalkResult talk_unique_paels_mom()
     }
     if (game_data.quest_flags.pael_and_her_mom == 1000)
     {
-        if (game_data.current_map == mdata_t::MapId::noyel
-            && area_data[game_data.current_map].christmas_festival)
+        if (game_data.current_map == mdata_t::MapId::noyel &&
+            area_data[game_data.current_map].christmas_festival)
         {
             buff = i18n::s.get(
                 "core.locale.talk.unique.paels_mom.progress.festival.dialog");
@@ -2221,8 +2221,8 @@ TalkResult talk_unique_raphael()
 
         return TalkResult::talk_end;
     }
-    if (game_data.quest_flags.wife_collector == 1
-        || game_data.quest_flags.wife_collector == 1000)
+    if (game_data.quest_flags.wife_collector == 1 ||
+        game_data.quest_flags.wife_collector == 1000)
     {
         ELONA_APPEND_RESPONSE(
             1,
@@ -2719,8 +2719,8 @@ TalkResult talk_unique_gilbert()
 
         return TalkResult::talk_end;
     }
-    if (game_data.quest_flags.defense_line == 1
-        || game_data.quest_flags.defense_line == 2)
+    if (game_data.quest_flags.defense_line == 1 ||
+        game_data.quest_flags.defense_line == 2)
     {
         ELONA_APPEND_RESPONSE(
             1,
@@ -2845,8 +2845,8 @@ TalkResult talk_unique_arnord()
 
         return TalkResult::talk_end;
     }
-    if (game_data.quest_flags.kamikaze_attack == 1
-        || game_data.quest_flags.kamikaze_attack == 2)
+    if (game_data.quest_flags.kamikaze_attack == 1 ||
+        game_data.quest_flags.kamikaze_attack == 2)
     {
         ELONA_APPEND_RESPONSE(
             1,
@@ -3052,8 +3052,8 @@ TalkResult talk_unique_renton()
         ELONA_TALK_SCENE_CUT();
         return TalkResult::talk_end;
     }
-    if (game_data.quest_flags.rare_books == 0
-        || game_data.quest_flags.rare_books == 1)
+    if (game_data.quest_flags.rare_books == 0 ||
+        game_data.quest_flags.rare_books == 1)
     {
         listmax = 0;
         buff =
@@ -3515,8 +3515,8 @@ TalkResult talk_unique_icolle()
 
         return TalkResult::talk_end;
     }
-    if (game_data.quest_flags.ambitious_scientist >= 1
-        && game_data.quest_flags.ambitious_scientist <= 5)
+    if (game_data.quest_flags.ambitious_scientist >= 1 &&
+        game_data.quest_flags.ambitious_scientist <= 5)
     {
         f = _icolle_check_monster_balls();
         if (f)
@@ -4866,8 +4866,8 @@ void _part_time_worker_switch_religion()
 
 TalkResult talk_unique_part_time_worker()
 {
-    if (game_data.current_map != mdata_t::MapId::noyel
-        || area_data[game_data.current_map].christmas_festival == 0)
+    if (game_data.current_map != mdata_t::MapId::noyel ||
+        area_data[game_data.current_map].christmas_festival == 0)
     {
         return TalkResult::talk_end;
     }

--- a/src/tcg.cpp
+++ b/src/tcg.cpp
@@ -236,9 +236,9 @@ int card_ref(int prm_991)
     if (cardreftype == 10)
     {
         cardrefbg = cardrefdomain;
-        rtvaln += " <" + i18n::s.get("core.locale.tcg.card.creature") + ">  "
-            + i18n::s.get("core.locale.tcg.card.race") + ":" + cardrefrace
-            + u8"  Hp:"s + cardrefhp + u8"  Atk:"s + cardrefattack;
+        rtvaln += " <" + i18n::s.get("core.locale.tcg.card.creature") + ">  " +
+            i18n::s.get("core.locale.tcg.card.race") + ":" + cardrefrace +
+            u8"  Hp:"s + cardrefhp + u8"  Atk:"s + cardrefattack;
     }
     if (cardreftype == 30)
     {
@@ -250,10 +250,10 @@ int card_ref(int prm_991)
         cardrefbg = 5;
         rtvaln += " <" + i18n::s.get("core.locale.tcg.card.spell") + ">";
     }
-    rtvaln += "  " + i18n::s.get("core.locale.tcg.card.domain") + ":"
-        + domname_at_tcg(cardrefdomain);
-    rtvaln += "  " + i18n::s.get("core.locale.tcg.card.rare") + ":"
-        + cnvrare(cardrefrare);
+    rtvaln += "  " + i18n::s.get("core.locale.tcg.card.domain") + ":" +
+        domname_at_tcg(cardrefdomain);
+    rtvaln += "  " + i18n::s.get("core.locale.tcg.card.rare") + ":" +
+        cnvrare(cardrefrare);
     if (cardrefskill != 0)
     {
         s_at_tcg = "";
@@ -450,8 +450,8 @@ void tcgdrawcard(int prm_994, int prm_995)
             gmode(4, card_at_tcg(7, prm_994) * 15);
         }
         pos(x_at_tcg, y_at_tcg);
-        if (cdbit(1, prm_994) == 1
-            || (card_at_tcg(1, prm_994) == 0 && cnt == 1))
+        if (cdbit(1, prm_994) == 1 ||
+            (card_at_tcg(1, prm_994) == 0 && cnt == 1))
         {
             if (card_at_tcg(17, prm_994) > 0)
             {
@@ -459,8 +459,8 @@ void tcgdrawcard(int prm_994, int prm_995)
                 p_at_tcg = card_at_tcg(17, prm_994) % 1000;
                 auto rect = chara_preparepic(card_at_tcg(17, prm_994));
                 pos(x_at_tcg + 13,
-                    y_at_tcg + 32 - chara_chips[p_at_tcg].offset_y
-                        + rect->height / 6);
+                    y_at_tcg + 32 - chara_chips[p_at_tcg].offset_y +
+                        rect->height / 6);
                 gcopy(rect->buffer, 0, 960, rect->width, rect->height);
             }
             else
@@ -593,17 +593,17 @@ void tcgdraw()
             {
                 continue;
             }
-            if (card_at_tcg(2, c_at_tcg) != card_at_tcg(4, c_at_tcg)
-                || card_at_tcg(3, c_at_tcg) != card_at_tcg(5, c_at_tcg)
-                || card_at_tcg(7, c_at_tcg) > 0)
+            if (card_at_tcg(2, c_at_tcg) != card_at_tcg(4, c_at_tcg) ||
+                card_at_tcg(3, c_at_tcg) != card_at_tcg(5, c_at_tcg) ||
+                card_at_tcg(7, c_at_tcg) > 0)
             {
                 anime_at_tcg = 1;
                 p_at_tcg = 0;
                 if (card_at_tcg(2, c_at_tcg) != card_at_tcg(4, c_at_tcg))
                 {
                     p_at_tcg =
-                        (card_at_tcg(4, c_at_tcg) - card_at_tcg(2, c_at_tcg))
-                        / 6;
+                        (card_at_tcg(4, c_at_tcg) - card_at_tcg(2, c_at_tcg)) /
+                        6;
                     if (card_at_tcg(2, c_at_tcg) > card_at_tcg(4, c_at_tcg))
                     {
                         --p_at_tcg;
@@ -618,8 +618,8 @@ void tcgdraw()
                 if (card_at_tcg(3, c_at_tcg) != card_at_tcg(5, c_at_tcg))
                 {
                     p_at_tcg =
-                        (card_at_tcg(5, c_at_tcg) - card_at_tcg(3, c_at_tcg))
-                        / 6;
+                        (card_at_tcg(5, c_at_tcg) - card_at_tcg(3, c_at_tcg)) /
+                        6;
                     if (card_at_tcg(3, c_at_tcg) > card_at_tcg(5, c_at_tcg))
                     {
                         --p_at_tcg;
@@ -1224,9 +1224,9 @@ void saccard(int prm_1019, int prm_1020)
     int stat = card_ref(500 + card_at_tcg(23, prm_1019) * 2 + rnd(2));
     create_card(prm_1019, stat);
     cdbitmod(1, prm_1019, 1);
-    card_at_tcg(4, prm_1019) = landix_at_tcg(prm_1020)
-        + landsum_at_tcg(prm_1020)
-            * clamp(
+    card_at_tcg(4, prm_1019) = landix_at_tcg(prm_1020) +
+        landsum_at_tcg(prm_1020) *
+            clamp(
                 (landspace_at_tcg - landsum_at_tcg(prm_1020) / 2),
                 4,
                 landspace_at_tcg);
@@ -1313,8 +1313,8 @@ void actionproc()
                              ++cnt)
                         {
                             c_at_tcg = clist_at_tcg(cnt, cl_at_tcg);
-                            if (cdbit(0, c_at_tcg) == 0
-                                || card_at_tcg(14, c_at_tcg) == -4)
+                            if (cdbit(0, c_at_tcg) == 0 ||
+                                card_at_tcg(14, c_at_tcg) == -4)
                             {
                                 cs_at_tcg = cnt;
                                 csline_at_tcg = cl_at_tcg;
@@ -1488,9 +1488,9 @@ int putcard(int prm_1024, int prm_1025)
     if (card_at_tcg(9, prm_1024) == 30)
     {
         cdbitmod(1, prm_1024, 1);
-        card_at_tcg(4, prm_1024) = landix_at_tcg(prm_1025)
-            + landsum_at_tcg(prm_1025)
-                * clamp(
+        card_at_tcg(4, prm_1024) = landix_at_tcg(prm_1025) +
+            landsum_at_tcg(prm_1025) *
+                clamp(
                     (landspace_at_tcg - landsum_at_tcg(prm_1025) / 2),
                     4,
                     landspace_at_tcg);
@@ -1627,8 +1627,8 @@ void tcginit()
 
 int calcstartcard(int prm_1026)
 {
-    return 6 - (cpdata_at_tcg(9, prm_1026) > 2)
-        - (cpdata_at_tcg(9, prm_1026) > 3) - (cpdata_at_tcg(9, prm_1026) > 4);
+    return 6 - (cpdata_at_tcg(9, prm_1026) > 2) -
+        (cpdata_at_tcg(9, prm_1026) > 3) - (cpdata_at_tcg(9, prm_1026) > 4);
 }
 
 
@@ -1745,8 +1745,8 @@ void tcgdeck()
             {
                 if (game_data.tcg_decks.at(cnt) != 30)
                 {
-                    s_at_tcg(cnt) += u8" (NG "s + game_data.tcg_decks.at(cnt)
-                        + u8"/"s + 30 + u8")"s;
+                    s_at_tcg(cnt) += u8" (NG "s + game_data.tcg_decks.at(cnt) +
+                        u8"/"s + 30 + u8")"s;
                 }
                 if (game_data.tcg_used_deck == cnt)
                 {
@@ -2083,9 +2083,9 @@ void tcg_update_mana()
              cnt < cnt_end;
              ++cnt)
         {
-            x_at_tcg = landix_at_tcg(cnt2_at_tcg)
-                + cnt
-                    * clamp(
+            x_at_tcg = landix_at_tcg(cnt2_at_tcg) +
+                cnt *
+                    clamp(
                         (landspace_at_tcg - landsum_at_tcg(cnt2_at_tcg) / 2),
                         4,
                         landspace_at_tcg);
@@ -2133,8 +2133,8 @@ void tcg_update_mana()
                 auto rect = chara_preparepic(card_at_tcg(17, m_at_tcg));
                 gsel(4);
                 pos(x_at_tcg + 13,
-                    y_at_tcg + 32 - chara_chips[n_at_tcg].offset_y
-                        + rect->height / 6);
+                    y_at_tcg + 32 - chara_chips[n_at_tcg].offset_y +
+                        rect->height / 6);
                 gcopy(rect->buffer, 0, 960, rect->width, rect->height);
             }
             else
@@ -2228,11 +2228,11 @@ void tcg_draw_selection()
     font(13 - en * 2);
     color(255, 255, 255);
     pos(basex_at_tcg + 160, basey_at_tcg + 510);
-    mes(""s + key_next + u8","s + key_prev
-        + i18n::s.get("core.locale.tcg.select.hint"));
+    mes(""s + key_next + u8","s + key_prev +
+        i18n::s.get("core.locale.tcg.select.hint"));
     pos(basex_at_tcg + 700, basey_at_tcg + 510);
-    mes(u8"Page "s + dsc_at_tcg / 8 / 3 + u8"/"s
-        + (dlistmax_at_tcg - 1) / 8 / 3);
+    mes(u8"Page "s + dsc_at_tcg / 8 / 3 + u8"/"s +
+        (dlistmax_at_tcg - 1) / 8 / 3);
     color(0, 0, 0);
 }
 
@@ -2277,8 +2277,8 @@ void tcg_draw_deck_editor()
             }
             else
             {
-                s_at_tcg = ""s + cpdata_at_tcg(5, cnt) + u8"/"s
-                    + cpdata_at_tcg(6, cnt);
+                s_at_tcg = ""s + cpdata_at_tcg(5, cnt) + u8"/"s +
+                    cpdata_at_tcg(6, cnt);
             }
             pos(x_at_tcg + 36 - strlen_u(s_at_tcg) * 3, y_at_tcg + 95 - en);
             mes(s_at_tcg);
@@ -2493,10 +2493,10 @@ label_1829_internal:
         }
         for (int cnt = 0, cnt_end = (dlistmax_at_tcg - 1); cnt < cnt_end; ++cnt)
         {
-            p_at_tcg(0) = card_at_tcg(10, dlist_at_tcg(0, cnt)) * 10000
-                + card_at_tcg(18, dlist_at_tcg(0, cnt));
-            p_at_tcg(1) = card_at_tcg(10, dlist_at_tcg(0, (cnt + 1))) * 10000
-                + card_at_tcg(18, dlist_at_tcg(0, (cnt + 1)));
+            p_at_tcg(0) = card_at_tcg(10, dlist_at_tcg(0, cnt)) * 10000 +
+                card_at_tcg(18, dlist_at_tcg(0, cnt));
+            p_at_tcg(1) = card_at_tcg(10, dlist_at_tcg(0, (cnt + 1))) * 10000 +
+                card_at_tcg(18, dlist_at_tcg(0, (cnt + 1)));
             if (p_at_tcg > p_at_tcg(1))
             {
                 f_at_tcg = 1;
@@ -2587,8 +2587,8 @@ label_1830_internal:
             act_at_tcg(1) = 0;
             act_at_tcg(2) = 0;
             cc_at_tcg = dlist_at_tcg(0, dsc_at_tcg);
-            if (deck(card_at_tcg(18, cc_at_tcg))
-                < card(0, card_at_tcg(18, cc_at_tcg)))
+            if (deck(card_at_tcg(18, cc_at_tcg)) <
+                card(0, card_at_tcg(18, cc_at_tcg)))
             {
                 act_at_tcg(0) = 1;
             }
@@ -2765,8 +2765,8 @@ void tcg_prompt_action()
             {
                 if (card_at_tcg(10, cc_at_tcg) <= cpdata_at_tcg(5, cp_at_tcg))
                 {
-                    if (card_at_tcg(9, cc_at_tcg) == 20
-                        || selectmode_at_tcg == 0)
+                    if (card_at_tcg(9, cc_at_tcg) == 20 ||
+                        selectmode_at_tcg == 0)
                     {
                         act_at_tcg(0) = 1;
                         s_at_tcg +=
@@ -2779,8 +2779,8 @@ void tcg_prompt_action()
                     {
                         act_at_tcg(1) = 1;
                         s_at_tcg +=
-                            i18n::s.get("core.locale.tcg.action.sacrifice")
-                            + "\n";
+                            i18n::s.get("core.locale.tcg.action.sacrifice") +
+                            "\n";
                     }
                 }
             }
@@ -2795,8 +2795,8 @@ void tcg_prompt_action()
                             act_at_tcg(0) = 1;
                             s_at_tcg +=
                                 i18n::s.get(
-                                    "core.locale.tcg.action.declare_attack")
-                                + "\n";
+                                    "core.locale.tcg.action.declare_attack") +
+                                "\n";
                         }
                     }
                 }

--- a/src/tests/config_def.cpp
+++ b/src/tests/config_def.cpp
@@ -105,17 +105,17 @@ config def {
 )");
 
     REQUIRE(
-        def.get_metadata("core.config.foo").platform
-        == ConfigDef::Platform::all);
+        def.get_metadata("core.config.foo").platform ==
+        ConfigDef::Platform::all);
     REQUIRE(
-        def.get_metadata("core.config.baz").platform
-        == ConfigDef::Platform::desktop);
+        def.get_metadata("core.config.baz").platform ==
+        ConfigDef::Platform::desktop);
     REQUIRE(
-        def.get_metadata("core.config.hoge").platform
-        == ConfigDef::Platform::android);
+        def.get_metadata("core.config.hoge").platform ==
+        ConfigDef::Platform::android);
     REQUIRE(
-        def.get_metadata("core.config.fuga").platform
-        == ConfigDef::Platform::all);
+        def.get_metadata("core.config.fuga").platform ==
+        ConfigDef::Platform::all);
 }
 
 TEST_CASE("Test metadata: platform_default", "[Config: Definition]")
@@ -139,14 +139,14 @@ config def {
 )");
 
     REQUIRE(
-        static_cast<bool>(def.get_metadata("core.config.foo").default_value)
-        == false);
+        static_cast<bool>(def.get_metadata("core.config.foo").default_value) ==
+        false);
     REQUIRE(
-        def.get_metadata("core.config.bar").default_value->as<std::string>()
-        == "hoge");
+        def.get_metadata("core.config.bar").default_value->as<std::string>() ==
+        "hoge");
     REQUIRE(
-        static_cast<bool>(def.get_metadata("core.config.baz").default_value)
-        == false);
+        static_cast<bool>(def.get_metadata("core.config.baz").default_value) ==
+        false);
 }
 
 TEST_CASE("Test metadata: is_visible()", "[Config: Definition]")

--- a/src/tests/elonacore.cpp
+++ b/src/tests/elonacore.cpp
@@ -20,8 +20,8 @@ TEST_CASE("Test cutname", "[C++: Misc.]")
 
     REQUIRE(cutname(u8"タイム・デューク シュハード", 0) == u8"");
     REQUIRE(
-        cutname(u8"タイム・デューク シュハード", 99)
-        == u8"タイム・デューク シュハード");
+        cutname(u8"タイム・デューク シュハード", 99) ==
+        u8"タイム・デューク シュハード");
 
     REQUIRE(cutname(u8"タイム・デューク シュハード", 1) == u8"");
     REQUIRE(cutname(u8"タイム・デューク シュハード", 6) == u8"タイム");
@@ -36,33 +36,33 @@ TEST_CASE("Test cutname", "[C++: Misc.]")
     REQUIRE(
         cutname(u8"タイム・デューク シュハード", 18) == u8"タイム・デューク ");
     REQUIRE(
-        cutname(u8"タイム・デューク シュハード", 19)
-        == u8"タイム・デューク シ");
+        cutname(u8"タイム・デューク シュハード", 19) ==
+        u8"タイム・デューク シ");
     REQUIRE(
-        cutname(u8"タイム・デューク シュハード", 25)
-        == u8"タイム・デューク シュハー");
+        cutname(u8"タイム・デューク シュハード", 25) ==
+        u8"タイム・デューク シュハー");
     REQUIRE(
-        cutname(u8"タイム・デューク シュハード", 26)
-        == u8"タイム・デューク シュハー");
+        cutname(u8"タイム・デューク シュハード", 26) ==
+        u8"タイム・デューク シュハー");
     REQUIRE(
-        cutname(u8"タイム・デューク シュハード", 27)
-        == u8"タイム・デューク シュハード");
+        cutname(u8"タイム・デューク シュハード", 27) ==
+        u8"タイム・デューク シュハード");
     REQUIRE(
-        cutname(u8"タイム・デューク シュハード", 28)
-        == u8"タイム・デューク シュハード");
+        cutname(u8"タイム・デューク シュハード", 28) ==
+        u8"タイム・デューク シュハード");
     REQUIRE(
-        cutname(u8"タイム・デューク シュハード", 29)
-        == u8"タイム・デューク シュハード");
+        cutname(u8"タイム・デューク シュハード", 29) ==
+        u8"タイム・デューク シュハード");
 
     REQUIRE(cutname(u8"Gentleness of Immortality Sonya", 1) == u8"G");
     REQUIRE(cutname(u8"Gentleness of Immortality Sonya", 2) == u8"Ge");
     REQUIRE(
-        cutname(u8"Gentleness of Immortality Sonya", 30)
-        == u8"Gentleness of Immortality Sony");
+        cutname(u8"Gentleness of Immortality Sonya", 30) ==
+        u8"Gentleness of Immortality Sony");
     REQUIRE(
-        cutname(u8"Gentleness of Immortality Sonya", 31)
-        == u8"Gentleness of Immortality Sonya");
+        cutname(u8"Gentleness of Immortality Sonya", 31) ==
+        u8"Gentleness of Immortality Sonya");
     REQUIRE(
-        cutname(u8"Gentleness of Immortality Sonya", 32)
-        == u8"Gentleness of Immortality Sonya");
+        cutname(u8"Gentleness of Immortality Sonya", 32) ==
+        u8"Gentleness of Immortality Sonya");
 }

--- a/src/tests/filesystem.cpp
+++ b/src/tests/filesystem.cpp
@@ -7,14 +7,14 @@ using namespace elona;
 TEST_CASE("Test resolve_path_for_mod", "[C++: Filesystem]")
 {
     REQUIRE(
-        filesystem::resolve_path_for_mod("__BUILTIN__/dood")
-        == filesystem::dir::exe() / "dood");
+        filesystem::resolve_path_for_mod("__BUILTIN__/dood") ==
+        filesystem::dir::exe() / "dood");
     REQUIRE(
-        filesystem::resolve_path_for_mod("__test__/dood")
-        == filesystem::dir::for_mod("test") / "dood");
+        filesystem::resolve_path_for_mod("__test__/dood") ==
+        filesystem::dir::for_mod("test") / "dood");
     REQUIRE(
-        filesystem::resolve_path_for_mod("__test__/__dood__/file.txt")
-        == filesystem::dir::for_mod("test") / "__dood__" / "file.txt");
+        filesystem::resolve_path_for_mod("__test__/__dood__/file.txt") ==
+        filesystem::dir::for_mod("test") / "__dood__" / "file.txt");
 
     REQUIRE_THROWS(filesystem::resolve_path_for_mod("file.txt"));
     REQUIRE_THROWS(filesystem::resolve_path_for_mod("____"));

--- a/src/tests/i18n.cpp
+++ b/src/tests/i18n.cpp
@@ -36,8 +36,8 @@ TEST_CASE("test formats", "[I18N: Formatting]")
     REQUIRE(
         i18n::fmt_hil("You see ${_1}.", u8"Palmia") == u8"You see Palmia."s);
     REQUIRE(
-        i18n::fmt_hil("You see ${_1} the ${_2}.", u8"Adam", u8"rock thrower")
-        == u8"You see Adam the rock thrower."s);
+        i18n::fmt_hil("You see ${_1} the ${_2}.", u8"Adam", u8"rock thrower") ==
+        u8"You see Adam the rock thrower."s);
 }
 
 TEST_CASE("test format chara", "[I18N: Formatting]")
@@ -47,8 +47,8 @@ TEST_CASE("test format chara", "[I18N: Formatting]")
     Character& chara = elona::cdata[elona::rc];
 
     REQUIRE(
-        i18n::fmt_hil("${_1}", chara)
-        == u8"<Character: "s + std::to_string(chara.index) + u8">"s);
+        i18n::fmt_hil("${_1}", chara) ==
+        u8"<Character: "s + std::to_string(chara.index) + u8">"s);
 }
 
 TEST_CASE("test format item", "[I18N: Formatting]")
@@ -58,8 +58,8 @@ TEST_CASE("test format item", "[I18N: Formatting]")
     Item& i = elona::inv[elona::ci];
 
     REQUIRE(
-        i18n::fmt_hil("${_1}", i)
-        == u8"<Item: "s + std::to_string(i.index) + u8">"s);
+        i18n::fmt_hil("${_1}", i) ==
+        u8"<Item: "s + std::to_string(i.index) + u8">"s);
 }
 
 TEST_CASE("test format character by function", "[I18N: Formatting]")
@@ -189,8 +189,8 @@ locale {
     REQUIRE(store.get(u8"test.locale.foo", 12, u8"bar") == u8"bar: 12");
     REQUIRE(store.get(u8"test.locale.foo", u8"bar", u8"baz") == u8"baz: bar");
     REQUIRE(
-        store.get(u8"test.locale.foo", u8"bar", u8"baz", "hoge")
-        == u8"baz: bar");
+        store.get(u8"test.locale.foo", u8"bar", u8"baz", "hoge") ==
+        u8"baz: bar");
 }
 
 
@@ -210,11 +210,11 @@ locale {
 )");
 
     REQUIRE(
-        store.get_enum_property(u8"test.locale.foo", "name", 1, "dood")
-        == u8"bar: dood");
+        store.get_enum_property(u8"test.locale.foo", "name", 1, "dood") ==
+        u8"bar: dood");
     REQUIRE(
-        store.get_enum_property(u8"test.locale.foo", "name", 2, "dood")
-        == u8"baz: dood");
+        store.get_enum_property(u8"test.locale.foo", "name", 2, "dood") ==
+        u8"baz: dood");
 }
 
 

--- a/src/tests/i18n_builtins.cpp
+++ b/src/tests/i18n_builtins.cpp
@@ -164,11 +164,11 @@ TEST_CASE("test i18n builtin: s()", "[I18N: Builtins]")
     update_slight();
 
     REQUIRE(
-        i18n::fmt_hil("something go${s(_1)} to hell.", chara)
-        == u8"something gos to hell.");
+        i18n::fmt_hil("something go${s(_1)} to hell.", chara) ==
+        u8"something gos to hell.");
     REQUIRE(
-        i18n::fmt_hil("something go${s(_1, true)} to hell.", chara)
-        == u8"something goes to hell.");
+        i18n::fmt_hil("something go${s(_1, true)} to hell.", chara) ==
+        u8"something goes to hell.");
     REQUIRE(i18n::fmt_hil("${_1} stone${s(_1)}", 0) == u8"0 stones");
     REQUIRE(i18n::fmt_hil("${_1} stone${s(_1)}", 1) == u8"1 stone");
     REQUIRE(i18n::fmt_hil("${_1} stone${s(_1)}", 2) == u8"2 stones");
@@ -186,13 +186,13 @@ TEST_CASE("test i18n builtin: is()", "[I18N: Builtins]")
 
     REQUIRE(i18n::fmt_hil("you ${is(_1)} killed.", you) == u8"you are killed.");
     REQUIRE(
-        i18n::fmt_hil("something ${is(_1)} killed.", chara)
-        == u8"something is killed.");
+        i18n::fmt_hil("something ${is(_1)} killed.", chara) ==
+        u8"something is killed.");
     REQUIRE(
         i18n::fmt_hil("you ${is(true)} killed.", you) == u8"you are killed.");
     REQUIRE(
-        i18n::fmt_hil("something ${is(false)} killed.", chara)
-        == u8"something is killed.");
+        i18n::fmt_hil("something ${is(false)} killed.", chara) ==
+        u8"something is killed.");
 }
 
 TEST_CASE("test i18n builtin: have()", "[I18N: Builtins]")
@@ -275,8 +275,8 @@ TEST_CASE("test i18n builtin: you()", "[I18N: Builtins]")
         testing::set_japanese();
         REQUIRE(i18n::fmt_hil("${you()}") == u8"あなた");
         REQUIRE(
-            i18n::fmt_hil(u8"うわああ！${you()}は階段から足を踏み外した。")
-            == u8"うわああ！あなたは階段から足を踏み外した。");
+            i18n::fmt_hil(u8"うわああ！${you()}は階段から足を踏み外した。") ==
+            u8"うわああ！あなたは階段から足を踏み外した。");
     }
     SECTION("English")
     {

--- a/src/tests/i18n_regressions.cpp
+++ b/src/tests/i18n_regressions.cpp
@@ -37,7 +37,7 @@ TEST_CASE("test foodname", "[I18N: Regressions]")
             i18n::fmt_hil("${itemname(_1)}", item) == u8"鳥のレアチーズケーキ");
         item.subname = 3;
         REQUIRE(
-            i18n::fmt_hil("${itemname(_1)}", item)
-            == u8"プチのレアチーズケーキ");
+            i18n::fmt_hil("${itemname(_1)}", item) ==
+            u8"プチのレアチーズケーキ");
     }
 }

--- a/src/tests/lua_data_character.cpp
+++ b/src/tests/lua_data_character.cpp
@@ -31,8 +31,8 @@ TEST_CASE("test reading invalid enum", "[Lua: Data]")
     auto data = db["chara_invalid_enum.putit"];
     REQUIRE_NONE(data);
     REQUIRE(
-        *db.error(SharedId("chara_invalid_enum.putit"))
-        == "Enum value Whatever for Color not found.");
+        *db.error(SharedId("chara_invalid_enum.putit")) ==
+        "Enum value Whatever for Color not found.");
 }
 
 TEST_CASE("test reading duplicate keys", "[Lua: Data]")

--- a/src/tests/lua_handles.cpp
+++ b/src/tests/lua_handles.cpp
@@ -437,8 +437,8 @@ TEST_CASE("Test copying of character handles", "[Lua: Handles]")
     // Copying will create a handle with a unique UUID if no item
     // existed before at the new index.
     REQUIRE(
-        handle["__uuid"].get<std::string>()
-        != handle_copy["__uuid"].get<std::string>());
+        handle["__uuid"].get<std::string>() !=
+        handle_copy["__uuid"].get<std::string>());
 
     // Assert that copying to an existing character will not try to
     // overwrite the existing handle.
@@ -598,8 +598,8 @@ TEST_CASE("Test copying of item handles", "[Lua: Handles]")
     // Copying will create a handle with a unique UUID if no item
     // existed before at the new index.
     REQUIRE(
-        handle["__uuid"].get<std::string>()
-        != handle_copy["__uuid"].get<std::string>());
+        handle["__uuid"].get<std::string>() !=
+        handle_copy["__uuid"].get<std::string>());
 
     // Assert that copying to an existing item will not try to
     // overwrite the existing handle.

--- a/src/tests/util.cpp
+++ b/src/tests/util.cpp
@@ -87,8 +87,8 @@ void register_lua_function(
         "\
 local Exports = {}\
 \
-function Exports."
-            + callback_signature + "\n" + callback_body + R"(
+function Exports." +
+            callback_signature + "\n" + callback_body + R"(
 end
 
 return {

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -269,11 +269,11 @@ std::string maplevel(int)
     }
     if (map_shows_floor_count_in_name())
     {
-        return ""s
-            + cnvrank(
-                   (game_data.current_dungeon_level
-                    - area_data[game_data.current_map].danger_level + 1))
-            + i18n::s.get("core.locale.map.nefia.level");
+        return ""s +
+            cnvrank(
+                   (game_data.current_dungeon_level -
+                    area_data[game_data.current_map].danger_level + 1)) +
+            i18n::s.get("core.locale.map.nefia.level");
     }
 
     return "";
@@ -306,8 +306,8 @@ std::string mapname(int id, bool description)
         {
             name = i18n::s.get("core.locale.map.quest.outskirts");
         }
-        if (game_data.executing_immediate_quest_type == 1010
-            || game_data.executing_immediate_quest_type == 1008)
+        if (game_data.executing_immediate_quest_type == 1010 ||
+            game_data.executing_immediate_quest_type == 1008)
         {
             name = i18n::s.get("core.locale.map.quest.urban_area");
         }
@@ -434,8 +434,8 @@ std::string _yoro(int mark)
          {u8"よろしくでござりまする", u8"どうぞよしなに"}},
         {{u8"よろしくッス"}, {u8"よろしくにゃの"}},
     };
-    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex])
-        + i18n::_(u8"ui", u8"mark", u8"_"s + mark);
+    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex]) +
+        i18n::_(u8"ui", u8"mark", u8"_"s + mark);
 }
 
 
@@ -455,8 +455,8 @@ std::string _dozo(int mark)
          {u8"お待たせ致しました", u8"ささ、どうぞ"}},
         {{u8"お待たせッス"}, {u8"お待たせにゃん"}},
     };
-    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex])
-        + i18n::_(u8"ui", u8"mark", u8"_"s + mark);
+    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex]) +
+        i18n::_(u8"ui", u8"mark", u8"_"s + mark);
 }
 
 
@@ -475,8 +475,8 @@ std::string _thanks(int mark)
          {u8"ありがたや", u8"お礼申し上げます"}},
         {{u8"アザーッス"}, {u8"にゃりーん"}},
     };
-    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex])
-        + i18n::_(u8"ui", u8"mark", u8"_"s + mark);
+    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex]) +
+        i18n::_(u8"ui", u8"mark", u8"_"s + mark);
 }
 
 
@@ -502,8 +502,8 @@ std::string _rob(int mark)
          {u8"ご無体な", u8"まあ、お戯れが過ぎますわ"}},
         {{u8"見損なったッス"}, {u8"にゃりーん"}},
     };
-    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex])
-        + i18n::_(u8"ui", u8"mark", u8"_"s + mark);
+    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex]) +
+        i18n::_(u8"ui", u8"mark", u8"_"s + mark);
 }
 
 
@@ -519,8 +519,8 @@ std::string _ka(int mark)
         {{u8"でござるか"}, {u8"でござりまするか"}},
         {{u8"ッスか"}, {u8"かにゃ", u8"かニャン"}},
     };
-    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex])
-        + i18n::_(u8"ui", u8"mark", u8"_"s + mark);
+    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex]) +
+        i18n::_(u8"ui", u8"mark", u8"_"s + mark);
 }
 
 
@@ -536,8 +536,8 @@ std::string _da(int mark)
         {{u8"でござる", u8"でござるよ"}, {u8"でござりまする"}},
         {{u8"ッス"}, {u8"みゃん", u8"ミャ"}},
     };
-    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex])
-        + i18n::_(u8"ui", u8"mark", u8"_"s + mark);
+    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex]) +
+        i18n::_(u8"ui", u8"mark", u8"_"s + mark);
 }
 
 
@@ -553,8 +553,8 @@ std::string _nda(int mark)
         {{u8"のでござる"}, {u8"のでございます"}},
         {{u8"んだッス"}, {u8"のニャ", u8"のにゃん"}},
     };
-    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex])
-        + i18n::_(u8"ui", u8"mark", u8"_"s + mark);
+    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex]) +
+        i18n::_(u8"ui", u8"mark", u8"_"s + mark);
 }
 
 
@@ -570,8 +570,8 @@ std::string _noka(int mark)
         {{u8"のでござるか"}, {u8"のでございます"}},
         {{u8"のッスか"}, {u8"にゃんか", u8"ニャン"}},
     };
-    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex])
-        + i18n::_(u8"ui", u8"mark", u8"_"s + mark);
+    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex]) +
+        i18n::_(u8"ui", u8"mark", u8"_"s + mark);
 }
 
 
@@ -587,8 +587,8 @@ std::string _kana(int mark)
         {{u8"でござるか"}, {u8"でございますか"}},
         {{u8"ッスか"}, {u8"かにゃん", u8"かニャ"}},
     };
-    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex])
-        + i18n::_(u8"ui", u8"mark", u8"_"s + mark);
+    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex]) +
+        i18n::_(u8"ui", u8"mark", u8"_"s + mark);
 }
 
 
@@ -604,8 +604,8 @@ std::string _kimi(int mark)
         {{u8"そこもと"}, {u8"そなた様"}},
         {{u8"アンタ"}, {u8"あにゃた"}},
     };
-    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex])
-        + i18n::_(u8"ui", u8"mark", u8"_"s + mark);
+    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex]) +
+        i18n::_(u8"ui", u8"mark", u8"_"s + mark);
 }
 
 
@@ -621,8 +621,8 @@ std::string _ru(int mark)
         {{u8"るでござる", u8"るでござるよ"}, {u8"るのでございます"}},
         {{u8"るッス"}, {u8"るのニャ", u8"るにゃん"}},
     };
-    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex])
-        + i18n::_(u8"ui", u8"mark", u8"_"s + mark);
+    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex]) +
+        i18n::_(u8"ui", u8"mark", u8"_"s + mark);
 }
 
 
@@ -639,8 +639,8 @@ std::string _tanomu(int mark)
         {{u8"頼み申す", u8"頼むでござる"}, {u8"お頼み申し上げます"}},
         {{u8"頼むッス"}, {u8"おねがいにゃ", u8"おねがいニャン"}},
     };
-    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex])
-        + i18n::_(u8"ui", u8"mark", u8"_"s + mark);
+    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex]) +
+        i18n::_(u8"ui", u8"mark", u8"_"s + mark);
 }
 
 
@@ -656,8 +656,8 @@ std::string _ore(int mark)
         {{u8"拙者"}, {u8"手前"}},
         {{u8"あっし"}, {u8"みゅー"}},
     };
-    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex])
-        + i18n::_(u8"ui", u8"mark", u8"_"s + mark);
+    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex]) +
+        i18n::_(u8"ui", u8"mark", u8"_"s + mark);
 }
 
 
@@ -673,8 +673,8 @@ std::string _ga(int mark)
         {{u8"でござるが"}, {u8"でございますが"}},
         {{u8"ッスけど", u8"ッスが"}, {u8"ニャけど", u8"にゃが"}},
     };
-    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex])
-        + i18n::_(u8"ui", u8"mark", u8"_"s + mark);
+    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex]) +
+        i18n::_(u8"ui", u8"mark", u8"_"s + mark);
 }
 
 
@@ -690,8 +690,8 @@ std::string _dana(int mark)
         {{u8"でござるな"}, {u8"でございますね"}},
         {{u8"ッスね"}, {u8"にゃ", u8"みゃ"}},
     };
-    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex])
-        + i18n::_(u8"ui", u8"mark", u8"_"s + mark);
+    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex]) +
+        i18n::_(u8"ui", u8"mark", u8"_"s + mark);
 }
 
 
@@ -707,8 +707,8 @@ std::string _kure(int mark)
         {{u8"頂きたいでござる"}, {u8"くださいませ"}},
         {{u8"くれッス"}, {u8"にゃ", u8"みゃ"}},
     };
-    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex])
-        + i18n::_(u8"ui", u8"mark", u8"_"s + mark);
+    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex]) +
+        i18n::_(u8"ui", u8"mark", u8"_"s + mark);
 }
 
 
@@ -724,8 +724,8 @@ std::string _daro(int mark)
         {{u8"でござろうな"}, {u8"でございましょう"}},
         {{u8"ッスね"}, {u8"にゃ", u8"みゃ"}},
     };
-    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex])
-        + i18n::_(u8"ui", u8"mark", u8"_"s + mark);
+    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex]) +
+        i18n::_(u8"ui", u8"mark", u8"_"s + mark);
 }
 
 
@@ -741,8 +741,8 @@ std::string _yo(int mark)
         {{u8"でござろう"}, {u8"でございますわ"}},
         {{u8"ッスよ", u8"ッス"}, {u8"にゃぁ", u8"みゃぁ"}},
     };
-    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex])
-        + i18n::_(u8"ui", u8"mark", u8"_"s + mark);
+    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex]) +
+        i18n::_(u8"ui", u8"mark", u8"_"s + mark);
 }
 
 
@@ -758,8 +758,8 @@ std::string _aru(int mark)
         {{u8"あるでござる", u8"あるでござるな"}, {u8"ござます"}},
         {{u8"あるッスよ", u8"あるッス"}, {u8"あにゅ", u8"あみぅ"}},
     };
-    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex])
-        + i18n::_(u8"ui", u8"mark", u8"_"s + mark);
+    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex]) +
+        i18n::_(u8"ui", u8"mark", u8"_"s + mark);
 }
 
 
@@ -775,8 +775,8 @@ std::string _u(int mark)
         {{u8"うでござる", u8"うでござるよ"}, {u8"うでございます"}},
         {{u8"うッスよ", u8"うッス"}, {u8"うにぁ", u8"うみぁ"}},
     };
-    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex])
-        + i18n::_(u8"ui", u8"mark", u8"_"s + mark);
+    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex]) +
+        i18n::_(u8"ui", u8"mark", u8"_"s + mark);
 }
 
 
@@ -792,8 +792,8 @@ std::string _na(int mark)
         {{u8"でござるな"}, {u8"でございますわ"}},
         {{u8"ッスね", u8"ッス"}, {u8"ニァ", u8"ミァ"}},
     };
-    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex])
-        + i18n::_(u8"ui", u8"mark", u8"_"s + mark);
+    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex]) +
+        i18n::_(u8"ui", u8"mark", u8"_"s + mark);
 }
 
 
@@ -809,8 +809,8 @@ std::string _ta(int mark)
         {{u8"たでござる"}, {u8"ましてございます"}},
         {{u8"たッスよ", u8"たッス"}, {u8"たにゃぁ", u8"たみゃぁ"}},
     };
-    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex])
-        + i18n::_(u8"ui", u8"mark", u8"_"s + mark);
+    return choice(candidates[cdata[tc].talk_type][cdata[tc].sex]) +
+        i18n::_(u8"ui", u8"mark", u8"_"s + mark);
 }
 
 
@@ -1002,9 +1002,9 @@ void get_npc_talk()
                 u8"%SLAVEKEEPER,"s + i18n::s.get("core.locale.meta.tag"));
             break;
         }
-        if ((cdata[tc].character_role >= 1000
-             && cdata[tc].character_role < 2000)
-            || cdata[tc].character_role == 2003)
+        if ((cdata[tc].character_role >= 1000 &&
+             cdata[tc].character_role < 2000) ||
+            cdata[tc].character_role == 2003)
         {
             if (rnd(3))
             {
@@ -1035,8 +1035,8 @@ void get_npc_talk()
                     p = instr(
                         buff,
                         0,
-                        u8"%FEST,"s + game_data.current_map + u8","s
-                            + i18n::s.get("core.locale.meta.tag"));
+                        u8"%FEST,"s + game_data.current_map + u8","s +
+                            i18n::s.get("core.locale.meta.tag"));
                     break;
                 }
             }
@@ -1046,8 +1046,8 @@ void get_npc_talk()
             p = instr(
                 buff,
                 0,
-                u8"%PERSONALITY,"s + cdata[tc].personality + u8","s
-                    + i18n::s.get("core.locale.meta.tag"));
+                u8"%PERSONALITY,"s + cdata[tc].personality + u8","s +
+                    i18n::s.get("core.locale.meta.tag"));
             break;
         }
         if (rnd(3))
@@ -1055,8 +1055,8 @@ void get_npc_talk()
             p = instr(
                 buff,
                 0,
-                u8"%AREA,"s + game_data.current_map + u8","s
-                    + i18n::s.get("core.locale.meta.tag"));
+                u8"%AREA,"s + game_data.current_map + u8","s +
+                    i18n::s.get("core.locale.meta.tag"));
             break;
         }
     }
@@ -1072,8 +1072,8 @@ void get_npc_talk()
 
 std::string cnvweight(int weight)
 {
-    return ""s + std::abs(weight) / 1000 + '.' + std::abs(weight) % 1000 / 100
-        + i18n::_(u8"ui", u8"unit_of_weight");
+    return ""s + std::abs(weight) / 1000 + '.' + std::abs(weight) % 1000 / 100 +
+        i18n::_(u8"ui", u8"unit_of_weight");
 }
 
 
@@ -1098,43 +1098,43 @@ void quest_update_main_quest_journal()
     int progress;
 
     noteadd("@QM[" + i18n::s.get("core.locale.quest.journal.main.title") + "]");
-    if (game_data.quest_flags.main_quest >= 0
-        && game_data.quest_flags.main_quest < 30)
+    if (game_data.quest_flags.main_quest >= 0 &&
+        game_data.quest_flags.main_quest < 30)
     {
         progress = 0;
     }
-    if (game_data.quest_flags.main_quest >= 30
-        && game_data.quest_flags.main_quest < 50)
+    if (game_data.quest_flags.main_quest >= 30 &&
+        game_data.quest_flags.main_quest < 50)
     {
         progress = 1;
     }
-    if (game_data.quest_flags.main_quest >= 50
-        && game_data.quest_flags.main_quest < 60)
+    if (game_data.quest_flags.main_quest >= 50 &&
+        game_data.quest_flags.main_quest < 60)
     {
         progress = 2;
     }
-    if (game_data.quest_flags.main_quest >= 60
-        && game_data.quest_flags.main_quest < 100)
+    if (game_data.quest_flags.main_quest >= 60 &&
+        game_data.quest_flags.main_quest < 100)
     {
         progress = 3;
     }
-    if (game_data.quest_flags.main_quest >= 100
-        && game_data.quest_flags.main_quest < 110)
+    if (game_data.quest_flags.main_quest >= 100 &&
+        game_data.quest_flags.main_quest < 110)
     {
         progress = 4;
     }
-    if (game_data.quest_flags.main_quest >= 110
-        && game_data.quest_flags.main_quest < 125)
+    if (game_data.quest_flags.main_quest >= 110 &&
+        game_data.quest_flags.main_quest < 125)
     {
         progress = 5;
     }
-    if (game_data.quest_flags.main_quest >= 125
-        && game_data.quest_flags.main_quest < 180)
+    if (game_data.quest_flags.main_quest >= 125 &&
+        game_data.quest_flags.main_quest < 180)
     {
         progress = 6;
     }
-    if (game_data.quest_flags.main_quest >= 180
-        && game_data.quest_flags.main_quest < 1000)
+    if (game_data.quest_flags.main_quest >= 180 &&
+        game_data.quest_flags.main_quest < 1000)
     {
         progress = 7;
     }
@@ -1164,8 +1164,8 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
@@ -1201,8 +1201,8 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
@@ -1238,8 +1238,8 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
@@ -1264,8 +1264,8 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
@@ -1312,8 +1312,8 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
@@ -1437,8 +1437,8 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
@@ -1463,8 +1463,8 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
@@ -1500,8 +1500,8 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
@@ -1548,8 +1548,8 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
@@ -1585,8 +1585,8 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
@@ -1633,8 +1633,8 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
@@ -1659,8 +1659,8 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
@@ -1685,8 +1685,8 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
@@ -1712,8 +1712,8 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
@@ -1752,17 +1752,17 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
     if (val0 == 0)
     {
-        if (p
-            == game_data.quest_flags.ambitious_scientist
-                    * (game_data.quest_flags.ambitious_scientist < 6)
-                + (game_data.quest_flags.ambitious_scientist == 0))
+        if (p ==
+            game_data.quest_flags.ambitious_scientist *
+                    (game_data.quest_flags.ambitious_scientist < 6) +
+                (game_data.quest_flags.ambitious_scientist == 0))
         {
             s1 = i18n::s.get_enum(
                 "core.locale.quest.journal.sub.ambitious_scientist.progress",
@@ -1783,8 +1783,8 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
@@ -1821,8 +1821,8 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
@@ -1850,8 +1850,8 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
@@ -1878,8 +1878,8 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
@@ -1908,8 +1908,8 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
@@ -1937,8 +1937,8 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
@@ -1967,8 +1967,8 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
@@ -1995,8 +1995,8 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
@@ -2032,8 +2032,8 @@ void append_subquest_journal(int val0)
             if (p >= 1000)
             {
                 noteadd(
-                    "[" + i18n::s.get("core.locale.quest.journal.sub.done")
-                    + "]" + s);
+                    "[" + i18n::s.get("core.locale.quest.journal.sub.done") +
+                    "]" + s);
             }
         }
     }
@@ -2059,30 +2059,30 @@ void append_quest_item_journal()
     if (game_data.quest_flags.main_quest >= 30)
     {
         noteadd(
-            "["
-            + i18n::s.get("core.locale.quest.journal.item.letter_to_the_king")
-            + "]");
+            "[" +
+            i18n::s.get("core.locale.quest.journal.item.letter_to_the_king") +
+            "]");
     }
     if (game_data.quest_flags.magic_stone_of_fool != 0)
     {
         noteadd(
-            "["
-            + i18n::s.get("core.locale.quest.journal.item.fools_magic_stone")
-            + "]");
+            "[" +
+            i18n::s.get("core.locale.quest.journal.item.fools_magic_stone") +
+            "]");
     }
     if (game_data.quest_flags.magic_stone_of_king != 0)
     {
         noteadd(
-            "["
-            + i18n::s.get("core.locale.quest.journal.item.kings_magic_stone")
-            + "]");
+            "[" +
+            i18n::s.get("core.locale.quest.journal.item.kings_magic_stone") +
+            "]");
     }
     if (game_data.quest_flags.magic_stone_of_sage != 0)
     {
         noteadd(
-            "["
-            + i18n::s.get("core.locale.quest.journal.item.sages_magic_stone")
-            + "]");
+            "[" +
+            i18n::s.get("core.locale.quest.journal.item.sages_magic_stone") +
+            "]");
     }
 }
 
@@ -2162,8 +2162,8 @@ std::string randomname()
         }
         if (jp)
         {
-            if (strutil::starts_with(ret, u8"ー")
-                || strutil::contains(ret, u8"ーッ"))
+            if (strutil::starts_with(ret, u8"ー") ||
+                strutil::contains(ret, u8"ーッ"))
             {
                 continue;
             }
@@ -2356,8 +2356,8 @@ skip:
                       u8"The party of ",
                       u8"The house of ",
                       u8"Clan ",
-                  })
-                + ret;
+                  }) +
+                ret;
         }
         else
         {
@@ -2565,9 +2565,9 @@ std::string name(int cc)
     {
         return i18n::s.get("core.locale.chara.something");
     }
-    if (cdata.player().blind != 0
-        || (cdata[cc].is_invisible() == 1
-            && cdata.player().can_see_invisible() == 0 && cdata[cc].wet == 0))
+    if (cdata.player().blind != 0 ||
+        (cdata[cc].is_invisible() == 1 &&
+         cdata.player().can_see_invisible() == 0 && cdata[cc].wet == 0))
     {
         return i18n::s.get("core.locale.chara.something");
     }

--- a/src/trait.cpp
+++ b/src/trait.cpp
@@ -155,8 +155,8 @@ void trait_format_other_parameterless(
 
 bool trait_is_obtainable(const I18NKey& i18n_prefix, int tid)
 {
-    return trait(tid) >= 0
-        && i18n::s.get_enum_property_opt(i18n_prefix + ".levels", "name", 0);
+    return trait(tid) >= 0 &&
+        i18n::s.get_enum_property_opt(i18n_prefix + ".levels", "name", 0);
 }
 
 
@@ -837,9 +837,9 @@ void trait_load_desc()
             }
             if (featrq == -1)
             {
-                s += u8"("s
-                    + i18n::s.get("core.locale.trait.window.requirement")
-                    + u8")"s;
+                s += u8"("s +
+                    i18n::s.get("core.locale.trait.window.requirement") +
+                    u8")"s;
             }
             pos(wx + 30, wy + 61 + cnt * 19);
             x = 84;
@@ -850,28 +850,28 @@ void trait_load_desc()
             x = 70;
             if (traitref == 0)
             {
-                s = u8"["s
-                    + i18n::s.get("core.locale.trait.window.category.feat")
-                    + u8"]"s;
+                s = u8"["s +
+                    i18n::s.get("core.locale.trait.window.category.feat") +
+                    u8"]"s;
             }
             if (traitref == 1)
             {
-                s = u8"["s
-                    + i18n::s.get("core.locale.trait.window.category.mutation")
-                    + u8"]"s;
+                s = u8"["s +
+                    i18n::s.get("core.locale.trait.window.category.mutation") +
+                    u8"]"s;
             }
             if (traitref == 2)
             {
-                s = u8"["s
-                    + i18n::s.get("core.locale.trait.window.category.race")
-                    + u8"]"s;
+                s = u8"["s +
+                    i18n::s.get("core.locale.trait.window.category.race") +
+                    u8"]"s;
             }
             if (traitref == 3)
             {
-                s = u8"["s
-                    + i18n::s.get(
-                        "core.locale.trait.window.category.ether_disease")
-                    + u8"]"s;
+                s = u8"["s +
+                    i18n::s.get(
+                        "core.locale.trait.window.category.ether_disease") +
+                    u8"]"s;
             }
             s += traitrefn(2 + std::abs(trait(tid)));
         }
@@ -881,36 +881,36 @@ void trait_load_desc()
     {
         list(0, listmax) = 1;
         list(1, listmax) = 99999;
-        listn(0, listmax) = u8"["s
-            + i18n::s.get("core.locale.trait.window.category.etc") + u8"]"s
-            + i18n::s.get("core.locale.trait.incognito");
+        listn(0, listmax) = u8"["s +
+            i18n::s.get("core.locale.trait.window.category.etc") + u8"]"s +
+            i18n::s.get("core.locale.trait.incognito");
         ++listmax;
     }
     if (cdata[tc].is_pregnant() == 1)
     {
         list(0, listmax) = 1;
         list(1, listmax) = 99999;
-        listn(0, listmax) = u8"["s
-            + i18n::s.get("core.locale.trait.window.category.etc") + u8"]"s
-            + i18n::s.get("core.locale.trait.pregnant");
+        listn(0, listmax) = u8"["s +
+            i18n::s.get("core.locale.trait.window.category.etc") + u8"]"s +
+            i18n::s.get("core.locale.trait.pregnant");
         ++listmax;
     }
     if (cdata[tc].has_anorexia() == 1)
     {
         list(0, listmax) = 1;
         list(1, listmax) = 99999;
-        listn(0, listmax) = u8"["s
-            + i18n::s.get("core.locale.trait.window.category.etc") + u8"]"s
-            + i18n::s.get("core.locale.trait.anorexia");
+        listn(0, listmax) = u8"["s +
+            i18n::s.get("core.locale.trait.window.category.etc") + u8"]"s +
+            i18n::s.get("core.locale.trait.anorexia");
         ++listmax;
     }
     if (cdata[tc].speed_correction_value != 0)
     {
         list(0, listmax) = 1;
         list(1, listmax) = 99999;
-        listn(0, listmax) = u8"["s
-            + i18n::s.get("core.locale.trait.window.category.etc") + u8"]"s
-            + i18n::s.get(
+        listn(0, listmax) = u8"["s +
+            i18n::s.get("core.locale.trait.window.category.etc") + u8"]"s +
+            i18n::s.get(
                 "core.locale.trait.body_is_complicated",
                 cdata[tc].speed_correction_value);
         ++listmax;
@@ -921,18 +921,18 @@ void trait_load_desc()
         {
             list(0, listmax) = 1;
             list(1, listmax) = 99999;
-            listn(0, listmax) = u8"["s
-                + i18n::s.get("core.locale.trait.window.category.etc") + u8"]"s
-                + i18n::s.get("core.locale.trait.ether_disease_grows.fast");
+            listn(0, listmax) = u8"["s +
+                i18n::s.get("core.locale.trait.window.category.etc") + u8"]"s +
+                i18n::s.get("core.locale.trait.ether_disease_grows.fast");
             ++listmax;
         }
         else
         {
             list(0, listmax) = 1;
             list(1, listmax) = 99999;
-            listn(0, listmax) = u8"["s
-                + i18n::s.get("core.locale.trait.window.category.etc") + u8"]"s
-                + i18n::s.get("core.locale.trait.ether_disease_grows.slow");
+            listn(0, listmax) = u8"["s +
+                i18n::s.get("core.locale.trait.window.category.etc") + u8"]"s +
+                i18n::s.get("core.locale.trait.ether_disease_grows.slow");
             ++listmax;
         }
     }

--- a/src/turn_sequence.cpp
+++ b/src/turn_sequence.cpp
@@ -122,9 +122,9 @@ TurnResult npc_turn()
     if (cdata[cc].relationship >= 10)
     {
         --cdata[cc].hate;
-        if (cdata[cc].enemy_id == 0 || cdata[cc].hate <= 0
-            || (cdata[cdata[cc].enemy_id].relationship >= -2
-                && cdata[cdata[cc].enemy_id].enemy_id != cc))
+        if (cdata[cc].enemy_id == 0 || cdata[cc].hate <= 0 ||
+            (cdata[cdata[cc].enemy_id].relationship >= -2 &&
+             cdata[cdata[cc].enemy_id].enemy_id != cc))
         {
             cdata[cc].enemy_id = 0;
             if (pcattacker != 0)
@@ -147,11 +147,11 @@ TurnResult npc_turn()
             }
             if (cdata[cc].enemy_id == 0)
             {
-                if (cdata.player().enemy_id != 0
-                    && cdata[cdata.player().enemy_id].relationship <= -3)
+                if (cdata.player().enemy_id != 0 &&
+                    cdata[cdata.player().enemy_id].relationship <= -3)
                 {
-                    if (cdata[cdata.player().enemy_id].state()
-                        == Character::State::alive)
+                    if (cdata[cdata.player().enemy_id].state() ==
+                        Character::State::alive)
                     {
                         if (fov_los(
                                 cdata[cc].position.x,
@@ -216,9 +216,9 @@ TurnResult npc_turn()
             p(2) = 16;
         }
         i = cdata[cc].enemy_id;
-        if (cdata[i].relationship == p
-            && cdata[i].state() == Character::State::alive && i >= p(1)
-            && i < p(1) + p(2))
+        if (cdata[i].relationship == p &&
+            cdata[i].state() == Character::State::alive && i >= p(1) &&
+            i < p(1) + p(2))
         {
             if (rnd(10) != 0)
             {
@@ -239,8 +239,8 @@ TurnResult npc_turn()
                 }
             }
         }
-        if (cdata[cdata[cc].enemy_id].relationship != p
-            || cdata[cdata[cc].enemy_id].state() != Character::State::alive)
+        if (cdata[cdata[cc].enemy_id].relationship != p ||
+            cdata[cdata[cc].enemy_id].state() != Character::State::alive)
         {
             f = 0;
             for (int cnt = p(1), cnt_end = cnt + (p(2)); cnt < cnt_end; ++cnt)
@@ -277,8 +277,8 @@ TurnResult npc_turn()
             {
                 if (game_data.released_fire_giant != 0)
                 {
-                    if (cdata[game_data.fire_giant].state()
-                        == Character::State::alive)
+                    if (cdata[game_data.fire_giant].state() ==
+                        Character::State::alive)
                     {
                         cdata[cc].enemy_id = game_data.fire_giant;
                         cdata[cc].hate = 500;
@@ -326,17 +326,16 @@ TurnResult npc_turn()
             {
                 if (rnd(4) == 0)
                 {
-                    if (cdata.player().position.x > cdata[cc].position.x - 10
-                        && cdata.player().position.x
-                            < cdata[cc].position.x + 10)
+                    if (cdata.player().position.x > cdata[cc].position.x - 10 &&
+                        cdata.player().position.x < cdata[cc].position.x + 10)
                     {
-                        if (cdata.player().position.y
-                                > cdata[cc].position.y - 10
-                            && cdata.player().position.y
-                                < cdata[cc].position.y + 10)
+                        if (cdata.player().position.y >
+                                cdata[cc].position.y - 10 &&
+                            cdata.player().position.y <
+                                cdata[cc].position.y + 10)
                         {
-                            if (cdata.player().continuous_action.type
-                                != ContinuousAction::Type::perform)
+                            if (cdata.player().continuous_action.type !=
+                                ContinuousAction::Type::perform)
                             {
                                 if (cdata[cc].hate <= 0)
                                 {
@@ -361,8 +360,7 @@ TurnResult npc_turn()
                     cdata.player().position.x,
                     cdata.player().position.y,
                     cdata[cc].position.x,
-                    cdata[cc].position.y)
-                == 1)
+                    cdata[cc].position.y) == 1)
             {
                 x = cdata.player().position.x;
                 y = cdata.player().position.y;
@@ -456,8 +454,7 @@ label_2689_internal:
             if (tc == 0)
             {
                 if (cell_data.at(cdata[cc].position.x, cdata[cc].position.y)
-                        .item_appearances_actual
-                    != 0)
+                        .item_appearances_actual != 0)
                 {
                     const auto item_info = cell_itemoncell(cdata[cc].position);
                     const auto number = item_info.first;
@@ -501,8 +498,8 @@ label_2689_internal:
                             {
                                 if (ibit(5, ci) == 0)
                                 {
-                                    if (map_data.type
-                                        != mdata_t::MapType::player_owned)
+                                    if (map_data.type !=
+                                        mdata_t::MapType::player_owned)
                                     {
                                         in = inv[ci].number();
                                         if (game_data.mount != cc)
@@ -722,8 +719,8 @@ TurnResult turn_begin()
     int spd = 0;
     ct = 0;
     mef_update();
-    gspd = cdata.player().current_speed
-        * (100 + cdata.player().speed_percentage) / 100;
+    gspd = cdata.player().current_speed *
+        (100 + cdata.player().speed_percentage) / 100;
     if (gspd < 10)
     {
         gspd = 10;
@@ -782,8 +779,8 @@ TurnResult turn_begin()
         {
             game_data.left_minutes_of_executing_quest -=
                 game_data.date.second / 60;
-            if (game_data.executing_immediate_quest_time_left_display_period
-                > game_data.left_minutes_of_executing_quest / 10)
+            if (game_data.executing_immediate_quest_time_left_display_period >
+                game_data.left_minutes_of_executing_quest / 10)
             {
                 txt(i18n::s.get(
                         "core.locale.quest.minutes_left",
@@ -907,11 +904,11 @@ TurnResult pass_one_turn(bool label_2738_flg)
                         "core.locale.magic.return.prevented.overweight"));
                     goto label_2740_internal;
                 }
-                if (game_data.destination_map
-                    == game_data.destination_outer_map)
+                if (game_data.destination_map ==
+                    game_data.destination_outer_map)
                 {
-                    if (game_data.current_map
-                        == game_data.destination_outer_map)
+                    if (game_data.current_map ==
+                        game_data.destination_outer_map)
                     {
                         txt(i18n::s.get("core.locale.common.nothing_happens"));
                         goto label_2740_internal;
@@ -974,8 +971,9 @@ TurnResult pass_one_turn(bool label_2738_flg)
         }
         else if (rnd(1500) == 0)
         {
-            if (area_data[game_data.current_map].id != mdata_t::MapId::your_home
-                && game_data.current_map != mdata_t::MapId::shelter_)
+            if (area_data[game_data.current_map].id !=
+                    mdata_t::MapId::your_home &&
+                game_data.current_map != mdata_t::MapId::shelter_)
             {
                 modify_ether_disease_stage(10);
             }
@@ -983,8 +981,7 @@ TurnResult pass_one_turn(bool label_2738_flg)
     }
     tc = cc;
     if (cell_data.at(cdata[tc].position.x, cdata[tc].position.y)
-            .mef_index_plus_one
-        != 0)
+            .mef_index_plus_one != 0)
     {
         mef_proc(tc);
     }
@@ -1009,8 +1006,8 @@ TurnResult pass_one_turn(bool label_2738_flg)
             }
         }
     }
-    if (cdata[cc].choked > 0 || cdata[cc].sleep > 0 || cdata[cc].paralyzed > 0
-        || cdata[cc].dimmed >= 60)
+    if (cdata[cc].choked > 0 || cdata[cc].sleep > 0 ||
+        cdata[cc].paralyzed > 0 || cdata[cc].dimmed >= 60)
     {
         if (cc == 0)
         {
@@ -1041,8 +1038,7 @@ TurnResult pass_one_turn(bool label_2738_flg)
                             cdata[cc].position.x,
                             cdata[cc].position.y,
                             cnt.position.x,
-                            cnt.position.y)
-                        > 5)
+                            cnt.position.y) > 5)
                     {
                         continue;
                     }
@@ -1050,13 +1046,12 @@ TurnResult pass_one_turn(bool label_2738_flg)
                             cdata[cc].position.x,
                             cdata[cc].position.y,
                             cnt.position.x,
-                            cnt.position.y)
-                        == 0)
+                            cnt.position.y) == 0)
                     {
                         continue;
                     }
-                    if (cnt.index == cc || rnd(3)
-                        || map_data.type == mdata_t::MapType::world_map)
+                    if (cnt.index == cc || rnd(3) ||
+                        map_data.type == mdata_t::MapType::world_map)
                     {
                         continue;
                     }
@@ -1200,12 +1195,12 @@ TurnResult turn_end()
                 txt(i18n::s.get("core.locale.action.backpack_squashing"));
                 damage_hp(
                     cdata[cc],
-                    cdata[cc].max_hp
-                            * (cdata.player().inventory_weight * 10
-                                   / cdata.player().max_inventory_weight
-                               + 10)
-                            / 200
-                        + 1,
+                    cdata[cc].max_hp *
+                            (cdata.player().inventory_weight * 10 /
+                                 cdata.player().max_inventory_weight +
+                             10) /
+                            200 +
+                        1,
                     -6);
             }
         }
@@ -1226,8 +1221,8 @@ TurnResult turn_end()
     if (game_data.left_turns_of_timestop > 0)
     {
         --game_data.left_turns_of_timestop;
-        if (cdata[cc].state() != Character::State::alive
-            || game_data.left_turns_of_timestop == 0)
+        if (cdata[cc].state() != Character::State::alive ||
+            game_data.left_turns_of_timestop == 0)
         {
             txt(i18n::s.get("core.locale.action.time_stop.ends"),
                 Message::color{ColorIndex::cyan});
@@ -1313,8 +1308,8 @@ TurnResult pc_turn(bool advance_time)
             {
                 game_data.player_cellaccess_check_flag = 0;
             }
-            if (cell_data.at(x, y).feats != 0
-                && cell_data.at(x, y).feats != 999)
+            if (cell_data.at(x, y).feats != 0 &&
+                cell_data.at(x, y).feats != 999)
             {
                 game_data.player_cellaccess_check_flag = 0;
             }
@@ -1363,9 +1358,9 @@ TurnResult pc_turn(bool advance_time)
         if (autosave)
         {
             autosave = 0;
-            if (game_data.wizard == 0
-                && game_data.current_map != mdata_t::MapId::pet_arena
-                && Config::instance().autosave)
+            if (game_data.wizard == 0 &&
+                game_data.current_map != mdata_t::MapId::pet_arena &&
+                Config::instance().autosave)
             {
                 do_save_game();
             }
@@ -1385,8 +1380,8 @@ TurnResult pc_turn(bool advance_time)
             bool pet_exists = false;
             for (int cc = 1; cc < 16; ++cc)
             {
-                if (cdata[cc].state() == Character::State::alive
-                    && cdata[cc].relationship == 10)
+                if (cdata[cc].state() == Character::State::alive &&
+                    cdata[cc].relationship == 10)
                 {
                     pet_exists = true;
                     break;
@@ -1407,12 +1402,12 @@ TurnResult pc_turn(bool advance_time)
                 snd("core.exitmap1");
                 for (int cc = 0; cc < 16; ++cc)
                 {
-                    if (arenaop == 0 && followerin(cc) == 1
-                        && cdata[cc].state() == Character::State::pet_dead)
+                    if (arenaop == 0 && followerin(cc) == 1 &&
+                        cdata[cc].state() == Character::State::pet_dead)
                         continue;
-                    if (petarenawin != 1 && followerin(cc) == 1
-                        && cdata[cc].state() == Character::State::pet_dead
-                        && rnd(5) == 0)
+                    if (petarenawin != 1 && followerin(cc) == 1 &&
+                        cdata[cc].state() == Character::State::pet_dead &&
+                        rnd(5) == 0)
                         continue;
                     cdata[cc].set_state(
                         static_cast<Character::State>(followerexist(cc)));
@@ -1445,8 +1440,8 @@ TurnResult pc_turn(bool advance_time)
                 {
                     continue;
                 }
-                if (cdata[camera].state() != Character::State::alive
-                    || camera == 0)
+                if (cdata[camera].state() != Character::State::alive ||
+                    camera == 0)
                 {
                     camera = p;
                     break;
@@ -1500,22 +1495,22 @@ TurnResult pc_turn(bool advance_time)
         if (trait(210) != 0 && rnd(5) == 0)
         {
             ci = get_random_inv(0);
-            if (inv[ci].number() > 0
-                && the_item_db[inv[ci].id]->category == 52000)
+            if (inv[ci].number() > 0 &&
+                the_item_db[inv[ci].id]->category == 52000)
             {
                 dbid = inv[ci].id;
                 access_item_db(15);
             }
         }
-        if (trait(214) != 0 && rnd(250) == 0
-            && map_data.type != mdata_t::MapType::world_map)
+        if (trait(214) != 0 && rnd(250) == 0 &&
+            map_data.type != mdata_t::MapType::world_map)
         {
             efid = 408;
             magic();
         }
-        if (cdata[cdata.player().enemy_id].is_invisible() == 1
-            && cdata.player().can_see_invisible() == 0
-            && cdata[cdata.player().enemy_id].wet == 0)
+        if (cdata[cdata.player().enemy_id].is_invisible() == 1 &&
+            cdata.player().can_see_invisible() == 0 &&
+            cdata[cdata.player().enemy_id].wet == 0)
         {
             cdata.player().enemy_id = 0;
         }

--- a/src/turn_sequence_pc_actions.cpp
+++ b/src/turn_sequence_pc_actions.cpp
@@ -30,10 +30,10 @@ static bool _proc_autodig()
     int y = cdata.player().next_position.y;
     if (foobar_data.is_autodig_enabled)
     {
-        if (0 <= x && x < map_data.width && 0 <= y && y < map_data.height
-            && (chipm(7, cell_data.at(x, y).chip_id_actual) & 4)
-            && chipm(0, cell_data.at(x, y).chip_id_actual) != 3
-            && map_data.type != mdata_t::MapType::world_map)
+        if (0 <= x && x < map_data.width && 0 <= y && y < map_data.height &&
+            (chipm(7, cell_data.at(x, y).chip_id_actual) & 4) &&
+            chipm(0, cell_data.at(x, y).chip_id_actual) != 3 &&
+            map_data.type != mdata_t::MapType::world_map)
         {
             refx = x;
             refy = y;
@@ -226,13 +226,13 @@ optional<TurnResult> handle_pc_action(std::string& action)
             {
                 action = "go_down";
             }
-            if (inv[ci].id == 750
-                && game_data.current_map == mdata_t::MapId::your_home)
+            if (inv[ci].id == 750 &&
+                game_data.current_map == mdata_t::MapId::your_home)
             {
                 action = "go_up";
             }
-            if (inv[ci].id == 751
-                && game_data.current_map == mdata_t::MapId::your_home)
+            if (inv[ci].id == 751 &&
+                game_data.current_map == mdata_t::MapId::your_home)
             {
                 action = "go_down";
             }

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -99,8 +99,8 @@ void render_weather_effect_rain()
         particles.resize(max_particles * 2);
     }
 
-    for (int i = 0; i
-         < max_particles * (1 + (map_data.type == mdata_t::MapType::world_map));
+    for (int i = 0; i <
+         max_particles * (1 + (map_data.type == mdata_t::MapType::world_map));
          ++i)
     {
         auto&& particle = particles[i];
@@ -143,8 +143,8 @@ void render_weather_effect_hard_rain()
         particles.resize(max_particles * 2);
     }
 
-    for (int i = 0; i
-         < max_particles * (1 + (map_data.type == mdata_t::MapType::world_map));
+    for (int i = 0; i <
+         max_particles * (1 + (map_data.type == mdata_t::MapType::world_map));
          ++i)
     {
         auto&& particle = particles[i];
@@ -310,8 +310,8 @@ void highlight_characters_in_pet_arena()
         }
         const int x = (cc.position.x - scx) * inf_tiles + inf_screenx;
         const int y = (cc.position.y - scy) * inf_tiles + inf_screeny;
-        if (0 <= x && x - inf_screenx < (inf_screenw - 1) * inf_tiles && 0 <= y
-            && y < (inf_screenh - 1) * inf_tiles)
+        if (0 <= x && x - inf_screenx < (inf_screenw - 1) * inf_tiles &&
+            0 <= y && y < (inf_screenh - 1) * inf_tiles)
         {
             boxf(
                 x,
@@ -559,11 +559,11 @@ void render_clock()
         game_data.date.minute * 6);
 
     pos(inf_clockw - 3, inf_clocky + 17 + vfix);
-    mes(""s + game_data.date.year + u8"/"s + game_data.date.month + u8"/"s
-        + game_data.date.day);
+    mes(""s + game_data.date.year + u8"/"s + game_data.date.month + u8"/"s +
+        game_data.date.day);
     bmes(
-        i18n::_(u8"ui", u8"time", u8"_"s + game_data.date.hour / 4) + u8" "s
-            + i18n::_(u8"ui", u8"weather", u8"_"s + game_data.weather),
+        i18n::_(u8"ui", u8"time", u8"_"s + game_data.date.hour / 4) + u8" "s +
+            i18n::_(u8"ui", u8"weather", u8"_"s + game_data.weather),
         inf_clockw + 6,
         inf_clocky + 35);
 }
@@ -596,24 +596,23 @@ void render_skill_trackers()
             16,
             inf_clocky + 107 + y * 16);
         bmes(
-            ""s + sdata.get(skill, chara).original_level + u8"."s
-                + std::to_string(
-                      1000 + sdata.get(skill, chara).experience % 1000)
-                      .substr(1),
+            ""s + sdata.get(skill, chara).original_level + u8"."s +
+                std::to_string(1000 + sdata.get(skill, chara).experience % 1000)
+                    .substr(1),
             66,
             inf_clocky + 107 + y * 16);
         if (elona::Config::instance().allow_enhanced_skill)
         {
             elona::snail::Color col{255, 130, 130};
 
-            if (sdata.get(skill, chara).potential
-                > elona::Config::instance().enhanced_skill_upperbound)
+            if (sdata.get(skill, chara).potential >
+                elona::Config::instance().enhanced_skill_upperbound)
             {
                 col = {130, 255, 130};
             }
             else if (
-                sdata.get(skill, chara).potential
-                > elona::Config::instance().enhanced_skill_lowerbound)
+                sdata.get(skill, chara).potential >
+                elona::Config::instance().enhanced_skill_lowerbound)
             {
                 col = {255, 255, 130};
             }
@@ -950,10 +949,10 @@ void render_autoturn_animation()
         load_continuous_action_animation();
     }
 
-    if (firstautoturn
-        || (cdata.player().continuous_action.type
-                == ContinuousAction::Type::fish
-            && rowactre == 0 && fishanime == 0))
+    if (firstautoturn ||
+        (cdata.player().continuous_action.type ==
+             ContinuousAction::Type::fish &&
+         rowactre == 0 && fishanime == 0))
     {
         ui_render_non_hud();
         render_hud();
@@ -978,15 +977,15 @@ void render_autoturn_animation()
     gmode(2);
     draw_rotated("hourglass", sx + 18, sy + 12, game_data.date.minute / 4 * 24);
 
-    if (cdata.player().continuous_action.type
-            == ContinuousAction::Type::dig_ground
-        || cdata.player().continuous_action.type
-            == ContinuousAction::Type::dig_wall
-        || cdata.player().continuous_action.type
-            == ContinuousAction::Type::search_material
-        || (cdata.player().continuous_action.type
-                == ContinuousAction::Type::fish
-            && rowactre != 0))
+    if (cdata.player().continuous_action.type ==
+            ContinuousAction::Type::dig_ground ||
+        cdata.player().continuous_action.type ==
+            ContinuousAction::Type::dig_wall ||
+        cdata.player().continuous_action.type ==
+            ContinuousAction::Type::search_material ||
+        (cdata.player().continuous_action.type ==
+             ContinuousAction::Type::fish &&
+         rowactre != 0))
     {
         if (Config::instance().animewait != 0)
         {
@@ -997,8 +996,8 @@ void render_autoturn_animation()
                 {
                     gmode(0);
                     pos(sx + 2, sy - 102);
-                    if (cdata.player().continuous_action.type
-                        == ContinuousAction::Type::dig_wall)
+                    if (cdata.player().continuous_action.type ==
+                        ContinuousAction::Type::dig_wall)
                     {
                         if (cnt == 2)
                         {
@@ -1007,8 +1006,8 @@ void render_autoturn_animation()
                         gcopy(9, cnt / 2 % 5 * 144, 0, 144, 96);
                         await(Config::instance().animewait * 2);
                     }
-                    if (cdata.player().continuous_action.type
-                        == ContinuousAction::Type::fish)
+                    if (cdata.player().continuous_action.type ==
+                        ContinuousAction::Type::fish)
                     {
                         if (racount == 0)
                         {
@@ -1020,8 +1019,8 @@ void render_autoturn_animation()
                         gcopy(9, cnt / 3 % 3 * 144, 0, 144, 96);
                         await(Config::instance().animewait * 2.5);
                     }
-                    if (cdata.player().continuous_action.type
-                        == ContinuousAction::Type::search_material)
+                    if (cdata.player().continuous_action.type ==
+                        ContinuousAction::Type::search_material)
                     {
                         if (cnt == 4)
                         {
@@ -1030,8 +1029,8 @@ void render_autoturn_animation()
                         gcopy(9, cnt / 2 % 3 * 144, 0, 144, 96);
                         await(Config::instance().animewait * 2.75);
                     }
-                    if (cdata.player().continuous_action.type
-                        == ContinuousAction::Type::dig_ground)
+                    if (cdata.player().continuous_action.type ==
+                        ContinuousAction::Type::dig_ground)
                     {
                         if (cnt == 2)
                         {
@@ -1115,8 +1114,8 @@ Position gmes(
             byte = 1;
         std::string m_ = strmid(message, pos, byte);
         pos += byte;
-        if (m_ == u8"。" || m_ == u8"、" || m_ == u8"」" || m_ == u8"』"
-            || m_ == u8"！" || m_ == u8"？" || m_ == u8"…")
+        if (m_ == u8"。" || m_ == u8"、" || m_ == u8"」" || m_ == u8"』" ||
+            m_ == u8"！" || m_ == u8"？" || m_ == u8"…")
         {
             wait_to_break_line = true;
         }
@@ -1357,8 +1356,8 @@ void update_minimap()
     {
         for (int x = 0; x < map_data.width; ++x)
         {
-            if (cell_data.at(x, y).chip_id_memory
-                == cell_data.at(x, y).chip_id_actual)
+            if (cell_data.at(x, y).chip_id_memory ==
+                cell_data.at(x, y).chip_id_actual)
             {
                 draw_minimap_pixel(x, y);
             }
@@ -1387,8 +1386,8 @@ void render_hud()
     font(12 - en * 2, snail::Font::Style::bold);
     render_hp_bar(cdata.player(), inf_hpx, inf_hpy, true);
     render_mp_bar(cdata.player(), inf_mpx, inf_mpy, true);
-    if (game_data.mount != 0
-        && cdata[game_data.mount].state() == Character::State::alive)
+    if (game_data.mount != 0 &&
+        cdata[game_data.mount].state() == Character::State::alive)
     {
         render_hp_bar(cdata[game_data.mount], inf_hpx - 120, inf_hpy);
     }
@@ -1458,8 +1457,8 @@ void load_continuous_action_animation()
 {
     gsel(9);
     pos(0, 0);
-    if (cdata.player().continuous_action.type
-        == ContinuousAction::Type::dig_wall)
+    if (cdata.player().continuous_action.type ==
+        ContinuousAction::Type::dig_wall)
     {
         picload(filesystem::dir::graphic() / u8"anime1.bmp");
     }
@@ -1470,13 +1469,13 @@ void load_continuous_action_animation()
             picload(filesystem::dir::graphic() / u8"anime2.bmp");
         }
     }
-    if (cdata.player().continuous_action.type
-        == ContinuousAction::Type::search_material)
+    if (cdata.player().continuous_action.type ==
+        ContinuousAction::Type::search_material)
     {
         picload(filesystem::dir::graphic() / u8"anime3.bmp");
     }
-    if (cdata.player().continuous_action.type
-        == ContinuousAction::Type::dig_ground)
+    if (cdata.player().continuous_action.type ==
+        ContinuousAction::Type::dig_ground)
     {
         picload(filesystem::dir::graphic() / u8"anime4.bmp");
     }
@@ -1672,16 +1671,16 @@ void update_slight()
             }
             if (cdata.player().blind != 0)
             {
-                if (sx != cdata.player().position.x
-                    || sy != cdata.player().position.y)
+                if (sx != cdata.player().position.x ||
+                    sy != cdata.player().position.y)
                 {
                     goto label_1431_internal;
                 }
             }
             if (sy(2) <= sy && sy <= sy(3))
             {
-                if (sx >= fovlist[sy + center.y][0] + center.x
-                    && sx < fovlist[sy + center.y][1] + center.x)
+                if (sx >= fovlist[sy + center.y][0] + center.x &&
+                    sx < fovlist[sy + center.y][1] + center.x)
                 {
                     if (fov_los(
                             cdata.player().position.x,
@@ -1696,8 +1695,8 @@ void update_slight()
                             cdata[cell_data.at(sx, sy).chara_index_plus_one - 1]
                                 .vision_flag = msync;
                         }
-                        if (cell_data.at(sx, sy).chip_id_memory
-                            != cell_data.at(sx, sy).chip_id_actual)
+                        if (cell_data.at(sx, sy).chip_id_memory !=
+                            cell_data.at(sx, sy).chip_id_actual)
                         {
                             cell_data.at(sx, sy).chip_id_memory =
                                 cell_data.at(sx, sy).chip_id_actual;
@@ -1759,13 +1758,13 @@ void ui_scroll_screen()
 {
     int scxbk2 = 0;
     int scybk2 = 0;
-    if (std::abs(cdata.player().next_position.x - cdata.player().position.x)
-        > 1)
+    if (std::abs(cdata.player().next_position.x - cdata.player().position.x) >
+        1)
     {
         return;
     }
-    if (std::abs(cdata.player().next_position.y - cdata.player().position.y)
-        > 1)
+    if (std::abs(cdata.player().next_position.y - cdata.player().position.y) >
+        1)
     {
         return;
     }
@@ -1778,8 +1777,7 @@ void ui_scroll_screen()
                 0,
                 cell_data
                     .at(cdata.player().position.x, cdata.player().position.y)
-                    .chip_id_actual)
-            == 4)
+                    .chip_id_actual) == 4)
         {
             scrollp = 9;
         }
@@ -1812,10 +1810,10 @@ void ui_scroll_screen()
         {
             ++scrturn;
         }
-        sxfix = (cdata.player().next_position.x - cdata.player().position.x)
-            * cnt * inf_tiles / scrollp * -1;
-        syfix = (cdata.player().next_position.y - cdata.player().position.y)
-            * cnt * inf_tiles / scrollp * -1;
+        sxfix = (cdata.player().next_position.x - cdata.player().position.x) *
+            cnt * inf_tiles / scrollp * -1;
+        syfix = (cdata.player().next_position.y - cdata.player().position.y) *
+            cnt * inf_tiles / scrollp * -1;
         gsel(4);
         pos(0, 0);
         gmode(0);
@@ -1995,8 +1993,9 @@ void render_fishing_animation()
         if (fishanime(1) > 15)
         {
             sx += (cdata.player().position.x - fishx) * 8 * (fishanime(1) - 15);
-            sy += (cdata.player().position.y - fishy) * 8 * (fishanime(1) - 15)
-                + fishanime(1);
+            sy +=
+                (cdata.player().position.y - fishy) * 8 * (fishanime(1) - 15) +
+                fishanime(1);
             pos(sx, sy - 44);
             gcopy(9, 144 + fishanime(1) / 2 % 2 * 48, 0, 48, 48);
         }
@@ -2168,8 +2167,8 @@ void display_window(
     font(15 + en - en * 2);
     bmes(
         s,
-        window_x + 45 * window_width / 200 + 34 - strlen_u(s) * 4
-            + clamp(int(strlen_u(s) * 8 - 120), 0, 200) / 2,
+        window_x + 45 * window_width / 200 + 34 - strlen_u(s) * 4 +
+            clamp(int(strlen_u(s) * 8 - 120), 0, 200) / 2,
         window_y + 4 + vfix,
         {255, 255, 255},
         {20, 10, 0});
@@ -2415,8 +2414,8 @@ void cs_list(
     case 0: color(10, 10, 10); break;
     case 1:
         color(0, 0, 0);
-        if (inv[ci].identification_state
-            == IdentifyState::completely_identified)
+        if (inv[ci].identification_state ==
+            IdentifyState::completely_identified)
         {
             switch (inv[ci].curse_state)
             {

--- a/src/ui/ui_menu_adventurers.cpp
+++ b/src/ui/ui_menu_adventurers.cpp
@@ -93,8 +93,8 @@ _draw_list_entry_pic_and_rank(int cnt, const Character& chara, int _p)
     draw_chara_scale_height(chara, wx + 40, wy + 74 + cnt * 19 - 8);
 
     pos(wx + 84, wy + 66 + cnt * 19 + 2);
-    mes(cnvrank(_p + 1)
-        + i18n::s.get("core.locale.ui.adventurers.rank_counter"));
+    mes(cnvrank(_p + 1) +
+        i18n::s.get("core.locale.ui.adventurers.rank_counter"));
 }
 
 static void _draw_list_entry_name(int cnt, const Character& chara)

--- a/src/ui/ui_menu_character_sheet.cpp
+++ b/src/ui/ui_menu_character_sheet.cpp
@@ -121,8 +121,8 @@ static void _load_list_proficiency_category(CharacterSheetOperation op)
     ++listmax;
     _load_weapon_proficiency_list(op);
 
-    if (op != CharacterSheetOperation::train_skill
-        && op != CharacterSheetOperation::learn_skill)
+    if (op != CharacterSheetOperation::train_skill &&
+        op != CharacterSheetOperation::learn_skill)
     {
         _load_resistances_list();
     }
@@ -143,8 +143,8 @@ static void _load_portrait()
     picload(filesystem::dir::graphic() / u8"face1.bmp", 1);
     if (cdata[cc].portrait < 0)
     {
-        const auto filepath = filesystem::dir::user() / u8"graphic"
-            / (u8"face"s + std::abs(cdata[cc].portrait + 1) + u8".bmp");
+        const auto filepath = filesystem::dir::user() / u8"graphic" /
+            (u8"face"s + std::abs(cdata[cc].portrait + 1) + u8".bmp");
         if (cdata[cc].portrait != -1)
         {
             if (fs::exists(filepath))
@@ -167,8 +167,8 @@ bool UIMenuCharacterSheet::init()
         cc = 0;
     }
 
-    if (_operation == CharacterSheetOperation::train_skill
-        || _operation == CharacterSheetOperation::learn_skill)
+    if (_operation == CharacterSheetOperation::train_skill ||
+        _operation == CharacterSheetOperation::learn_skill)
     {
         page = 1;
     }
@@ -227,18 +227,18 @@ static void _draw_title(CharacterSheetOperation op)
     case CharacterSheetOperation::normal:
         if (page == 0)
         {
-            title = i18n::s.get("core.locale.ui.chara_sheet.hint.hint")
-                + strhint6 + strhint2 + strhint3;
+            title = i18n::s.get("core.locale.ui.chara_sheet.hint.hint") +
+                strhint6 + strhint2 + strhint3;
         }
         else
         {
-            title = i18n::s.get("core.locale.ui.chara_sheet.hint.spend_bonus")
-                + strhint2 + strhint3;
+            title = i18n::s.get("core.locale.ui.chara_sheet.hint.spend_bonus") +
+                strhint2 + strhint3;
         }
         break;
     case CharacterSheetOperation::character_making:
-        title = i18n::s.get("core.locale.ui.chara_sheet.hint.reroll") + strhint6
-            + i18n::s.get("core.locale.ui.chara_sheet.hint.confirm");
+        title = i18n::s.get("core.locale.ui.chara_sheet.hint.reroll") +
+            strhint6 + i18n::s.get("core.locale.ui.chara_sheet.hint.confirm");
         break;
     case CharacterSheetOperation::train_skill:
         if (page == 0)
@@ -247,8 +247,8 @@ static void _draw_title(CharacterSheetOperation op)
         }
         else
         {
-            title = i18n::s.get("core.locale.ui.chara_sheet.hint.train_skill")
-                + strhint2 + strhint3;
+            title = i18n::s.get("core.locale.ui.chara_sheet.hint.train_skill") +
+                strhint2 + strhint3;
         }
         break;
     case CharacterSheetOperation::learn_skill:
@@ -258,15 +258,16 @@ static void _draw_title(CharacterSheetOperation op)
         }
         else
         {
-            title = i18n::s.get("core.locale.ui.chara_sheet.hint.learn_skill")
-                + strhint2 + strhint3;
+            title = i18n::s.get("core.locale.ui.chara_sheet.hint.learn_skill") +
+                strhint2 + strhint3;
         }
         break;
     case CharacterSheetOperation::investigate_ally:
         if (page == 0)
         {
-            title = i18n::s.get("core.locale.ui.chara_sheet.hint.blessing_info")
-                + strhint6 + strhint2 + strhint3;
+            title =
+                i18n::s.get("core.locale.ui.chara_sheet.hint.blessing_info") +
+                strhint6 + strhint2 + strhint3;
         }
         else
         {
@@ -279,9 +280,9 @@ static void _draw_title(CharacterSheetOperation op)
     {
         if (page != 0)
         {
-            title += ""s + key_mode2 + u8" ["s
-                + i18n::s.get("core.locale.ui.chara_sheet.hint.track_skill")
-                + u8"]"s;
+            title += ""s + key_mode2 + u8" ["s +
+                i18n::s.get("core.locale.ui.chara_sheet.hint.track_skill") +
+                u8"]"s;
         }
     }
 
@@ -362,8 +363,8 @@ static void _draw_portrait_face()
     }
     else
     {
-        const auto filepath = filesystem::dir::user() / u8"graphic"
-            / (u8"face"s + std::abs(cdata[cc].portrait + 1) + u8".bmp");
+        const auto filepath = filesystem::dir::user() / u8"graphic" /
+            (u8"face"s + std::abs(cdata[cc].portrait + 1) + u8".bmp");
         if (cdata[cc].portrait != -1)
         {
             if (fs::exists(filepath))
@@ -511,8 +512,8 @@ static void _draw_first_page_text_name()
     {
         s(3) = cnven(i18n::_(u8"ui", u8"female"));
     }
-    s(5) = ""s + calcage(cc) + u8" "s
-        + i18n::s.get("core.locale.ui.chara_sheet.personal.age_counter");
+    s(5) = ""s + calcage(cc) + u8" "s +
+        i18n::s.get("core.locale.ui.chara_sheet.personal.age_counter");
     s(6) = ""s + cdata[cc].height + u8" cm"s;
     s(7) = ""s + cdata[cc].weight + u8" kg"s;
     for (int cnt = 0; cnt < 8; ++cnt)
@@ -611,8 +612,8 @@ static void _draw_first_page_weapon_info()
     prot = calcattackdmg(2);
     font(14 - en * 2);
     pos(wx + 460 + en * 8, wy + 279 + p(2) * 16);
-    mes(""s + (100 - 10000 / (prot + 100)) + u8"% + "s + protdice1 + u8"d"s
-        + protdice2);
+    mes(""s + (100 - 10000 / (prot + 100)) + u8"% + "s + protdice1 + u8"d"s +
+        protdice2);
     pos(wx + 625 - en * 8, wy + 279 + p(2) * 16);
     mes(""s + evade + u8"%"s);
     ++p(2);
@@ -652,8 +653,8 @@ static void _draw_first_page_stats_fame()
     s(1) =
         ""s + sdata(3, cc) + u8"("s + sdata.get(3, cc).original_level + u8")"s;
     s(2) = ""s + cdata[cc].insanity;
-    s(3) = ""s + cdata[cc].current_speed + u8"("s
-        + sdata.get(18, cc).original_level + u8")"s;
+    s(3) = ""s + cdata[cc].current_speed + u8"("s +
+        sdata.get(18, cc).original_level + u8")"s;
     s(4) = "";
     s(5) = ""s + cdata[cc].fame;
     s(6) = ""s + cdata[cc].karma;
@@ -675,9 +676,8 @@ static void _draw_first_page_stats_time()
     s(1) = i18n::s.get(
         "core.locale.ui.chara_sheet.time.days_counter", game_data.play_days);
     s(2) = ""s + game_data.kill_count;
-    s(3) = ""s
-        + cnvplaytime(
-               (game_data.play_time + timeGetTime() / 1000 - time_begin));
+    s(3) = ""s +
+        cnvplaytime((game_data.play_time + timeGetTime() / 1000 - time_begin));
     s(4) = "";
     s(5) = "";
     for (int cnt = 0; cnt < 5; ++cnt)
@@ -734,13 +734,13 @@ static void _draw_first_page_buffs(int& _cs_buff, int& _cs_buffmax)
             cdata[cc].buffs[_cs_buff].id, cdata[cc].buffs[_cs_buff].power);
         const auto description = get_buff_description(
             cdata[cc].buffs[_cs_buff].id, cdata[cc].buffs[_cs_buff].power);
-        buff_desc = ""s
-            + i18n::_(u8"buff",
-                      std::to_string(cdata[cc].buffs[_cs_buff].id),
-                      u8"name")
-            + u8": "s + cdata[cc].buffs[_cs_buff].turns
-            + i18n::s.get("core.locale.ui.chara_sheet.buff.duration", duration)
-            + description;
+        buff_desc = ""s +
+            i18n::_(u8"buff",
+                    std::to_string(cdata[cc].buffs[_cs_buff].id),
+                    u8"name") +
+            u8": "s + cdata[cc].buffs[_cs_buff].turns +
+            i18n::s.get("core.locale.ui.chara_sheet.buff.duration", duration) +
+            description;
     }
     else
     {
@@ -793,8 +793,8 @@ static void _draw_other_pages_topics()
     display_topic(
         i18n::s.get("core.locale.ui.chara_sheet.skill.name"), wx + 28, wy + 36);
     display_topic(
-        i18n::s.get("core.locale.ui.chara_sheet.skill.level") + "("
-            + i18n::s.get("core.locale.ui.chara_sheet.skill.potential") + ")",
+        i18n::s.get("core.locale.ui.chara_sheet.skill.level") + "(" +
+            i18n::s.get("core.locale.ui.chara_sheet.skill.potential") + ")",
         wx + 182,
         wy + 36);
     display_topic(
@@ -918,9 +918,9 @@ static void _draw_skill_power(int cnt, int skill_id)
     }
     else
     {
-        desc = ""s + sdata.get(skill_id, cc).original_level + u8"."s
-            + std::to_string(1000 + sdata.get(skill_id, cc).experience % 1000)
-                  .substr(1);
+        desc = ""s + sdata.get(skill_id, cc).original_level + u8"."s +
+            std::to_string(1000 + sdata.get(skill_id, cc).experience % 1000)
+                .substr(1);
         if (sdata.get(skill_id, cc).original_level != sdata(skill_id, cc))
         {
             power =
@@ -988,8 +988,8 @@ static void _draw_skill_entry(int cnt, int skill_id, CharacterSheetOperation op)
     _draw_skill_power(cnt, skill_id);
     _draw_skill_desc(cnt, skill_id);
 
-    if (op == CharacterSheetOperation::train_skill
-        || op == CharacterSheetOperation::learn_skill)
+    if (op == CharacterSheetOperation::train_skill ||
+        op == CharacterSheetOperation::learn_skill)
     {
         bool is_training = op == CharacterSheetOperation::train_skill;
         _draw_skill_train_cost(cnt, skill_id, is_training);
@@ -1175,8 +1175,8 @@ optional<UIMenuCharacterSheet::ResultType> UIMenuCharacterSheet::on_key(
     {
         if (_operation != CharacterSheetOperation::investigate_ally)
         {
-            if (_operation == CharacterSheetOperation::train_skill
-                || _operation == CharacterSheetOperation::learn_skill)
+            if (_operation == CharacterSheetOperation::train_skill ||
+                _operation == CharacterSheetOperation::learn_skill)
             {
                 screenupdate = -1;
                 update_screen();
@@ -1184,8 +1184,8 @@ optional<UIMenuCharacterSheet::ResultType> UIMenuCharacterSheet::on_key(
                 return UIMenuCharacterSheet::Result::finish(
                     UIMenuCompositeCharacterResult{skill_id});
             }
-            if (cdata.player().skill_bonus < 1 || skill_id < 0
-                || skill_id < 100)
+            if (cdata.player().skill_bonus < 1 || skill_id < 0 ||
+                skill_id < 100)
             {
                 set_reupdate();
                 return none;

--- a/src/ui/ui_menu_charamake_alias.cpp
+++ b/src/ui/ui_menu_charamake_alias.cpp
@@ -67,8 +67,8 @@ void UIMenuCharamakeAlias::update()
 static void _draw_window()
 {
     s(0) = i18n::s.get("core.locale.chara_making.select_alias.title");
-    s(1) = strhint3b + key_mode2 + " ["
-        + i18n::s.get("core.locale.chara_making.select_alias.lock_alias") + "]";
+    s(1) = strhint3b + key_mode2 + " [" +
+        i18n::s.get("core.locale.chara_making.select_alias.lock_alias") + "]";
     display_window(
         (windoww - 400) / 2 + inf_screenx, winposy(458, 1) + 20, 400, 458);
     ++cmbg;

--- a/src/ui/ui_menu_charamake_attributes.cpp
+++ b/src/ui/ui_menu_charamake_attributes.cpp
@@ -37,9 +37,10 @@ void UIMenuCharamakeAttributes::_reroll_attributes()
                 sdata.get(cnt, rc).original_level -=
                     rnd(sdata.get(cnt, rc).original_level / 2 + 1);
             }
-            _attributes(cnt - 10) = sdata.get(cnt, rc).original_level * 1000000
-                + sdata.get(cnt, rc).experience * 1000
-                + sdata.get(cnt, rc).potential;
+            _attributes(cnt - 10) =
+                sdata.get(cnt, rc).original_level * 1000000 +
+                sdata.get(cnt, rc).experience * 1000 +
+                sdata.get(cnt, rc).potential;
         }
     }
 }
@@ -86,9 +87,8 @@ static void _draw_window_background()
 {
     s(0) = i18n::s.get(
         "core.locale.chara_making.roll_attributes.attribute_reroll");
-    s(1) = strhint3b + key_mode2 + " ["
-        + i18n::s.get("core.locale.chara_making.roll_attributes.min_roll")
-        + "]";
+    s(1) = strhint3b + key_mode2 + " [" +
+        i18n::s.get("core.locale.chara_making.roll_attributes.min_roll") + "]";
     display_window(
         (windoww - 360) / 2 + inf_screenx, winposy(352, 1) - 20, 360, 352);
 }
@@ -115,8 +115,8 @@ static void _draw_window_desc(int locks_left)
         "core.locale.chara_making.roll_attributes.locked_items_desc"));
     font(13 - en * 2, snail::Font::Style::bold);
     pos(wx + 180, wy + 84);
-    mes(i18n::s.get("core.locale.chara_making.roll_attributes.locks_left")
-        + u8": "s + locks_left);
+    mes(i18n::s.get("core.locale.chara_making.roll_attributes.locks_left") +
+        u8": "s + locks_left);
 }
 
 static void _draw_window(int locks_left)

--- a/src/ui/ui_menu_charamake_class.cpp
+++ b/src/ui/ui_menu_charamake_class.cpp
@@ -70,8 +70,8 @@ _draw_class_info(int chip_male, int chip_female, const std::string& race)
         gcopy(rect->buffer, 0, 960, inf_tiles, rect->height);
     }
     pos(wx + 460, wy + 38);
-    mes(i18n::s.get("core.locale.chara_making.select_race.race_info.race")
-        + u8": "s + race);
+    mes(i18n::s.get("core.locale.chara_making.select_race.race_info.race") +
+        u8": "s + race);
 
     draw_race_or_class_info();
 }

--- a/src/ui/ui_menu_composite.hpp
+++ b/src/ui/ui_menu_composite.hpp
@@ -201,8 +201,8 @@ private:
         }
 
         bmes(
-            ""s + key_prev + u8","s + key_next + u8",Tab,Ctrl+Tab ["s
-                + i18n::s.get("core.locale.ui.menu.change") + u8"]"s,
+            ""s + key_prev + u8","s + key_next + u8",Tab,Ctrl+Tab ["s +
+                i18n::s.get("core.locale.ui.menu.change") + u8"]"s,
             x + width - 215,
             y + 28);
     }

--- a/src/ui/ui_menu_crafting.cpp
+++ b/src/ui/ui_menu_crafting.cpp
@@ -178,8 +178,8 @@ static void _draw_recipe_desc(const CraftingRecipe& recipe)
         desc += *text;
     }
 
-    desc += u8" "s + recipe.required_skill_level + u8"("s
-        + sdata(recipe.skill_used, 0) + u8")"s;
+    desc += u8" "s + recipe.required_skill_level + u8"("s +
+        sdata(recipe.skill_used, 0) + u8")"s;
 
     if (recipe.required_skill_level <= sdata(recipe.skill_used, 0))
     {
@@ -199,9 +199,9 @@ static void _draw_single_recipe_required_material(
     int mat_index,
     const RequiredMaterial& required_mat)
 {
-    std::string mat_desc = matname(required_mat.id) + " "
-        + i18n::s.get("core.locale.crafting.menu.x") + " " + required_mat.amount
-        + u8"("s + mat(required_mat.id) + u8")"s;
+    std::string mat_desc = matname(required_mat.id) + " " +
+        i18n::s.get("core.locale.crafting.menu.x") + " " + required_mat.amount +
+        u8"("s + mat(required_mat.id) + u8")"s;
 
     if (mat(required_mat.id) >= required_mat.amount)
     {

--- a/src/ui/ui_menu_ctrl_ally.cpp
+++ b/src/ui/ui_menu_ctrl_ally.cpp
@@ -27,8 +27,8 @@ bool UIMenuCtrlAlly::_should_display_ally(const Character& chara)
             return false;
         }
     }
-    if (_operation == ControlAllyOperation::staying
-        || _operation == ControlAllyOperation::gene_engineer)
+    if (_operation == ControlAllyOperation::staying ||
+        _operation == ControlAllyOperation::gene_engineer)
     {
         if (chara.state() != Character::State::alive)
         {
@@ -44,8 +44,8 @@ bool UIMenuCtrlAlly::_should_display_ally(const Character& chara)
     }
     if (chara.current_map != 0)
     {
-        if (_operation == ControlAllyOperation::sell
-            || _operation == ControlAllyOperation::pet_arena)
+        if (_operation == ControlAllyOperation::sell ||
+            _operation == ControlAllyOperation::pet_arena)
         {
             return false;
         }
@@ -166,8 +166,8 @@ static void _update_pet_arena()
     {
         Message::instance().txtef(ColorIndex::blue);
     }
-    txt(i18n::s.get("core.locale.ui.ally_list.pet_arena.prompt") + ": " + i
-        + u8" / "s + arenaop(1));
+    txt(i18n::s.get("core.locale.ui.ally_list.pet_arena.prompt") + ": " + i +
+        u8" / "s + arenaop(1));
     s(10) = i18n::s.get("core.locale.ui.ally_list.pet_arena.title");
     s(11) = strhint2 + strhint3;
     s(12) = i18n::s.get("core.locale.ui.ally_list.name");
@@ -306,8 +306,8 @@ std::string UIMenuCtrlAlly::_get_general_ally_info(const Character& chara)
         }
         else
         {
-            ally_info += u8"(Hp: "s + chara.hp * 100 / chara.max_hp + u8"%) "s
-                + i18n::s.get("core.locale.ui.ally_list.waiting");
+            ally_info += u8"(Hp: "s + chara.hp * 100 / chara.max_hp + u8"%) "s +
+                i18n::s.get("core.locale.ui.ally_list.waiting");
         }
     }
     if (chara.state() == Character::State::alive)
@@ -331,8 +331,8 @@ std::string UIMenuCtrlAlly::_get_specific_ally_info(const Character& chara)
 
     if (area_data[game_data.current_map].id == mdata_t::MapId::shop)
     {
-        _s = u8"   "s + sdata(17, chara.index) + u8" / "
-            + sdata(156, chara.index);
+        _s = u8"   "s + sdata(17, chara.index) + u8" / " +
+            sdata(156, chara.index);
     }
     else if (area_data[game_data.current_map].id == mdata_t::MapId::ranch)
     {
@@ -344,9 +344,9 @@ std::string UIMenuCtrlAlly::_get_specific_ally_info(const Character& chara)
 
 static bool _has_general_info(ControlAllyOperation operation)
 {
-    return operation != ControlAllyOperation::staying
-        || (operation == ControlAllyOperation::staying
-            && game_data.current_map == mdata_t::MapId::your_home);
+    return operation != ControlAllyOperation::staying ||
+        (operation == ControlAllyOperation::staying &&
+         game_data.current_map == mdata_t::MapId::your_home);
 }
 
 std::string UIMenuCtrlAlly::_get_ally_info(const Character& chara)
@@ -396,15 +396,15 @@ std::string UIMenuCtrlAlly::_modify_ally_info_gene_engineer(
             }
             else
             {
-                ally_info += ""s
-                    + i18n::s.get_m(
+                ally_info += ""s +
+                    i18n::s.get_m(
                         "locale.ability",
                         the_ability_db.get_id_from_legacy(rtval)->get(),
                         "name");
                 if (rtval(1) != -1)
                 {
-                    ally_info += u8", "s
-                        + i18n::s.get_m(
+                    ally_info += u8", "s +
+                        i18n::s.get_m(
                             "locale.ability",
                             the_ability_db.get_id_from_legacy(rtval(1))->get(),
                             "name");

--- a/src/ui/ui_menu_equipment.cpp
+++ b/src/ui/ui_menu_equipment.cpp
@@ -124,8 +124,8 @@ static void _draw_window_background()
     display_window(
         (windoww - 690) / 2 + inf_screenx, winposy(428), 690, 428, 64);
     display_topic(
-        i18n::s.get("core.locale.ui.equip.category") + "/"
-            + i18n::s.get("core.locale.ui.equip.name"),
+        i18n::s.get("core.locale.ui.equip.category") + "/" +
+            i18n::s.get("core.locale.ui.equip.name"),
         wx + 28,
         wy + 30);
 }
@@ -153,13 +153,13 @@ static void _draw_window_deco(bool show_resistances)
 static void _draw_window_headers()
 {
     display_note(
-        i18n::s.get("core.locale.ui.equip.equip_weight") + ": "
-        + cnvweight(cdata[cc].sum_of_equipment_weight) + cnveqweight(cc) + " "
-        + i18n::s.get("core.locale.ui.equip.hit_bonus") + ":"
-        + cdata[cc].hit_bonus + " "
-        + i18n::s.get("core.locale.ui.equip.damage_bonus") + ":"
-        + cdata[cc].damage_bonus + u8"  DV/PV:"s + cdata[cc].dv + u8"/"s
-        + cdata[cc].pv);
+        i18n::s.get("core.locale.ui.equip.equip_weight") + ": " +
+        cnvweight(cdata[cc].sum_of_equipment_weight) + cnveqweight(cc) + " " +
+        i18n::s.get("core.locale.ui.equip.hit_bonus") + ":" +
+        cdata[cc].hit_bonus + " " +
+        i18n::s.get("core.locale.ui.equip.damage_bonus") + ":" +
+        cdata[cc].damage_bonus + u8"  DV/PV:"s + cdata[cc].dv + u8"/"s +
+        cdata[cc].pv);
 }
 
 static void _draw_window(bool show_resistances)

--- a/src/ui/ui_menu_feats.cpp
+++ b/src/ui/ui_menu_feats.cpp
@@ -61,11 +61,10 @@ static void _add_trait_desc(int tc_, const std::string& trait_desc)
     listn(0, listmax) = i18n::s.get(
         "core.locale.trait.window.his_equipment",
         cnven(
-            (jp)
-                ? ((tc_ == 0) ? u8"あなたの"
-                              : (cdata[tc_].sex == 0 ? u8"彼の" : u8"彼女の"))
-                : ((tc_ == 0) ? "your"
-                              : (cdata[tc_].sex == 0 ? u8"his" : u8"her"))),
+            (jp) ? ((tc_ == 0) ? u8"あなたの"
+                               : (cdata[tc_].sex == 0 ? u8"彼の" : u8"彼女の"))
+                 : ((tc_ == 0) ? "your"
+                               : (cdata[tc_].sex == 0 ? u8"his" : u8"her"))),
         trait_desc);
     ++listmax;
 }
@@ -150,9 +149,9 @@ void UIMenuFeats::update()
 static void _draw_window_background(bool is_chara_making)
 {
     s(0) = i18n::s.get("core.locale.trait.window.title");
-    s(1) = i18n::s.get("core.locale.trait.window.enter") + "  " + strhint2
-        + strhint3 + u8"z,x ["s + i18n::s.get("core.locale.trait.window.ally")
-        + u8"]"s;
+    s(1) = i18n::s.get("core.locale.trait.window.enter") + "  " + strhint2 +
+        strhint3 + u8"z,x ["s + i18n::s.get("core.locale.trait.window.ally") +
+        u8"]"s;
 
     int y_adjust;
     if (is_chara_making)
@@ -392,8 +391,8 @@ static bool _gain_trait(int p_, bool show_text)
 
 static bool _can_select_trait(int p_, int tc_)
 {
-    return game_data.acquirable_feat_count > 0 && list(1, p_) < 10000
-        && tc_ == 0;
+    return game_data.acquirable_feat_count > 0 && list(1, p_) < 10000 &&
+        tc_ == 0;
 }
 
 static void _switch_target(bool is_forwards)

--- a/src/ui/ui_menu_game_help.cpp
+++ b/src/ui/ui_menu_game_help.cpp
@@ -215,11 +215,11 @@ void UIMenuGameHelp::_update_key_list()
     }
     font(13 - en * 2);
     pos(x + 38, y + 408);
-    mes(u8"F9 "s
-        + i18n::s.get("core.locale.ui.manual.keys.other.hide_interface")
-        + u8"F11  "
-        + i18n::s.get("core.locale.ui.manual.keys.other.export_chara_sheet")
-        + u8"F12  " + i18n::s.get("core.locale.ui.manual.keys.other.console"));
+    mes(u8"F9 "s +
+        i18n::s.get("core.locale.ui.manual.keys.other.hide_interface") +
+        u8"F11  " +
+        i18n::s.get("core.locale.ui.manual.keys.other.export_chara_sheet") +
+        u8"F12  " + i18n::s.get("core.locale.ui.manual.keys.other.console"));
 }
 
 void UIMenuGameHelp::_update_regular_pages()

--- a/src/ui/ui_menu_hire.cpp
+++ b/src/ui/ui_menu_hire.cpp
@@ -13,8 +13,8 @@ bool UIMenuHire::_should_display_chara(const Character& chara)
 {
     if (_operation == HireOperation::revive)
     {
-        if (chara.state() != Character::State::pet_dead
-            && chara.state() != Character::State::villager_dead)
+        if (chara.state() != Character::State::pet_dead &&
+            chara.state() != Character::State::villager_dead)
         {
             return false;
         }

--- a/src/ui/ui_menu_journal.cpp
+++ b/src/ui/ui_menu_journal.cpp
@@ -84,16 +84,16 @@ bool UIMenuJournal::init()
     noteadd(u8" - Title & Ranking - "s);
     noteadd(""s);
     noteadd(
-        i18n::s.get("core.locale.ui.journal.rank.fame") + ": "
-        + cdata.player().fame);
+        i18n::s.get("core.locale.ui.journal.rank.fame") + ": " +
+        cdata.player().fame);
     noteadd(""s);
     for (int cnt = 0; cnt < 9; ++cnt)
     {
         if (game_data.ranks.at(cnt) < 10000)
         {
             noteadd(
-                ""s + ranktitle(cnt) + u8" Rank."s
-                + game_data.ranks.at(cnt) / 100);
+                ""s + ranktitle(cnt) + u8" Rank."s +
+                game_data.ranks.at(cnt) / 100);
             s = i18n::s.get("core.locale.ui.journal.rank.pay", calcincome(cnt));
             gold += calcincome(cnt);
             if (cnt != 3 && cnt != 4 && cnt != 5 && cnt != 8)

--- a/src/ui/ui_menu_keybindings.cpp
+++ b/src/ui/ui_menu_keybindings.cpp
@@ -54,15 +54,15 @@ static std::string _get_localized_action_name(
         {
             action_index_plus_1 -= 10;
         }
-        localized_name = i18n::s.get(mod_name + ".locale.keybind.shortcut")
-            + std::to_string(action_index_plus_1);
+        localized_name = i18n::s.get(mod_name + ".locale.keybind.shortcut") +
+            std::to_string(action_index_plus_1);
         break;
     }
     case ActionCategory::selection:
     {
         const auto action_index_plus_1 = keybind_index_number(action_id) + 1;
-        localized_name = i18n::s.get(mod_name + ".locale.keybind.select")
-            + std::to_string(action_index_plus_1);
+        localized_name = i18n::s.get(mod_name + ".locale.keybind.select") +
+            std::to_string(action_index_plus_1);
         break;
     }
     default:

--- a/src/ui/ui_menu_materials.cpp
+++ b/src/ui/ui_menu_materials.cpp
@@ -95,8 +95,8 @@ static void _draw_keys()
 
 static void _draw_single_list_entry_name(int cnt, int list_item)
 {
-    std::string mat_name = ""s + matname(list_item) + " "
-        + i18n::s.get("core.locale.crafting.menu.x") + " " + mat(list_item);
+    std::string mat_name = ""s + matname(list_item) + " " +
+        i18n::s.get("core.locale.crafting.menu.x") + " " + mat(list_item);
     cs_list(cs == cnt, mat_name, wx + 96, wy + 66 + cnt * 19 - 1, 0, 0);
 }
 

--- a/src/ui/ui_menu_npc_tone.cpp
+++ b/src/ui/ui_menu_npc_tone.cpp
@@ -66,8 +66,8 @@ void UIMenuNPCTone::update()
 void UIMenuNPCTone::draw()
 {
     s(0) = i18n::s.get("core.locale.action.interact.change_tone.title");
-    s(1) = i18n::s.get("core.locale.action.interact.change_tone.hint")
-        + strhint2 + strhint3;
+    s(1) = i18n::s.get("core.locale.action.interact.change_tone.hint") +
+        strhint2 + strhint3;
     display_window((windoww - 500) / 2 + inf_screenx, winposy(400), 500, 400);
 
     x = ww / 5 * 3;

--- a/src/ui/ui_menu_skills.cpp
+++ b/src/ui/ui_menu_skills.cpp
@@ -145,8 +145,8 @@ static void _draw_skill_name(int cnt, int skill_id)
         i18n::s.get_m(
             "locale.ability",
             the_ability_db.get_id_from_legacy(skill_id)->get(),
-            "name")
-            + skill_shortcut,
+            "name") +
+            skill_shortcut,
         wx + 84,
         wy + 66 + cnt * 19 - 1);
 }

--- a/src/ui/ui_menu_spells.cpp
+++ b/src/ui/ui_menu_spells.cpp
@@ -71,9 +71,9 @@ static void _draw_window()
     display_window((windoww - 720) / 2 + inf_screenx, winposy(438), 720, 438);
     display_topic(i18n::s.get("core.locale.ui.spell.name"), wx + 28, wy + 36);
     display_topic(
-        i18n::s.get("core.locale.ui.spell.cost") + "("
-            + i18n::s.get("core.locale.ui.spell.stock") + ")" + " "
-            + i18n::s.get("core.locale.ui.spell.lv_chance"),
+        i18n::s.get("core.locale.ui.spell.cost") + "(" +
+            i18n::s.get("core.locale.ui.spell.stock") + ")" + " " +
+            i18n::s.get("core.locale.ui.spell.lv_chance"),
         wx + 220,
         wy + 36);
     display_topic(
@@ -140,16 +140,16 @@ static void _draw_spell_name(int cnt, int spell_id)
         i18n::s.get_m(
             "locale.ability",
             the_ability_db.get_id_from_legacy(spell_id)->get(),
-            "name")
-            + spell_shortcut,
+            "name") +
+            spell_shortcut,
         wx + 84,
         wy + 66 + cnt * 19 - 1);
 }
 
 static void _draw_spell_cost(int cnt, int spell_id)
 {
-    std::string spell_cost = ""s + calcspellcostmp(spell_id, cc) + u8" ("s
-        + spell((spell_id - 400)) + u8")"s;
+    std::string spell_cost = ""s + calcspellcostmp(spell_id, cc) + u8" ("s +
+        spell((spell_id - 400)) + u8")"s;
     pos(wx + 328 - strlen_u(spell_cost) * 7, wy + 66 + cnt * 19 + 2);
     mes(spell_cost);
 }
@@ -159,8 +159,8 @@ static void _draw_spell_power(int cnt, int spell_id)
     draw_spell_power_entry(spell_id);
     std::string spell_power = strmid(s, 0, 40);
     pos(wx + 340, wy + 66 + cnt * 19 + 2);
-    mes(""s + sdata(spell_id, cc) + u8"/"s + calcspellfail(spell_id, cc)
-        + u8"%"s);
+    mes(""s + sdata(spell_id, cc) + u8"/"s + calcspellfail(spell_id, cc) +
+        u8"%"s);
     pos(wx + 420, wy + 66 + cnt * 19 + 2);
     mes(spell_power);
 }

--- a/src/ui/ui_menu_town_chart.cpp
+++ b/src/ui/ui_menu_town_chart.cpp
@@ -56,8 +56,8 @@ void UIMenuTownChart::draw()
     int j0 = 0;
     int n = 0;
     cs_listbk();
-    if (area_data[game_data.current_map].quest_town_id == 0
-        || game_data.current_dungeon_level != 1)
+    if (area_data[game_data.current_map].quest_town_id == 0 ||
+        game_data.current_dungeon_level != 1)
     {
         font(14 - en * 2);
         pos(wx + 40, wy + 50);

--- a/src/ui/ui_menu_town_economy.cpp
+++ b/src/ui/ui_menu_town_economy.cpp
@@ -107,15 +107,15 @@ static void _draw_economy_info(int _city)
     _show_economy_info(
         x,
         y,
-        i18n::s.get("core.locale.ui.economy.basic_tax") + u8" ("s
-            + game_data.politics_tax_amount + u8"%)"s,
+        i18n::s.get("core.locale.ui.economy.basic_tax") + u8" ("s +
+            game_data.politics_tax_amount + u8"%)"s,
         podata(102, _city),
         podata(103, _city));
     _show_economy_info(
         x,
         y + 16,
-        i18n::s.get("core.locale.ui.economy.excise_tax") + u8" ("s
-            + podata(150, _city) + u8"%)"s,
+        i18n::s.get("core.locale.ui.economy.excise_tax") + u8" ("s +
+            podata(150, _city) + u8"%)"s,
         podata(104, _city),
         podata(105, _city));
 }
@@ -135,8 +135,8 @@ static void _draw_economy_details()
 
 static bool _map_has_economy()
 {
-    return area_data[game_data.current_map].quest_town_id != 0
-        && game_data.current_dungeon_level == 1;
+    return area_data[game_data.current_map].quest_town_id != 0 &&
+        game_data.current_dungeon_level == 1;
 }
 
 void UIMenuTownEconomy::draw()

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -106,8 +106,8 @@ inline bool has_prefix(const std::string& str, const std::string& prefix)
         return false;
     }
 
-    return std::mismatch(prefix.begin(), prefix.end(), str.begin()).first
-        == prefix.end();
+    return std::mismatch(prefix.begin(), prefix.end(), str.begin()).first ==
+        prefix.end();
 }
 
 
@@ -236,16 +236,15 @@ inline size_t utf8_cut_index(
     int current_char = 0;
     size_t current_byte = 0;
     bool multibyte = false;
-    while (current_char < max_length_charwise
-           && current_byte < utf8_string.size())
+    while (current_char < max_length_charwise &&
+           current_byte < utf8_string.size())
     {
         if (static_cast<unsigned char>(utf8_string[current_byte]) > 0x7F)
         {
             current_byte++;
             current_char++;
-            while (
-                (static_cast<unsigned char>(utf8_string[current_byte] & 0xC0))
-                == 0x80)
+            while ((static_cast<unsigned char>(
+                       utf8_string[current_byte] & 0xC0)) == 0x80)
             {
                 // Fullwidth characters count as length 2.
                 if (!multibyte)
@@ -379,8 +378,8 @@ struct ByLineReader
         if (!in)
         {
             throw std::runtime_error(
-                u8"Could not open file "
-                + filesystem::make_preferred_path_in_utf8(filepath));
+                u8"Could not open file " +
+                filesystem::make_preferred_path_in_utf8(filepath));
         }
         skip_bom(in);
     }

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -526,8 +526,8 @@ bool wish_for_item(const std::string& input)
             curse_state = CurseState::blessed;
         }
         else if (
-            contains(input, u8"呪われていない")
-            || contains(input, u8"uncursed "))
+            contains(input, u8"呪われていない") ||
+            contains(input, u8"uncursed "))
         {
             curse_state = CurseState::none;
         }
@@ -626,8 +626,8 @@ bool wish_for_item(const std::string& input)
             inv[ci].curse_state = CurseState::blessed;
             txt(i18n::s.get("core.locale.wish.it_is_sold_out"));
         }
-        if (the_item_db[inv[ci].id]->category == 52000
-            || the_item_db[inv[ci].id]->category == 53000)
+        if (the_item_db[inv[ci].id]->category == 52000 ||
+            the_item_db[inv[ci].id]->category == 53000)
         {
             inv[ci].set_number(3 + rnd(2));
             if (inv[ci].value >= 20000)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #1038.


# Summary

Change "BreakBeforeBinaryOperators" option to None in .clang-format. There are two allowed values other than "None": "NonAssignment" and "All". However, the two have a bug, inserting unexpected spaces. It has been fixed in the latest `clang-format`, but we decide to change the value itself in order to make both old `clang-format` and new one output the same result.

I tried running `clang-format` with several versions which were installed via homebrew in my computer, and checked that the result is the same as the latest.