### PR TITLE
Use "key" global for some edge cases difficult to handle in keybinds

### DIFF
--- a/src/elona/init.cpp
+++ b/src/elona/init.cpp
@@ -313,6 +313,8 @@ void initialize_elona()
     buffer(3, 1440, 800);
     picload(filesystem::dir::graphic() / u8"interface.bmp", 1);
 
+    mesbox(keylog);
+
     pos(0, 656);
     picload(filesystem::dir::graphic() / u8"interface_ex1.png", 1);
     pos(144, 656);

--- a/src/elona/input.cpp
+++ b/src/elona/input.cpp
@@ -312,6 +312,22 @@ static void _handle_msgalert()
     }
 }
 
+static void _update_pressed_key_name()
+{
+    key = "";
+    if (keylog != ""s)
+    {
+        keylog = strmid(keylog, 0, 1);
+        if (keylog(0)[0] == '\n')
+        {
+            keylog = "Enter";
+        }
+        key = keylog;
+        keylog = "";
+    }
+}
+
+
 std::string key_check(KeyWaitDelay delay_type)
 {
     if (msgalert == 1)
@@ -320,9 +336,27 @@ std::string key_check(KeyWaitDelay delay_type)
         msgalert = 0;
     }
 
+    _update_pressed_key_name();
+
     await(Config::instance().wait1);
     return InputContext::for_menu().check_for_command(delay_type);
 }
+
+
+std::string key_check_pc_turn(KeyWaitDelay delay_type)
+{
+    if (msgalert == 1)
+    {
+        _handle_msgalert();
+        msgalert = 0;
+    }
+
+    _update_pressed_key_name();
+
+    await(Config::instance().wait1);
+    return InputContext::instance().check_for_command(delay_type);
+}
+
 
 std::string cursor_check_ex(int& index)
 {
@@ -331,6 +365,8 @@ std::string cursor_check_ex(int& index)
         _handle_msgalert();
         msgalert = 0;
     }
+
+    _update_pressed_key_name();
 
     await(Config::instance().wait1);
     return InputContext::for_menu().check_for_command_with_list(index);
@@ -350,6 +386,8 @@ std::string get_selected_item(int& p_)
         _handle_msgalert();
         msgalert = 0;
     }
+
+    _update_pressed_key_name();
 
     int index{};
     await(Config::instance().wait1);

--- a/src/elona/input.hpp
+++ b/src/elona/input.hpp
@@ -40,6 +40,7 @@ bool input_text_dialog(
 StickKey stick(StickKey allow_repeat_keys = StickKey::none);
 
 std::string key_check(KeyWaitDelay = KeyWaitDelay::always);
+std::string key_check_pc_turn(KeyWaitDelay = KeyWaitDelay::always);
 std::string cursor_check_ex();
 std::string cursor_check_ex(int& index);
 std::string get_selected_item(int& p_);

--- a/src/elona/keybind/input_context.cpp
+++ b/src/elona/keybind/input_context.cpp
@@ -31,8 +31,8 @@ int last_held_key_frames = 0;
 static std::map<InputContextType, std::vector<ActionCategory>> input_context_types =
 {
     {InputContextType::menu, {ActionCategory::shortcut,
-                              ActionCategory::menu,
                               ActionCategory::selection,
+                              ActionCategory::menu,
                               ActionCategory::default_}},
 
     {InputContextType::game, {ActionCategory::wizard,

--- a/src/elona/turn_sequence.cpp
+++ b/src/elona/turn_sequence.cpp
@@ -1573,16 +1573,7 @@ label_2747:
     auto command = key_check_pc_turn(KeyWaitDelay::walk_run);
     player_queried_for_input = false;
 
-    if (key != ""s)
-    {
-        const auto angband_result = check_angband();
-        if (angband_result)
-        {
-            return *angband_result;
-        }
-    }
-
-    if (command == ""s)
+    if (command == ""s && key == ""s)
     {
         goto label_2747;
     }

--- a/src/elona/turn_sequence.cpp
+++ b/src/elona/turn_sequence.cpp
@@ -1570,9 +1570,17 @@ label_2747:
     // to quicksave at any place await() could be called.
     player_queried_for_input = true;
     await(Config::instance().wait1);
-    auto command =
-        InputContext::instance().check_for_command(KeyWaitDelay::walk_run);
+    auto command = key_check_pc_turn(KeyWaitDelay::walk_run);
     player_queried_for_input = false;
+
+    if (key != ""s)
+    {
+        const auto angband_result = check_angband();
+        if (angband_result)
+        {
+            return *angband_result;
+        }
+    }
 
     if (command == ""s)
     {

--- a/src/elona/turn_sequence_pc_actions.cpp
+++ b/src/elona/turn_sequence_pc_actions.cpp
@@ -306,15 +306,6 @@ optional<TurnResult> handle_pc_action(std::string& action)
         await(100);
     }
 
-    // TODO
-    if (key != ""s)
-    {
-        const auto angband_result = check_angband();
-        if (angband_result)
-        {
-            return *angband_result;
-        }
-    }
     if (action == "quick_menu")
     {
         action = show_quick_menu();

--- a/src/elona/turn_sequence_pc_actions.cpp
+++ b/src/elona/turn_sequence_pc_actions.cpp
@@ -306,6 +306,14 @@ optional<TurnResult> handle_pc_action(std::string& action)
         await(100);
     }
 
+    if (key != ""s)
+    {
+        const auto angband_result = check_angband();
+        if (angband_result)
+        {
+            return *angband_result;
+        }
+    }
     if (action == "quick_menu")
     {
         action = show_quick_menu();

--- a/src/elona/ui/ui_menu_character_sheet.cpp
+++ b/src/elona/ui/ui_menu_character_sheet.cpp
@@ -8,6 +8,7 @@
 #include "../class.hpp"
 #include "../draw.hpp"
 #include "../enchantment.hpp"
+#include "../keybind/keybind.hpp"
 #include "../map.hpp"
 #include "../menu.hpp"
 #include "../message.hpp"
@@ -1068,7 +1069,17 @@ optional<UIMenuCharacterSheet::ResultType> UIMenuCharacterSheet::on_key(
 {
     if (page == 0)
     {
-        if (action == "portrait")
+        // HACK: Horrible workaround as 'p' also gets bound to a list selection
+        // key by default. Maybe in this case key conflicts should be allowed
+        // with a warning.
+        // This is caused because 'p' is used differently depending on what page
+        // is selected. This is the only menu where this is the case.
+        std::string action_ = action;
+        if (key == get_bound_shortcut_key_name_by_action_id("portrait"))
+        {
+            action_ = "portrait";
+        }
+        if (action_ == "portrait")
         {
             if (cc < 16)
             {
@@ -1082,7 +1093,7 @@ optional<UIMenuCharacterSheet::ResultType> UIMenuCharacterSheet::on_key(
                 return none;
             }
         }
-        else if (action == "north")
+        else if (action_ == "north")
         {
             --_cs_buff;
             if (_cs_buff < 0)
@@ -1092,7 +1103,7 @@ optional<UIMenuCharacterSheet::ResultType> UIMenuCharacterSheet::on_key(
             set_reupdate();
             return none;
         }
-        else if (action == "south")
+        else if (action_ == "south")
         {
             ++_cs_buff;
             if (_cs_buff >= _cs_buffmax)


### PR DESCRIPTION
# Related Issues

Close #1056.


# Summary
Use the `key` global as it was used before for certain key detection edge cases that are difficult to handle through the keybinding system.

- Angband easter egg.
- Usage of 'p' key in character sheet.