### PR TITLE
Restore Angband easter egg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ MKDIR := mkdir
 
 
 all: $(BIN_DIR)
-	cd $(BIN_DIR); cmake .. $(CMAKE_ARGS); make
+	cd $(BIN_DIR); cmake .. $(CMAKE_ARGS); make -j24
 
 
 build: $(BIN_DIR) $(PROGRAM)

--- a/src/elona/casino.cpp
+++ b/src/elona/casino.cpp
@@ -62,7 +62,6 @@ void casino_dealer()
 void casino_choose_card()
 {
 label_18671_internal:
-    key = "";
     keylog = "";
     screenupdate = -1;
     update_screen();

--- a/src/elona/elonacore.cpp
+++ b/src/elona/elonacore.cpp
@@ -12429,10 +12429,12 @@ optional<TurnResult> check_angband()
         map_data.type == mdata_t::MapType::world_map)
         return none;
 
+    auto key = keybind::pressed_key_name();
+
     switch (game_data.angband_flag)
     {
     case 0:
-        if (key == u8"Q"s)
+        if (key == "Q")
         {
             txt(i18n::s.get("core.locale.action.angband.q"));
             ++game_data.angband_flag;
@@ -12441,7 +12443,7 @@ optional<TurnResult> check_angband()
         }
         break;
     case 1:
-        if (key == u8"y"s)
+        if (key == "y")
         {
             txt(i18n::s.get("core.locale.action.angband.y"));
             ++game_data.angband_flag;
@@ -12450,7 +12452,7 @@ optional<TurnResult> check_angband()
         }
         break;
     case 2:
-        if (key == u8"@"s)
+        if (key == "@")
         {
             txt(i18n::s.get("core.locale.action.angband.at"));
             for (int i = 0; i < 10; ++i)

--- a/src/elona/elonacore.cpp
+++ b/src/elona/elonacore.cpp
@@ -36,6 +36,7 @@
 #include "input_prompt.hpp"
 #include "item.hpp"
 #include "itemgen.hpp"
+#include "keybind/input_context.hpp"
 #include "log.hpp"
 #include "lua_env/interface.hpp"
 #include "lua_env/lua_env.hpp"
@@ -12429,12 +12430,18 @@ optional<TurnResult> check_angband()
         map_data.type == mdata_t::MapType::world_map)
         return none;
 
-    auto key = keybind::pressed_key_name();
+    const auto key = keybind::pressed_key_name();
+    auto shift = is_modifier_pressed(snail::ModKey::shift);
+
+    if (!key)
+    {
+        return none;
+    }
 
     switch (game_data.angband_flag)
     {
     case 0:
-        if (key == "Q")
+        if (*key == "q" && shift)
         {
             txt(i18n::s.get("core.locale.action.angband.q"));
             ++game_data.angband_flag;
@@ -12443,7 +12450,7 @@ optional<TurnResult> check_angband()
         }
         break;
     case 1:
-        if (key == "y")
+        if (*key == "y" && !shift)
         {
             txt(i18n::s.get("core.locale.action.angband.y"));
             ++game_data.angband_flag;
@@ -12452,7 +12459,7 @@ optional<TurnResult> check_angband()
         }
         break;
     case 2:
-        if (key == "@")
+        if (*key == "2" && shift)
         {
             txt(i18n::s.get("core.locale.action.angband.at"));
             for (int i = 0; i < 10; ++i)

--- a/src/elona/init.cpp
+++ b/src/elona/init.cpp
@@ -346,7 +346,6 @@ void initialize_elona()
     DIM2(dir, 5);
     DIM3(dblist, 2, 800);
     SDIM2(inputlog, 100);
-    SDIM2(key, 20);
     SDIM2(keylog, 20);
     SDIM3(randn1, 30, 20);
     DIM2(rtval, 10);

--- a/src/elona/input.cpp
+++ b/src/elona/input.cpp
@@ -442,5 +442,18 @@ void wait_key_pressed(bool only_enter_or_cancel)
 }
 
 
+bool nonmodifier_key_pressed()
+{
+    auto keys = snail::Input::instance().pressed_keys();
+
+    for (auto key : keys)
+    {
+        if (!is_modifier(key))
+            return true;
+    }
+
+    return false;
+}
+
 
 } // namespace elona

--- a/src/elona/input.cpp
+++ b/src/elona/input.cpp
@@ -441,19 +441,4 @@ void wait_key_pressed(bool only_enter_or_cancel)
     keyhalt = 1;
 }
 
-
-bool nonmodifier_key_pressed()
-{
-    auto keys = snail::Input::instance().pressed_keys();
-
-    for (auto key : keys)
-    {
-        if (!is_modifier(key))
-            return true;
-    }
-
-    return false;
-}
-
-
 } // namespace elona

--- a/src/elona/input.cpp
+++ b/src/elona/input.cpp
@@ -146,7 +146,6 @@ void input_number_dialog(int x, int y, int max_number, int initial_number)
         rtval = -1;
     }
     keywait = 1;
-    key = "";
     rtval = 0;
 }
 
