### PR TITLE
[WIP] When trading, allow specifying the amount to trade if it can match

### DIFF
--- a/runtime/locale/en/ctrl_inventory.hcl
+++ b/runtime/locale/en/ctrl_inventory.hcl
@@ -167,6 +167,10 @@ locale {
             trade {
                 too_low_value = "You don't have stuff that match ${itemname(_1)}."
                 you_receive = "You receive ${itemname(_1)} in exchange for ${itemname(_2)}."
+                how_many = "How many? (${_2} to ${_3})"
+                need_at_least = "You need to trade at least ${_1} to match one ${itemname(_2, 1)}."
+                confirm_trade_for = "Trade ${_1} for ${_2}?"
+                no_room = "${name(_1)} ${have(_1)} no room to keep the remaining items."
             }
 
             take {

--- a/runtime/locale/jp/ctrl_inventory.hcl
+++ b/runtime/locale/jp/ctrl_inventory.hcl
@@ -165,6 +165,10 @@ locale {
             trade {
                 too_low_value = "${itemname(_1)}に見合う物を所持していない。"
                 you_receive = "${itemname(_2)}を${itemname(_1)}と交換した。"
+                how_many = "${itemname(_1, 1)}をいくつ交換する？ (${_2}〜${_3}) "
+                need_at_least = "${itemname(_2, 1)}に見合うには、${_1}を交換する必要がある。"
+                confirm_trade_for = "本当に${_2}を${_1}と交換する？"
+                no_room = "${name(_1)}は残りのアイテムを持てない。"
             }
 
             take {

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -1807,4 +1807,9 @@ int calc_exp_gain_crafting(int mat_amount)
     return 50 + mat_amount * 20;
 }
 
+int calc_trade_minimum_value_needed(int item_value)
+{
+    return item_value / 2 * 3;
+}
+
 } // namespace elona

--- a/src/elona/calc.hpp
+++ b/src/elona/calc.hpp
@@ -211,4 +211,14 @@ int calc_exp_gain_weight_lifting(const Character& chara);
 int calc_exp_gain_memorization(int spell_id);
 int calc_exp_gain_crafting(int mat_amount);
 
+/**
+ * Calculates the minimum item value needed to trade for a single item of the
+ * given value.
+ *
+ * @param item_value the value of the item that is wanted
+ *
+ * @return the minimum value needed to trade for the item
+ */
+int calc_trade_minimum_value_needed(int item_value);
+
 } // namespace elona

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -585,6 +585,15 @@ void Item::set_number(int number_)
 
 
 
+/**
+ * Attempts to separate an item stack into two item stacks by separating out a
+ * stack of quantity 1 into a free item slot inside the inventory of the item's
+ * owner. On failure, the item at the given item slot is set to quantity 1.
+ *
+ * @param ci inventory index to separate
+ *
+ * @return index of the larger stack.
+ */
 int item_separate(int ci)
 {
     if (inv[ci].number() <= 1)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

Close #948.

# Summary
- When trading with adventurers, you can now specify how many items you want to trade. If both the item being traded for and the traded item are stacks, you can adjust the number of items to trade and the corresponding amount of the item received will be adjusted accordingly.
- The trade screen now has a confirmation prompt.