### PR TITLE
Measure the elapsed time on testing in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,11 +99,11 @@ script:
   - if [[ "$BUILD_TYPE" == "linux" ]]; then
        make tests VERBOSE=1;
        cd bin;
-       ./Elona_foobar;
+       ./Elona_foobar --durations=yes;
     elif [[ "$BUILD_TYPE" == "osx" ]]; then
        make tests VERBOSE=1;
        cd bin;
-       ./Elona_foobar;
+       ./Elona_foobar --durations=yes;
     elif [[ "$BUILD_TYPE" == "android" ]]; then
        make android;
     fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -87,7 +87,7 @@ build_script:
   - cmake -DCMAKE_PREFIX_PATH=%PREFIX% -DWITH_TESTS=TESTS %CMAKE_ARGS% -DCMAKE_BUILD_TYPE=%CONFIGURATION% ..
   - cmake --build . --config %CONFIGURATION%
   - cd %CONFIGURATION%
-  - Elona_foobar.exe
+  - Elona_foobar.exe --durations=yes
   - cd %APPVEYOR_BUILD_FOLDER%\bin
   - cmake -DCMAKE_PREFIX_PATH=%PREFIX% -DWITH_TESTS=OFF %CMAKE_ARGS% -DCMAKE_BUILD_TYPE=%CONFIGURATION% ..
   - cmake --build . --config %CONFIGURATION%


### PR DESCRIPTION
# Related Issues

#1064 


# Summary

Add `--durations=yes` option to output execution time on testing for the purpose of detecting the bottleneck of slow Appveyor execution.
