### PR TITLE
Improve ELONA_LOG() macro and output well-formatted logs

### DIFF
--- a/src/elona/audio.cpp
+++ b/src/elona/audio.cpp
@@ -158,13 +158,13 @@ void play_music_inner(const SharedId& music_id, int musicloop)
         auto music = the_music_db[music_id];
         if (!music)
         {
-            ELONA_ERROR() << "Cannot load music " << music_id.get();
+            ELONA_ERROR("Audio") << "Cannot load music " << music_id.get();
             return;
         }
         if (!fs::exists(music->file))
         {
-            ELONA_ERROR() << "Cannot load file " << music->file.string()
-                          << " for music " << music_id.get();
+            ELONA_ERROR("Audio") << "Cannot load file " << music->file.string()
+                                 << " for music " << music_id.get();
             return;
         }
 
@@ -554,7 +554,7 @@ void snd_at(
 
     if (!sound)
     {
-        ELONA_ERROR() << "Cannot load sound " << sound_id;
+        ELONA_ERROR("Audio") << "Cannot load sound " << sound_id;
         return;
     }
 
@@ -576,7 +576,7 @@ void snd(SharedId sound_id, bool loop, bool allow_duplicate)
 
     if (!sound)
     {
-        ELONA_ERROR() << "Cannot load sound " << sound_id;
+        ELONA_ERROR("Audio") << "Cannot load sound " << sound_id;
         return;
     }
 

--- a/src/elona/audio.cpp
+++ b/src/elona/audio.cpp
@@ -158,13 +158,13 @@ void play_music_inner(const SharedId& music_id, int musicloop)
         auto music = the_music_db[music_id];
         if (!music)
         {
-            ELONA_LOG() << "Cannot load music " << music_id.get();
+            ELONA_ERROR() << "Cannot load music " << music_id.get();
             return;
         }
         if (!fs::exists(music->file))
         {
-            ELONA_LOG() << "Cannot load file " << music->file.string()
-                        << " for music " << music_id.get();
+            ELONA_ERROR() << "Cannot load file " << music->file.string()
+                          << " for music " << music_id.get();
             return;
         }
 
@@ -554,7 +554,7 @@ void snd_at(
 
     if (!sound)
     {
-        ELONA_LOG() << "Cannot load sound " << sound_id;
+        ELONA_ERROR() << "Cannot load sound " << sound_id;
         return;
     }
 
@@ -576,7 +576,7 @@ void snd(SharedId sound_id, bool loop, bool allow_duplicate)
 
     if (!sound)
     {
-        ELONA_LOG() << "Cannot load sound " << sound_id;
+        ELONA_ERROR() << "Cannot load sound " << sound_id;
         return;
     }
 

--- a/src/elona/audio.cpp
+++ b/src/elona/audio.cpp
@@ -158,14 +158,13 @@ void play_music_inner(const SharedId& music_id, int musicloop)
         auto music = the_music_db[music_id];
         if (!music)
         {
-            ELONA_LOG("Cannot load music " << music_id.get());
+            ELONA_LOG() << "Cannot load music " << music_id.get();
             return;
         }
         if (!fs::exists(music->file))
         {
-            ELONA_LOG(
-                "Cannot load file " << music->file.string() << " for music "
-                                    << music_id.get());
+            ELONA_LOG() << "Cannot load file " << music->file.string()
+                        << " for music " << music_id.get();
             return;
         }
 
@@ -555,7 +554,7 @@ void snd_at(
 
     if (!sound)
     {
-        ELONA_LOG("Cannot load sound " << sound_id);
+        ELONA_LOG() << "Cannot load sound " << sound_id;
         return;
     }
 
@@ -577,7 +576,7 @@ void snd(SharedId sound_id, bool loop, bool allow_duplicate)
 
     if (!sound)
     {
-        ELONA_LOG("Cannot load sound " << sound_id);
+        ELONA_LOG() << "Cannot load sound " << sound_id;
         return;
     }
 

--- a/src/elona/config/config.cpp
+++ b/src/elona/config/config.cpp
@@ -207,8 +207,8 @@ void convert_and_set_requested_font_quality(std::string variant)
         if (variant != "high")
         {
             // Unknown font quality; fallback to the default value, "high".
-            ELONA_LOG() << "[Config] Warning: Unsupported font quality: "
-                        << variant;
+            ELONA_WARN() << "[Config] Warning: Unsupported font quality: "
+                         << variant;
         }
         snail::Application::instance()
             .get_renderer()

--- a/src/elona/config/config.cpp
+++ b/src/elona/config/config.cpp
@@ -207,8 +207,7 @@ void convert_and_set_requested_font_quality(std::string variant)
         if (variant != "high")
         {
             // Unknown font quality; fallback to the default value, "high".
-            ELONA_WARN() << "[Config] Warning: Unsupported font quality: "
-                         << variant;
+            ELONA_WARN("Config") << "Unsupported font quality: " << variant;
         }
         snail::Application::instance()
             .get_renderer()

--- a/src/elona/config/config.cpp
+++ b/src/elona/config/config.cpp
@@ -207,8 +207,8 @@ void convert_and_set_requested_font_quality(std::string variant)
         if (variant != "high")
         {
             // Unknown font quality; fallback to the default value, "high".
-            ELONA_LOG(
-                "[Config] Warning: Unsupported font quality: " << variant);
+            ELONA_LOG() << "[Config] Warning: Unsupported font quality: "
+                        << variant;
         }
         snail::Application::instance()
             .get_renderer()

--- a/src/elona/config/config.hpp
+++ b/src/elona/config/config.hpp
@@ -159,10 +159,10 @@ public:
             std::string current = get<std::string>(key);
             if (!EnumDef.get_index_of(current))
             {
-                ELONA_LOG() << "Config key "s << key << " had invalid variant "s
-                            << current << ". "s
-                            << "("s << def.type_to_string(key) << ")"s
-                            << "Setting to "s << EnumDef.get_default() << "."s;
+                ELONA_WARN() << "Config key "s << key
+                             << " had invalid variant "s << current << ". "s
+                             << "("s << def.type_to_string(key) << ")"s
+                             << "Setting to "s << EnumDef.get_default() << "."s;
                 set(key, EnumDef.get_default());
             }
         }

--- a/src/elona/config/config.hpp
+++ b/src/elona/config/config.hpp
@@ -159,10 +159,11 @@ public:
             std::string current = get<std::string>(key);
             if (!EnumDef.get_index_of(current))
             {
-                ELONA_WARN() << "Config key "s << key
-                             << " had invalid variant "s << current << ". "s
-                             << "("s << def.type_to_string(key) << ")"s
-                             << "Setting to "s << EnumDef.get_default() << "."s;
+                ELONA_WARN("Config")
+                    << "Config key "s << key << " had invalid variant "s
+                    << current << ". "s
+                    << "("s << def.type_to_string(key) << ")"s
+                    << "Setting to "s << EnumDef.get_default() << "."s;
                 set(key, EnumDef.get_default());
             }
         }
@@ -208,7 +209,7 @@ public:
 
     void set(const std::string& key, const hcl::Value value)
     {
-        ELONA_LOG() << "Set config option: " << key << " to " << value;
+        ELONA_LOG("Config") << "Set: " << key << " to " << value;
 
         if (!def.exists(key))
         {

--- a/src/elona/config/config.hpp
+++ b/src/elona/config/config.hpp
@@ -159,11 +159,10 @@ public:
             std::string current = get<std::string>(key);
             if (!EnumDef.get_index_of(current))
             {
-                ELONA_LOG(
-                    "Config key "s
-                    << key << " had invalid variant "s << current << ". "s
-                    << "("s << def.type_to_string(key) << ")"s
-                    << "Setting to "s << EnumDef.get_default() << "."s);
+                ELONA_LOG() << "Config key "s << key << " had invalid variant "s
+                            << current << ". "s
+                            << "("s << def.type_to_string(key) << ")"s
+                            << "Setting to "s << EnumDef.get_default() << "."s;
                 set(key, EnumDef.get_default());
             }
         }
@@ -209,7 +208,7 @@ public:
 
     void set(const std::string& key, const hcl::Value value)
     {
-        ELONA_LOG("Set config option: " << key << " to " << value);
+        ELONA_LOG() << "Set config option: " << key << " to " << value;
 
         if (!def.exists(key))
         {

--- a/src/elona/ctrl_file.cpp
+++ b/src/elona/ctrl_file.cpp
@@ -197,7 +197,6 @@ void arrayfile(
 {
     if (!fread)
     {
-        ELONA_LOG() << "arrayfile_write: " << filepath;
         arrayfile_write(fmode_str, filepath);
     }
     else
@@ -220,7 +219,9 @@ void load_v1(
     std::ifstream in{filepath.native(), std::ios::binary};
     if (in.fail())
     {
-        ELONA_FATAL() << "error:could not open file at";
+        ELONA_FATAL("Save")
+            << "Could not open file at "
+            << filepathutil::make_preferred_path_in_utf8(filepath);
         throw std::runtime_error(
             u8"Could not open file at "s + filepath.string());
     }
@@ -769,8 +770,6 @@ void fmode_7_8(bool read, const fs::path& dir)
         }
     }
 
-    ELONA_LOG() << "dir:" << dir;
-
     arrayfile(read, u8"cdatan1", dir / u8"cdatan.s1");
     arrayfile(read, u8"qname", dir / u8"qname.s1");
     arrayfile(read, u8"gdatan", dir / u8"gdatan.s1");
@@ -800,7 +799,6 @@ void fmode_7_8(bool read, const fs::path& dir)
             bload(dir / u8"evlist.s1", evlist);
         }
     }
-    ELONA_LOG() << "ctrlfile7:end";
 }
 
 
@@ -1482,7 +1480,6 @@ void Save::clear()
 
 void Save::add(const fs::path& filename)
 {
-    ELONA_LOG() << "add:" << filename;
     saved_files[filename] = true;
 }
 
@@ -1490,7 +1487,6 @@ void Save::add(const fs::path& filename)
 
 void Save::remove(const fs::path& filename)
 {
-    ELONA_LOG() << "remove:" << filename;
     saved_files[filename] = false;
 }
 
@@ -1583,7 +1579,6 @@ void tmpload(const fs::path& filename)
     const auto already_exists = writeloadedbuff(filename);
     if (already_exists)
     {
-        ELONA_LOG() << "tmpload:tmp:" << filename;
         return;
     }
 
@@ -1591,15 +1586,10 @@ void tmpload(const fs::path& filename)
     const auto original_file = filesystem::dir::save(playerid) / filename;
     if (fs::exists(original_file))
     {
-        ELONA_LOG() << "tmpload:copy:" << filename;
         fs::copy_file(
             original_file,
             filesystem::dir::tmp() / filename,
             fs::copy_option::overwrite_if_exists);
-    }
-    else
-    {
-        ELONA_LOG() << "tmpload:not found:" << original_file;
     }
 }
 

--- a/src/elona/ctrl_file.cpp
+++ b/src/elona/ctrl_file.cpp
@@ -220,7 +220,7 @@ void load_v1(
     std::ifstream in{filepath.native(), std::ios::binary};
     if (in.fail())
     {
-        ELONA_LOG() << "error:could not open file at";
+        ELONA_FATAL() << "error:could not open file at";
         throw std::runtime_error(
             u8"Could not open file at "s + filepath.string());
     }

--- a/src/elona/ctrl_file.cpp
+++ b/src/elona/ctrl_file.cpp
@@ -197,7 +197,7 @@ void arrayfile(
 {
     if (!fread)
     {
-        ELONA_LOG("arrayfile_write: " << filepath);
+        ELONA_LOG() << "arrayfile_write: " << filepath;
         arrayfile_write(fmode_str, filepath);
     }
     else
@@ -220,7 +220,7 @@ void load_v1(
     std::ifstream in{filepath.native(), std::ios::binary};
     if (in.fail())
     {
-        ELONA_LOG("error:could not open file at");
+        ELONA_LOG() << "error:could not open file at";
         throw std::runtime_error(
             u8"Could not open file at "s + filepath.string());
     }
@@ -769,7 +769,7 @@ void fmode_7_8(bool read, const fs::path& dir)
         }
     }
 
-    ELONA_LOG("dir:" << dir);
+    ELONA_LOG() << "dir:" << dir;
 
     arrayfile(read, u8"cdatan1", dir / u8"cdatan.s1");
     arrayfile(read, u8"qname", dir / u8"qname.s1");
@@ -800,7 +800,7 @@ void fmode_7_8(bool read, const fs::path& dir)
             bload(dir / u8"evlist.s1", evlist);
         }
     }
-    ELONA_LOG("ctrlfile7:end");
+    ELONA_LOG() << "ctrlfile7:end";
 }
 
 
