### PR TITLE
Enhance message log

### DIFF
--- a/src/elona/Android.mk
+++ b/src/elona/Android.mk
@@ -82,6 +82,7 @@ mef.cpp \
 menu.cpp \
 menu_quick_menu.cpp \
 message.cpp \
+message_log.cpp \
 network.cpp \
 proc_event.cpp \
 quest.cpp \

--- a/src/elona/CMakeLists.txt
+++ b/src/elona/CMakeLists.txt
@@ -65,6 +65,7 @@ set(ELONA_SOURCES
   menu.cpp
   menu_quick_menu.cpp
   message.cpp
+  message_log.cpp
   network.cpp
   proc_event.cpp
   quest.cpp

--- a/src/elona/elonacore.cpp
+++ b/src/elona/elonacore.cpp
@@ -156,7 +156,7 @@ void weather_changes_by_location(bool output_immediately = true)
             }
             else
             {
-                Message::instance().msg_append(
+                Message::instance().buffered_message_append(
                     i18n::s.get("core.locale.action.weather.changes"));
             }
         }
@@ -175,7 +175,7 @@ void weather_changes_by_location(bool output_immediately = true)
             }
             else
             {
-                Message::instance().msg_append(
+                Message::instance().buffered_message_append(
                     i18n::s.get("core.locale.action.weather.changes"));
             }
         }
@@ -4082,7 +4082,7 @@ TurnResult exit_map()
         rq = game_data.executing_immediate_quest;
         quest_exit_map();
     }
-    Message::instance().msg_append_begin("  ");
+    Message::instance().buffered_message_begin("  ");
     if (game_data.current_map == mdata_t::MapId::show_house ||
         game_data.current_map == mdata_t::MapId::arena ||
         game_data.current_map == mdata_t::MapId::pet_arena)
