### PR TITLE
Add is_cancelable to DialogData, the flag whether you can cancel a talk

### DIFF
--- a/src/elona/dialog/dialog_data.cpp
+++ b/src/elona/dialog/dialog_data.cpp
@@ -153,7 +153,7 @@ bool DialogData::state_is_valid()
 
 bool DialogData::is_cancelable_now()
 {
-    return false;
+    return is_cancelable;
 }
 
 static bool _run_callback(

--- a/src/elona/dialog/dialog_data.hpp
+++ b/src/elona/dialog/dialog_data.hpp
@@ -121,8 +121,10 @@ public:
     DialogData(
         map_type nodes,
         std::string starting_node,
+        bool is_cancelable,
         lua::ExportManager& export_manager)
         : nodes(nodes)
+        , is_cancelable(is_cancelable)
         , export_manager(export_manager)
     {
         set_node(starting_node);
@@ -199,6 +201,7 @@ private:
     bool show_dialog();
 
     map_type nodes;
+    bool is_cancelable;
     size_t current_text_index = 0;
     optional<std::string> current_node_id = none;
 

--- a/src/elona/dialog/dialog_decoder.cpp
+++ b/src/elona/dialog/dialog_decoder.cpp
@@ -241,6 +241,8 @@ DialogData DialogDecoderLogic::decode(lua::ConfigTable& table)
     DialogData::map_type nodes;
     std::string full_id = table.required<std::string>("_full_id");
 
+    bool is_cancelable = table.optional_or<bool>("is_cancelable", true);
+
     sol::object nodes_table = table.required<sol::object>("nodes");
     if (nodes_table == sol::lua_nil)
     {
@@ -266,8 +268,7 @@ DialogData DialogDecoderLogic::decode(lua::ConfigTable& table)
             full_id + ": Cannot find starting dialog node " + starting_node);
     }
 
-    DialogData the_dialog(nodes, starting_node, export_manager);
-    return the_dialog;
+    return {nodes, starting_node, is_cancelable, export_manager};
 }
 
 } // namespace elona


### PR DESCRIPTION
# Related Issues

Close #892.


# Summary

Before, `DialogData::is_cancelable_now()` always returns false, and now,
it returns `DialogData::is_cancelable` given by dialog definition data.
The function's name has "now", but currently returns the same value.
This limit will be abolished in the future.

The new field is optional, and set to true by default as many vanilla
dialog window (currently hard-coded) are.