@@ -1482,7 +1482,7 @@ void Save::clear()
 
 void Save::add(const fs::path& filename)
 {
-    ELONA_LOG("add:" << filename);
+    ELONA_LOG() << "add:" << filename;
     saved_files[filename] = true;
 }
 
@@ -1490,7 +1490,7 @@ void Save::add(const fs::path& filename)
 
 void Save::remove(const fs::path& filename)
 {
-    ELONA_LOG("remove:" << filename);
+    ELONA_LOG() << "remove:" << filename;
     saved_files[filename] = false;
 }
 
@@ -1583,7 +1583,7 @@ void tmpload(const fs::path& filename)
     const auto already_exists = writeloadedbuff(filename);
     if (already_exists)
     {
-        ELONA_LOG("tmpload:tmp:" << filename);
+        ELONA_LOG() << "tmpload:tmp:" << filename;
         return;
     }
 
@@ -1591,7 +1591,7 @@ void tmpload(const fs::path& filename)
     const auto original_file = filesystem::dir::save(playerid) / filename;
     if (fs::exists(original_file))
     {
-        ELONA_LOG("tmpload:copy:" << filename);
+        ELONA_LOG() << "tmpload:copy:" << filename;
         fs::copy_file(
             original_file,
             filesystem::dir::tmp() / filename,
@@ -1599,7 +1599,7 @@ void tmpload(const fs::path& filename)
     }
     else
     {
-        ELONA_LOG("tmpload:not found:" << original_file);
+        ELONA_LOG() << "tmpload:not found:" << original_file;
     }
 }
 

--- a/src/elona/ctrl_file.cpp
+++ b/src/elona/ctrl_file.cpp
@@ -800,7 +800,7 @@ void fmode_7_8(bool read, const fs::path& dir)
             bload(dir / u8"evlist.s1", evlist);
         }
     }
-    ELONA_LOG("ctrlfile7:end")
+    ELONA_LOG("ctrlfile7:end");
 }
 
 

