### PR TITLE
Make methods for each ibit() and ibitmod() calls

### DIFF
--- a/src/elona/access_item_db.cpp
+++ b/src/elona/access_item_db.cpp
@@ -100,7 +100,7 @@ int access_item_db(int dbmode)
             fixeditemenc(2) = 61;
             fixeditemenc(3) = 200;
             fixeditemenc(4) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -169,8 +169,8 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].function = 26;
-            ibitmod(5, ci, 1);
-            ibitmod(7, ci, 1);
+            inv[ci].is_precious() = true;
+            inv[ci].has_cooldown_time() = true;
             inv[ci].param3 = 240;
             fixlv = Quality::special;
         }
@@ -179,8 +179,8 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].function = 26;
-            ibitmod(5, ci, 1);
-            ibitmod(7, ci, 1);
+            inv[ci].is_precious() = true;
+            inv[ci].has_cooldown_time() = true;
             inv[ci].param3 = 240;
             fixlv = Quality::special;
         }
@@ -188,7 +188,7 @@ int access_item_db(int dbmode)
     case 775:
         if (dbmode == 3)
         {
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].param2 = 8;
         }
         break;
@@ -235,7 +235,7 @@ int access_item_db(int dbmode)
             fixeditemenc(1) = 100;
             fixeditemenc(2) = 0;
             inv[ci].function = 17;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].param1 = 200;
             fixlv = Quality::special;
         }
@@ -244,7 +244,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].function = 49;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].param1 = rnd(20000) + 1;
             fixlv = Quality::special;
         }
@@ -262,7 +262,7 @@ int access_item_db(int dbmode)
             fixeditemenc(0) = 35;
             fixeditemenc(1) = 100;
             fixeditemenc(2) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -281,7 +281,7 @@ int access_item_db(int dbmode)
             fixeditemenc(8) = 33;
             fixeditemenc(9) = 100;
             fixeditemenc(10) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -302,15 +302,15 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].function = 48;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
         }
         break;
     case 748:
         if (dbmode == 3)
         {
             inv[ci].function = 47;
-            ibitmod(5, ci, 1);
-            ibitmod(16, ci, 1);
+            inv[ci].is_precious() = true;
+            inv[ci].is_showroom_only() = true;
         }
         break;
     case 747:
@@ -329,8 +329,8 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].function = 30;
-            ibitmod(5, ci, 1);
-            ibitmod(7, ci, 1);
+            inv[ci].is_precious() = true;
+            inv[ci].has_cooldown_time() = true;
             inv[ci].param1 = 1132;
             inv[ci].param2 = 100;
             inv[ci].param3 = 24;
@@ -340,8 +340,8 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].function = 30;
-            ibitmod(5, ci, 1);
-            ibitmod(7, ci, 1);
+            inv[ci].is_precious() = true;
+            inv[ci].has_cooldown_time() = true;
             inv[ci].param1 = 1132;
             inv[ci].param2 = 100;
             inv[ci].param3 = 24;
@@ -351,8 +351,8 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].function = 30;
-            ibitmod(5, ci, 1);
-            ibitmod(7, ci, 1);
+            inv[ci].is_precious() = true;
+            inv[ci].has_cooldown_time() = true;
             inv[ci].param1 = 1132;
             inv[ci].param2 = 100;
             inv[ci].param3 = 24;
@@ -362,8 +362,8 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].function = 30;
-            ibitmod(5, ci, 1);
-            ibitmod(7, ci, 1);
+            inv[ci].is_precious() = true;
+            inv[ci].has_cooldown_time() = true;
             inv[ci].param1 = 1132;
             inv[ci].param2 = 100;
             inv[ci].param3 = 24;
@@ -372,7 +372,7 @@ int access_item_db(int dbmode)
     case 742:
         if (dbmode == 3)
         {
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             fixlv = Quality::special;
         }
         if (dbmode == 13)
@@ -394,7 +394,7 @@ int access_item_db(int dbmode)
             fixeditemenc(6) = 10011;
             fixeditemenc(7) = 720;
             fixeditemenc(8) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -409,7 +409,7 @@ int access_item_db(int dbmode)
             fixeditemenc(4) = 20057;
             fixeditemenc(5) = 400;
             fixeditemenc(6) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -431,7 +431,7 @@ int access_item_db(int dbmode)
             fixeditemenc(10) = 80003;
             fixeditemenc(11) = 350;
             fixeditemenc(12) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -479,7 +479,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 3 + rnd(3) - rnd(3);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -493,7 +493,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 3 + rnd(3) - rnd(3);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -506,7 +506,7 @@ int access_item_db(int dbmode)
     case 730:
         if (dbmode == 3)
         {
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
         }
         break;
     case 728:
@@ -519,7 +519,7 @@ int access_item_db(int dbmode)
             fixeditemenc(4) = 20050;
             fixeditemenc(5) = 350;
             fixeditemenc(6) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -533,7 +533,7 @@ int access_item_db(int dbmode)
             fixeditemenc(2) = 20058;
             fixeditemenc(3) = 450;
             fixeditemenc(4) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -549,7 +549,7 @@ int access_item_db(int dbmode)
             fixeditemenc(4) = 53;
             fixeditemenc(5) = 400;
             fixeditemenc(6) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -565,7 +565,7 @@ int access_item_db(int dbmode)
             fixeditemenc(4) = 44;
             fixeditemenc(5) = 450;
             fixeditemenc(6) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -573,7 +573,7 @@ int access_item_db(int dbmode)
     case 724:
         if (dbmode == 3)
         {
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
         }
         break;
     case 723:
@@ -584,7 +584,7 @@ int access_item_db(int dbmode)
             fixeditemenc(2) = 30166;
             fixeditemenc(3) = 650;
             fixeditemenc(4) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -597,7 +597,7 @@ int access_item_db(int dbmode)
             fixeditemenc(2) = 30109;
             fixeditemenc(3) = 700;
             fixeditemenc(4) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -606,8 +606,8 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].function = 43;
-            ibitmod(5, ci, 1);
-            ibitmod(7, ci, 1);
+            inv[ci].is_precious() = true;
+            inv[ci].has_cooldown_time() = true;
             inv[ci].param3 = 480;
             fixlv = Quality::special;
         }
@@ -629,7 +629,7 @@ int access_item_db(int dbmode)
             fixeditemenc(4) = 33;
             fixeditemenc(5) = 100;
             fixeditemenc(6) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -649,7 +649,7 @@ int access_item_db(int dbmode)
             fixeditemenc(8) = 30;
             fixeditemenc(9) = 500;
             fixeditemenc(10) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -664,7 +664,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].skill = 111;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -713,7 +713,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 3 + rnd(3) - rnd(3);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -749,7 +749,7 @@ int access_item_db(int dbmode)
             fixeditemenc(1) = 100;
             fixeditemenc(2) = 0;
             inv[ci].function = 17;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].param1 = 180;
             fixlv = Quality::special;
         }