@@ -262,7 +261,6 @@ bool input_text_dialog(
             {
                 inputlog = "";
                 keywait = 1;
-                key = "";
                 break;
             }
         }

--- a/src/elona/input.hpp
+++ b/src/elona/input.hpp
@@ -49,7 +49,6 @@ int yes_or_no(int x, int y, int width);
 bool is_modifier_pressed(snail::ModKey modifier);
 void wait_key_released();
 void wait_key_pressed(bool only_enter_or_cancel = false);
-bool nonmodifier_key_pressed();
 
 
 } // namespace elona

--- a/src/elona/input.hpp
+++ b/src/elona/input.hpp
@@ -49,6 +49,7 @@ int yes_or_no(int x, int y, int width);
 bool is_modifier_pressed(snail::ModKey modifier);
 void wait_key_released();
 void wait_key_pressed(bool only_enter_or_cancel = false);
+bool nonmodifier_key_pressed();
 
 
 } // namespace elona

--- a/src/elona/input_prompt.cpp
+++ b/src/elona/input_prompt.cpp
@@ -39,16 +39,20 @@ int Prompt::query(int x, int y, int width)
         auto action = cursor_check_ex();
         int ret = -1;
 
-        auto keys = snail::Input::instance().pressed_keys();
-
-        for (const auto& entry : _entries)
+        if (keyhalt == 0)
         {
-            if (keys.find(entry.key) != keys.end())
+            auto keys = snail::Input::instance().pressed_keys();
+
+            for (const auto& entry : _entries)
             {
-                ret = entry.value;
-                break;
+                if (keys.find(entry.key) != keys.end())
+                {
+                    ret = entry.value;
+                    break;
+                }
             }
         }
+
         if (action == "enter")
         {
             ret = _entries.at(cs).value;

--- a/src/elona/keybind/input_context.cpp
+++ b/src/elona/keybind/input_context.cpp
@@ -19,7 +19,6 @@ namespace
 snail::Key last_held_key = snail::Key::none;
 int last_held_key_frames = 0;
 
-} // namespace
 
 // This map holds the action categories available in an input context.
 // Categories at the top will override categories further down. This is to
@@ -28,7 +27,7 @@ int last_held_key_frames = 0;
 // categories.
 
 // clang-format off
-static std::map<InputContextType, std::vector<ActionCategory>> input_context_types =
+std::map<InputContextType, std::vector<ActionCategory>> input_context_types =
 {
     {InputContextType::menu, {ActionCategory::shortcut,
                               ActionCategory::menu,
@@ -41,6 +40,8 @@ static std::map<InputContextType, std::vector<ActionCategory>> input_context_typ
                               ActionCategory::default_}}
 };
 // clang-format on
+
+} // namespace
 
 bool InputContext::_matches(
     const std::string& action_id,
@@ -591,5 +592,27 @@ std::unordered_set<ActionCategory> keybind_conflicting_action_categories(
     }
     return result;
 }
+
+namespace keybind
+{
+std::string pressed_key_name()
+{
+    if (last_held_key == snail::Key::none ||
+        _is_keypress_delayed(last_held_key_frames, 1, 20))
+    {
+        return "";
+    }
+
+    auto shift = (snail::Input::instance().modifiers() &
+                  snail::ModKey::shift) != snail::ModKey::none;
+
+    if (auto name = keybind_key_name(last_held_key, shift))
+    {
+        return *name;
+    }
+
+    return "";
+}
+} // namespace keybind
 
 } // namespace elona

--- a/src/elona/keybind/input_context.hpp
+++ b/src/elona/keybind/input_context.hpp
@@ -88,4 +88,9 @@ private:
     bool _menu_cycle_key_pressed{};
 };
 
+namespace keybind
+{
+std::string pressed_key_name();
+}
+
 } // namespace elona

--- a/src/elona/keybind/input_context.hpp
+++ b/src/elona/keybind/input_context.hpp
@@ -90,7 +90,7 @@ private:
 
 namespace keybind
 {
-std::string pressed_key_name();
+optional<std::string> pressed_key_name();
 }
 
 } // namespace elona