--- a/src/elona/data/lua_lazy_cache.hpp
+++ b/src/elona/data/lua_lazy_cache.hpp
@@ -218,7 +218,7 @@ private:
         {
             std::string message = "Error initializing "s + Traits::type_id +
                 ":" + id.get() + ": " + e.what();
-            ELONA_WARN() << message;
+            ELONA_WARN("Lua.Data") << message;
             std::cerr << message << std::endl;
 
             _errors.emplace(id, e.what());

--- a/src/elona/data/lua_lazy_cache.hpp
+++ b/src/elona/data/lua_lazy_cache.hpp
@@ -218,7 +218,7 @@ private:
         {
             std::string message = "Error initializing "s + Traits::type_id +
                 ":" + id.get() + ": " + e.what();
-            ELONA_LOG(message);
+            ELONA_LOG() << message;
             std::cerr << message << std::endl;
 
             _errors.emplace(id, e.what());

--- a/src/elona/data/lua_lazy_cache.hpp
+++ b/src/elona/data/lua_lazy_cache.hpp
@@ -218,7 +218,7 @@ private:
         {
             std::string message = "Error initializing "s + Traits::type_id +
                 ":" + id.get() + ": " + e.what();
-            ELONA_LOG() << message;
+            ELONA_WARN() << message;
             std::cerr << message << std::endl;
 
             _errors.emplace(id, e.what());

--- a/src/elona/i18n.hpp
+++ b/src/elona/i18n.hpp
@@ -575,7 +575,7 @@ public:
         {
             if (unknown_keys.find(key) == unknown_keys.end())
             {
-                ELONA_ERROR() << "Unknown I18N ID: " << key;
+                ELONA_ERROR("I18N") << "Unknown I18N ID: " << key;
                 unknown_keys.insert(key);
             }
             return u8"<Unknown ID: " + key + ">";
@@ -593,7 +593,7 @@ public:
         {
             if (unknown_keys.find(key) == unknown_keys.end())
             {
-                ELONA_ERROR() << "Unknown I18N ID: " << key;
+                ELONA_ERROR("I18N") << "Unknown I18N ID: " << key;
                 unknown_keys.insert(key);
             }
             return u8"<Unknown ID: " + key + ">";

--- a/src/elona/i18n.hpp
+++ b/src/elona/i18n.hpp
@@ -575,7 +575,7 @@ public:
         {
             if (unknown_keys.find(key) == unknown_keys.end())
             {
-                ELONA_LOG() << "Unknown I18N ID: " << key;
+                ELONA_ERROR() << "Unknown I18N ID: " << key;
                 unknown_keys.insert(key);
             }
             return u8"<Unknown ID: " + key + ">";
@@ -593,7 +593,7 @@ public:
         {
             if (unknown_keys.find(key) == unknown_keys.end())
             {
-                ELONA_LOG() << "Unknown I18N ID: " << key;
+                ELONA_ERROR() << "Unknown I18N ID: " << key;
                 unknown_keys.insert(key);
             }
             return u8"<Unknown ID: " + key + ">";

--- a/src/elona/i18n.hpp
+++ b/src/elona/i18n.hpp
@@ -575,7 +575,7 @@ public:
         {
             if (unknown_keys.find(key) == unknown_keys.end())
             {
-                ELONA_LOG("Unknown I18N ID: " << key);
+                ELONA_LOG() << "Unknown I18N ID: " << key;
                 unknown_keys.insert(key);
             }
             return u8"<Unknown ID: " + key + ">";
@@ -593,7 +593,7 @@ public:
         {
             if (unknown_keys.find(key) == unknown_keys.end())
             {
-                ELONA_LOG("Unknown I18N ID: " << key);
+                ELONA_LOG() << "Unknown I18N ID: " << key;
                 unknown_keys.insert(key);
             }
             return u8"<Unknown ID: " + key + ">";

--- a/src/elona/keybind/keybind.cpp
+++ b/src/elona/keybind/keybind.cpp
@@ -142,7 +142,7 @@ bool keybind_action_has_category(
     }
     if (keybind::actions.find(action_id) == keybind::actions.end())
     {
-        ELONA_WARN() << "No such keybind action " << action_id;
+        ELONA_WARN("KeyBinding") << "No such keybind action " << action_id;
         return false;
     }
 

--- a/src/elona/keybind/keybind.cpp
+++ b/src/elona/keybind/keybind.cpp
@@ -142,7 +142,7 @@ bool keybind_action_has_category(
     }
     if (keybind::actions.find(action_id) == keybind::actions.end())
     {
-        ELONA_LOG("No such keybind action " << action_id);
+        ELONA_LOG() << "No such keybind action " << action_id;
         return false;
     }
 

--- a/src/elona/keybind/keybind.cpp
+++ b/src/elona/keybind/keybind.cpp
@@ -142,7 +142,7 @@ bool keybind_action_has_category(
     }
     if (keybind::actions.find(action_id) == keybind::actions.end())
     {
-        ELONA_LOG() << "No such keybind action " << action_id;
+        ELONA_WARN() << "No such keybind action " << action_id;
         return false;
     }
 

--- a/src/elona/log.cpp
+++ b/src/elona/log.cpp
@@ -21,8 +21,9 @@ void Logger::init(std::ofstream&& out)
 
 
 
-Logger::_OneLineLogger Logger::_get_one_line_logger()
+Logger::_OneLineLogger Logger::_get_one_line_logger(Level level)
 {
+    (void)level;
     return {_out};
 }
 

--- a/src/elona/log.cpp
+++ b/src/elona/log.cpp
@@ -7,18 +7,24 @@ namespace elona
 namespace log
 {
 
-namespace detail
+void Logger::init()
 {
-std::ofstream out;
+    init(std::ofstream((filesystem::dir::exe() / u8"log.txt").native()));
 }
 
 
 
-void initialize()
+void Logger::init(std::ofstream&& out)
 {
-    detail::out.open((filesystem::dir::exe() / u8"log.txt").native());
+    _out = std::move(out);
 }
 
+
+
+Logger::_OneLineLogger Logger::_get_one_line_logger()
+{
+    return {_out};
+}
 
 } // namespace log
 } // namespace elona

--- a/src/elona/log.cpp
+++ b/src/elona/log.cpp
@@ -2,6 +2,7 @@
 #include "filesystem.hpp"
 
 
+
 namespace elona
 {
 namespace log
@@ -17,14 +18,6 @@ void Logger::init()
 void Logger::init(std::ofstream&& out)
 {
     _out = std::move(out);
-}
-
-
-
-Logger::_OneLineLogger Logger::_get_one_line_logger(Level level)
-{
-    (void)level;
-    return {_out};
 }
 
 } // namespace log

--- a/src/elona/log.hpp
+++ b/src/elona/log.hpp
@@ -14,7 +14,35 @@ namespace log
 class Logger : lib::noncopyable
 {
 public:
+    /// Log severity level
+    enum class Level
+    {
+        /**
+         * Normal; everything is okay.
+         * E.g., launching, loading save, loading mod.
+         */
+        log,
+        /**
+         * Unusual, but easily recoverable; Elona will continue to run.
+         * E.g., detected obsolete things, trivial errors.
+         */
+        warn,
+        /**
+         * Serious; Elona will handle the errors and continue to run, but the
+         * error will be notified to let players know there are something wrong.
+         * E.g., mod loading error, corrupted save.
+         */
+        error,
+        /**
+         * Unrecoverable; Elona will stop to run.
+         * E.g., failure of loading core files.
+         */
+        fatal,
+    };
+
+
     // It is public, but DO NOT use this type directly!
+    // To insert a line break at the end of each log, use RAII idiom.
     class _OneLineLogger
     {
     public:
@@ -59,7 +87,8 @@ public:
     void init(std::ofstream&& out);
 
     // It is public, but DO NOT call this function directly!
-    _OneLineLogger _get_one_line_logger();
+    _OneLineLogger _get_one_line_logger(Level level);
+
 
 
 private:
@@ -73,4 +102,18 @@ private:
 
 
 
-#define ELONA_LOG(x) ::elona::log::Logger::instance()._get_one_line_logger()
+#define ELONA_LOG() \
+    ::elona::log::Logger::instance()._get_one_line_logger( \
+        ::elona::log::Logger::Level::log)
+
+#define ELONA_WARN() \
+    ::elona::log::Logger::instance()._get_one_line_logger( \
+        ::elona::log::Logger::Level::warn)
+
+#define ELONA_ERROR() \
+    ::elona::log::Logger::instance()._get_one_line_logger( \
+        ::elona::log::Logger::Level::error)
+
+#define ELONA_FATAL() \
+    ::elona::log::Logger::instance()._get_one_line_logger( \
+        ::elona::log::Logger::Level::fatal)

--- a/src/elona/log.hpp
+++ b/src/elona/log.hpp
@@ -45,7 +45,12 @@ public:
 
 
 
-    static Logger& instance();
+    static Logger& instance()
+    {
+        static Logger instance;
+        return instance;
+    }
+
 
     /// Initialize the logger with the default output file.
     void init();
@@ -68,8 +73,4 @@ private:
 
 
 
-#define ELONA_LOG(x) \
-    do \
-    { \
-        ::elona::log::Logger::instance()._get_one_line_logger() << x; \
-    } while (0)
+#define ELONA_LOG(x) ::elona::log::Logger::instance()._get_one_line_logger()

--- a/src/elona/log.hpp
+++ b/src/elona/log.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <cassert>
 #include <fstream>
 #include <iostream>
+#include <type_traits>
 #include "../util/noncopyable.hpp"
 
 
@@ -11,6 +13,8 @@ namespace elona
 namespace log
 {
 
+// Log format: Level [Tag] Message
+// Example: ERROR [Mod] Failed to load mod "api_nuts".
 class Logger : lib::noncopyable
 {
 public:
@@ -46,15 +50,26 @@ public:
     class _OneLineLogger
     {
     public:
-        _OneLineLogger(std::ofstream& out, bool output_stdout)
+        _OneLineLogger(std::ofstream& out, const std::string& tag, Level level)
             : _out(out)
         {
+            *this << _to_string(level) << u8"[" << tag << u8"] ";
         }
 
 
         ~_OneLineLogger()
         {
-            _out << std::endl;
+            // Need to explicit the template parameters of `std::endl` here
+            // because a compiler cannot infer `T` of the below template
+            // function (`operator<<`). Normal output stream classes like
+            // `std::basic_ostream` have overloads of `operator<<()` which take
+            // manipulators so that we usually don't have to specify
+            // `std::endl`'s template parameters.
+            using StreamT = std::remove_reference_t<decltype(_out)>;
+            using CharT = StreamT::char_type;
+            using CharTraitsT = StreamT::traits_type;
+
+            *this << std::endl<CharT, CharTraitsT>;
         }
 
 
@@ -69,10 +84,24 @@ public:
 
     private:
         std::ofstream& _out;
+
+
+        std::string _to_string(Logger::Level level)
+        {
+            switch (level)
+            {
+            case Logger::Level::log: return "INFO  ";
+            case Logger::Level::warn: return "WARN  ";
+            case Logger::Level::error: return "ERROR ";
+            case Logger::Level::fatal: return "FATAL ";
+            default: assert(0); return "";
+            }
+        }
     };
 
 
 
+    /// Get the singleton instance.
     static Logger& instance()
     {
         static Logger instance;
@@ -87,7 +116,10 @@ public:
     void init(std::ofstream&& out);
 
     // It is public, but DO NOT call this function directly!
-    _OneLineLogger _get_one_line_logger(Level level);
+    _OneLineLogger _get_one_line_logger(const std::string& tag, Level level)
+    {
+        return {_out, tag, level};
+    }
 
 
 
@@ -102,18 +134,18 @@ private:
 
 
 
-#define ELONA_LOG() \
+#define ELONA_LOG(tag) \
     ::elona::log::Logger::instance()._get_one_line_logger( \
-        ::elona::log::Logger::Level::log)
+        tag, ::elona::log::Logger::Level::log)
 
-#define ELONA_WARN() \
+#define ELONA_WARN(tag) \
     ::elona::log::Logger::instance()._get_one_line_logger( \
-        ::elona::log::Logger::Level::warn)
+        tag, ::elona::log::Logger::Level::warn)
 
-#define ELONA_ERROR() \
+#define ELONA_ERROR(tag) \
     ::elona::log::Logger::instance()._get_one_line_logger( \
-        ::elona::log::Logger::Level::error)
+        tag, ::elona::log::Logger::Level::error)
 
-#define ELONA_FATAL() \
+#define ELONA_FATAL(tag) \
     ::elona::log::Logger::instance()._get_one_line_logger( \
-        ::elona::log::Logger::Level::fatal)
+        tag, ::elona::log::Logger::Level::fatal)

--- a/src/elona/lua_env/api_manager.cpp
+++ b/src/elona/lua_env/api_manager.cpp
@@ -95,7 +95,7 @@ void APIManager::load_lua_support_libraries(LuaEnv& lua)
     {
         sol::error err = result;
         std::string what = err.what();
-        ELONA_FATAL() << what;
+        ELONA_FATAL("Lua.Core") << what;
         throw std::runtime_error("Failed initializing Lua support libraries.");
     }
 }

--- a/src/elona/lua_env/api_manager.cpp
+++ b/src/elona/lua_env/api_manager.cpp
@@ -95,7 +95,7 @@ void APIManager::load_lua_support_libraries(LuaEnv& lua)
     {
         sol::error err = result;
         std::string what = err.what();
-        ELONA_LOG() << what;
+        ELONA_FATAL() << what;
         throw std::runtime_error("Failed initializing Lua support libraries.");
     }
 }

--- a/src/elona/lua_env/api_manager.cpp
+++ b/src/elona/lua_env/api_manager.cpp
@@ -95,7 +95,7 @@ void APIManager::load_lua_support_libraries(LuaEnv& lua)
     {
         sol::error err = result;
         std::string what = err.what();
-        ELONA_LOG(what);
+        ELONA_LOG() << what;
         throw std::runtime_error("Failed initializing Lua support libraries.");
     }
 }

--- a/src/elona/lua_env/event_manager.cpp
+++ b/src/elona/lua_env/event_manager.cpp
@@ -182,8 +182,8 @@ void EventManager::trigger_event(EventKind event, sol::table data)
     }
     else
     {
-        ELONA_LOG() << "No callbacks registered for event "
-                    << static_cast<int>(event) << ", skipping.";
+        ELONA_LOG("Lua.Event") << "No callbacks registered for event "
+                               << static_cast<int>(event) << ", skipping.";
     }
 }
 

--- a/src/elona/lua_env/event_manager.cpp
+++ b/src/elona/lua_env/event_manager.cpp
@@ -182,9 +182,8 @@ void EventManager::trigger_event(EventKind event, sol::table data)
     }
     else
     {
-        ELONA_LOG(
-            "No callbacks registered for event " << static_cast<int>(event)
-                                                 << ", skipping.");
+        ELONA_LOG() << "No callbacks registered for event "
+                    << static_cast<int>(event) << ", skipping.";
     }
 }
 

--- a/src/elona/lua_env/lua_api/lua_api_debug.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_debug.cpp
@@ -29,7 +29,7 @@ void LuaApiDebug::report_error(const std::string& message)
         txt(line + "  ", Message::color{ColorIndex::red});
     }
 
-    ELONA_LOG() << "Script error: " << message;
+    ELONA_ERROR() << "Script error: " << message;
     std::cerr << "Script error: " << message << std::endl;
 }
 