@@ -4136,7 +4136,7 @@ TurnResult exit_map()
         f = 0;
         if (feat(1) == 11)
         {
-            Message::instance().msg_append(
+            Message::instance().buffered_message_append(
                 i18n::s.get("core.locale.misc.walk_down_stairs"));
             f = 1;
             game_data.entrance_type = 1;
@@ -4155,7 +4155,7 @@ TurnResult exit_map()
         }
         if (feat(1) == 10)
         {
-            Message::instance().msg_append(
+            Message::instance().buffered_message_append(
                 i18n::s.get("core.locale.misc.walk_up_stairs"));
             f = 1;
             game_data.entrance_type = 2;
@@ -4252,13 +4252,13 @@ TurnResult exit_map()
             {
                 if (game_data.current_dungeon_level == 1)
                 {
-                    Message::instance().msg_append(i18n::s.get(
+                    Message::instance().buffered_message_append(i18n::s.get(
                         "core.locale.action.exit_map.surface.returned_to",
                         mapname(game_data.current_map)));
                 }
                 else
                 {
-                    Message::instance().msg_append(i18n::s.get(
+                    Message::instance().buffered_message_append(i18n::s.get(
                         "core.locale.action.exit_map.surface.left",
                         mapname(game_data.current_map)));
                 }
@@ -4307,7 +4307,8 @@ TurnResult exit_map()
     }
     if (rdtry > 1)
     {
-        Message::instance().msg_append(u8"(再生成"s + rdtry + u8"回)"s);
+        Message::instance().buffered_message_append(
+            u8"(再生成"s + rdtry + u8"回)"s);
     }
     if (game_data.current_map != game_data.previous_map)
     {
@@ -4351,7 +4352,7 @@ TurnResult exit_map()
         }
         if (event_find(6))
         {
-            Message::instance().msg_append(i18n::s.get(
+            Message::instance().buffered_message_append(i18n::s.get(
                 "core.locale.action.exit_map.delivered_to_your_home"));
             weather_changes_by_location(false);
         }
@@ -4359,19 +4360,19 @@ TurnResult exit_map()
             area_data[game_data.previous_map].type ==
             mdata_t::MapType::world_map)
         {
-            Message::instance().msg_append(i18n::s.get(
+            Message::instance().buffered_message_append(i18n::s.get(
                 "core.locale.action.exit_map.entered",
                 mapname(game_data.current_map)));
         }
         else if (map_data.type == mdata_t::MapType::temporary)
         {
-            Message::instance().msg_append(i18n::s.get(
+            Message::instance().buffered_message_append(i18n::s.get(
                 "core.locale.action.exit_map.returned_to",
                 mapname(game_data.current_map)));
         }
         else
         {
-            Message::instance().msg_append(i18n::s.get(
+            Message::instance().buffered_message_append(i18n::s.get(
                 "core.locale.action.exit_map.left",
                 mapname(game_data.previous_map)));
         }
@@ -4382,7 +4383,7 @@ TurnResult exit_map()
                 area_data[game_data.current_map].type ==
                     mdata_t::MapType::field)
             {
-                Message::instance().msg_append(i18n::s.get(
+                Message::instance().buffered_message_append(i18n::s.get(
                     "core.locale.action.exit_map.burdened_by_cargo"));
             }
         }
@@ -4396,7 +4397,7 @@ TurnResult exit_map()
             game_data.current_dungeon_level =
                 area_data[game_data.current_map].deepest_level - 1;
             game_data.entrance_type = 1;
-            Message::instance().msg_append(
+            Message::instance().buffered_message_append(
                 i18n::s.get("core.locale.action.exit_map.mountain_pass"));
         }
     }
@@ -4408,7 +4409,7 @@ TurnResult exit_map()
             game_data.current_map = static_cast<int>(mdata_t::MapId::larna);
             game_data.current_dungeon_level = 1;
             game_data.entrance_type = 2;
-            Message::instance().msg_append(
+            Message::instance().buffered_message_append(
                 i18n::s.get("core.locale.action.exit_map.larna"));
         }
     }
@@ -4676,7 +4677,7 @@ void map_global_proc_diastrophism()
         game_data.reset_world_map_in_diastrophism_flag)
     {
         game_data.diastrophism_flag = 0;
-        Message::instance().msg_append(
+        Message::instance().buffered_message_append(
             i18n::s.get("core.locale.action.move.global.diastrophism"));
         for (int cnt = 450; cnt < 500; ++cnt)
         {

--- a/src/elona/init.cpp
+++ b/src/elona/init.cpp
@@ -833,7 +833,7 @@ void initialize_game()
 
     mtilefilecur = -1;
     firstturn = 1;
-    Message::instance().msg_append_begin(
+    Message::instance().buffered_message_begin(
         "  Lafrontier presents Elona ver 1.22. Welcome traveler! ");
     if (mode == 5)
     {

--- a/src/elona/initialize_map.cpp
+++ b/src/elona/initialize_map.cpp
@@ -327,7 +327,7 @@ static void _proc_three_years_later()
             cdata.player().position.y = area_data[11].position.y;
             game_data.player_next_move_direction = 1;
             game_data.player_x_on_map_leave = -1;
-            Message::instance().msg_append_begin(
+            Message::instance().buffered_message_begin(
                 "  " + i18n::s.get("core.locale.scenario.three_years_later"));
         }
     }
@@ -892,7 +892,7 @@ static void _proc_no_dungeon_master()
     {
         if (area_data[game_data.current_map].has_been_conquered == -1)
         {
-            Message::instance().msg_append(i18n::s.get(
+            Message::instance().buffered_message_append(i18n::s.get(
                 "core.locale.map.no_dungeon_master",
                 mapname(game_data.current_map)));
         }
@@ -1338,7 +1338,7 @@ init_map_after_refresh:
         {
             screenupdate = -1;
             update_entire_screen();
-            Message::instance().msg_append_end();
+            Message::instance().buffered_message_end();
             screenupdate = -1;
             update_screen();
             if (evnum == 0)
@@ -1364,7 +1364,7 @@ init_map_after_refresh:
     mode = 0;
     screenupdate = -1;
     update_entire_screen();
-    Message::instance().msg_append_end();
+    Message::instance().buffered_message_end();
 
     // Check more main quest flags and run map-specific behaviors.
     _proc_map_hooks_2();

--- a/src/elona/message.cpp
+++ b/src/elona/message.cpp
@@ -30,10 +30,6 @@ std::vector<LogObserver*> observers;
 
 
 
-MessageLog message_log;
-
-
-
 LogObserver::~LogObserver()
 {
     unsubscribe_log(this);
@@ -204,18 +200,14 @@ void Message::_msg_write(std::string& message)
     mes(message);
     elona::color(0, 0, 0);
 
-    if (message_log.lines.empty())
-    {
-        message_log.lines.emplace_back();
-    }
-    message_log.lines.back().spans.emplace_back(message, text_color);
+    message_log.append(message, text_color);
 }
 
 
 
 void Message::_msg_newline()
 {
-    message_log.lines.emplace_back();
+    message_log.linebreak();
 
     message_width = 0;
     ++msgline;

--- a/src/elona/message.cpp
+++ b/src/elona/message.cpp
@@ -124,22 +124,22 @@ void help_halt()
 
 
 
-void Message::msg_append_begin(const std::string& first)
+void Message::buffered_message_begin(const std::string& message)
 {
     _msg_newline();
-    msgtemp = first;
+    msgtemp = message;
 }
 
 
 
-void Message::msg_append(const std::string& msg)
+void Message::buffered_message_append(const std::string& message)
 {
-    msgtemp += msg;
+    msgtemp += message;
 }
 
 
 
-void Message::msg_append_end()
+void Message::buffered_message_end()
 {
     _txt_conv();
 }

--- a/src/elona/message.hpp
+++ b/src/elona/message.hpp
@@ -88,9 +88,20 @@ public:
     }
 
 
-    void msg_append_begin(const std::string&);
-    void msg_append(const std::string&);
-    void msg_append_end();
+    /**
+     * Messages passed to these three functions are "buffered". They does not
+     * shown immediately, and the output of them is delayed until
+     * buffered_message_end() is called.
+     * @example
+     * Message::instance().buffered_message_begin("1");
+     * Message::instance().buffered_message_append("2");
+     * Message::instance().buffered_message_append("3");
+     * // The joined message "123" is shwon at the below line.
+     * Message::instance().buffered_message_end();
+     */
+    void buffered_message_begin(const std::string& message);
+    void buffered_message_append(const std::string& message);
+    void buffered_message_end();
 
 
 

--- a/src/elona/message_log.cpp
+++ b/src/elona/message_log.cpp
@@ -1,0 +1,50 @@
+#include "message_log.hpp"
+
+
+
+namespace
+{
+
+// TODO: should be configurable.
+constexpr int max_log_lines = 1000;
+
+} // namespace
+
+
+
+namespace elona
+{
+
+MessageLog message_log;
+
+
+
+void MessageLogLine::append(const std::string& text, const snail::Color& color)
+{
+    spans.emplace_back(text, color);
+}
+
+
+
+void MessageLog::append(const std::string& text, const snail::Color& color)
+{
+    if (lines.empty())
+    {
+        lines.emplace_back();
+    }
+
+    lines.back().append(text, color);
+}
+
+
+
+void MessageLog::linebreak()
+{
+    lines.emplace_back();
+    if (lines.size() > max_log_lines)
+    {
+        lines.erase(std::begin(lines));
+    }
+}
+
+} // namespace elona

--- a/src/elona/message_log.hpp
+++ b/src/elona/message_log.hpp
@@ -35,6 +35,8 @@ struct MessageLog
     std::vector<MessageLogLine> lines;
 };
 
+
+
 extern MessageLog message_log;
 
 } // namespace elona

--- a/src/elona/message_log.hpp
+++ b/src/elona/message_log.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <deque>
 #include <string>
+#include <vector>
 #include "../snail/color.hpp"
 
 
@@ -10,12 +12,12 @@ namespace elona
 
 struct MessageLogSpan
 {
-    std::string content;
+    std::string text;
     snail::Color color;
 
 
-    MessageLogSpan(const std::string& content, const snail::Color& color)
-        : content(content)
+    MessageLogSpan(const std::string& text, const snail::Color& color)
+        : text(text)
         , color(color)
     {
     }
@@ -25,14 +27,54 @@ struct MessageLogSpan
 
 struct MessageLogLine
 {
-    std::vector<MessageLogSpan> spans;
+private:
+    using Container = std::vector<MessageLogSpan>;
+    using ConstIterator = Container::const_iterator;
+
+
+public:
+    void append(const std::string& text, const snail::Color& color);
+
+
+
+    ConstIterator begin() const
+    {
+        return spans.begin();
+    }
+
+
+    ConstIterator end() const
+    {
+        return spans.end();
+    }
+
+
+private:
+    Container spans;
 };
 
 
 
 struct MessageLog
 {
-    std::vector<MessageLogLine> lines;
+public:
+    void append(const std::string& text, const snail::Color& color);
+
+    void linebreak();
+
+    size_t line_size() const
+    {
+        return lines.size();
+    }
+
+    const MessageLogLine& at(size_t index) const
+    {
+        return lines.at(index);
+    }
+
+
+private:
+    std::deque<MessageLogLine> lines;
 };
 
 

--- a/src/elona/ui/ui_menu_message_log.cpp
+++ b/src/elona/ui/ui_menu_message_log.cpp
@@ -39,43 +39,41 @@ void _draw_window()
 
 
 
-int message_width{};
-int offset{};
-void _draw_single_message(size_t cnt)
+void _draw_single_message(size_t cnt, int message_offset)
 {
-    const auto n = message_log.lines.size();
+    const auto n = message_log.line_size();
     if (n == 0)
     {
         return;
     }
-    if (static_cast<int>(n) + offset < static_cast<int>(cnt) + 4)
+    if (static_cast<int>(n) + message_offset < static_cast<int>(cnt) + 4)
     {
         return;
     }
 
-    message_width = 0;
+    int message_width = 0;
     font(inf_mesfont - en * 2);
-    for (const auto& msgs : message_log.lines.at(n - cnt - 4 + offset).spans)
+    for (const auto& span : message_log.at(n - cnt - 4 + message_offset))
     {
         pos(message_width * inf_mesfont / 2 + inf_msgx + 6,
             inf_msgy - cnt * inf_msgspace + vfix);
-        color(msgs.color.r, msgs.color.g, msgs.color.b);
-        mes(msgs.content);
+        color(span.color.r, span.color.g, span.color.b);
+        mes(span.text);
 
-        message_width += strlen_u(msgs.content);
+        message_width += strlen_u(span.text);
     }
 }
 
 
 
-void _draw_messages()
+void _draw_messages(int message_offset)
 {
     gsel(4);
     gmode(0);
     boxf();
     for (int cnt = 0; cnt < inf_maxlog - 3; ++cnt)
     {
-        _draw_single_message(cnt);
+        _draw_single_message(cnt, message_offset);
     }
     gsel(0);
     gmode(2);
@@ -121,7 +119,7 @@ void UIMenuMessageLog::update()
 void UIMenuMessageLog::draw()
 {
     _draw_window();
-    _draw_messages();
+    _draw_messages(message_offset);
 }
 
 
@@ -131,19 +129,19 @@ optional<UIMenuMessageLog::ResultType> UIMenuMessageLog::on_key(
 {
     if (action == "north")
     {
-        offset -= 1;
-        if (offset < 4 - static_cast<int>(message_log.lines.size()))
+        message_offset -= 1;
+        if (message_offset < 4 - static_cast<int>(message_log.line_size()))
         {
-            offset = 4 - static_cast<int>(message_log.lines.size());
+            message_offset = 4 - static_cast<int>(message_log.line_size());
         }
         return none;
     }
     else if (action == "south")
     {
-        offset += 1;
-        if (offset > 0)
+        message_offset += 1;
+        if (message_offset > 0)
         {
-            offset = 0;
+            message_offset = 0;
         }
         return none;
     }

--- a/src/elona/ui/ui_menu_message_log.cpp
+++ b/src/elona/ui/ui_menu_message_log.cpp
@@ -129,20 +129,34 @@ optional<UIMenuMessageLog::ResultType> UIMenuMessageLog::on_key(
 {
     if (action == "north")
     {
-        message_offset -= 1;
-        if (message_offset < 4 - static_cast<int>(message_log.line_size()))
-        {
-            message_offset = 4 - static_cast<int>(message_log.line_size());
-        }
+        _scroll_by(-1);
         return none;
     }
     else if (action == "south")
     {
-        message_offset += 1;
-        if (message_offset > 0)
-        {
-            message_offset = 0;
-        }
+        _scroll_by(1);
+        return none;
+    }
+    else if (action == "previous_page" || action == "northwest")
+    {
+        _scroll_by(-(inf_maxlog - 3));
+        return none;
+    }
+    else if (action == "next_page" || action == "southwest")
+    {
+        _scroll_by(inf_maxlog - 3);
+        return none;
+    }
+    else if (action == "northeast")
+    {
+        // Jump to the oldest.
+        message_offset = 4 - static_cast<int>(message_log.line_size());
+        return none;
+    }
+    else if (action == "southeast")
+    {
+        // Jump to the newest.
+        message_offset = 0;
         return none;
     }
     else if (action != ""s)
@@ -152,6 +166,24 @@ optional<UIMenuMessageLog::ResultType> UIMenuMessageLog::on_key(
     }
 
     return none;
+}
+
+
+
+void UIMenuMessageLog::_scroll_by(int lines)
+{
+    const auto min = 4 - static_cast<int>(message_log.line_size());
+    const auto max = 0;
+
+    message_offset += lines;
+    if (message_offset < min)
+    {
+        message_offset = min;
+    }
+    if (max < message_offset)
+    {
+        message_offset = max;
+    }
 }
 
 } // namespace ui

--- a/src/elona/ui/ui_menu_message_log.hpp
+++ b/src/elona/ui/ui_menu_message_log.hpp
@@ -23,6 +23,9 @@ protected:
 
 
 private:
+    void _scroll_by(int lines);
+
+
     int message_offset{};
 };
 

--- a/src/elona/ui/ui_menu_message_log.hpp
+++ b/src/elona/ui/ui_menu_message_log.hpp
@@ -13,12 +13,17 @@ public:
     {
     }
 
+
 protected:
     virtual bool init();
     virtual void update();
     virtual void draw();
     virtual optional<UIMenuMessageLog::ResultType> on_key(
         const std::string& key);
+
+
+private:
+    int message_offset{};
 };
 
 } // namespace ui


### PR DESCRIPTION

<!-- For new feature -->
# Related Issues

Close #913.


# Summary

- Limit the number of the message log lines to 1000.
  - The upper limit should be configurable.
- Add key mappings to scroll message log by page.
  - PageUp or Left: scroll 1 page up(to older)
  - PageDown or Right: scroll 1 page down(to newer)
  - Home: go top(oldest)
  - End: go bottom(latest)