### PR TITLE
Change View Homepage in main menu to About

### DIFF
--- a/runtime/locale/en/main_menu.hcl
+++ b/runtime/locale/en/main_menu.hcl
@@ -1,0 +1,40 @@
+locale {
+    main_menu {
+        title_menu {
+            continue = "Restore an Adventurer"
+            new = "Generate an Adventurer"
+            incarnate = "Incarnate an Adventurer"
+            about = "About"
+            options = "Options"
+            exit = "Exit"
+        }
+
+        continue {
+            which_save = "Which save game do you want to continue?"
+            title = "Game Selection"
+            key_hint = "BackSpace [Delete]  "
+            no_save = "No save files found"
+            delete = "Do you really want to delete ${_1} ?"
+            delete2 = "Are you sure you really want to delete ${_1} ?"
+        }
+
+        incarnate {
+            which_gene = "Which gene do you want to incarnate?"
+            title = "Gene Selection"
+            no_gene = "No gene files found"
+        }
+
+        about {
+            title = "About"
+            vanilla_homepage = "Vanilla Elona Homepage"
+            foobar_homepage = "Elona foobar Homepage"
+            foobar_changelog = "Elona foobar Changelog"
+            license = "License"
+            credits = "Credits"
+        }
+
+        about_changelog {
+            title = "Changelogs"
+        }
+    }
+}

--- a/runtime/locale/jp/main_menu.hcl
+++ b/runtime/locale/jp/main_menu.hcl
@@ -1,0 +1,40 @@
+locale {
+    main_menu {
+        title_menu {
+            continue = "冒険を再開する"
+            new = "新しい冒険者を作成する"
+            incarnate = "冒険者の引継ぎ"
+            about = "このゲームについて"
+            options = "設定の変更"
+            exit = "終了"
+        }
+
+        continue {
+            which_save = "どの冒険を再開するんだい？"
+            title = "冒険者の選択"
+            key_hint = "BackSpace [削除]  "
+            no_save = "No save files found"
+            delete = "本当に${_1}を削除していいのかい？"
+            delete2 = "本当の本当に${_1}を削除していいのかい？"
+        }
+
+        incarnate {
+            which_gene = "どの遺伝子を引き継ぐ？"
+            title = "遺伝子の選択"
+            no_gene = "No gene files found"
+        }
+
+        about {
+            title = "About"
+            vanilla_homepage = "本家ホームページ"
+            foobar_homepage = "Elona foobar ホームページ"
+            foobar_changelog = "Elona foobar 変更履歴"
+            license = "ライセンス"
+            credits = "クレジット"
+        }
+
+        about_changelog {
+            title = "更新履歴"
+        }
+    }
+}

--- a/src/elona/Android.mk
+++ b/src/elona/Android.mk
@@ -28,6 +28,7 @@ area.cpp \
 audio.cpp \
 autopick.cpp \
 blending.cpp \
+browser.cpp \
 buff.cpp \
 building.cpp \
 calc.cpp \