--- a/src/elona/lua_env/lua_api/lua_api_debug.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_debug.cpp
@@ -15,7 +15,7 @@ namespace lua
 
 void LuaApiDebug::log(const std::string& message)
 {
-    ELONA_LOG() << message;
+    ELONA_LOG("Lua.Debug") << message;
 }
 
 void LuaApiDebug::report_error(const std::string& message)
@@ -29,36 +29,35 @@ void LuaApiDebug::report_error(const std::string& message)
         txt(line + "  ", Message::color{ColorIndex::red});
     }
 
-    ELONA_ERROR() << "Script error: " << message;
+    ELONA_ERROR("Lua.Debug") << "Script error: " << message;
     std::cerr << "Script error: " << message << std::endl;
 }
 
 void LuaApiDebug::dump_characters()
 {
-    ELONA_LOG() << "===== Charas =====";
+    ELONA_LOG("Lua.Debug") << "===== Charas =====";
     for (int cnt = 0; cnt < ELONA_MAX_CHARACTERS; ++cnt)
     {
         if (elona::cdata[cnt].state() != Character::State::empty)
-            ELONA_LOG() << elona::cdata[cnt].index
-                        << ") Name: " << elona::name(cnt)
-                        << ", Pos: " << elona::cdata[cnt].position;
+            ELONA_LOG("Lua.Debug")
+                << elona::cdata[cnt].index << ") Name: " << elona::name(cnt)
+                << ", Pos: " << elona::cdata[cnt].position;
     }
 }
 
 void LuaApiDebug::dump_items()
 {
-    ELONA_LOG() << "===== Items  =====";
+    ELONA_LOG("Lua.Debug") << "===== Items  =====";
     for (const auto& cnt : items(-1))
     {
         if (elona::inv[cnt].number() != 0)
-            ELONA_LOG() << elona::inv[cnt].index
-                        << ") Name: " << elona::itemname(cnt)
-                        << ", Pos: " << elona::inv[cnt].position << ", Curse: "
-                        << static_cast<int>(elona::inv[cnt].curse_state)
-                        << ", Ident: "
-                        << static_cast<int>(
-                               elona::inv[cnt].identification_state)
-                        << ", Count: " << elona::inv[cnt].count;
+            ELONA_LOG("Lua.Debug")
+                << elona::inv[cnt].index << ") Name: " << elona::itemname(cnt)
+                << ", Pos: " << elona::inv[cnt].position
+                << ", Curse: " << static_cast<int>(elona::inv[cnt].curse_state)
+                << ", Ident: "
+                << static_cast<int>(elona::inv[cnt].identification_state)
+                << ", Count: " << elona::inv[cnt].count;
     }
 }
 

