### PR TITLE
Do not define "DEBUG" in release build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,9 +337,7 @@ else()
     list(APPEND DEBUG_OPTIONS
       "g"
       "O0"
-      )
-    list(APPEND EXTRA_DEFINES
-      "DEBUG"
+      "DDEBUG"
       )
     if(ELONA_BUILD_TARGET STREQUAL "BENCH")
       list(APPEND GENERAL_OPTIONS "g1")


### PR DESCRIPTION
# Summary

The macro was defined in Linux and macOS regardless of the build type.