--- a/src/elona/CMakeLists.txt
+++ b/src/elona/CMakeLists.txt
@@ -11,6 +11,7 @@ set(ELONA_SOURCES
   audio.cpp
   autopick.cpp
   blending.cpp
+  browser.cpp
   buff.cpp
   building.cpp
   calc.cpp

--- a/src/elona/browser.cpp
+++ b/src/elona/browser.cpp
@@ -1,0 +1,82 @@
+#include "browser.hpp"
+#include <cstdlib>
+#include <string>
+#include "../util/range.hpp"
+#include "config/config.hpp"
+
+#ifdef ELONA_OS_WINDOWS
+#include <windows.h>
+#endif
+
+using namespace std::literals::string_literals;
+
+
+
+namespace
+{
+
+bool _is_trusted_url(const char* url)
+{
+    const char* trusted_urls[] = {
+        "http://ylvania.org/jp",
+        "http://ylvania.org/en",
+        "https://elonafoobar.com",
+    };
+
+    return range::find(trusted_urls, url) != std::end(trusted_urls);
+}
+
+} // namespace
+
+
+
+namespace elona
+{
+
+void open_browser(const char* url)
+{
+    if (Config::instance().is_test)
+    {
+        return;
+    }
+
+    if (!_is_trusted_url(url))
+    {
+        throw std::runtime_error{"Try to open unknown URL!"};
+    }
+
+#if defined(ELONA_OS_WINDOWS)
+    HWND parent = NULL;
+    LPCWSTR operation = NULL;
+    // `url` must be ascii only.
+    const auto len = std::strlen(url);
+    std::basic_string<WCHAR> url_(len, L'\0');
+    for (size_t i = 0; i < len; ++i)
+    {
+        url_[i] = url[i];
+    }
+    LPCWSTR extra_parameter = NULL;
+    LPCWSTR default_dir = NULL;
+    INT show_command = SW_SHOWNORMAL;
+
+    ::ShellExecute(
+        parent,
+        operation,
+        url_.c_str(),
+        extra_parameter,
+        default_dir,
+        show_command);
+#elif defined(ELONA_OS_MACOS)
+    std::system(("open "s + url).c_str());
+#elif defined(ELONA_OS_LINUX)
+    std::system(("xdg-open "s + url).c_str());
+#elif defined(ELONA_OS_ANDROID)
+    // TODO: implement for android.
+    (void)url;
+    return;
+#else
+#error "Unsupported OS"
+#endif
+}
+
+} // namespace elona

--- a/src/elona/browser.hpp
+++ b/src/elona/browser.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+
+
+namespace elona
+{
+
+/**
+ * CAUTION: This function's validation is NOT perfect. Passing untrusted string
+ * like user input may cause serious vulnerability. Make sure that `url` is a
+ * hard-coded literal.
+ */
+void open_browser(const char* url);
+
+} // namespace elona

--- a/src/elona/elona.hpp
+++ b/src/elona/elona.hpp
@@ -400,9 +400,6 @@ int dialog(const std::string& message, int = 0);
 
 
 
-void exec(const std::string&, int);
-
-
 void font(int size, snail::Font::Style style = snail::Font::Style::regular);
 
 void gcopy(

--- a/src/elona/main_menu.cpp
+++ b/src/elona/main_menu.cpp
@@ -177,30 +177,20 @@ MainMenuResult main_title_menu()
     gcopy_c(2, cmbg / 2 * 180, cmbg % 2 * 300, 180, 300, x, y);
     gmode(2);
 
-    if (jp)
-    {
-        s(0) = u8"Restore an adventurer"s;
-        s(1) = u8"冒険を再開する"s;
-        s(2) = u8"Generate an adventurer"s;
-        s(3) = u8"新しい冒険者を作成する"s;
-        s(4) = u8"Incarnate an adventurer"s;
-        s(5) = u8"冒険者の引継ぎ"s;
-        s(6) = u8"About"s;
-        s(7) = u8"このゲームについて"s;
-        s(8) = u8"Configure"s;
-        s(9) = u8"設定の変更"s;
-        s(10) = u8"Exit"s;
-        s(11) = u8"終了"s;
-    }
-    if (en)
-    {
-        s(0) = u8"Restore an Adventurer"s;
-        s(1) = u8"Generate an Adventurer"s;
-        s(2) = u8"Incarnate an Adventurer"s;
-        s(3) = u8"About"s;
-        s(4) = u8"Options"s;
-        s(5) = u8"Exit"s;
-    }
+    std::vector<std::string> items = {
+        u8"Restore an Adventurer",
+        i18n::s.get("core.locale.main_menu.title_menu.continue"),
+        u8"Generate an Adventurer",
+        i18n::s.get("core.locale.main_menu.title_menu.new"),
+        u8"Incarnate an Adventurer",
+        i18n::s.get("core.locale.main_menu.title_menu.incarnate"),
+        u8"About",
+        i18n::s.get("core.locale.main_menu.title_menu.about"),
+        u8"Options",
+        i18n::s.get("core.locale.main_menu.title_menu.options"),
+        u8"Exit",
+        i18n::s.get("core.locale.main_menu.title_menu.exit"),
+    };
 
     gsel(3);
     pos(960, 96);
@@ -229,18 +219,18 @@ MainMenuResult main_title_menu()
             x = wx + 40;
             y = cnt * 35 + wy + 50;
             display_customkey(key_select(cnt), x, y);
-            if (jp)
+            if (en)
             {
-                font(11 - en * 2);
-                pos(x + 40, y - 4);
-                mes(s(cnt * 2));
-                font(13 - en * 2);
-                cs_list(cs == cnt, s(cnt * 2 + 1), x + 40, y + 8);
+                font(14 - en * 2);
+                cs_list(cs == cnt, items.at(cnt * 2 + 1), x + 40, y + 1);
             }
             else
             {
-                font(14 - en * 2);
-                cs_list(cs == cnt, s(cnt), x + 40, y + 1);
+                font(11 - en * 2);
+                pos(x + 40, y - 4);
+                mes(items.at(cnt * 2));
+                font(13 - en * 2);
+                cs_list(cs == cnt, items.at(cnt * 2 + 1), x + 40, y + 8);
             }
         }
         cs_bk = cs;
@@ -456,14 +446,13 @@ MainMenuResult main_menu_continue()
 
         clear_background_in_continue();
         ui_draw_caption(
-            jp ? u8"どの冒険を再開するんだい？"
-               : u8"Which save game do you want to continue?");
+            i18n::s.get("core.locale.main_menu.continue.which_save"));
         windowshadow = 1;
     savegame_draw_page:
         ui_display_window(
-            jp ? u8"冒険者の選択" : u8"Game Selection",
-            jp ? u8"BackSpace [削除]  " + strhint2 + strhint3b
-               : u8"BackSpace [Delete]  " + strhint2 + strhint3b,
+            i18n::s.get("core.locale.main_menu.continue.title"),
+            i18n::s.get("core.locale.main_menu.continue.key_hint") + strhint2 +
+                strhint3b,
             (windoww - 440) / 2 + inf_screenx,
             winposy(288, 1),
             440,
@@ -492,7 +481,7 @@ MainMenuResult main_menu_continue()
         {
             font(14 - en * 2);
             pos(wx + 140, wy + 120);
-            mes(u8"No save files found"s);
+            mes(i18n::s.get("core.locale.main_menu.continue.no_save"));
         }
         redraw();
 
@@ -528,20 +517,15 @@ MainMenuResult main_menu_continue()
                 {
                     p = list(0, cs);
                     playerid = listn(0, p);
-                    ui_draw_caption(
-                        jp ? u8"本当に" + playerid + u8"を削除していいのかい？"
-                           : u8"Do you really want to delete " + playerid +
-                                u8" ?");
+                    ui_draw_caption(i18n::s.get(
+                        "core.locale.main_menu.continue.delete", playerid));
                     rtval = yes_or_no(promptx, prompty, 200);
                     if (rtval != 0)
                     {
                         return MainMenuResult::main_menu_continue;
                     }
-                    ui_draw_caption(
-                        jp ? u8"本当の本当に" + playerid +
-                                u8"を削除していいのかい？"
-                           : u8"Are you sure you really want to delete " +
-                                playerid + u8" ?");
+                    ui_draw_caption(i18n::s.get(
+                        "core.locale.main_menu.continue.delete2", playerid));
                     rtval = yes_or_no(promptx, prompty, 200);
                     if (rtval == 0)
                     {
@@ -593,9 +577,7 @@ MainMenuResult main_menu_incarnate()
     pos(0, 0);
     gcopy(4, 0, 0, windoww, windowh);
     gmode(2);
-    ui_draw_caption(
-        jp ? u8"どの遺伝子を引き継ぐ？"
-           : u8"Which gene do you want to incarnate?");
+    ui_draw_caption(i18n::s.get("core.locale.main_menu.incarnate.which_gene"));
     keyrange = 0;
     listmax = 0;
     for (const auto& entry : filesystem::dir_entries(
@@ -621,7 +603,7 @@ MainMenuResult main_menu_incarnate()
     while (1)
     {
         ui_display_window(
-            jp ? u8"遺伝子の選択" : u8"Gene Selection",
+            i18n::s.get("core.locale.main_menu.incarnate.title"),
             strhint3b,
             (windoww - 440) / 2 + inf_screenx,
             winposy(288, 1),
@@ -644,7 +626,7 @@ MainMenuResult main_menu_incarnate()
         {
             font(14 - en * 2);
             pos(wx + 140, wy + 120);
-            mes(u8"No gene files found"s);
+            mes(i18n::s.get("core.locale.main_menu.incarnate.no_gene"));
         }
         redraw();
 
@@ -695,29 +677,18 @@ MainMenuResult main_menu_about()
 
     windowshadow = 1;
     ui_display_window(
-        "About",
+        i18n::s.get("core.locale.main_menu.about.title"),
         strhint3b,
         (windoww - 440) / 2 + inf_screenx,
         winposy(288, 1),
         440,
         288);
 
-    if (jp)
-    {
-        s(0) = "本家ホームページ";
-        s(1) = "Elona foobar ホームページ";
-        s(2) = "Elona foobar 変更履歴";
-        s(3) = "ライセンス";
-        s(4) = "クレジット";
-    }
-    else
-    {
-        s(0) = "Vanilla Elona Homepage";
-        s(1) = "Elona foobar Homepage";
-        s(2) = "Elona foobar Changelog";
-        s(3) = "License";
-        s(4) = "Credits";
-    }
+    s(0) = i18n::s.get("core.locale.main_menu.about.vanilla_homepage");
+    s(1) = i18n::s.get("core.locale.main_menu.about.foobar_homepage");
+    s(2) = i18n::s.get("core.locale.main_menu.about.foobar_changelog");
+    s(3) = i18n::s.get("core.locale.main_menu.about.license");
+    s(4) = i18n::s.get("core.locale.main_menu.about.credits");
 
     gsel(0);
 
@@ -829,7 +800,7 @@ void main_menu_about_one_changelog(const Release& release)
     gmode(2);
     gsel(0);
 
-    ui_draw_caption(jp ? u8"更新履歴" : u8"Changelogs");
+    ui_draw_caption(i18n::s.get("core.locale.main_menu.about_changelog.title"));
 
     while (true)
     {
@@ -914,7 +885,7 @@ MainMenuResult main_menu_about_changelogs()
     gmode(2);
     gsel(0);
 
-    ui_draw_caption(jp ? u8"更新履歴" : u8"Changelogs");
+    ui_draw_caption(i18n::s.get("core.locale.main_menu.about_changelog.title"));
 
     Changelog changelog;
     if (jp)

--- a/src/elona/main_menu.cpp
+++ b/src/elona/main_menu.cpp
@@ -766,25 +766,36 @@ void main_menu_about_one_changelog(const Release& release)
     }
     else
     {
-        constexpr size_t text_width = 60;
-        constexpr size_t lines_per_page = 10;
-        std::string buffer = release.content;
-        talk_conv(buffer, text_width);
-        size_t line_count = 0;
-        for (const auto& line : strutil::split_lines(buffer))
+        const size_t text_width = 75 - en * 15;
+        constexpr size_t lines_per_page = 16;
+
+        std::vector<std::string> buffer;
+        range::copy(
+            strutil::split_lines(release.content), std::back_inserter(buffer));
+        for (auto&& line : buffer)
         {
-            if (line_count == 0)
+            // talk_conv only accepts single line text, so you need to split by
+            // line.
+            talk_conv(line, text_width);
+        }
+        size_t line_count = 0;
+        for (const auto& lines : buffer)
+        {
+            for (const auto& line : strutil::split_lines(lines))
             {
-                changes.push_back(line + '\n');
-            }
-            else
-            {
-                changes.back() += line + '\n';
-            }
-            ++line_count;
-            if (line_count == lines_per_page)
-            {
-                line_count = 0;
+                if (line_count == 0)
+                {
+                    changes.push_back(line + '\n');
+                }
+                else
+                {
+                    changes.back() += line + '\n';
+                }
+                ++line_count;
+                if (line_count == lines_per_page)
+                {
+                    line_count = 0;
+                }
             }
         }
     }
@@ -825,12 +836,12 @@ void main_menu_about_one_changelog(const Release& release)
         ui_display_window(
             release.title(),
             strhint2 + strhint3b,
-            (windoww - 440) / 2 + inf_screenx,
-            winposy(288, 1),
-            440,
-            288);
+            (windoww - 600) / 2 + inf_screenx,
+            winposy(425, 1),
+            600,
+            425);
 
-        font(13 - en * 2);
+        font(13);
         pos(wx + 20, wy + 30);
         mes(changes.at(page));
 

--- a/src/elona/main_menu.cpp
+++ b/src/elona/main_menu.cpp
@@ -1021,7 +1021,125 @@ MainMenuResult main_menu_about_changelogs()
 
 MainMenuResult main_menu_about_license()
 {
-    return MainMenuResult::main_menu_about;
+    std::vector<std::string> license_text_lines;
+    range::copy(
+        fileutil::read_by_line(filesystem::path("../LICENSE")),
+        std::back_inserter(license_text_lines));
+
+    std::vector<std::string> license_pages;
+
+    if (license_text_lines.empty())
+    {
+        license_pages.push_back("");
+    }
+    else
+    {
+        const size_t text_width = 75 - en * 15;
+        constexpr size_t lines_per_page = 16;
+
+        for (auto&& line : license_text_lines)
+        {
+            // talk_conv only accepts single line text, so you need to split by
+            // line.
+            talk_conv(line, text_width);
+        }
+        size_t line_count = 0;
+        for (const auto& lines : license_text_lines)
+        {
+            for (const auto& line : strutil::split_lines(lines))
+            {
+                if (line_count == 0)
+                {
+                    license_pages.push_back(line + '\n');
+                }
+                else
+                {
+                    license_pages.back() += line + '\n';
+                }
+                ++line_count;
+                if (line_count == lines_per_page)
+                {
+                    line_count = 0;
+                }
+            }
+        }
+    }
+    pagemax = license_pages.size() - 1;
+
+    page = 0;
+
+    gsel(4);
+    gmode(0);
+    pos(0, 0);
+    picload(filesystem::dir::graphic() / u8"void.bmp", 1);
+    gcopy(4, 0, 0, 800, 600, windoww, windowh);
+    gmode(2);
+    gsel(0);
+
+    ui_draw_caption(i18n::s.get("core.locale.main_menu.about.license"));
+
+    while (true)
+    {
+    savegame_change_page:
+        gmode(0);
+        pos(0, 0);
+        gcopy(4, 0, 0, windoww, windowh);
+        gmode(2);
+
+        cs_bk = -1;
+        if (page < 0)
+        {
+            page = pagemax;
+        }
+        else if (page > pagemax)
+        {
+            page = 0;
+        }
+
+        windowshadow = 1;
+    savegame_draw_page:
+        ui_display_window(
+            "",
+            strhint2 + strhint3b,
+            (windoww - 600) / 2 + inf_screenx,
+            winposy(425, 1),
+            600,
+            425);
+
+        font(13);
+        pos(wx + 20, wy + 30);
+        mes(license_pages.at(page));
+
+        redraw();
+
+        int cursor{};
+        auto action = cursor_check_ex(cursor);
+        (void)cursor;
+
+        if (action == "next_page")
+        {
+            if (pagemax != 0)
+            {
+                snd("core.pop1");
+                ++page;
+                goto savegame_change_page;
+            }
+        }
+        if (action == "previous_page")
+        {
+            if (pagemax != 0)
+            {
+                snd("core.pop1");
+                --page;
+                goto savegame_change_page;
+            }
+        }
+        if (action == "cancel")
+        {
+            return MainMenuResult::main_menu_about;
+        }
+        goto savegame_draw_page;
+    }
 }
 
 

--- a/src/elona/main_menu.hpp
+++ b/src/elona/main_menu.hpp
@@ -9,6 +9,10 @@ enum class MainMenuResult
     main_menu_new_game,
     main_menu_continue,
     main_menu_incarnate,
+    main_menu_about,
+    main_menu_about_changelogs,
+    main_menu_about_license,
+    main_menu_about_credits,
     character_making_select_race,
     character_making_select_sex,
     character_making_select_sex_looped,
@@ -30,5 +34,9 @@ MainMenuResult main_menu_new_game();
 MainMenuResult main_title_menu();
 MainMenuResult main_menu_continue();
 MainMenuResult main_menu_incarnate();
+MainMenuResult main_menu_about();
+MainMenuResult main_menu_about_changelogs();
+MainMenuResult main_menu_about_license();
+MainMenuResult main_menu_about_credits();
 
 } // namespace elona

--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -295,8 +295,9 @@ void text_set()
         _melee(1, 7) = u8"attack"s;
         _melee(2, 7) = u8"spore"s;
     }
-    homepage = i18n::s.get("core.locale.system.lafrontier_homepage");
 }
+
+
 
 bool maybe_show_ex_help(int id, bool should_update_screen)
 {

--- a/src/elona/std.cpp
+++ b/src/elona/std.cpp
@@ -333,12 +333,6 @@ int dialog(const std::string& message, int option)
 
 
 
-void exec(const std::string&, int)
-{
-}
-
-
-
 void font(int size, snail::Font::Style style)
 {
     snail::hsp::font(

--- a/src/elona/variables.hpp
+++ b/src/elona/variables.hpp
@@ -628,7 +628,6 @@ ELONA_EXTERN(std::string dbidn);
 ELONA_EXTERN(std::string defload);
 ELONA_EXTERN(std::string fmapfile);
 ELONA_EXTERN(std::string geneuse);
-ELONA_EXTERN(std::string homepage);
 ELONA_EXTERN(std::string mid);
 ELONA_EXTERN(std::string note_buff);
 ELONA_EXTERN(std::string playerid);


### PR DESCRIPTION
# Summary

"View the Homepage" in the main title menu was not implemented before in this variant. In addition, vanilla's (and most variants other than foobar) link to Elona's website has broken. This pul request changes the menu item to "About" which shows more detailed information.

# Screenshots

Japanese

![image](https://user-images.githubusercontent.com/36858341/50782582-cef09a80-12eb-11e9-9d95-f2bb458c4528.png)

English
![image](https://user-images.githubusercontent.com/36858341/50783330-d7e26b80-12ed-11e9-971f-650ba2357d56.png)



# Details

- Vanilla Elona Homepage
  - Open the website, http://ylvania.org/jp or http://ylvania.org/en.
- Elona foobar Homepage
  - Open the website, https://elonafoobar.com.
- Elona foobar Changelog
  - Format CHANGELOG.md or CHANGELOG-jp.md and show it.
- License
  - Show LICENSE.
- Credits
  - Show CREDITS.

The current implementation only shows Elona foobar's LICENSE and CREDITS.