--- a/src/elona/lua_env/lua_api/lua_api_debug.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_debug.cpp
@@ -15,7 +15,7 @@ namespace lua
 
 void LuaApiDebug::log(const std::string& message)
 {
-    ELONA_LOG(message);
+    ELONA_LOG() << message;
 }
 
 void LuaApiDebug::report_error(const std::string& message)
@@ -29,36 +29,36 @@ void LuaApiDebug::report_error(const std::string& message)
         txt(line + "  ", Message::color{ColorIndex::red});
     }
 
-    ELONA_LOG("Script error: " << message);
+    ELONA_LOG() << "Script error: " << message;
     std::cerr << "Script error: " << message << std::endl;
 }
 
 void LuaApiDebug::dump_characters()
 {
-    ELONA_LOG("===== Charas =====")
+    ELONA_LOG() << "===== Charas =====";
     for (int cnt = 0; cnt < ELONA_MAX_CHARACTERS; ++cnt)
     {
         if (elona::cdata[cnt].state() != Character::State::empty)
-            ELONA_LOG(
-                elona::cdata[cnt].index
-                << ") Name: " << elona::name(cnt)
-                << ", Pos: " << elona::cdata[cnt].position);
+            ELONA_LOG() << elona::cdata[cnt].index
+                        << ") Name: " << elona::name(cnt)
+                        << ", Pos: " << elona::cdata[cnt].position;
     }
 }
 
 void LuaApiDebug::dump_items()
 {
-    ELONA_LOG("===== Items  =====")
+    ELONA_LOG() << "===== Items  =====";
     for (const auto& cnt : items(-1))
     {
         if (elona::inv[cnt].number() != 0)
-            ELONA_LOG(
-                elona::inv[cnt].index
-                << ") Name: " << elona::itemname(cnt)
-                << ", Pos: " << elona::inv[cnt].position << ", Curse: "
-                << static_cast<int>(elona::inv[cnt].curse_state) << ", Ident: "
-                << static_cast<int>(elona::inv[cnt].identification_state)
-                << ", Count: " << elona::inv[cnt].count);
+            ELONA_LOG() << elona::inv[cnt].index
+                        << ") Name: " << elona::itemname(cnt)
+                        << ", Pos: " << elona::inv[cnt].position << ", Curse: "
+                        << static_cast<int>(elona::inv[cnt].curse_state)
+                        << ", Ident: "
+                        << static_cast<int>(
+                               elona::inv[cnt].identification_state)
+                        << ", Count: " << elona::inv[cnt].count;
     }
 }
 

--- a/src/elona/lua_env/lua_enums.hpp
+++ b/src/elona/lua_env/lua_enums.hpp
@@ -44,8 +44,8 @@ public:
         auto it = storage.find(key);
         if (it == storage.end())
         {
-            ELONA_LOG() << "Enum value " << key << " for " << name
-                        << " not found, using default";
+            ELONA_WARN() << "Enum value " << key << " for " << name
+                         << " not found, using default";
             return default_val;
         }
 

--- a/src/elona/lua_env/lua_enums.hpp
+++ b/src/elona/lua_env/lua_enums.hpp
@@ -44,9 +44,8 @@ public:
         auto it = storage.find(key);
         if (it == storage.end())
         {
-            ELONA_LOG(
-                "Enum value " << key << " for " << name
-                              << " not found, using default");
+            ELONA_LOG() << "Enum value " << key << " for " << name
+                        << " not found, using default";
             return default_val;
         }
 

--- a/src/elona/lua_env/lua_enums.hpp
+++ b/src/elona/lua_env/lua_enums.hpp
@@ -44,8 +44,8 @@ public:
         auto it = storage.find(key);
         if (it == storage.end())
         {
-            ELONA_WARN() << "Enum value " << key << " for " << name
-                         << " not found, using default";
+            ELONA_WARN("Lua.Enum") << "Enum value " << key << " for " << name
+                                   << " not found, using default";
             return default_val;
         }
 

