### PR TITLE
Fix default key bindings of x and X

### DIFF
--- a/src/elona/keybind/keybind_actions.cpp
+++ b/src/elona/keybind/keybind_actions.cpp
@@ -88,8 +88,8 @@ void initialize_keybind_actions(ActionMap& actions)
     actions.emplace("wait",                  Action{ActionCategory::game,      {{Key::period,          ModKey::none}, {Key::keypad_5, ModKey::none}}});
     actions.emplace("quick_menu",            Action{ActionCategory::game,      {{Key::key_z,           ModKey::none}}});
     actions.emplace("zap",                   Action{ActionCategory::game,      {{Key::key_z,           ModKey::shift}}});
-    actions.emplace("inventory",             Action{ActionCategory::game,      {{Key::key_x,           ModKey::none}}});
     actions.emplace("quick_inventory",       Action{ActionCategory::game,      {{Key::key_x,           ModKey::shift}}});
+    actions.emplace("inventory",             Action{ActionCategory::game,      {{Key::key_x,           ModKey::none}}});
     actions.emplace("get",                   Action{ActionCategory::game,      {{Key::key_g,           ModKey::none}, {Key::keypad_0, ModKey::none}}});
     actions.emplace("drop",                  Action{ActionCategory::game,      {{Key::key_d,           ModKey::none}}});
     actions.emplace("chara_info",            Action{ActionCategory::game,      {{Key::key_c,           ModKey::none}}});

--- a/src/elona/keybind/keybind_actions.cpp
+++ b/src/elona/keybind/keybind_actions.cpp
@@ -88,8 +88,8 @@ void initialize_keybind_actions(ActionMap& actions)
     actions.emplace("wait",                  Action{ActionCategory::game,      {{Key::period,          ModKey::none}, {Key::keypad_5, ModKey::none}}});
     actions.emplace("quick_menu",            Action{ActionCategory::game,      {{Key::key_z,           ModKey::none}}});
     actions.emplace("zap",                   Action{ActionCategory::game,      {{Key::key_z,           ModKey::shift}}});
-    actions.emplace("quick_inventory",       Action{ActionCategory::game,      {{Key::key_x,           ModKey::shift}}});
-    actions.emplace("inventory",             Action{ActionCategory::game,      {{Key::key_x,           ModKey::none}}});
+    actions.emplace("quick_inventory",       Action{ActionCategory::game,      {{Key::key_x,           ModKey::none}}});
+    actions.emplace("inventory",             Action{ActionCategory::game,      {{Key::key_x,           ModKey::shift}}});
     actions.emplace("get",                   Action{ActionCategory::game,      {{Key::key_g,           ModKey::none}, {Key::keypad_0, ModKey::none}}});
     actions.emplace("drop",                  Action{ActionCategory::game,      {{Key::key_d,           ModKey::none}}});
     actions.emplace("chara_info",            Action{ActionCategory::game,      {{Key::key_c,           ModKey::none}}});


### PR DESCRIPTION
# Related issues

Close #1149.

# Summary

- Fix default key binding of x and X.
  - `x` -> quick inventory
  - `X` -> examine
- Change the order of `x` and `X`.
  - Before:
    - quick menu
    - zap
    - examine
    - quick inventory
  - After:
    - quick menu
     - zap
     - quick inventory
     - examine