--- a/src/elona/message.cpp
+++ b/src/elona/message.cpp
@@ -66,7 +66,6 @@ void unsubscribe_log(LogObserver* observer)
 
 void anime_halt(int x_at_txtfunc, int y_at_txtfunc)
 {
-    key = "";
     objprm(0, ""s);
     keylog = "";
     gmode(0);

--- a/src/elona/random_event.cpp
+++ b/src/elona/random_event.cpp
@@ -609,7 +609,6 @@ int show_random_event_window(
     pagemax = 0;
     pagesize = 16;
     cs_bk = -1;
-    key = "";
     objprm(0, ""s);
     keylog = "";
     if (listmax <= 1)
@@ -700,7 +699,6 @@ int show_random_event_window(
         if (rtval != -1)
         {
             snd("core.click1");
-            key = "";
             return rtval;
         }
     }

--- a/src/elona/talk.cpp
+++ b/src/elona/talk.cpp
@@ -545,7 +545,6 @@ int talk_window_query()
         ++keyrange;
     }
     keyrange = listmax;
-    key = "";
     objprm(0, ""s);
     keylog = "";
     talk_window_init_and_show();

--- a/src/elona/tcg.cpp
+++ b/src/elona/tcg.cpp
@@ -2838,7 +2838,6 @@ void tcg_prompt_action()
             tcgdraw();
             tcg_update_selection();
             cc_at_tcg = clist_at_tcg(cs_at_tcg, csline_at_tcg);
-            key = "";
             if (f_at_tcg == -1)
             {
                 continue;

--- a/src/elona/turn_sequence.cpp
+++ b/src/elona/turn_sequence.cpp
@@ -1243,7 +1243,6 @@ TurnResult turn_end()
 }
 
 
-
 TurnResult pc_turn(bool advance_time)
 {
     if (advance_time)
@@ -1517,7 +1516,6 @@ TurnResult pc_turn(bool advance_time)
         }
         t = 1;
         keylog = "";
-        key = "";
         objprm(0, ""s);
     }
 
@@ -1573,6 +1571,12 @@ label_2747:
         InputContext::instance().check_for_command(KeyWaitDelay::walk_run);
     player_queried_for_input = false;
 
+    const auto angband_result = check_angband();
+    if (angband_result)
+    {
+        return *angband_result;
+    }
+
     if (command == ""s)
     {
         goto label_2747;
@@ -1589,6 +1593,6 @@ label_2747:
     }
 
     goto label_2747;
-}
+} // namespace elona
 
 } // namespace elona

--- a/src/elona/turn_sequence_pc_actions.cpp
+++ b/src/elona/turn_sequence_pc_actions.cpp
@@ -99,14 +99,12 @@ optional<TurnResult> handle_pc_action(std::string& action)
 
     if (action == "quicksave")
     {
-        key = "";
         save_game();
         txt(i18n::s.get("core.locale.action.quicksave"));
         return none;
     }
     if (action == "quickload")
     {
-        key = "";
         Message::instance().clear();
         firstturn = 1;
         load_save_data();

--- a/src/elona/turn_sequence_pc_actions.cpp
+++ b/src/elona/turn_sequence_pc_actions.cpp
@@ -305,8 +305,7 @@ optional<TurnResult> handle_pc_action(std::string& action)
         await(100);
     }
 
-    // TODO
-    if (key != ""s)
+    if (action == "")
     {
         const auto angband_result = check_angband();
         if (angband_result)

--- a/src/elona/turn_sequence_pc_actions.cpp
+++ b/src/elona/turn_sequence_pc_actions.cpp
@@ -50,6 +50,11 @@ static bool _proc_autodig()
 
 optional<TurnResult> handle_pc_action(std::string& action)
 {
+    if (action != "cancel" && game_data.angband_flag != -1)
+    {
+        game_data.angband_flag = 0;
+    }
+
     if (game_data.wizard)
     {
         if (action == "wizard_open_console")
@@ -303,14 +308,6 @@ optional<TurnResult> handle_pc_action(std::string& action)
         await(100);
     }
 
-    if (action == "")
-    {
-        const auto angband_result = check_angband();
-        if (angband_result)
-        {
-            return *angband_result;
-        }
-    }
     if (action == "quick_menu")
     {
         action = show_quick_menu();

--- a/src/elona/ui/ui_menu_dialog.cpp
+++ b/src/elona/ui/ui_menu_dialog.cpp
@@ -32,7 +32,6 @@ bool UIMenuDialog::init()
     }
     keyrange = listmax;
 
-    key = "";
     objprm(0, ""s);
     keylog = "";
     buff = i18n::s.get(_dialog.text_key());

--- a/src/elona/ui/ui_menu_god.cpp
+++ b/src/elona/ui/ui_menu_god.cpp
@@ -38,7 +38,6 @@ bool UIMenuGod::init()
     pagemax = 0;
     pagesize = 16;
     cs_bk = -1;
-    key = "";
     objprm(0, ""s);
     keylog = "";
     listmax = 0;

--- a/src/elona/variables.hpp
+++ b/src/elona/variables.hpp
@@ -245,7 +245,6 @@ ELONA_EXTERN(elona_vector1<std::string> invkey);
 ELONA_EXTERN(elona_vector1<std::string> ioriginalnameref2);
 ELONA_EXTERN(elona_vector1<std::string> ioriginalnameref);
 ELONA_EXTERN(elona_vector1<std::string> jkey);
-ELONA_EXTERN(elona_vector1<std::string> key);
 ELONA_EXTERN(std::string key_identify);
 ELONA_EXTERN(std::string key_pageup);
 ELONA_EXTERN(std::string key_pagedown);


### PR DESCRIPTION
# Related Issues

Close #1056.


# Summary
Restores the easter egg accessible by pressing `Qy@`. It currently takes precedence over any shortcut keys bound until it is triggered for the first time, unless a key in the sequence is pressed twice, so keys bound to them should still be usable.