--- a/src/elona/lua_env/mod_manager.cpp
+++ b/src/elona/lua_env/mod_manager.cpp
@@ -76,7 +76,7 @@ void ModManager::load_mods(
 void report_error(sol::error err)
 {
     std::string what = err.what();
-    ELONA_ERROR() << what;
+    ELONA_ERROR("Lua.Mod") << what;
 }
 
 
@@ -150,7 +150,7 @@ void ModManager::scan_mod(const fs::path& mod_dir)
     ModManifest manifest = ModManifest::load(manifest_path);
 
     const std::string mod_name = mod_dir.filename().string();
-    ELONA_LOG() << "Found mod " << mod_name;
+    ELONA_LOG("Lua.Mod") << "Found mod " << mod_name;
 
     if (!_is_alnum_only(mod_name))
     {
@@ -224,7 +224,7 @@ void ModManager::load_scanned_mods()
         {
             load_mod(*mod);
         }
-        ELONA_LOG() << "Loaded mod " << mod->manifest.name;
+        ELONA_LOG("Lua.Mod") << "Loaded mod " << mod->manifest.name;
     }
 
     lua_->get_event_manager().run_callbacks<EventKind::all_mods_loaded>();
@@ -253,7 +253,7 @@ void ModManager::run_startup_script(const std::string& name)
     // Bypass read-only metatable
     script_mod->env.raw_set("data", lua_->get_data_manager().get().storage);
 
-    ELONA_LOG() << "Loaded startup script " << name;
+    ELONA_LOG("Lua.Mod") << "Loaded startup script " << name;
     txt(i18n::s.get("core.locale.mod.loaded_script", name),
         Message::color{ColorIndex::purple});
     Message::instance().linebreak();

--- a/src/elona/lua_env/mod_manager.cpp
+++ b/src/elona/lua_env/mod_manager.cpp
@@ -76,7 +76,7 @@ void ModManager::load_mods(
 void report_error(sol::error err)
 {
     std::string what = err.what();
-    ELONA_LOG(what);
+    ELONA_LOG() << what;
 }
 
 
@@ -150,7 +150,7 @@ void ModManager::scan_mod(const fs::path& mod_dir)
     ModManifest manifest = ModManifest::load(manifest_path);
 
     const std::string mod_name = mod_dir.filename().string();
-    ELONA_LOG("Found mod " << mod_name);
+    ELONA_LOG() << "Found mod " << mod_name;
 
     if (!_is_alnum_only(mod_name))
     {
@@ -224,7 +224,7 @@ void ModManager::load_scanned_mods()
         {
             load_mod(*mod);
         }
-        ELONA_LOG("Loaded mod " << mod->manifest.name);
+        ELONA_LOG() << "Loaded mod " << mod->manifest.name;
     }
 
     lua_->get_event_manager().run_callbacks<EventKind::all_mods_loaded>();
@@ -253,7 +253,7 @@ void ModManager::run_startup_script(const std::string& name)
     // Bypass read-only metatable
     script_mod->env.raw_set("data", lua_->get_data_manager().get().storage);
 
-    ELONA_LOG("Loaded startup script " << name);
+    ELONA_LOG() << "Loaded startup script " << name;
     txt(i18n::s.get("core.locale.mod.loaded_script", name),
         Message::color{ColorIndex::purple});
     Message::instance().linebreak();

--- a/src/elona/lua_env/mod_manager.cpp
+++ b/src/elona/lua_env/mod_manager.cpp
@@ -76,7 +76,7 @@ void ModManager::load_mods(
 void report_error(sol::error err)
 {
     std::string what = err.what();
-    ELONA_LOG() << what;
+    ELONA_ERROR() << what;
 }
 
 

--- a/src/elona/save.cpp
+++ b/src/elona/save.cpp
@@ -16,7 +16,7 @@ namespace elona
 
 void load_save_data()
 {
-    ELONA_LOG("Load save data: " << playerid);
+    ELONA_LOG() << "Load save data: " << playerid;
 
     // TODO instead serialize/deserialize data
     lua::lua->get_handle_manager().clear_map_local_handles();
@@ -76,7 +76,7 @@ void load_save_data()
     }
     refresh_speed(cdata.player());
     time_begin = timeGetTime() / 1000;
-    ELONA_LOG("Load save data end: " << playerid);
+    ELONA_LOG() << "Load save data end: " << playerid;
 }
 
 
@@ -92,7 +92,7 @@ void do_save_game()
 
 void save_game()
 {
-    ELONA_LOG("Save game: " << playerid);
+    ELONA_LOG() << "Save game: " << playerid;
 
     int save_f = 0;
     if (game_data.current_map == mdata_t::MapId::show_house)
@@ -122,7 +122,7 @@ void save_game()
     Save::instance().save(save_dir);
     ctrl_file(FileOperation2::global_write, save_dir);
     Save::instance().clear();
-    ELONA_LOG("Save game: finish");
+    ELONA_LOG() << "Save game: finish";
 }
 
 } // namespace elona

--- a/src/elona/save.cpp
+++ b/src/elona/save.cpp
@@ -16,7 +16,7 @@ namespace elona
 
 void load_save_data()
 {
-    ELONA_LOG() << "Load save data: " << playerid;
+    ELONA_LOG("Save") << "Load: " << playerid;
 
     // TODO instead serialize/deserialize data
     lua::lua->get_handle_manager().clear_map_local_handles();
@@ -76,7 +76,7 @@ void load_save_data()
     }
     refresh_speed(cdata.player());
     time_begin = timeGetTime() / 1000;
-    ELONA_LOG() << "Load save data end: " << playerid;
+    ELONA_LOG("Save") << "Load end: " << playerid;
 }
 
 
@@ -92,7 +92,7 @@ void do_save_game()
 
 void save_game()
 {
-    ELONA_LOG() << "Save game: " << playerid;
+    ELONA_LOG("Save") << "Save: " << playerid;
 
     int save_f = 0;
     if (game_data.current_map == mdata_t::MapId::show_house)
@@ -122,7 +122,7 @@ void save_game()
     Save::instance().save(save_dir);
     ctrl_file(FileOperation2::global_write, save_dir);
     Save::instance().clear();
-    ELONA_LOG() << "Save game: finish";
+    ELONA_LOG("Save") << "Save end:" << playerid;
 }
 
 } // namespace elona

--- a/src/elona/save_update.cpp
+++ b/src/elona/save_update.cpp
@@ -75,8 +75,8 @@ void _update_save_data_1(const fs::path& save_dir, int serial_id)
             if (!old_race_id.empty() &&
                 !strutil::starts_with(old_race_id, "core."))
             {
-                ELONA_LOG() << "[Save data] Prepend \"core\" prefix to "
-                            << chara.at(0) << ": " << old_race_id;
+                ELONA_LOG("Save.Update") << "Prepend \"core\" prefix to "
+                                         << chara.at(0) << ": " << old_race_id;
                 chara.at(2) = "core." + old_race_id;
             }
         }
@@ -137,8 +137,8 @@ void _update_save_data_2(const fs::path& save_dir, int serial_id)
             if (!old_class_id.empty() &&
                 !strutil::starts_with(old_class_id, "core."))
             {
-                ELONA_LOG() << "[Save data] Prepend \"core\" prefix to "
-                            << chara.at(0) << ": " << old_class_id;
+                ELONA_LOG("Save.Update") << "Prepend \"core\" prefix to "
+                                         << chara.at(0) << ": " << old_class_id;
                 chara.at(3) = "core." + old_class_id;
             }
         }
@@ -464,9 +464,9 @@ void _update_save_data_3(const fs::path& save_dir, int serial_id)
             if (god_id != core_god::eyth &&
                 !strutil::starts_with(god_id, "core."))
             {
-                ELONA_LOG()
-                    << "[Save data] Prepend \"core\" prefix to character("
-                    << idx << "): " << god_id;
+                ELONA_LOG("Save.Update")
+                    << "Prepend \"core\" prefix to character(" << idx
+                    << "): " << god_id;
                 god_id = "core." + god_id;
             }
             // Dump character data to the memory stream.
@@ -721,7 +721,7 @@ void _update_save_data_4(const fs::path& save_dir, int serial_id)
             // Prepend "core" prefix to old god IDs.
             if (image == 649)
             {
-                ELONA_LOG() << "[Save data] Change item chip 649 to 261.";
+                ELONA_LOG("Save.Update") << "Change item chip 649 to 261.";
                 image = 261;
             }
             // Dump item data to the memory stream.
@@ -1154,9 +1154,10 @@ void _update_save_data_5(const fs::path& save_dir, int serial_id)
                 {
                     portrait_ = sex ? "core.woman1" : "core.man1";
                 }
