### PR TITLE
Remove `auto_action` action and use `enter` instead

### DIFF
--- a/runtime/locale/en/keybindings.hcl
+++ b/runtime/locale/en/keybindings.hcl
@@ -105,7 +105,6 @@ END
         dump_player_info = "Dump Player Info"
         enable_voldemort = "Enable Voldemort"
         reload_autopick = "Reload Autopick"
-        auto_action = "Auto Action"
 
         wizard_toggle_console = "Toggle Console"
         wizard_open_console = "Open Console"

--- a/runtime/locale/jp/keybindings.hcl
+++ b/runtime/locale/jp/keybindings.hcl
@@ -105,7 +105,6 @@ END
         dump_player_info = "プレイヤー情報出力"
         enable_voldemort = "Voldemortモード"
         reload_autopick = "Autopickの再読み込み"
-        auto_action = "自動行動"
 
         wizard_toggle_console = "コンソールを切り替える"
         wizard_open_console = "コンソールを開く"

--- a/src/elona/keybind/keybind_actions.cpp
+++ b/src/elona/keybind/keybind_actions.cpp
@@ -133,7 +133,6 @@ void initialize_keybind_actions(ActionMap& actions)
     actions.emplace("dump_player_info",      Action{ActionCategory::game,      {{Key::f11,             ModKey::none}}});
     actions.emplace("enable_voldemort",      Action{ActionCategory::game,      {{Key::f12,             ModKey::none}}});
     actions.emplace("reload_autopick",       Action{ActionCategory::game,      {{Key::backspace,       ModKey::shift}}});
-    actions.emplace("auto_action",           Action{ActionCategory::game,      {{Key::enter,           ModKey::none}}});
 
     actions.emplace("wizard_toggle_console", Action{ActionCategory::wizard,    {{Key::backquote,       ModKey::none}}});
     actions.emplace("wizard_open_console",   Action{ActionCategory::wizard,    {{Key::backquote,       ModKey::shift}}});

--- a/src/elona/turn_sequence_pc_actions.cpp
+++ b/src/elona/turn_sequence_pc_actions.cpp
@@ -180,7 +180,7 @@ optional<TurnResult> handle_pc_action(std::string& action)
         return none;
     }
 
-    if (action == "auto_action")
+    if (action == "enter")
     {
         action = "search";
         cell_featread(cdata[cc].position.x, cdata[cc].position.y);


### PR DESCRIPTION
# Related Issues

Close #1083.


# Summary
Instead of `auto_action`, use `enter` for the same effect. This allows keys bound to `Enter` to have the automatic action and reduces confusion.