### PR TITLE
Fix crash when you Return

### DIFF
--- a/runtime/mods/core/data/map.lua
+++ b/runtime/mods/core/data/map.lua
@@ -271,7 +271,7 @@ data:add_multi(
          -- Special case due to Your Home being able to change
          -- position/appearance, so those properties shouldn't be
          -- overwritten when all areas are refreshed.
-         is_home = true,
+         is_fixed = false,
       },
       {
          name = "show_house",
@@ -810,7 +810,7 @@ data:add_multi(
       {
          name = "museum",
          id = 101,
-         is_home = true,
+         is_fixed = false,
 
          -- Dummy; they are overwritten when you build the building.
          is_indoor = true,
@@ -830,7 +830,7 @@ data:add_multi(
       {
          name = "shop",
          id = 102,
-         is_home = true,
+         is_fixed = false,
 
          -- Dummy; they are overwritten when you build the building.
          is_indoor = true,
@@ -850,7 +850,7 @@ data:add_multi(
       {
          name = "crop",
          id = 103,
-         is_home = true,
+         is_fixed = false,
 
          -- Dummy; they are overwritten when you build the building.
          is_indoor = true,
@@ -870,7 +870,7 @@ data:add_multi(
       {
          name = "storage_house",
          id = 104,
-         is_home = true,
+         is_fixed = false,
 
          -- Dummy; they are overwritten when you build the building.
          is_indoor = true,
@@ -890,7 +890,7 @@ data:add_multi(
       {
          name = "ranch",
          id = 31,
-         is_home = true,
+         is_fixed = false,
 
          -- Dummy; they are overwritten when you build the building.
          is_indoor = true,
@@ -910,7 +910,7 @@ data:add_multi(
       {
          name = "your_dungeon",
          id = 39,
-         is_home = true,
+         is_fixed = false,
 
          -- Dummy; they are overwritten when you build the building.
          is_indoor = true,
@@ -930,7 +930,7 @@ data:add_multi(
       {
          name = "random_dungeon",
          id = 8,
-         is_home = true,
+         is_fixed = false,
 
          -- Dummy; they are overwritten when a dungeon is generated.
          is_indoor = true,

--- a/runtime/mods/core/data/map.lua
+++ b/runtime/mods/core/data/map.lua
@@ -927,4 +927,24 @@ data:add_multi(
          tile_set = "Normal",
          outer_map = 4,
       },
+      {
+         name = "random_dungeon",
+         id = 8,
+         is_home = true,
+
+         -- Dummy; they are overwritten when a dungeon is generated.
+         is_indoor = true,
+         appearance = 138,
+         base_turn_cost = 10000,
+         map_type = "PlayerOwned",
+         outer_map_position = { x = 0, y = 0 },
+         deepest_level = 1,
+         entrance_type = "South",
+         is_generated_every_time = false,
+         default_ai_calm = 1,
+         danger_level = 1,
+         tile_type = 3,
+         tile_set = "Normal",
+         outer_map = 4,
+      },
 })

--- a/src/elona/area.cpp
+++ b/src/elona/area.cpp
@@ -172,7 +172,7 @@ void initialize_adata()
 
         // Only set position/tiles of Your Home if it has not been upgraded. All
         // other maps all have fixed positions/tiles.
-        bool is_fixed_in_place = !map.is_home ||
+        bool is_fixed_in_place = map.is_fixed ||
             (map_id == static_cast<int>(mdata_t::MapId::your_home) &&
              game_data.home_scale == 0);
         if (is_fixed_in_place)

--- a/src/elona/data/types/type_map.cpp
+++ b/src/elona/data/types/type_map.cpp
@@ -28,7 +28,7 @@ MapDefData MapDefDB::convert(const lua::ConfigTable& data, const std::string&)
     DATA_OPT_OR(quest_town_id, int, 0);
 
     DATA_OPT_OR(can_return_to, bool, false);
-    DATA_OPT_OR(is_home, bool, false);
+    DATA_OPT_OR(is_fixed, bool, true);
     DATA_OPT_OR(reveals_fog, bool, false);
     DATA_OPT_OR(shows_floor_count_in_name, bool, false);
     DATA_OPT_OR(prevents_teleport, bool, false);
@@ -59,7 +59,7 @@ MapDefData MapDefDB::convert(const lua::ConfigTable& data, const std::string&)
                       quest_town_id,
 
                       can_return_to,
-                      is_home,
+                      is_fixed,
                       reveals_fog,
                       shows_floor_count_in_name,
                       prevents_teleport,

--- a/src/elona/data/types/type_map.hpp
+++ b/src/elona/data/types/type_map.hpp
@@ -25,7 +25,7 @@ struct MapDefData
     int quest_town_id{};
 
     bool can_return_to{};
-    bool is_home{};
+    bool is_fixed{};
     bool reveals_fog{};
     bool shows_floor_count_in_name{};
     bool prevents_teleport{};


### PR DESCRIPTION
# Related issues

#1095

# Summary

Fix crash when you Return if there are some random nefias. Map data of random nefia, map id 8, was missing, and it caused crash on Returning.