### PR TITLE
Fix text color in character making

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ MKDIR := mkdir
 
 
 all: $(BIN_DIR)
-	cd $(BIN_DIR); cmake .. $(CMAKE_ARGS); make
+	cd $(BIN_DIR); cmake .. $(CMAKE_ARGS); make -j8
 
 
 build: $(BIN_DIR) $(PROGRAM)
@@ -38,7 +38,7 @@ $(BIN_DIR):
 
 
 $(PROGRAM): FORCE
-	cd $(BIN_DIR); cmake .. $(CMAKE_ARGS) -DWITH_TESTS=OFF; make
+	cd $(BIN_DIR); cmake .. $(CMAKE_ARGS) -DWITH_TESTS=OFF; make -j8
 
 
 $(TEST_RUNNER):

--- a/src/elona/ui.cpp
+++ b/src/elona/ui.cpp
@@ -1536,7 +1536,6 @@ void ui_draw_caption(const std::string& text)
     int msgx = 0;
     gmode(0);
     font(16 - en * 2);
-    color(245, 245, 245);
     msgx = 20;
     msgy = 30;
     sx = 760;
@@ -1564,7 +1563,9 @@ void ui_draw_caption(const std::string& text)
         gcopy(3, 672, 477, ap, 2);
     }
     pos(msgx + 18, msgy + vfix + 4);
+    color(245, 245, 245);
     mes(text);
+    color(0, 0, 0);
     gmode(2);
 
     // __s__

--- a/src/snail/filedialog/sdl.cpp
+++ b/src/snail/filedialog/sdl.cpp
@@ -1,7 +1,7 @@
 #include <cstdlib>
 #include <type_traits>
 #include <nfd.h>
-#include "../util/scope_guard.hpp"
+#include "../../util/scope_guard.hpp"
 
 
 


### PR DESCRIPTION

# Related Issues

Close #1131 


# Summary

Restore the draw color changed by `ui_draw_caption()`.

# Screenshot

![image](https://user-images.githubusercontent.com/36858341/50974908-a0fb9800-152f-11e9-99f5-6df8d9a0851c.png)
