### PR TITLE
Delete unnecessary files before deployment

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -107,6 +107,8 @@ after_build:
   - rd /q /s bin\Elona_foobar\tests
   - rd /q /s bin\Elona_foobar\tmp
   - rd /q /s bin\Elona_foobar\user
+  - rd /q /s bin\Elona_foobar\save
+  - del bin\Elona_foobar\log.txt
   - xcopy /s /e /y runtime\* bin\Elona_foobar
   - cd bin
   - 7z a -y Elona_foobar_windows.zip Elona_foobar


### PR DESCRIPTION

# Summary

#1115 is not complete. Delete `log.txt` file and `save\` directory before deployment.