@@ -773,7 +773,7 @@ int access_item_db(int dbmode)
             fixeditemenc(4) = 41;
             fixeditemenc(5) = 100;
             fixeditemenc(6) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -796,7 +796,7 @@ int access_item_db(int dbmode)
     case 702:
         if (dbmode == 3)
         {
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].param2 = 4;
             fixlv = Quality::special;
         }
@@ -818,7 +818,7 @@ int access_item_db(int dbmode)
     case 699:
         if (dbmode == 3)
         {
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
         }
         break;
     case 698:
@@ -834,7 +834,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 2 + rnd(2) - rnd(2);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -848,7 +848,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 2 + rnd(2) - rnd(2);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -865,7 +865,7 @@ int access_item_db(int dbmode)
             fixeditemenc(0) = 44;
             fixeditemenc(1) = 750;
             fixeditemenc(2) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -918,7 +918,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 2 + rnd(2) - rnd(2);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -930,8 +930,8 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].function = 34;
-            ibitmod(5, ci, 1);
-            ibitmod(7, ci, 1);
+            inv[ci].is_precious() = true;
+            inv[ci].has_cooldown_time() = true;
             inv[ci].param3 = 720;
             fixlv = Quality::special;
         }
@@ -946,15 +946,15 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].function = 32;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
         }
         break;
     case 683:
         if (dbmode == 3)
         {
             inv[ci].function = 30;
-            ibitmod(5, ci, 1);
-            ibitmod(7, ci, 1);
+            inv[ci].is_precious() = true;
+            inv[ci].has_cooldown_time() = true;
             inv[ci].param1 = 1132;
             inv[ci].param2 = 100;
             inv[ci].param3 = 24;
@@ -965,8 +965,8 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].function = 31;
-            ibitmod(5, ci, 1);
-            ibitmod(7, ci, 1);
+            inv[ci].is_precious() = true;
+            inv[ci].has_cooldown_time() = true;
             inv[ci].param3 = 72;
             fixlv = Quality::special;
         }
@@ -975,8 +975,8 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].function = 30;
-            ibitmod(5, ci, 1);
-            ibitmod(7, ci, 1);
+            inv[ci].is_precious() = true;
+            inv[ci].has_cooldown_time() = true;
             inv[ci].param1 = 404;
             inv[ci].param2 = 400;
             inv[ci].param3 = 8;
@@ -987,8 +987,8 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].function = 30;
-            ibitmod(5, ci, 1);
-            ibitmod(7, ci, 1);
+            inv[ci].is_precious() = true;
+            inv[ci].has_cooldown_time() = true;
             inv[ci].param1 = 446;
             inv[ci].param2 = 300;
             inv[ci].param3 = 12;
@@ -1010,7 +1010,7 @@ int access_item_db(int dbmode)
             fixeditemenc(8) = 20054;
             fixeditemenc(9) = 400;
             fixeditemenc(10) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -1030,7 +1030,7 @@ int access_item_db(int dbmode)
             fixeditemenc(8) = 30185;
             fixeditemenc(9) = 600;
             fixeditemenc(10) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -1050,7 +1050,7 @@ int access_item_db(int dbmode)
             fixeditemenc(8) = 20056;
             fixeditemenc(9) = 150;
             fixeditemenc(10) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -1074,7 +1074,7 @@ int access_item_db(int dbmode)
             fixeditemenc(12) = 20052;
             fixeditemenc(13) = 250;
             fixeditemenc(14) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -1098,7 +1098,7 @@ int access_item_db(int dbmode)
             fixeditemenc(12) = 80025;
             fixeditemenc(13) = 100;
             fixeditemenc(14) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -1116,7 +1116,7 @@ int access_item_db(int dbmode)
             fixeditemenc(6) = 20057;
             fixeditemenc(7) = 350;
             fixeditemenc(8) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -1134,7 +1134,7 @@ int access_item_db(int dbmode)
             fixeditemenc(6) = 20052;
             fixeditemenc(7) = 300;
             fixeditemenc(8) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -1143,7 +1143,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].function = 29;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             fixlv = Quality::special;
         }
         break;
@@ -1151,7 +1151,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].function = 28;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             fixlv = Quality::special;
         }
         break;
@@ -1189,8 +1189,8 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].function = 27;
-            ibitmod(5, ci, 1);
-            ibitmod(7, ci, 1);
+            inv[ci].is_precious() = true;
+            inv[ci].has_cooldown_time() = true;
             inv[ci].param3 = 120;
             fixlv = Quality::special;
         }
@@ -1199,8 +1199,8 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].function = 26;
-            ibitmod(5, ci, 1);
-            ibitmod(7, ci, 1);
+            inv[ci].is_precious() = true;
+            inv[ci].has_cooldown_time() = true;
             inv[ci].param3 = 240;
             fixlv = Quality::special;
         }
@@ -1216,14 +1216,14 @@ int access_item_db(int dbmode)
     case 663:
         if (dbmode == 3)
         {
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             fixlv = Quality::special;
         }
         break;
     case 662:
         if (dbmode == 3)
         {
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].param2 = 7;
             fixlv = Quality::special;
         }
@@ -1240,7 +1240,7 @@ int access_item_db(int dbmode)
             fixeditemenc(6) = 30182;
             fixeditemenc(7) = 200;
             fixeditemenc(8) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -1249,7 +1249,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 5 + rnd(5) - rnd(5);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -1262,7 +1262,7 @@ int access_item_db(int dbmode)
     case 655:
         if (dbmode == 3)
         {
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].param2 = 7;
             fixlv = Quality::special;
         }
@@ -1295,7 +1295,7 @@ int access_item_db(int dbmode)
     case 641:
         if (dbmode == 3)
         {
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             fixlv = Quality::special;
         }
         break;
@@ -1308,7 +1308,7 @@ int access_item_db(int dbmode)
     case 639:
         if (dbmode == 3)
         {
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].param2 = 7;
             fixlv = Quality::special;
         }
@@ -1325,7 +1325,7 @@ int access_item_db(int dbmode)
     case 637:
         if (dbmode == 3)
         {
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             fixlv = Quality::special;
         }
         break;
