### PR TITLE
Move the position of the crypt of the damned right

### DIFF
--- a/runtime/mods/core/data/map.lua
+++ b/runtime/mods/core/data/map.lua
@@ -419,7 +419,7 @@ data:add_multi(
          appearance = 141,
          map_type = "Dungeon",
          outer_map = 4,
-         outer_map_position = { x = 37, y = 20 },
+         outer_map_position = { x = 38, y = 20 },
          entrance_type = "StairUp",
          tile_set = "Normal",
          tile_type = 0,


### PR DESCRIPTION
# Summary

The previous position, (37, 20), is not an accessible cell and the
actual position varies in each save data. In most cases, the actual
position become (38, 20) or (37, 21), but sometimes the crypt moves far
away or moves several times when a diastrophism occurs.

The new position, (38, 20), is the same as MMAh's. Thanks to the author
of MMAh and reporters of this bug.

Link to the post by the author of MMAh: http://jbbs.shitaraba.net/bbs/read.cgi/game/58103/1534584992/509