### PR TITLE
Fix selection key can select out-of-range choice

### DIFF
--- a/src/elona/input.cpp
+++ b/src/elona/input.cpp
@@ -358,7 +358,7 @@ std::string get_selected_item(int& p_)
     auto command = InputContext::for_menu().check_for_command_with_list(index);
 
     p_ = -1;
-    if (index != -1)
+    if (index != -1 && index < keyrange)
     {
         p_ = list(0, pagesize * page + index);
     }

--- a/src/elona/input.cpp
+++ b/src/elona/input.cpp
@@ -344,7 +344,8 @@ std::string cursor_check_ex()
     return cursor_check_ex(index);
 }
 
-std::string get_selected_item(int& p_, int& index)
+
+std::string get_selected_item(int& p_)
 {
     if (msgalert == 1)
     {
@@ -352,6 +353,7 @@ std::string get_selected_item(int& p_, int& index)
         msgalert = 0;
     }
 
+    int index{};
     await(Config::instance().wait1);
     auto command = InputContext::for_menu().check_for_command_with_list(index);
 
@@ -364,11 +366,6 @@ std::string get_selected_item(int& p_, int& index)
     return command;
 }
 
-std::string get_selected_item(int& p_)
-{
-    int index{};
-    return get_selected_item(p_, index);
-}
 
 
 optional<int> get_shortcut(const std::string& action)

--- a/src/elona/input.hpp
+++ b/src/elona/input.hpp
@@ -43,7 +43,6 @@ std::string key_check(KeyWaitDelay = KeyWaitDelay::always);
 std::string cursor_check_ex();
 std::string cursor_check_ex(int& index);
 std::string get_selected_item(int& p_);
-std::string get_selected_item(int& p_, int& index);
 optional<int> get_shortcut(const std::string& action);
 int yes_or_no(int x, int y, int width);
 bool is_modifier_pressed(snail::ModKey modifier);


### PR DESCRIPTION

<!-- For bug report -->
# Related Issues

Close #1065.

This bug also happens in other kinds of list selection menu, i.e., routines which `get_selected_item()` is called from.


# Summary

Check whether selection key is out of range or not. Selection key, in this case, means Enter and `a`, `b`, `c`, ..., `p`.
Before, you could select 5th item even if there were only 4 items in the current list menu. #1065 reported special case of that, you can select 1st item when there is no items in the inventory.