### PR TITLE
Fix prompt with number not returning input number

### DIFF
--- a/src/elona/blending.cpp
+++ b/src/elona/blending.cpp
@@ -665,12 +665,13 @@ label_1923:
             prompt.append("start", snail::Key::key_a);
             prompt.append("go_back", snail::Key::key_b);
             prompt.append("from_the_start", snail::Key::key_c);
-            rtval = prompt.query(promptx, prompty, 220);
+            const auto result = prompt.query(promptx, prompty, 220);
+            rtval = result.index;
 
             rpmode = 0;
             if (rtval == 0)
             {
-                rpref(1) = TODO_show_prompt_val;
+                rpref(1) = result.number;
                 rpref(2) = rpdata(1, rpid);
                 rpref(3) = rpdiff(rpid, step, -1);
                 continuous_action_blending();

--- a/src/elona/input.cpp
+++ b/src/elona/input.cpp
@@ -19,10 +19,6 @@
 namespace elona
 {
 
-
-int TODO_show_prompt_val;
-
-
 void input_number_dialog(int x, int y, int max_number, int initial_number)
 {
     snd("core.pop2");

--- a/src/elona/input.hpp
+++ b/src/elona/input.hpp
@@ -8,8 +8,6 @@
 namespace elona
 {
 
-extern int TODO_show_prompt_val;
-
 enum class ActionCategory;
 class InputContext;
 

--- a/src/elona/input_prompt.cpp
+++ b/src/elona/input_prompt.cpp
@@ -140,6 +140,14 @@ void Prompt::_draw_entries()
 }
 
 
+
+PromptWithNumber::Result PromptWithNumber::query(int x, int y, int width)
+{
+    const auto index = Prompt::query(x, y, width);
+    return {index, _show_prompt_val};
+}
+
+
 void PromptWithNumber::_draw_box()
 {
     dx(0) = 200;

--- a/src/elona/input_prompt.hpp
+++ b/src/elona/input_prompt.hpp
@@ -82,14 +82,27 @@ private:
     int _promptmax{};
 };
 
+
+
 class PromptWithNumber : public Prompt
 {
 public:
+    struct Result
+    {
+        int index;
+        int number;
+    };
+
+
     PromptWithNumber(int number, I18NKey locale_key_root)
         : Prompt(locale_key_root)
     {
         _number = number;
     }
+
+
+    Result query(int x, int y, int width);
+
 
 protected:
     void _draw_box() override;


### PR DESCRIPTION

# Related Issues

Close #1124 


# Summary

Delete legacy global variable, `TODO_show_prompt_val`, and use return value of `PromptWithNumber::query()` instead.