-                ELONA_LOG() << "[Save data] Convert portrait ID of "
-                            << "character(" << idx << "): " << portrait
-                            << " => " << portrait_;
+                ELONA_LOG("Save.Update")
+                    << "Convert portrait ID of "
+                    << "character(" << idx << "): " << portrait << " => "
+                    << portrait_;
             }
             // Dump character data to the memory stream.
             {
@@ -1333,8 +1334,8 @@ void _update_save_data_6(const fs::path& save_dir, int serial_id)
         // Modify indoor flags.
 
         const auto modify_indoor_flag = [&data](int map_id) {
-            ELONA_LOG() << "[Save data] Make the map(" << map_id
-                        << ") outdoor.";
+            ELONA_LOG("Save.Update")
+                << "Make the map(" << map_id << ") outdoor.";
             data.at(map_id * 40 + 21) = 2;
         };
 
@@ -1439,9 +1440,10 @@ void _update_save_data_7(const fs::path& save_dir, int serial_id)
             Position new_downstairs_pos{actual_stair_down_pos % 1000,
                                         actual_stair_down_pos / 1000};
 
-            ELONA_LOG() << "[Save data] Correct downstairs position in "
-                        << entry.path().filename() << ": " << old_downstairs_pos
-                        << " -> " << new_downstairs_pos << ".";
+            ELONA_LOG("Save.Update")
+                << "Correct downstairs position in " << entry.path().filename()
+                << ": " << old_downstairs_pos << " -> " << new_downstairs_pos
+                << ".";
 
             data.at(4) = actual_stair_down_pos;
             fixed = true;
@@ -1452,9 +1454,10 @@ void _update_save_data_7(const fs::path& save_dir, int serial_id)
             Position new_upstairs_pos{actual_stair_up_pos % 1000,
                                       actual_stair_up_pos / 1000};
 
-            ELONA_LOG() << "[Save data] Correct upstairs position in "
-                        << entry.path().filename() << ": " << old_upstairs_pos
-                        << " -> " << new_upstairs_pos << ".";
+            ELONA_LOG("Save.Update")
+                << "Correct upstairs position in " << entry.path().filename()
+                << ": " << old_upstairs_pos << " -> " << new_upstairs_pos
+                << ".";
 
             data.at(5) = actual_stair_up_pos;
             fixed = true;
@@ -1527,8 +1530,8 @@ void update_save_data(const fs::path& save_dir)
          serial_id != latest_version.serial_id;
          ++serial_id)
     {
-        ELONA_LOG() << "[Save data] Update save data from #" << serial_id
-                    << " to #" << (serial_id + 1) << ".";
+        ELONA_LOG("Save.Update") << "Update save data from #" << serial_id
+                                 << " to #" << (serial_id + 1) << ".";
         _update_save_data(save_dir, serial_id);
     }
     version = latest_version;

--- a/src/elona/save_update.cpp
+++ b/src/elona/save_update.cpp
@@ -75,9 +75,8 @@ void _update_save_data_1(const fs::path& save_dir, int serial_id)
             if (!old_race_id.empty() &&
                 !strutil::starts_with(old_race_id, "core."))
             {
-                ELONA_LOG(
-                    "[Save data] Prepend \"core\" prefix to "
-                    << chara.at(0) << ": " << old_race_id);
+                ELONA_LOG() << "[Save data] Prepend \"core\" prefix to "
+                            << chara.at(0) << ": " << old_race_id;
                 chara.at(2) = "core." + old_race_id;
             }
         }
@@ -138,9 +137,8 @@ void _update_save_data_2(const fs::path& save_dir, int serial_id)
             if (!old_class_id.empty() &&
                 !strutil::starts_with(old_class_id, "core."))
             {
-                ELONA_LOG(
-                    "[Save data] Prepend \"core\" prefix to "
-                    << chara.at(0) << ": " << old_class_id);
+                ELONA_LOG() << "[Save data] Prepend \"core\" prefix to "
+                            << chara.at(0) << ": " << old_class_id;
                 chara.at(3) = "core." + old_class_id;
             }
         }
@@ -466,9 +464,9 @@ void _update_save_data_3(const fs::path& save_dir, int serial_id)
             if (god_id != core_god::eyth &&
                 !strutil::starts_with(god_id, "core."))
             {
-                ELONA_LOG(
-                    "[Save data] Prepend \"core\" prefix to character("
-                    << idx << "): " << god_id);
+                ELONA_LOG()
+                    << "[Save data] Prepend \"core\" prefix to character("
+                    << idx << "): " << god_id;
                 god_id = "core." + god_id;
             }
             // Dump character data to the memory stream.
@@ -723,7 +721,7 @@ void _update_save_data_4(const fs::path& save_dir, int serial_id)
             // Prepend "core" prefix to old god IDs.
             if (image == 649)
             {
-                ELONA_LOG("[Save data] Change item chip 649 to 261.");
+                ELONA_LOG() << "[Save data] Change item chip 649 to 261.";
                 image = 261;
             }
             // Dump item data to the memory stream.
@@ -1156,10 +1154,9 @@ void _update_save_data_5(const fs::path& save_dir, int serial_id)
                 {
                     portrait_ = sex ? "core.woman1" : "core.man1";
                 }
-                ELONA_LOG(
-                    "[Save data] Convert portrait ID of "
-                    << "character(" << idx << "): " << portrait << " => "
-                    << portrait_);
+                ELONA_LOG() << "[Save data] Convert portrait ID of "
+                            << "character(" << idx << "): " << portrait
+                            << " => " << portrait_;
             }
             // Dump character data to the memory stream.
             {
@@ -1336,7 +1333,8 @@ void _update_save_data_6(const fs::path& save_dir, int serial_id)
         // Modify indoor flags.
 
         const auto modify_indoor_flag = [&data](int map_id) {
-            ELONA_LOG("[Save data] Make the map(" << map_id << ") outdoor.");
+            ELONA_LOG() << "[Save data] Make the map(" << map_id
+                        << ") outdoor.";
             data.at(map_id * 40 + 21) = 2;
         };
 
@@ -1441,10 +1439,9 @@ void _update_save_data_7(const fs::path& save_dir, int serial_id)
             Position new_downstairs_pos{actual_stair_down_pos % 1000,
                                         actual_stair_down_pos / 1000};
 
-            ELONA_LOG(
-                "[Save data] Correct downstairs position in "
-                << entry.path().filename() << ": " << old_downstairs_pos
-                << " -> " << new_downstairs_pos << ".");
+            ELONA_LOG() << "[Save data] Correct downstairs position in "
+                        << entry.path().filename() << ": " << old_downstairs_pos
+                        << " -> " << new_downstairs_pos << ".";
 
             data.at(4) = actual_stair_down_pos;
             fixed = true;
@@ -1455,10 +1452,9 @@ void _update_save_data_7(const fs::path& save_dir, int serial_id)
             Position new_upstairs_pos{actual_stair_up_pos % 1000,
                                       actual_stair_up_pos / 1000};
 
-            ELONA_LOG(
-                "[Save data] Correct upstairs position in "
-                << entry.path().filename() << ": " << old_upstairs_pos << " -> "
-                << new_upstairs_pos << ".");
+            ELONA_LOG() << "[Save data] Correct upstairs position in "
+                        << entry.path().filename() << ": " << old_upstairs_pos
+                        << " -> " << new_upstairs_pos << ".";
 
             data.at(5) = actual_stair_up_pos;
             fixed = true;
@@ -1531,9 +1527,8 @@ void update_save_data(const fs::path& save_dir)
          serial_id != latest_version.serial_id;
          ++serial_id)
     {
-        ELONA_LOG(
-            "[Save data] Update save data from #" << serial_id << " to #"
-                                                  << (serial_id + 1) << ".");
+        ELONA_LOG() << "[Save data] Update save data from #" << serial_id
+                    << " to #" << (serial_id + 1) << ".";
         _update_save_data(save_dir, serial_id);
     }
     version = latest_version;

