### PR TITLE
Restore default environment of Lua console

### DIFF
--- a/src/elona/lua_env/lua_console.cpp
+++ b/src/elona/lua_env/lua_console.cpp
@@ -268,11 +268,10 @@ bool LuaConsole::lua_error_handler(const sol::protected_function_result& pfr)
 }
 
 
-/// Returns true if the Lua input is incomplete, and multiline input should
-/// be used.
+/// Returns true if the Lua input is complete and was executed.
 bool LuaConsole::interpret_lua(const std::string& input)
 {
-    if (input == ""s)
+    if (input.empty())
     {
         return _is_multiline;
     }

--- a/src/elona/lua_env/lua_console.hpp
+++ b/src/elona/lua_env/lua_console.hpp
@@ -45,6 +45,7 @@ private:
 
     static bool is_incomplete_lua_line(const sol::error& error);
     void print_single_line(const std::string& line);
+    bool lua_error_handler(const sol::protected_function_result& pfr);
     bool interpret_lua(const std::string&);
     void input_loop();
     void read_line();


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

#984. Close #1103.


# Summary
Fix interpretation of Lua in the Lua console. (It was missing a pass by reference.)