@@ -1370,14 +1370,14 @@ int access_item_db(int dbmode)
         {
             inv[ci].function = 20;
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         break;
     case 628:
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -1403,7 +1403,7 @@ int access_item_db(int dbmode)
             fixeditemenc(10) = 30161;
             fixeditemenc(11) = 300;
             fixeditemenc(12) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -1411,7 +1411,7 @@ int access_item_db(int dbmode)
     case 626:
         if (dbmode == 3)
         {
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
         }
         if (dbmode == 15)
         {
@@ -1424,13 +1424,13 @@ int access_item_db(int dbmode)
     case 625:
         if (dbmode == 3)
         {
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
         }
         break;
     case 624:
         if (dbmode == 3)
         {
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
         }
         if (dbmode == 13)
         {
@@ -1443,7 +1443,7 @@ int access_item_db(int dbmode)
     case 623:
         if (dbmode == 3)
         {
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
         }
         if (dbmode == 13)
         {
@@ -1456,7 +1456,7 @@ int access_item_db(int dbmode)
     case 622:
         if (dbmode == 3)
         {
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
         }
         break;
     case 621:
@@ -1491,13 +1491,13 @@ int access_item_db(int dbmode)
     case 616:
         if (dbmode == 3)
         {
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
         }
         break;
     case 615:
         if (dbmode == 3)
         {
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
         }
         break;
     case 613:
@@ -1523,7 +1523,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].function = 44;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
         }
         break;
     case 602:
@@ -1540,7 +1540,7 @@ int access_item_db(int dbmode)
     case 600:
         if (dbmode == 3)
         {
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
         }
         break;
     case 598:
@@ -1579,7 +1579,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -1593,7 +1593,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 6 + rnd(6) - rnd(6);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -1656,7 +1656,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -1669,7 +1669,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -1683,14 +1683,14 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 12 + rnd(12) - rnd(12);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         break;
     case 567:
         if (dbmode == 3)
         {
             inv[ci].count = 12 + rnd(12) - rnd(12);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         break;
     case 566:
@@ -1706,7 +1706,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -1719,7 +1719,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -1749,7 +1749,7 @@ int access_item_db(int dbmode)
     case 560:
         if (dbmode == 3)
         {
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
         }
         break;
     case 559:
@@ -1825,7 +1825,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 3 + rnd(3) - rnd(3);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -1838,7 +1838,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -1861,7 +1861,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 3 + rnd(3) - rnd(3);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -1875,7 +1875,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -1889,7 +1889,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 7 + rnd(7) - rnd(7);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -1969,7 +1969,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 3 + rnd(3) - rnd(3);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -1982,7 +1982,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -2024,7 +2024,7 @@ int access_item_db(int dbmode)
             fixeditemenc(8) = 20059;
             fixeditemenc(9) = 300;
             fixeditemenc(10) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -2097,7 +2097,7 @@ int access_item_db(int dbmode)
     case 505:
         if (dbmode == 3)
         {
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
         }
         if (dbmode == 13)
         {
@@ -2224,7 +2224,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 8 + rnd(8) - rnd(8);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -2237,7 +2237,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2267,7 +2267,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 2 + rnd(2) - rnd(2);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2281,7 +2281,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 2 + rnd(2) - rnd(2);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -2345,7 +2345,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 2 + rnd(2) - rnd(2);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2496,7 +2496,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 3 + rnd(3) - rnd(3);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -2518,7 +2518,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2607,7 +2607,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 5 + rnd(5) - rnd(5);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2621,7 +2621,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2659,7 +2659,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -2699,7 +2699,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 3 + rnd(3) - rnd(3);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2713,7 +2713,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 3 + rnd(3) - rnd(3);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2727,7 +2727,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 6 + rnd(6) - rnd(6);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -2749,7 +2749,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2772,7 +2772,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 3 + rnd(3) - rnd(3);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2786,7 +2786,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 3 + rnd(3) - rnd(3);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2809,7 +2809,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 5 + rnd(5) - rnd(5);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2823,7 +2823,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 8 + rnd(8) - rnd(8);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -2854,7 +2854,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2868,7 +2868,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 3 + rnd(3) - rnd(3);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2891,7 +2891,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 3 + rnd(3) - rnd(3);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2914,7 +2914,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2937,7 +2937,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 3 + rnd(3) - rnd(3);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2951,7 +2951,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 7 + rnd(7) - rnd(7);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -2964,7 +2964,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 5 + rnd(5) - rnd(5);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3017,7 +3017,7 @@ int access_item_db(int dbmode)
             fixeditemenc(10) = 20059;
             fixeditemenc(11) = 200;
             fixeditemenc(12) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -3035,7 +3035,7 @@ int access_item_db(int dbmode)
             fixeditemenc(6) = 26;
             fixeditemenc(7) = 100;
             fixeditemenc(8) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -3057,7 +3057,7 @@ int access_item_db(int dbmode)
             fixeditemenc(10) = 30172;
             fixeditemenc(11) = 420;
             fixeditemenc(12) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -3082,7 +3082,7 @@ int access_item_db(int dbmode)
             fixeditemenc(14) = 24;
             fixeditemenc(15) = 100;
             fixeditemenc(16) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -3104,7 +3104,7 @@ int access_item_db(int dbmode)
             fixeditemenc(10) = 26;
             fixeditemenc(11) = 100;
             fixeditemenc(12) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -3127,7 +3127,7 @@ int access_item_db(int dbmode)
             fixeditemenc(12) = 25;
             fixeditemenc(13) = 100;
             fixeditemenc(14) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -3374,7 +3374,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 1 + rnd(1) - rnd(1);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -3387,7 +3387,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 1 + rnd(1) - rnd(1);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3437,7 +3437,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3451,7 +3451,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3465,7 +3465,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3479,7 +3479,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3493,7 +3493,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3507,7 +3507,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3527,7 +3527,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 3 + rnd(3) - rnd(3);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3541,7 +3541,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 3 + rnd(3) - rnd(3);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3555,7 +3555,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 3 + rnd(3) - rnd(3);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3609,7 +3609,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 5 + rnd(5) - rnd(5);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3654,7 +3654,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 2 + rnd(2) - rnd(2);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3668,7 +3668,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 3 + rnd(3) - rnd(3);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3682,7 +3682,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3696,7 +3696,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 5 + rnd(5) - rnd(5);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3710,7 +3710,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 3 + rnd(3) - rnd(3);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3724,7 +3724,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 2 + rnd(2) - rnd(2);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3738,7 +3738,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3947,7 +3947,7 @@ int access_item_db(int dbmode)
             fixeditemenc(10) = 70055;
             fixeditemenc(11) = 300;
             fixeditemenc(12) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -3965,7 +3965,7 @@ int access_item_db(int dbmode)
             fixeditemenc(6) = 30172;
             fixeditemenc(7) = 350;
             fixeditemenc(8) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -3994,7 +3994,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 8 + rnd(8) - rnd(8);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -4007,7 +4007,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 9 + rnd(9) - rnd(9);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -4228,7 +4228,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 8 + rnd(8) - rnd(8);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -4241,7 +4241,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 10 + rnd(10) - rnd(10);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -4317,7 +4317,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -4330,7 +4330,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 10 + rnd(10) - rnd(10);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -4343,7 +4343,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 8 + rnd(8) - rnd(8);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -4356,7 +4356,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 8 + rnd(8) - rnd(8);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -4369,7 +4369,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 10 + rnd(10) - rnd(10);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -4382,7 +4382,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 8 + rnd(8) - rnd(8);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -4395,7 +4395,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -4409,7 +4409,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -4515,7 +4515,7 @@ int access_item_db(int dbmode)
             fixeditemenc(0) = 37;
             fixeditemenc(1) = 100;
             fixeditemenc(2) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -4582,7 +4582,7 @@ int access_item_db(int dbmode)
             fixeditemenc(10) = 20056;
             fixeditemenc(11) = 200;
             fixeditemenc(12) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -4602,7 +4602,7 @@ int access_item_db(int dbmode)
             fixeditemenc(8) = 80025;
             fixeditemenc(9) = 100;
             fixeditemenc(10) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -4658,7 +4658,7 @@ int access_item_db(int dbmode)
             fixeditemenc(6) = 20058;
             fixeditemenc(7) = 200;
             fixeditemenc(8) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -4676,7 +4676,7 @@ int access_item_db(int dbmode)
             fixeditemenc(6) = 24;
             fixeditemenc(7) = 100;
             fixeditemenc(8) = 0;
-            ibitmod(5, ci, 1);
+            inv[ci].is_precious() = true;
             inv[ci].difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
@@ -4748,7 +4748,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -4762,7 +4762,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -4776,7 +4776,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -4878,7 +4878,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -4892,7 +4892,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 4 + rnd(4) - rnd(4);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -4906,7 +4906,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 5 + rnd(5) - rnd(5);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -4920,7 +4920,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 12 + rnd(12) - rnd(12);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -4933,7 +4933,7 @@ int access_item_db(int dbmode)
         if (dbmode == 3)
         {
             inv[ci].count = 8 + rnd(8) - rnd(8);
-            ibitmod(4, ci, 1);
+            inv[ci].has_charge() = true;
         }
         if (dbmode == 14)
         {

--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -1247,7 +1247,7 @@ void continuous_action_others()
             {
                 f = 1;
             }
-            if (ibit(5, ci) == 1)
+            if (inv[ci].is_precious())
             {
                 if (f != 1)
                 {
@@ -1304,7 +1304,7 @@ void continuous_action_others()
                 "core.locale.action.pick_up.your_inventory_is_full"));
             return;
         }
-        ibitmod(12, ci, 0);
+        inv[ci].is_quest_target() = false;
         if (inv[ci].body_part != 0)
         {
             tc = inv_getowner(ci);
@@ -1319,7 +1319,7 @@ void continuous_action_others()
         }
         item_copy(ci, ti);
         inv[ti].set_number(in);
-        ibitmod(9, ti, 1);
+        inv[ti].is_stolen() = true;
         inv[ti].own_state = 0;
         inv[ci].modify_number((-in));
         if (inv[ci].number() <= 0)

--- a/src/elona/blending.cpp
+++ b/src/elona/blending.cpp
@@ -963,7 +963,7 @@ label_1928_internal:
     if (p != -1)
     {
         ci = p;
-        if (ibit(13, ci))
+        if (inv[ci].is_marked_as_no_drop())
         {
             snd("core.fail1");
             txt(i18n::s.get("core.locale.ui.inv.common.set_as_no_drop"));
@@ -1672,7 +1672,7 @@ void blending_proc_on_success_events()
     switch (rpdata(0, rpid))
     {
     case 10000:
-        ibitmod(6, ci, 1);
+        inv[ci].is_aphrodisiac() = true;
         txt(i18n::s.get("core.locale.blending.succeeded", inv[ci]),
             Message::color{ColorIndex::green});
         txt(i18n::s.get("core.locale.action.dip.result.love_food.guilty"));
@@ -1685,7 +1685,7 @@ void blending_proc_on_success_events()
         snd("core.drink1");
         break;
     case 10002:
-        ibitmod(14, ci, 1);
+        inv[ci].is_poisoned() = true;
         txt(i18n::s.get("core.locale.blending.succeeded", inv[ci]),
             Message::color{ColorIndex::green});
         txt(i18n::s.get("core.locale.action.dip.result.poisoned_food"));
@@ -1701,7 +1701,7 @@ void blending_proc_on_success_events()
         }
         else
         {
-            ibitmod(2, ci, 1);
+            inv[ci].is_fireproof() = true;
             txt(i18n::s.get(
                 "core.locale.action.dip.result.gains_fireproof", inv[ci]));
         }
@@ -1711,7 +1711,7 @@ void blending_proc_on_success_events()
         txt(i18n::s.get(
                 "core.locale.action.dip.result.put_on", inv[ci], inv[ti]),
             Message::color{ColorIndex::green});
-        ibitmod(1, ci, 1);
+        inv[ci].is_acidproof() = true;
         txt(i18n::s.get(
             "core.locale.action.dip.result.gains_acidproof", inv[ci]));
         snd("core.drink1");

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -922,7 +922,7 @@ int calcitemvalue(int ci, int situation)
             }
         }
     }
-    if (ibit(4, ci) == 1)
+    if (inv[ci].has_charge())
     {
         dbid = inv[ci].id;
         access_item_db(2);
@@ -974,7 +974,7 @@ int calcitemvalue(int ci, int situation)
         {
             ret /= 20;
         }
-        if (ibit(9, ci))
+        if (inv[ci].is_stolen())
         {
             if (game_data.guild.belongs_to_thieves_guild == 0)
             {
@@ -1001,7 +1001,7 @@ int calcitemvalue(int ci, int situation)
         {
             ret = 15000;
         }
-        if (ibit(9, ci))
+        if (inv[ci].is_stolen())
         {
             ret = 1;
         }

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -1425,7 +1425,7 @@ TurnResult do_dip_command()
             {
                 dipcursed(ci);
             }
-            ibitmod(14, ci, 1);
+            inv[ci].is_poisoned() = true;
             return TurnResult::turn_end;
         }
     }
@@ -1444,7 +1444,7 @@ TurnResult do_dip_command()
             {
                 dipcursed(ci);
             }
-            ibitmod(6, ci, 1);
+            inv[ci].is_aphrodisiac() = true;
             return TurnResult::turn_end;
         }
     }
@@ -1491,7 +1491,7 @@ TurnResult do_dip_command()
         }
         else
         {
-            ibitmod(1, ci, 1);
+            inv[ci].is_acidproof() = true;
             txt(i18n::s.get(
                 "core.locale.action.dip.result.gains_acidproof", inv[ci]));
         }
@@ -1521,7 +1521,7 @@ TurnResult do_dip_command()
         }
         else
         {
-            ibitmod(2, ci, 1);
+            inv[ci].is_fireproof() = true;
             txt(i18n::s.get(
                 "core.locale.action.dip.result.gains_fireproof", inv[ci]));
         }