--- a/src/elona/std.cpp
+++ b/src/elona/std.cpp
@@ -118,7 +118,7 @@ void await(int msec)
             Config::instance().get<bool>("core.config.android.quicksave") &&
             !std::uncaught_exception())
         {
-            ELONA_LOG("Focus lost, quicksaving game.");
+            ELONA_LOG() << "Focus lost, quicksaving game.";
             snail::android::toast(
                 i18n::s.get("core.locale.ui.save_on_suspend"),
                 snail::android::ToastLength::long_length);

--- a/src/elona/std.cpp
+++ b/src/elona/std.cpp
@@ -118,7 +118,7 @@ void await(int msec)
             Config::instance().get<bool>("core.config.android.quicksave") &&
             !std::uncaught_exception())
         {
-            ELONA_LOG() << "Focus lost, quicksaving game.";
+            ELONA_LOG("GUI") << "Focus lost, quicksaving game.";
             snail::android::toast(
                 i18n::s.get("core.locale.ui.save_on_suspend"),
                 snail::android::ToastLength::long_length);

--- a/src/elona/testing.cpp
+++ b/src/elona/testing.cpp
@@ -127,7 +127,7 @@ void run_in_temporary_map(int map, int level, std::function<void()> f)
 
 void pre_init()
 {
-    log::initialize();
+    log::Logger::instance().init();
 
     const fs::path config_def_file =
         filesystem::dir::mods() / u8"core"s / u8"config"s / u8"config_def.hcl"s;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,7 @@ void report_error(const char* what)
     LOGD("Error: %s", what);
 #endif
 
-    ELONA_FATAL() << "Error: " << what;
+    ELONA_FATAL("System") << what;
     std::cerr << "Error: " << what << std::endl;
 }
 
@@ -39,7 +39,7 @@ int main(int argc, char** argv)
 
     log::Logger::instance().init();
 
-    ELONA_LOG() << latest_version.long_string();
+    ELONA_LOG("System") << latest_version.long_string();
 
 #if DEBUG
     return run();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,7 @@ void report_error(const char* what)
     LOGD("Error: %s", what);
 #endif
 
-    ELONA_LOG("Error: " << what);
+    ELONA_FATAL() << "Error: " << what;
     std::cerr << "Error: " << what << std::endl;
 }
 
@@ -39,7 +39,7 @@ int main(int argc, char** argv)
 
     log::Logger::instance().init();
 
-    ELONA_LOG(latest_version.long_string());
+    ELONA_LOG() << latest_version.long_string();
 
 #if DEBUG
     return run();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,11 +5,14 @@
 #include "elona/init.hpp"
 #include "elona/log.hpp"
 #include "version.hpp"
+
 #if defined(ELONA_OS_WINDOWS)
 #include <windows.h> // OutputDebugStringA
 #endif
 
-namespace elona
+
+
+namespace
 {
 
 void report_error(const char* what)
@@ -20,10 +23,12 @@ void report_error(const char* what)
 #elif defined(ELONA_OS_ANDROID)
     LOGD("Error: %s", what);
 #endif
+
     ELONA_LOG("Error: " << what);
     std::cerr << "Error: " << what << std::endl;
 }
-} // namespace elona
+
+} // namespace
 
 
 
@@ -32,7 +37,7 @@ int main(int argc, char** argv)
     using namespace elona;
     (void)argc, (void)argv;
 
-    log::initialize();
+    log::Logger::instance().init();
 
     ELONA_LOG(latest_version.long_string());
 

--- a/src/tests/serialization.cpp
+++ b/src/tests/serialization.cpp
@@ -8,7 +8,6 @@
 #include "../elona/init.hpp"
 #include "../elona/item.hpp"
 #include "../elona/itemgen.hpp"
-#include "../elona/log.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/variables.hpp"
 #include "tests.hpp"
@@ -91,9 +90,7 @@ TEST_CASE("Test item index preservation", "[C++: Serialization]")
 TEST_CASE("Test character data compatibility", "[C++: Serialization]")
 {
     int player_idx = 0;
-    ELONA_LOG("test begin");
     load_previous_savefile();
-    ELONA_LOG("test end");
     REQUIRE(elona::cdata[player_idx].index == player_idx);
     REQUIRE(elona::cdatan(0, player_idx) == u8"foobar_test");
 }
@@ -101,9 +98,7 @@ TEST_CASE("Test character data compatibility", "[C++: Serialization]")
 TEST_CASE("Test other character data compatibility", "[C++: Serialization]")
 {
     int chara_idx = 57;
-    ELONA_LOG("test begin2");
     load_previous_savefile();
-    ELONA_LOG("test end2");
     REQUIRE(elona::cdata[chara_idx].index == chara_idx);
     REQUIRE(elona::cdatan(0, chara_idx) == u8"風を聴く者『ラーネイレ』");
 }
@@ -111,9 +106,7 @@ TEST_CASE("Test other character data compatibility", "[C++: Serialization]")
 TEST_CASE("Test item data compatibility (in inventory)", "[C++: Serialization]")
 {
     int item_idx = 0;
-    ELONA_LOG("test begin3");
     load_previous_savefile();
-    ELONA_LOG("test end3");
     REQUIRE(elona::inv[item_idx].index == item_idx);
     REQUIRE(elona::itemname(item_idx) == u8"ブロンズの兜 [0,1]");
 }
@@ -121,9 +114,7 @@ TEST_CASE("Test item data compatibility (in inventory)", "[C++: Serialization]")
 TEST_CASE("Test item data compatibility (on ground)", "[C++: Serialization]")
 {
     int item_idx = 5080;
-    ELONA_LOG("test begin4");
     load_previous_savefile();
-    ELONA_LOG("test end4");
     REQUIRE(elona::inv[item_idx].index == item_idx);
     REQUIRE(elona::itemname(item_idx) == u8"割れたつぼ");
 }
@@ -132,9 +123,7 @@ TEST_CASE("Test ability data compatibility", "[C++: Serialization]")
 {
     int ability_idx = 170; // Medium Armor
     int chara_idx = 57;
-    ELONA_LOG("test begin5");
     load_previous_savefile();
-    ELONA_LOG("test end5");
     REQUIRE(elona::sdata.get(ability_idx, chara_idx).current_level == 28);
     REQUIRE(elona::sdata.get(ability_idx, chara_idx).original_level == 28);
     REQUIRE(elona::sdata.get(ability_idx, chara_idx).experience == 0);


### PR DESCRIPTION
# Summary

- Delete unused log: they were  for debugging, but no longer used.
- Change usage of `ELONA_LOG` macro.
  - Before: `ELONA_LOG(x << y << z)`
  - After: `ELONA_LOG(tag) << x << y << z`
- Add `ELONA_WARN()`, `ELONA_ERROR()`, `ELONA_FATAL()` for serious errors.
- Add tag and change log format.
  - Example: "INFO  [Lua.Mod] Found mod core"

# Example

<details>

```
INFO  [System] Elona foobar version 0.3.3 (db6faf65), compiled on Darwin-18.2.0 at 2019-01-18T19:11:20Z
INFO  [Config] Set: core.config.screen.display_mode to "800x600@60Hz"
INFO  [Config] Set: core.config.language.language to "__unknown__"
INFO  [Config] Set: core.config.game.default_save to ""
INFO  [Config] Set: core.config.game.default_save to ""
INFO  [Config] Set: core.config.screen.sound to true
INFO  [Config] Set: core.config.screen.music to "direct_music"
INFO  [Config] Set: core.config.screen.fullscreen to "windowed"
INFO  [Config] Set: core.config.screen.display_mode to "800x600@60Hz"
INFO  [Config] Set: core.config.screen.window_mode to "1024x600"
INFO  [Config] Set: core.config.input.key_wait to 5
INFO  [Config] Set: core.config.input.joypad to false
INFO  [Config] Set: core.config.balance.extra_race to false
INFO  [Config] Set: core.config.balance.extra_class to false
INFO  [Config] Set: core.config.language.language to "__unknown__"
INFO  [Config] Set: core.config.ui.msg_line to 4
INFO  [Config] Set: core.config.ui.tile_size to 48
INFO  [Config] Set: core.config.ui.font_size to 14
...
INFO  [Lua.Mod] Found mod core
INFO  [Lua.Mod] Found mod kiroku
INFO  [Lua.Mod] Loaded mod core
INFO  [Lua.Mod] Loaded mod kiroku
INFO  [Config] Set: core.config.font.vertical_offset to -3
INFO  [Save] Load: 6b1b-3a67-3c7c-77df
INFO  [Save] Load end: 6b1b-3a67-3c7c-77df
...
```

</details>
