### PR TITLE
Fix reference to undefined buff

### DIFF
--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -1770,7 +1770,7 @@ label_2181_internal:
                     break;
                 }
             }
-            if (the_buff_db[cdata[tc].buffs[i].id]->type != BuffType::hex)
+            if (cdata[tc].buffs[i].id == 0)
             {
                 continue;
             }
@@ -1778,7 +1778,7 @@ label_2181_internal:
             {
                 continue;
             }
-            if (cdata[tc].buffs[i].id == 0)
+            if (the_buff_db[cdata[tc].buffs[i].id]->type != BuffType::hex)
             {
                 continue;
             }


### PR DESCRIPTION

# Related Issues

Close #1108 


# Summary

Check whether buff's id is valid, that is, not zero, before calling `BuffDB::operator[]`.