### PR TITLE
Fix typo

### DIFF
--- a/runtime/locale/en/death.hcl
+++ b/runtime/locale/en/death.hcl
@@ -7,7 +7,7 @@ locale {
                 passive = "${name(_1)} ${is(_1)} transformed into several pieces of meat."
             }
             destroyed {
-                active = "destroy${s(_2)} ${him(_1)}"
+                active = "destroy${s(_2)} ${him(_1)}."
                 passive = "${name(_1)} ${is(_1)} killed."
             }
             minced {

--- a/runtime/locale/en/mod.hcl
+++ b/runtime/locale/en/mod.hcl
@@ -1,5 +1,5 @@
 locale {
     mod {
-        loaded_script = "Loaded script {_1}. "
+        loaded_script = "Loaded script ${_1}. "
     }
 }

--- a/runtime/locale/en/status_ailment.hcl
+++ b/runtime/locale/en/status_ailment.hcl
@@ -32,7 +32,7 @@ locale {
             }
             bleeding {
                 apply = "${name(_1)} begin${s(_1)} to bleed."
-                heal = "${name(_1)}${r(_1)} bleeding stops."
+                heal = "${name(_1)}${his_owned(_1)} bleeding stops."
             }
             drunk {
                 apply = "${name(_1)} get${s(_1)} drunk."

--- a/runtime/mods/core/data/item.lua
+++ b/runtime/mods/core/data/item.lua
@@ -1383,7 +1383,7 @@ data:add_multi(
          locale_key_prefix = "core.locale.item.raw_ore_of_rubynus",
       },
       {
-         name = "raw_ore_of_mika",
+         name = "raw_ore_of_mica",
          id = 40,
          image = 212,
          value = 720,
@@ -1414,7 +1414,7 @@ data:add_multi(
          has_random_name = false,
          tags = {},
          rftags = { "ore" },
-         locale_key_prefix = "core.locale.item.raw_ore_of_mika",
+         locale_key_prefix = "core.locale.item.raw_ore_of_mica",
       },
       {
          name = "raw_ore_of_emerald",

--- a/runtime/mods/core/locale/en/item.hcl
+++ b/runtime/mods/core/locale/en/item.hcl
@@ -300,8 +300,8 @@ locale {
         raw_ore_of_rubynus {
             name = "rubynus"
         }
-        raw_ore_of_mika {
-            name = "mika"
+        raw_ore_of_mica {
+            name = "mica"
         }
         raw_ore_of_emerald {
             name = "emerald"

--- a/runtime/mods/core/locale/jp/item.hcl
+++ b/runtime/mods/core/locale/jp/item.hcl
@@ -526,7 +526,7 @@ locale {
                 }
             }
         }
-        raw_ore_of_mika {
+        raw_ore_of_mica {
             name = "ミカ"
             description {
                 main {

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -988,15 +988,12 @@ TalkResult talk_ally_silence()
     if (cdata[tc].is_silent() == 0)
     {
         cdata[tc].is_silent() = true;
-        buff = u8"("s +
-            i18n::s.get("core.locale.talk.npc.ally.silence.start", cdata[tc]) +
-            u8")"s;
+        buff =
+            i18n::s.get("core.locale.talk.npc.ally.silence.start", cdata[tc]);
     }
     else
     {
-        buff = u8"("s +
-            i18n::s.get("core.locale.talk.npc.ally.silence.stop", cdata[tc]) +
-            u8")"s;
+        buff = i18n::s.get("core.locale.talk.npc.ally.silence.stop", cdata[tc]);
         cdata[tc].is_silent() = false;
     }
     return TalkResult::talk_npc;


### PR DESCRIPTION

# Related Issues

#1086 


# Summary

- Delete unnecessary parens in talk.
- Fix typo: mika to mica.
- Add missing dollar  sign in loading startup script.
- Fix wrong function name in locale: r -> his_owned
- Add missing period.