@@ -1582,7 +1582,7 @@ TurnResult do_use_command()
         }
     }
 
-    if (ibit(7, ci) == 1)
+    if (inv[ci].has_cooldown_time())
     {
         if (game_data.date.hours() < inv[ci].count)
         {
@@ -1595,7 +1595,7 @@ TurnResult do_use_command()
         item_separate(ci);
         inv[ci].count = game_data.date.hours() + inv[ci].param3;
     }
-    if (ibit(4, ci) == 1)
+    if (inv[ci].has_charge())
     {
         if (inv[ci].count <= 0)
         {
@@ -1646,7 +1646,7 @@ TurnResult do_use_command()
         crafting_menu();
         return TurnResult::turn_end;
     }
-    if (ibit(10, ci))
+    if (inv[ci].is_alive())
     {
         if (inv[ci].param2 < calcexpalive(inv[ci].param1))
         {

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -184,7 +184,7 @@ label_20591:
             reftype = the_item_db[inv[cnt].id]->category;
             if (inv[cnt].own_state == 5)
             {
-                if (ibit(16, cnt) == 0 || invctrl != 14)
+                if (!inv[cnt].is_showroom_only() || invctrl != 14)
                 {
                     if (invctrl != 1)
                     {
@@ -277,7 +277,7 @@ label_20591:
                 {
                     continue;
                 }
-                if (ibit(5, cnt) == 1)
+                if (inv[cnt].is_precious())
                 {
                     continue;
                 }
@@ -301,7 +301,8 @@ label_20591:
             if (invctrl == 14)
             {
                 if (inv[cnt].function == 0 &&
-                    !the_item_db[inv[cnt].id]->is_usable && ibit(10, cnt) == 0)
+                    !the_item_db[inv[cnt].id]->is_usable &&
+                    !inv[cnt].is_alive())
                 {
                     continue;
                 }
@@ -369,7 +370,7 @@ label_20591:
                 {
                     continue;
                 }
-                if (ibit(9, cnt))
+                if (inv[cnt].is_stolen())
                 {
                     continue;
                 }
@@ -402,7 +403,7 @@ label_20591:
                 }
                 if (invctrl(1) == 3)
                 {
-                    if (ibit(4, cnt) == 0)
+                    if (!inv[cnt].has_charge())
                     {
                         continue;
                     }
@@ -713,7 +714,7 @@ label_2060_internal:
             {
                 ci = p;
                 f = 1;
-                if (ibit(4, ci))
+                if (inv[ci].has_charge())
                 {
                     if (inv[ci].count <= 0)
                     {
@@ -1079,7 +1080,7 @@ label_2061_internal:
         }
         if (invctrl == 2)
         {
-            if (ibit(13, ci))
+            if (inv[ci].is_marked_as_no_drop())
             {
                 snd("core.fail1");
                 txt(i18n::s.get("core.locale.ui.inv.common.set_as_no_drop"));
@@ -1145,7 +1146,7 @@ label_2061_internal:
         {
             if (invctrl != 3 && invctrl != 22)
             {
-                if (ibit(13, ci))
+                if (inv[ci].is_marked_as_no_drop())
                 {
                     snd("core.fail1");
                     txt(i18n::s.get(
@@ -1360,7 +1361,7 @@ label_2061_internal:
         }
         if (invctrl == 5)
         {
-            if (ibit(13, ci))
+            if (inv[ci].is_marked_as_no_drop())
             {
                 snd("core.fail1");
                 txt(i18n::s.get("core.locale.ui.inv.common.set_as_no_drop"));
@@ -1447,7 +1448,7 @@ label_2061_internal:
         }
         if (invctrl == 10)
         {
-            if (ibit(13, ci))
+            if (inv[ci].is_marked_as_no_drop())
             {
                 snd("core.fail1");
                 txt(i18n::s.get("core.locale.ui.inv.common.set_as_no_drop"));
@@ -1720,7 +1721,7 @@ label_2061_internal:
         }
         if (invctrl == 19)
         {
-            if (ibit(13, ci))
+            if (inv[ci].is_marked_as_no_drop())
             {
                 snd("core.fail1");
                 txt(i18n::s.get("core.locale.ui.inv.common.set_as_no_drop"));
@@ -1741,7 +1742,7 @@ label_2061_internal:
         }
         if (invctrl == 21)
         {
-            if (ibit(13, ci))
+            if (inv[ci].is_marked_as_no_drop())
             {
                 snd("core.fail1");
                 txt(i18n::s.get("core.locale.ui.inv.common.set_as_no_drop"));
@@ -1754,7 +1755,7 @@ label_2061_internal:
                 cdata[tc].continuous_action.item = 0;
             }
             snd("core.equip1");
-            ibitmod(12, citrade, 0);
+            inv[citrade].is_quest_target() = false;
             txt(i18n::s.get(
                 "core.locale.ui.inv.trade.you_receive", inv[ci], inv[citrade]));
             if (inv[citrade].body_part != 0)
@@ -1789,7 +1790,7 @@ label_2061_internal:
         {
             if (invctrl(1) == 4)
             {
-                if (ibit(13, ci))
+                if (inv[ci].is_marked_as_no_drop())
                 {
                     snd("core.fail1");
                     txt(i18n::s.get(
@@ -1926,7 +1927,7 @@ label_2061_internal:
                 goto label_20591;
             }
             snd("core.equip1");
-            ibitmod(12, ci, 0);
+            inv[ci].is_quest_target() = false;
             if (inv[ci].id == 54)
             {
                 in = inv[ci].number();
@@ -2124,17 +2125,17 @@ label_2061_internal:
         if (invctrl == 1)
         {
             ci = list(0, pagesize * page + cs);
-            if (ibit(13, ci) == 0)
+            if (inv[ci].is_marked_as_no_drop())
             {
-                ibitmod(13, ci, 1);
+                inv[ci].is_marked_as_no_drop() = false;
                 txt(i18n::s.get(
-                    "core.locale.ui.inv.examine.no_drop.set", inv[ci]));
+                    "core.locale.ui.inv.examine.no_drop.unset", inv[ci]));
             }
             else
             {
-                ibitmod(13, ci, 0);
+                inv[ci].is_marked_as_no_drop() = true;
                 txt(i18n::s.get(
-                    "core.locale.ui.inv.examine.no_drop.unset", inv[ci]));
+                    "core.locale.ui.inv.examine.no_drop.set", inv[ci]));
             }
         }
         if (invctrl == 2)

--- a/src/elona/elonacore.cpp
+++ b/src/elona/elonacore.cpp
@@ -3009,7 +3009,7 @@ void character_drops_item()
                 {
                     continue;
                 }
-                if (ibit(5, ci))
+                if (inv[ci].is_precious())
                 {
                     continue;
                 }
@@ -3088,7 +3088,7 @@ void character_drops_item()
                 inv[ci].body_part = 0;
             }
             f = 0;
-            if (ibit(5, ci) == 0)
+            if (!inv[ci].is_precious())
             {
                 if (rnd(4) == 0)
                 {
@@ -3221,7 +3221,7 @@ void character_drops_item()
         {
             f = 1;
         }
-        if (ibit(12, ci))
+        if (inv[ci].is_quest_target())
         {
             f = 1;
         }
@@ -3231,7 +3231,7 @@ void character_drops_item()
         }
         if (catitem != 0)
         {
-            if (ibit(8, ci) == 0)
+            if (!inv[ci].is_blessed_by_ehekatl())
             {
                 if (the_item_db[inv[ci].id]->category < 50000)
                 {
@@ -3244,7 +3244,7 @@ void character_drops_item()
                                     cdata[catitem],
                                     inv[ci]),
                                 Message::color{ColorIndex::cyan});
-                            ibitmod(8, ci, 1);
+                            inv[ci].is_blessed_by_ehekatl() = true;
                             reftype = the_item_db[inv[ci].id]->category;
                             enchantment_add(
                                 ci,
@@ -6696,7 +6696,7 @@ void load_gene_files()
         {
             continue;
         }
-        if (ibit(5, cnt))
+        if (inv[cnt].is_precious())
         {
             continue;
         }
@@ -7698,7 +7698,7 @@ int decode_book()
             "core.locale.action.read.book.finished_decoding", inv[ci]));
         inv[ci].param2 = 1;
         inv[ci].count = 1;
-        ibitmod(4, ci, 0);
+        inv[ci].has_charge() = false;
         item_stack(0, ci, 1);
     }
     else
@@ -8950,7 +8950,7 @@ int pick_up_item()
     {
         inv[ci].own_state = 0;
     }
-    ibitmod(12, ci, 0);
+    inv[ci].is_quest_target() = false;
     item_checkknown(ci);
     int stat = item_stack(cc, ci);
     if (stat == 0)
@@ -9025,14 +9025,14 @@ int pick_up_item()
         {
             msgkeep = 1;
             sellgold = calcitemvalue(ci, 1) * in;
-            if (ibit(9, ti) == 0)
+            if (!inv[ti].is_stolen())
             {
                 txt(i18n::s.get(
                     "core.locale.action.pick_up.you_sell", itemname(ti, in)));
             }
             else
             {
-                ibitmod(9, ti, 0);
+                inv[ti].is_stolen() = false;
                 txt(i18n::s.get(
                     "core.locale.action.pick_up.you_sell_stolen",
                     itemname(ti, in)));
@@ -9741,7 +9741,7 @@ void proc_autopick()
             pick_up_item();
             if (int(op.type) & int(Autopick::Operation::Type::no_drop))
             {
-                ibitmod(13, ti, 1);
+                inv[ti].is_marked_as_no_drop() = true;
                 txt(i18n::s.get(
                     "core.locale.ui.inv.examine.no_drop.set", inv[ti]));
             }
@@ -11120,7 +11120,7 @@ label_22191_internal:
         if (cdata[tc].state() != Character::State::alive)
         {
             cw = attackitem;
-            if (ibit(10, cw))
+            if (inv[cw].is_alive())
             {
                 if (inv[cw].param2 < calcexpalive(inv[cw].param1))
                 {

--- a/src/elona/enchantment.cpp
+++ b/src/elona/enchantment.cpp
@@ -1461,7 +1461,7 @@ void add_enchantments()
         {
             if (reftype == 24000 || reftype == 10000)
             {
-                ibitmod(10, ci, 1);
+                inv[ci].is_alive() = true;
                 inv[ci].param1 = 1;
                 return;
             }
@@ -1480,7 +1480,7 @@ void add_enchantments()
             {
                 if (rnd(10) == 0)
                 {
-                    ibitmod(15, ci, 1);
+                    inv[ci].is_eternal_force() = true;
                     enchantment_add(
                         ci, enchantment_generate(99), enchantment_gen_p());
                     inv[ci].curse_state = CurseState::blessed;
@@ -1493,8 +1493,9 @@ void add_enchantments()
                 ci,
                 enchantment_generate(enchantment_gen_level(egolv)),
                 enchantment_gen_p() + (fixlv == Quality::godly) * 100 +
-                    (ibit(15, ci) == 1) * 100,
-                20 - (fixlv == Quality::godly) * 10 - (ibit(15, ci) == 1) * 20);
+                    (inv[ci].is_eternal_force()) * 100,
+                20 - (fixlv == Quality::godly) * 10 -
+                    (inv[ci].is_eternal_force()) * 20);
         }
     }
     if (fixlv == Quality::special)

--- a/src/elona/equipment.cpp
+++ b/src/elona/equipment.cpp
@@ -228,7 +228,7 @@ void supply_new_equipment()
             {
                 continue;
             }
-            if (ibit(12, ci))
+            if (inv[ci].is_quest_target())
             {
                 continue;
             }

--- a/src/elona/food.cpp
+++ b/src/elona/food.cpp
@@ -1310,7 +1310,7 @@ void apply_general_eating_effect(int cieat)
             "core.locale.food.effect.sisters_love_fueled_lunch", cdata[cc]));
         heal_insanity(cdata[cc], 30);
     }
-    if (ibit(14, ci) == 1)
+    if (inv[ci].is_poisoned())
     {
         if (is_in_fov(cdata[cc]))
         {
@@ -1331,7 +1331,7 @@ void apply_general_eating_effect(int cieat)
             return;
         }
     }
-    if (ibit(6, ci) == 1)
+    if (inv[ci].is_aphrodisiac())
     {
         if (cc == 0)
         {

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <bitset>
 #include <memory>
 #include <vector>
 #include "enums.hpp"
 #include "position.hpp"
+#include "putit.hpp"
 #include "range.hpp"
 
 
@@ -37,6 +39,11 @@ struct Enchantment
 
 struct Item
 {
+private:
+    using FlagSet = std::bitset<32>;
+
+
+public:
     Item();
 
     // NOTE: Don't add new fields unless you add them to serialization, which
@@ -78,8 +85,6 @@ struct Item
     int difficulty_of_identification = 0;
     int turn = 0;
 
-    int flags = 0;
-
     std::vector<Enchantment> enchantments;
 
 
@@ -103,7 +108,40 @@ struct Item
     void remove();
 
 
-    template <typename Archive>
+#define ELONA_ITEM_DEFINE_FLAG_ACCESSOR(name, n) \
+    bool name() const \
+    { \
+        return _flags[n]; \
+    } \
+    FlagSet::reference name() \
+    { \
+        return _flags[n]; \
+    }
+
+    ELONA_ITEM_DEFINE_FLAG_ACCESSOR(is_acidproof, 1)
+    ELONA_ITEM_DEFINE_FLAG_ACCESSOR(is_fireproof, 2)
+    ELONA_ITEM_DEFINE_FLAG_ACCESSOR(has_charge, 4)
+    ELONA_ITEM_DEFINE_FLAG_ACCESSOR(is_precious, 5)
+    ELONA_ITEM_DEFINE_FLAG_ACCESSOR(is_aphrodisiac, 6)
+    ELONA_ITEM_DEFINE_FLAG_ACCESSOR(has_cooldown_time, 7)
+    ELONA_ITEM_DEFINE_FLAG_ACCESSOR(is_blessed_by_ehekatl, 8)
+    ELONA_ITEM_DEFINE_FLAG_ACCESSOR(is_stolen, 9)
+    ELONA_ITEM_DEFINE_FLAG_ACCESSOR(is_alive, 10)
+    ELONA_ITEM_DEFINE_FLAG_ACCESSOR(is_quest_target, 12)
+    ELONA_ITEM_DEFINE_FLAG_ACCESSOR(is_marked_as_no_drop, 13)
+    ELONA_ITEM_DEFINE_FLAG_ACCESSOR(is_poisoned, 14)
+    ELONA_ITEM_DEFINE_FLAG_ACCESSOR(is_eternal_force, 15)
+    ELONA_ITEM_DEFINE_FLAG_ACCESSOR(is_showroom_only, 16)
+    ELONA_ITEM_DEFINE_FLAG_ACCESSOR(is_handmade, 17)
+
+#undef ELONA_ITEM_DEFINE_FLAG_ACCESSOR
+
+
+    template <
+        typename Archive,
+        std::enable_if_t<
+            std::is_base_of<putit::IArchiveBase, Archive>::value,
+            std::nullptr_t> = nullptr>
     void serialize(Archive& ar)
     {
         // WARNING: Changing this will break save compatibility!
@@ -137,7 +175,58 @@ struct Item
         ar(param4);
         ar(difficulty_of_identification);
         ar(turn);
-        ar(flags);
+        {
+            uint32_t tmp;
+            ar(tmp);
+            _flags = tmp;
+        }
+        range::for_each(
+            enchantments, [&](auto&& enchantment) { ar(enchantment); });
+    }
+
+
+    template <
+        typename Archive,
+        std::enable_if_t<
+            std::is_base_of<putit::OArchiveBase, Archive>::value,
+            std::nullptr_t> = nullptr>
+    void serialize(Archive& ar)
+    {
+        // WARNING: Changing this will break save compatibility!
+        ar(number_);
+        ar(value);
+        ar(image);
+        ar(id);
+        ar(quality);
+        ar(position);
+        ar(weight);
+        ar(identification_state);
+        ar(count);
+        ar(dice_x);
+        ar(dice_y);
+        ar(damage_bonus);
+        ar(hit_bonus);
+        ar(dv);
+        ar(pv);
+        ar(skill);
+        ar(curse_state);
+        ar(body_part);
+        ar(function);
+        ar(enhancement);
+        ar(own_state);
+        ar(color);
+        ar(subname);
+        ar(material);
+        ar(param1);
+        ar(param2);
+        ar(param3);
+        ar(param4);
+        ar(difficulty_of_identification);
+        ar(turn);
+        {
+            auto tmp = static_cast<uint32_t>(_flags.to_ulong());
+            ar(tmp);
+        }
         range::for_each(
             enchantments, [&](auto&& enchantment) { ar(enchantment); });
     }
@@ -155,6 +244,7 @@ private:
     static void refresh();
     int number_ = 0;
 
+    FlagSet _flags;
 
     Item(const Item&) = default;
     Item(Item&&) = default;
@@ -185,10 +275,6 @@ extern Inventory inv;
 
 struct Character;
 
-
-
-int ibit(size_t type, int ci);
-void ibitmod(size_t type, int ci, int on);
 
 
 IdentifyState item_identify(Item& ci, IdentifyState level);

--- a/src/elona/item_load_desc.cpp
+++ b/src/elona/item_load_desc.cpp
@@ -122,38 +122,38 @@ static void _load_item_stat_text(int ci, int& p)
             i18n::s.get("core.locale.item.desc.speeds_up_ether_disease");
         ++p;
     }
-    if (ibit(1, ci))
+    if (inv[ci].is_acidproof())
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::text);
         listn(0, p) = i18n::s.get("core.locale.item.desc.bit.acidproof");
         ++p;
     }
-    if (ibit(2, ci))
+    if (inv[ci].is_fireproof())
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::text);
         listn(0, p) = i18n::s.get("core.locale.item.desc.bit.fireproof");
         ++p;
     }
-    if (ibit(5, ci))
+    if (inv[ci].is_precious())
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::text);
         listn(0, p) = i18n::s.get("core.locale.item.desc.bit.precious");
         ++p;
     }
-    if (ibit(8, ci))
+    if (inv[ci].is_blessed_by_ehekatl())
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::text);
         listn(0, p) =
             i18n::s.get("core.locale.item.desc.bit.blessed_by_ehekatl");
         ++p;
     }
-    if (ibit(9, ci))
+    if (inv[ci].is_stolen())
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::text);
         listn(0, p) = i18n::s.get("core.locale.item.desc.bit.stolen");
         ++p;
     }
-    if (ibit(10, ci))
+    if (inv[ci].is_alive())
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::text);
         listn(0, p) = i18n::s.get("core.locale.item.desc.bit.alive") +
@@ -162,13 +162,13 @@ static void _load_item_stat_text(int ci, int& p)
             u8"%]"s;
         ++p;
     }
-    if (ibit(16, ci))
+    if (inv[ci].is_showroom_only())
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::text);
         listn(0, p) = i18n::s.get("core.locale.item.desc.bit.show_room_only");
         ++p;
     }
-    if (ibit(17, ci))
+    if (inv[ci].is_handmade())
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::text);
         listn(0, p) = i18n::s.get("core.locale.item.desc.bit.handmade");
@@ -271,7 +271,7 @@ static void _load_item_enchantment_desc(int ci, int& p)
         }
         ++p;
     }
-    if (ibit(15, ci))
+    if (inv[ci].is_eternal_force())
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::enchantment);
         listn(0, p) = i18n::s.get("core.locale.item.desc.bit.eternal_force");

--- a/src/elona/itemgen.cpp
+++ b/src/elona/itemgen.cpp
@@ -339,7 +339,7 @@ int do_create_item(int slot, int x, int y)
 
     if (inv[ci].id == 667)
     {
-        ibitmod(17, ci, 1);
+        inv[ci].is_handmade() = true;
     }
 
     if (inv[ci].id == 641)
@@ -779,11 +779,11 @@ void set_material_specific_attributes()
     {
         if (the_item_material_db[p]->fireproof)
         {
-            ibitmod(1, ci, 1);
+            inv[ci].is_acidproof() = true;
         }
         if (the_item_material_db[p]->acidproof)
         {
-            ibitmod(2, ci, 1);
+            inv[ci].is_fireproof() = true;
         }
     }
 }

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -3268,7 +3268,7 @@ label_2181_internal:
                 break;
             }
         }
-        if (inv[ci].quality >= Quality::miracle || ibit(10, ci) == 1)
+        if (inv[ci].quality >= Quality::miracle || inv[ci].is_alive())
         {
             txt(i18n::s.get("core.locale.magic.garoks_hammer.no_effect"));
             fixmaterial = 0;
@@ -3292,8 +3292,9 @@ label_2181_internal:
                 ci,
                 enchantment_generate(enchantment_gen_level(egolv)),
                 enchantment_gen_p() + (fixlv == Quality::godly) * 100 +
-                    (ibit(15, ci) == 1) * 100,
-                20 - (fixlv == Quality::godly) * 10 - (ibit(15, ci) == 1) * 20);
+                    (inv[ci].is_eternal_force()) * 100,
+                20 - (fixlv == Quality::godly) * 10 -
+                    (inv[ci].is_eternal_force()) * 20);
         }
         randomize();
         txt(i18n::s.get("core.locale.magic.garoks_hammer.apply", inv[ci]));
