### PR TITLE
Fix {sex} tag being always substituted by male

### DIFF
--- a/src/elona/text.cpp
+++ b/src/elona/text.cpp
@@ -811,7 +811,7 @@ std::string replace_tag(const std::string source)
     }
     if (source == u8"sex"s)
     {
-        return i18n::s.get_enum("core.locale.ui.sex2", 0);
+        return i18n::s.get_enum("core.locale.ui.sex2", cdata.player().sex);
     }
     if (source == u8"player"s)
     {


### PR DESCRIPTION
# Related Issues

Close #1169.

# Screenshot

![image](https://user-images.githubusercontent.com/36858341/51422400-6cec3b00-1bf1-11e9-9b2b-e43b0f743087.png)
