### PR TITLE
Fix not being able to choose correct ally

### DIFF
--- a/src/ui/ui_menu_ctrl_ally.cpp
+++ b/src/ui/ui_menu_ctrl_ally.cpp
@@ -607,7 +607,7 @@ optional<UIMenuCtrlAlly::Result> UIMenuCtrlAlly::on_key(
         }
         else
         {
-            return UIMenuCtrlAlly::Result::finish(_index);
+            return UIMenuCtrlAlly::Result::finish(list(0, _index));
         }
     }
     else if (action == "next_page")


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #1044.


# Summary

The cause of the bug is that the return value of `ctrl_ally`, a function to choose one of your allies, may be 0, which means the player character. Selling a slave deletes the sold character, so in this case, you are deleted.

This pull request also resolve these errors:

- Cannot call back your allies from a bartender.
- Cannot command your allies to stay in your home.
- Cannot investigate your allies' stats.