@@ -3326,7 +3327,7 @@ label_2181_internal:
             MenuResult result = ctrl_inventory();
             f = result.succeeded ? 1 : 0;
         }
-        if (inv[ci].quality == Quality::godly || ibit(10, ci) == 1)
+        if (inv[ci].quality == Quality::godly || inv[ci].is_alive())
         {
             if (efid == 1127)
             {
@@ -3730,7 +3731,7 @@ label_2181_internal:
         }
         if (f)
         {
-            if (inv[ci].quality > Quality::miracle || ibit(5, ci) == 1)
+            if (inv[ci].quality > Quality::miracle || inv[ci].is_precious())
             {
                 f = 0;
             }
@@ -4186,7 +4187,7 @@ label_2181_internal:
                 {
                     continue;
                 }
-                if (ibit(5, cnt))
+                if (inv[cnt].is_precious())
                 {
                     continue;
                 }
@@ -4203,7 +4204,7 @@ label_2181_internal:
             break;
         }
         ci = p;
-        if (ibit(6, ci))
+        if (inv[ci].is_aphrodisiac())
         {
             if (is_in_fov(cdata[tc]))
             {

--- a/src/elona/quest.cpp
+++ b/src/elona/quest.cpp
@@ -659,7 +659,7 @@ int quest_generate()
                 inv[ci].count = rq;
                 i(0) = n;
                 i(1) = inv[ci].id;
-                ibitmod(12, ci, 1);
+                inv[ci].is_quest_target() = true;
                 break;
             }
             else

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -2227,7 +2227,7 @@ TalkResult talk_npc()
                 {
                     continue;
                 }
-                if (ibit(13, cnt))
+                if (inv[cnt].is_marked_as_no_drop())
                 {
                     continue;
                 }

--- a/src/elona/turn_sequence.cpp
+++ b/src/elona/turn_sequence.cpp
@@ -498,7 +498,7 @@ label_2689_internal:
                         {
                             if (inv[ci].own_state <= 0)
                             {
-                                if (ibit(5, ci) == 0)
+                                if (!inv[ci].is_precious())
                                 {
                                     if (map_data.type !=
                                         mdata_t::MapType::player_owned)

--- a/src/elona/ui.cpp
+++ b/src/elona/ui.cpp
@@ -2471,7 +2471,7 @@ void cs_list(
             case CurseState::blessed: color(10, 110, 30); break;
             }
         }
-        if (ibit(13, ci))
+        if (inv[ci].is_marked_as_no_drop())
         {
             color(120, 80, 0);
         }

--- a/src/elona/wish.cpp
+++ b/src/elona/wish.cpp
@@ -596,7 +596,7 @@ bool wish_for_item(const std::string& input)
         nooracle = 0;
 
         // Unwishable item
-        if (ibit(5, ci) || inv[ci].quality == Quality::special)
+        if (inv[ci].is_precious() || inv[ci].quality == Quality::special)
         {
             if (!game_data.wizard)
             {

--- a/src/tests/serialization.cpp
+++ b/src/tests/serialization.cpp
@@ -40,7 +40,7 @@ TEST_CASE("Test item saving and reloading", "[C++: Serialization]")
     int number = 3;
     REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, x, y, number));
     int index = elona::ci;
-    ibitmod(6, index, 1);
+    elona::inv[index].is_aphrodisiac() = true;
     elona::inv[index].curse_state = CurseState::blessed;
 
     save_and_reload();
@@ -50,7 +50,7 @@ TEST_CASE("Test item saving and reloading", "[C++: Serialization]")
     REQUIRE(elona::inv[index].position.x == 4);
     REQUIRE(elona::inv[index].position.y == 8);
     REQUIRE(elona::inv[index].curse_state == CurseState::blessed);
-    REQUIRE(elona::ibit(6, index) == 1);
+    REQUIRE(elona::inv[index].is_aphrodisiac());
     REQUIRE(itemname(index) == u8"3個のプチトロ(媚薬混入)");
 }
 


### PR DESCRIPTION
# Summary


Like `cbit()`, make methods for each `ibit()` and `ibitmod()` calls.

- ibit(1, x): is_acidproof
- ibit(2, x): is_fireproof
- ibit(4, x): has_charge
- ibit(5, x): is_precious
- ibit(6, x): is_aphrodisiac
- ibit(7, x): has_cooldown_time
- ibit(8, x): is_blessed_by_ehekatl
- ibit(9, x): is_stolen
- ibit(10, x): is_alive
- ibit(12, x): is_quest_target
- ibit(13, x): is_marked_as_no_drop
- ibit(14, x): is_poisoned
- ibit(15, x): is_eternal_force
- ibit(16, x): is_showroom_only
- ibit(17, x): is_handmade
