### PR TITLE
Fix Christmas festival items in Noyel not being removed completely

### DIFF
--- a/src/elona/ctrl_file.cpp
+++ b/src/elona/ctrl_file.cpp
@@ -1143,7 +1143,7 @@ void fmode_16()
 
     load_v3(
         fmapfile + u8".map", map, 0, map_data.width, 0, map_data.height, 0, 3);
-    cell_data.unpack_from(map);
+    cell_data.unpack_from(map, false);
 
     const auto filepath = fmapfile + u8".obj"s;
     if (!fs::exists(filepath))

--- a/src/elona/initialize_map.cpp
+++ b/src/elona/initialize_map.cpp
@@ -398,6 +398,8 @@ static bool _should_regenerate_map()
         game_data.current_dungeon_level == 1;
 }
 
+
+
 static void _regenerate_map()
 {
     if (game_data.current_map == mdata_t::MapId::lumiest)
@@ -428,18 +430,18 @@ static void _regenerate_map()
     {
         if (game_data.date.month == 12)
         {
-            if (area_data[game_data.current_map].christmas_festival == 0)
+            if (!area_data[game_data.current_map].christmas_festival)
             {
-                area_data[game_data.current_map].christmas_festival = 1;
+                area_data[game_data.current_map].christmas_festival = true;
                 map_reload_noyel();
             }
             map_reload(u8"noyel_fest"s);
         }
         else
         {
-            if (area_data[game_data.current_map].christmas_festival == 1)
+            if (area_data[game_data.current_map].christmas_festival)
             {
-                area_data[game_data.current_map].christmas_festival = 0;
+                area_data[game_data.current_map].christmas_festival = false;
                 map_reload_noyel();
             }
             map_reload(u8"noyel"s);
@@ -447,6 +449,8 @@ static void _regenerate_map()
         game_data.released_fire_giant = 0;
     }
 }
+
+
 
 static void _relocate_character(Character& chara)
 {

--- a/src/elona/map.cpp
+++ b/src/elona/map.cpp
@@ -226,6 +226,7 @@ void map_reload(const std::string& map_filename)
 }
 
 
+
 // Used for huntex/conquer quests.
 std::string map_get_custom_map_name(int map_id)
 {
@@ -936,6 +937,7 @@ void map_proc_regen_and_update()
 }
 
 
+
 void map_reload_noyel()
 {
     for (const auto& cnt : items(-1))
@@ -948,7 +950,8 @@ void map_reload_noyel()
 
         cell_refresh(inv[cnt].position.x, inv[cnt].position.y);
     }
-    if (area_data[game_data.current_map].christmas_festival == 1)
+
+    if (area_data[game_data.current_map].christmas_festival)
     {
         flt();
         int stat = itemcreate(-1, 763, 29, 16, 0);
@@ -1218,7 +1221,7 @@ void map_reload_noyel()
     {
         for (auto&& cnt : cdata.others())
         {
-            if (cnt.only_christmas() == 1)
+            if (cnt.only_christmas())
             {
                 chara_vanquish(cnt.index);
             }

--- a/src/elona/map.hpp
+++ b/src/elona/map.hpp
@@ -152,6 +152,12 @@ struct Cell
     void unpack_from(elona_vector3<int>& legacy_map, int x, int y);
 
     /**
+     * Moves part of `map` fields into this struct. To be called after
+     * deserializing `map`.
+     */
+    void partly_unpack_from(elona_vector3<int>& legacy_map, int x, int y);
+
+    /**
      * Clear this Cell.
      */
     void clear();
@@ -193,8 +199,10 @@ struct CellData
     void pack_to(elona_vector3<int>& legacy_map);
 
 
-    // Helper method to unpack all cell data from `map`.
-    void unpack_from(elona_vector3<int>& legacy_map);
+    /// Helper method to unpack all cell data from `map`.
+    /// @param clear Whether the previous data is cleared or not. If it is true,
+    /// the size of `map` must be the same as the previous one.
+    void unpack_from(elona_vector3<int>& legacy_map, bool clear = true);
 
 
 private:

--- a/src/elona/talk_unique.cpp
+++ b/src/elona/talk_unique.cpp
@@ -4861,7 +4861,7 @@ void _part_time_worker_switch_religion()
 TalkResult talk_unique_part_time_worker()
 {
     if (game_data.current_map != mdata_t::MapId::noyel ||
-        area_data[game_data.current_map].christmas_festival == 0)
+        !area_data[game_data.current_map].christmas_festival)
     {
         return TalkResult::talk_end;
     }


### PR DESCRIPTION
# Related Issues

Close #1085.


# Summary

On map re-construction, the corresponding map file (`map/*.map`) is partly loaded (`map` data has 10 fields, but in this case, only updates 3 of 10.) However, `CellData::unpack_from()` function updated the rest 7 fields. It causes data mismatching.