### PR TITLE
Fix skyline packing algorithm

### DIFF
--- a/src/pic_loader/pic_loader.hpp
+++ b/src/pic_loader/pic_loader.hpp
@@ -111,7 +111,7 @@ public:
                 y = std::max(y, skyline.y);
 
                 bool contained =
-                    x >= 0 && y >= 0 && x + w < width && y + h < height;
+                    x >= 0 && y >= 0 && x + w <= width && y + h <= height;
 
                 if (!contained)
                 {
@@ -207,6 +207,7 @@ public:
                     if (now.width <= shrink_amount)
                     {
                         skylines.erase(skylines.begin() + i);
+                        --i;
                     }
                     else
                     {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #957.


# Summary

Fix skyline packing algorithm.

```diff
- x >= 0 && y >= 0 && x + w < width && y + h < height;
+ x >= 0 && y >= 0 && x + w <= width && y + h <= height;
```

E.g.,
    x = 50
    w = 100
    width = 150

The rectangle apparently has enough width.

```diff
+ --i;
```

Since erase() method changes index, needs to decrement the index in
order to shrink skylines again based on the current skyline (which was inserted just now).

# TODO

- [x] Delete temporary code for debugging after testing.