### PR TITLE
Fix wrong map IDs

### DIFF
--- a/runtime/mods/core/data/map.lua
+++ b/runtime/mods/core/data/map.lua
@@ -295,7 +295,7 @@ data:add_multi(
       },
       {
          name = "arena",
-         id = 40,
+         id = 6,
          appearance = 0,
          map_type = "Temporary",
          outer_map = 4,
@@ -770,7 +770,7 @@ data:add_multi(
       },
       {
          name = "shelter",
-         id = 6,
+         id = 30,
          appearance = 0,
          map_type = "PlayerOwned",
          outer_map = 4,


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #1043.


# Summary

The map IDs of arena and shelter were wrong.