### PR TITLE
Fix crash from using Cat's Cradle

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1740,6 +1740,14 @@ int chara_copy(const Character& source)
     const auto x = pos->x;
     const auto y = pos->y;
 
+    if (source.state() != Character::State::empty)
+    {
+        // Clean up any stale handles that may have been left over from a
+        // character in the same index being removed.
+        lua::lua->get_handle_manager().remove_chara_handle_run_callbacks(
+            cdata[slot]);
+    }
+
     // Delete completely the previous character in `slot`.
     chara_delete(slot);
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -485,6 +485,13 @@ void item_copy(int a, int b)
 
     bool was_empty = inv[b].number() == 0;
 
+    if (was_empty && inv[a].number() > 0)
+    {
+        // Clean up any stale handles that may have been left over from an item
+        // in the same index being removed.
+        lua::lua->get_handle_manager().remove_item_handle_run_callbacks(inv[b]);
+    }
+
     Item::copy(inv[a], inv[b]);
 
     if (was_empty && inv[b].number() != 0)

--- a/src/tests/lua_handles.cpp
+++ b/src/tests/lua_handles.cpp
@@ -431,7 +431,7 @@ TEST_CASE("Test copying of character handles", "[Lua: Handles]")
     Character& chara = elona::cdata[elona::rc];
     auto handle = handle_mgr.get_handle(chara);
 
-    int tc = chara_copy(chara);
+    int tc = elona::chara_copy(chara);
     Character& copy = elona::cdata[tc];
     sol::table handle_copy = handle_mgr.get_handle(copy);
 
@@ -447,6 +447,25 @@ TEST_CASE("Test copying of character handles", "[Lua: Handles]")
     // Assert that copying to an existing character will not try to
     // overwrite the existing handle (it would cause an exception).
     REQUIRE_NOTHROW(elona::Character::copy(chara, copy));
+}
+
+TEST_CASE("Test copying of character handles after removal", "[Lua: Handles]")
+{
+    reset_state();
+    start_in_debug_map();
+    auto& handle_mgr = elona::lua::lua->get_handle_manager();
+
+    REQUIRE(chara_create(-1, PUTIT_PROTO_ID, 4, 8));
+    Character& a = elona::cdata[elona::rc];
+
+    REQUIRE(chara_create(-1, PUTIT_PROTO_ID, 4, 9));
+    Character& b = elona::cdata[elona::rc];
+
+    // Mark the handle in b's slot as invalid.
+    b.set_state(Character::State::empty);
+
+    // chara_copy should clean up the handle in b's slot.
+    REQUIRE_NOTHROW(elona::chara_copy(a));
 }
 
 TEST_CASE(
@@ -585,6 +604,26 @@ TEST_CASE("Test copying of item handles", "[Lua: Handles]")
     // Assert that copying to an existing item will not try to
     // overwrite the existing handle.
     REQUIRE_NOTHROW(elona::item_copy(elona::ci, ti));
+}
+
+TEST_CASE("Test copying of item handles after removal", "[Lua: Handles]")
+{
+    reset_state();
+    start_in_debug_map();
+    auto& handle_mgr = elona::lua::lua->get_handle_manager();
+    int amount = 1;
+
+    REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, amount));
+    Item& a = elona::inv[elona::ci];
+
+    REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 9, amount));
+    Item& b = elona::inv[elona::ci];
+
+    // Mark the handle in b's slot as invalid.
+    b.set_number(0);
+
+    // item_copy should clean up the handle in b's slot.
+    REQUIRE_NOTHROW(elona::item_copy(a.index, b.index));
 }
 
 TEST_CASE("Test swapping of item handles", "[Lua: Handles]")


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #1050.

# Summary
Before, `item_copy()` and `chara_copy()` could copy into slots occupied by Lua references whose concrete object had already been removed, but where the reference is still valid. This is due to the changes in e4ef187f causing Lua references to not be invalidated at the point of removal, only at the exact moment a new object occupies a previously invalidated slot.

The solution is to check before copying whether the reference in the item/character slot is valid, and to clear it before copying.

There are probably other bugs of this kind where a stale reference is not cleared before performing an action that would create a new handle in the same slot.
