### PR TITLE
Fix game help text being blurred

### DIFF
--- a/src/elona/ui.cpp
+++ b/src/elona/ui.cpp
@@ -1130,6 +1130,8 @@ int evtiles = 0;
 int evscrh = 0;
 int evscrw = 0;
 
+
+
 Position gmes(
     const std::string& text,
     int x_base,
@@ -1141,42 +1143,35 @@ Position gmes(
     int font_size = 14;
     font(font_size - en * 2);
 
-    const auto message = text + u8"$end";
     int x = x_base;
     int y = y_base;
     size_t pos = 0;
     snail::Color text_color = text_color_base;
 
-    while (message.find(u8"$end", pos) != pos)
+    while (pos < text.size())
     {
         bool wait_to_break_line = false;
-        uint8_t first = message[pos];
-        size_t byte;
-        if (first <= 0x7F)
-            byte = 1;
-        else if (first >= 0xc2 && first <= 0xdf)
-            byte = 2;
-        else if (first >= 0xe0 && first <= 0xef)
-            byte = 3;
-        else if (first >= 0xf0 && first <= 0xf7)
-            byte = 4;
-        else if (first >= 0xf8 && first <= 0xfb)
-            byte = 5;
-        else if (first >= 0xfc && first <= 0xfd)
-            byte = 6;
-        else
-            byte = 1;
-        std::string m_ = strmid(message, pos, byte);
+        const auto byte = strutil::byte_count(text[pos]);
+        std::string one_char = text.substr(pos, byte);
         pos += byte;
-        if (m_ == u8"。" || m_ == u8"、" || m_ == u8"」" || m_ == u8"』" ||
-            m_ == u8"！" || m_ == u8"？" || m_ == u8"…")
+
+        if (one_char == u8"。" || one_char == u8"、" || one_char == u8"」" ||
+            one_char == u8"』" || one_char == u8"！" || one_char == u8"？" ||
+            one_char == u8"…")
         {
             wait_to_break_line = true;
         }
-        else if (m_ == u8"<")
+        else if (one_char == u8"<")
         {
-            const auto tag = strmid(message, pos, instr(message, pos, u8">"));
-            pos += instr(message, pos, u8">") + 1;
+            const auto closing_tag_pos = text.find(u8">", pos);
+            if (closing_tag_pos == std::string::npos)
+            {
+                ELONA_ERROR("Text") << "Invalid notation: missing '>'";
+                // Stop processing, return immediately.
+                return {x_base, y + font_size + 4};
+            }
+            const auto tag = text.substr(pos, closing_tag_pos - pos);
+            pos = closing_tag_pos + 1;
             if (tag == u8"emp1")
             {
                 font(font_size - en * 2, snail::Font::Style::underline);
@@ -1227,11 +1222,13 @@ Position gmes(
             }
             continue;
         }
-        if (m_ == u8"^")
+        else if (one_char == u8"^")
         {
-            m_ = strmid(message, pos, 1);
+            // Escape
+            one_char = text.substr(pos, 1);
             ++pos;
         }
+
         if (!wait_to_break_line)
         {
             if (x >= x_base + width)
@@ -1242,9 +1239,9 @@ Position gmes(
         }
         if (shadow)
         {
-            elona::mes(x + 1, y + 1, m_, {180, 160, 140});
+            mes(x + 1, y + 1, one_char, {180, 160, 140});
         }
-        elona::mes(x, y, m_, text_color);
+        mes(x, y, one_char, text_color);
         x += font_size / 2 * (byte == 1 ? 1 : 2);
     }
 

--- a/src/elona/ui/ui_menu_game_help.cpp
+++ b/src/elona/ui/ui_menu_game_help.cpp
@@ -70,26 +70,6 @@ bool UIMenuGameHelp::init()
 
 
 
-void UIMenuGameHelp::_remove_parenthesis_around_keys()
-{
-    if (jp)
-        return;
-
-    for (int cnt = 0; cnt < 24; ++cnt)
-    {
-        if (!strutil::contains(s(cnt), u8"("))
-        {
-            continue;
-        }
-        s(cnt) = cnven(strmid(
-            s(cnt),
-            instr(s(cnt), 0, u8"("s) + 1,
-            instr(s(cnt), 0, u8")"s) - instr(s(cnt), 0, u8"("s) - 1));
-    }
-}
-
-
-
 void UIMenuGameHelp::_draw_key_list()
 {
     x = wx + 188;
@@ -128,7 +108,7 @@ void UIMenuGameHelp::_draw_key_list()
     s(21) = key_throw;
     s(22) = i18n::s.get("core.locale.ui.manual.keys.item.ammo");
     s(23) = key_ammo;
-    _remove_parenthesis_around_keys();
+
     for (int cnt = 0; cnt < 12; ++cnt)
     {
         font(13 - en * 2);
@@ -162,7 +142,7 @@ void UIMenuGameHelp::_draw_key_list()
     s(23) = key_open;
     s(24) = "";
     s(25) = "";
-    _remove_parenthesis_around_keys();
+
     for (int cnt = 0; cnt < 12; ++cnt)
     {
         font(13 - en * 2);
@@ -182,7 +162,7 @@ void UIMenuGameHelp::_draw_key_list()
     s(9) = key_material;
     s(10) = i18n::s.get("core.locale.ui.manual.keys.info.feat");
     s(11) = key_trait;
-    _remove_parenthesis_around_keys();
+
     for (int cnt = 0; cnt < 6; ++cnt)
     {
         font(13 - en * 2);
@@ -203,7 +183,7 @@ void UIMenuGameHelp::_draw_key_list()
     s(10) = "";
     s(11) = "";
     s(12) = "";
-    _remove_parenthesis_around_keys();
+
     for (int cnt = 0; cnt < 6; ++cnt)
     {
         font(13 - en * 2);

--- a/src/elona/ui/ui_menu_game_help.cpp
+++ b/src/elona/ui/ui_menu_game_help.cpp
@@ -10,6 +10,7 @@ namespace elona
 {
 namespace ui
 {
+
 bool UIMenuGameHelp::init()
 {
     // pre - notesel init
@@ -67,6 +68,8 @@ bool UIMenuGameHelp::init()
     return true;
 }
 
+
+
 void UIMenuGameHelp::_remove_parenthesis_around_keys()
 {
     if (jp)
@@ -85,7 +88,9 @@ void UIMenuGameHelp::_remove_parenthesis_around_keys()
     }
 }
 
-void UIMenuGameHelp::_update_key_list()
+
+
+void UIMenuGameHelp::_draw_key_list()
 {
     x = wx + 188;
     y = wy + 6;
@@ -217,7 +222,9 @@ void UIMenuGameHelp::_update_key_list()
             i18n::s.get("core.locale.ui.manual.keys.other.console"));
 }
 
-void UIMenuGameHelp::_update_regular_pages()
+
+
+void UIMenuGameHelp::_draw_regular_pages()
 {
     s(1) = listn(0, pagesize * page_bk + cs_bk2);
     display_topic(s(1), wx + 206, wy + 36);
@@ -240,6 +247,8 @@ void UIMenuGameHelp::_update_regular_pages()
     }
 }
 
+
+
 void UIMenuGameHelp::_draw_navigation_menu()
 {
     font(14 - en * 2);
@@ -255,11 +264,14 @@ void UIMenuGameHelp::_draw_navigation_menu()
         s = listn(0, p);
         cs_list(cs == cnt, s, wx + 66, wy + 66 + cnt * 19 - 1);
     }
+
     if (keyrange != 0)
     {
         cs_bk = cs;
     }
 }
+
+
 
 void UIMenuGameHelp::_draw_background_vignette(int id, int type)
 {
@@ -280,6 +292,8 @@ void UIMenuGameHelp::_draw_background_vignette(int id, int type)
     gmode(2);
 }
 
+
+
 void UIMenuGameHelp::update()
 {
     cs_bk = -1;
@@ -288,7 +302,11 @@ void UIMenuGameHelp::update()
         page = pagemax;
     else if (page > pagemax)
         page = 0;
+}
 
+
+void UIMenuGameHelp::_draw_window()
+{
     int y;
     if (mode == 1)
     {
@@ -323,17 +341,19 @@ void UIMenuGameHelp::update()
 
     // Draws the first page, key lists, in a specific way
     if (cs_bk2 == 0 && page_bk == 0)
-        _update_key_list();
+        _draw_key_list();
     else
-        _update_regular_pages();
+        _draw_regular_pages();
 }
+
 
 
 void UIMenuGameHelp::draw()
 {
-    // Draws the left part of the window continuously, ensuring key refreshing
+    _draw_window();
     _draw_navigation_menu();
 }
+
 
 
 optional<UIMenuGameHelp::ResultType> UIMenuGameHelp::on_key(
@@ -376,5 +396,6 @@ optional<UIMenuGameHelp::ResultType> UIMenuGameHelp::on_key(
     }
     return none;
 }
+
 } // namespace ui
 } // namespace elona

--- a/src/elona/ui/ui_menu_game_help.cpp
+++ b/src/elona/ui/ui_menu_game_help.cpp
@@ -72,134 +72,154 @@ bool UIMenuGameHelp::init()
 
 void UIMenuGameHelp::_draw_key_list()
 {
-    x = wx + 188;
-    y = wy + 6;
-    display_topic(
-        i18n::s.get("core.locale.ui.manual.keys.item.title"), x + 18, y + 30);
-    display_topic(
-        i18n::s.get("core.locale.ui.manual.keys.action.title"),
-        x + 18,
-        y + 142);
-    display_topic(
-        i18n::s.get("core.locale.ui.manual.keys.info.title"), x + 18, y + 256);
-    display_topic(
-        i18n::s.get("core.locale.ui.manual.keys.other.title"), x + 18, y + 328);
-    s(0) = i18n::s.get("core.locale.ui.manual.keys.item.get");
-    s(1) = key_get;
-    s(2) = i18n::s.get("core.locale.ui.manual.keys.item.drop");
-    s(3) = key_drop;
-    s(4) = i18n::s.get("core.locale.ui.manual.keys.item.examine");
-    s(5) = key_inventory;
-    s(6) = i18n::s.get("core.locale.ui.manual.keys.item.wear_wield");
-    s(7) = key_wear;
-    s(8) = i18n::s.get("core.locale.ui.manual.keys.item.eat");
-    s(9) = key_eat;
-    s(10) = i18n::s.get("core.locale.ui.manual.keys.item.quaff");
-    s(11) = key_drink;
-    s(12) = i18n::s.get("core.locale.ui.manual.keys.item.read");
-    s(13) = key_read;
-    s(14) = i18n::s.get("core.locale.ui.manual.keys.item.zap");
-    s(15) = key_zap;
-    s(16) = i18n::s.get("core.locale.ui.manual.keys.item.tool");
-    s(17) = key_use;
-    s(18) = i18n::s.get("core.locale.ui.manual.keys.item.blend");
-    s(19) = key_dip;
-    s(20) = i18n::s.get("core.locale.ui.manual.keys.item.throw");
-    s(21) = key_throw;
-    s(22) = i18n::s.get("core.locale.ui.manual.keys.item.ammo");
-    s(23) = key_ammo;
+    const auto x = wx + 188;
+    const auto y = wy + 6;
+    const auto desc_font_size = 13 - en * 2;
+    const auto key_font_size = 15 - en * 2;
 
-    for (int cnt = 0; cnt < 12; ++cnt)
+    struct KeyDescPair
     {
-        font(13 - en * 2);
-        mes(x + 38 + cnt / 6 * 290, y + 58 + cnt % 6 * 14, s(cnt * 2));
-        font(15 - en * 2);
-        mes(x + 248 + cnt / 6 * 290, y + 57 + cnt % 6 * 14, s(cnt * 2 + 1));
-    }
-    s(0) = i18n::s.get("core.locale.ui.manual.keys.action.search");
-    s(1) = key_search;
-    s(2) = i18n::s.get("core.locale.ui.manual.keys.action.cast");
-    s(3) = key_cast;
-    s(4) = i18n::s.get("core.locale.ui.manual.keys.action.interact");
-    s(5) = key_interact;
-    s(6) = i18n::s.get("core.locale.ui.manual.keys.action.go_down");
-    s(7) = key_godown;
-    s(8) = i18n::s.get("core.locale.ui.manual.keys.action.go_up");
-    s(9) = key_goup;
-    s(10) = i18n::s.get("core.locale.ui.manual.keys.action.wait");
-    s(11) = key_wait;
-    s(12) = i18n::s.get("core.locale.ui.manual.keys.action.target");
-    s(13) = key_target;
-    s(14) = i18n::s.get("core.locale.ui.manual.keys.action.fire");
-    s(15) = key_fire;
-    s(16) = i18n::s.get("core.locale.ui.manual.keys.action.apply");
-    s(17) = key_skill;
-    s(18) = i18n::s.get("core.locale.ui.manual.keys.action.bash");
-    s(19) = key_bash;
-    s(20) = i18n::s.get("core.locale.ui.manual.keys.action.dig");
-    s(21) = key_dig;
-    s(22) = i18n::s.get("core.locale.ui.manual.keys.action.open");
-    s(23) = key_open;
-    s(24) = "";
-    s(25) = "";
+        std::string key;
+        std::string desc;
+    };
 
-    for (int cnt = 0; cnt < 12; ++cnt)
     {
-        font(13 - en * 2);
-        mes(x + 38 + cnt / 6 * 290, y + 170 + cnt % 6 * 14, s(cnt * 2));
-        font(15 - en * 2);
-        mes(x + 248 + cnt / 6 * 290, y + 169 + cnt % 6 * 14, s(cnt * 2 + 1));
-    }
-    s(0) = i18n::s.get("core.locale.ui.manual.keys.info.chara");
-    s(1) = key_charainfo;
-    s(2) = i18n::s.get("core.locale.ui.manual.keys.info.journal");
-    s(3) = key_journal;
-    s(4) = i18n::s.get("core.locale.ui.manual.keys.info.help");
-    s(5) = key_help;
-    s(6) = i18n::s.get("core.locale.ui.manual.keys.info.log");
-    s(7) = key_msglog;
-    s(8) = i18n::s.get("core.locale.ui.manual.keys.info.material");
-    s(9) = key_material;
-    s(10) = i18n::s.get("core.locale.ui.manual.keys.info.feat");
-    s(11) = key_trait;
+        // Section "Item"
+        display_topic(
+            i18n::s.get("core.locale.ui.manual.keys.item.title"),
+            x + 18,
+            y + 30);
 
-    for (int cnt = 0; cnt < 6; ++cnt)
-    {
-        font(13 - en * 2);
-        mes(x + 38 + cnt / 3 * 290, y + 284 + cnt % 3 * 14, s(cnt * 2));
-        font(15 - en * 2);
-        mes(x + 248 + cnt / 3 * 290, y + 283 + cnt % 3 * 14, s(cnt * 2 + 1));
-    }
-    s(0) = i18n::s.get("core.locale.ui.manual.keys.other.save");
-    s(1) = key_save;
-    s(2) = i18n::s.get("core.locale.ui.manual.keys.other.pray");
-    s(3) = key_pray;
-    s(4) = i18n::s.get("core.locale.ui.manual.keys.other.offer");
-    s(5) = key_offer;
-    s(6) = i18n::s.get("core.locale.ui.manual.keys.other.close");
-    s(7) = key_close;
-    s(8) = i18n::s.get("core.locale.ui.manual.keys.other.give");
-    s(9) = key_give;
-    s(10) = "";
-    s(11) = "";
-    s(12) = "";
+        std::vector<KeyDescPair> keys{
+            {key_get, i18n::s.get("core.locale.ui.manual.keys.item.get")},
+            {key_read, i18n::s.get("core.locale.ui.manual.keys.item.read")},
+            {key_drop, i18n::s.get("core.locale.ui.manual.keys.item.drop")},
+            {key_zap, i18n::s.get("core.locale.ui.manual.keys.item.zap")},
+            {key_inventory,
+             i18n::s.get("core.locale.ui.manual.keys.item.examine")},
+            {key_use, i18n::s.get("core.locale.ui.manual.keys.item.tool")},
+            {key_wear,
+             i18n::s.get("core.locale.ui.manual.keys.item.wear_wield")},
+            {key_dip, i18n::s.get("core.locale.ui.manual.keys.item.blend")},
+            {key_eat, i18n::s.get("core.locale.ui.manual.keys.item.eat")},
+            {key_throw, i18n::s.get("core.locale.ui.manual.keys.item.throw")},
+            {key_drink, i18n::s.get("core.locale.ui.manual.keys.item.quaff")},
+            {key_ammo, i18n::s.get("core.locale.ui.manual.keys.item.ammo")},
+        };
 
-    for (int cnt = 0; cnt < 6; ++cnt)
-    {
-        font(13 - en * 2);
-        mes(x + 38 + cnt / 3 * 290, y + 356 + cnt % 3 * 14, s(cnt * 2));
-        font(15 - en * 2);
-        mes(x + 248 + cnt / 3 * 290, y + 355 + cnt % 3 * 14, s(cnt * 2 + 1));
+        int index = 0;
+        for (const auto& pair : keys)
+        {
+            font(desc_font_size);
+            mes(x + 38 + index % 2 * 290, y + 58 + index / 2 * 14, pair.desc);
+            font(key_font_size);
+            mes(x + 248 + index % 2 * 290, y + 57 + index / 2 * 14, pair.key);
+            ++index;
+        }
     }
-    font(13 - en * 2);
-    mes(x + 38,
-        y + 408,
-        u8"F9 "s +
-            i18n::s.get("core.locale.ui.manual.keys.other.hide_interface") +
-            u8"F11  " +
-            i18n::s.get("core.locale.ui.manual.keys.other.export_chara_sheet") +
-            u8"F12  " +
-            i18n::s.get("core.locale.ui.manual.keys.other.console"));
+
+    // Section "Action"
+    {
+        display_topic(
+            i18n::s.get("core.locale.ui.manual.keys.action.title"),
+            x + 18,
+            y + 142);
+
+        std::vector<KeyDescPair> keys{
+            {key_search,
+             i18n::s.get("core.locale.ui.manual.keys.action.search")},
+            {key_target,
+             i18n::s.get("core.locale.ui.manual.keys.action.target")},
+            {key_cast, i18n::s.get("core.locale.ui.manual.keys.action.cast")},
+            {key_fire, i18n::s.get("core.locale.ui.manual.keys.action.fire")},
+            {key_interact,
+             i18n::s.get("core.locale.ui.manual.keys.action.interact")},
+            {key_skill, i18n::s.get("core.locale.ui.manual.keys.action.apply")},
+            {key_godown,
+             i18n::s.get("core.locale.ui.manual.keys.action.go_down")},
+            {key_bash, i18n::s.get("core.locale.ui.manual.keys.action.bash")},
+            {key_goup, i18n::s.get("core.locale.ui.manual.keys.action.go_up")},
+            {key_dig, i18n::s.get("core.locale.ui.manual.keys.action.dig")},
+            {key_wait, i18n::s.get("core.locale.ui.manual.keys.action.wait")},
+            {key_open, i18n::s.get("core.locale.ui.manual.keys.action.open")},
+        };
+
+        int index = 0;
+        for (const auto& pair : keys)
+        {
+            font(desc_font_size);
+            mes(x + 38 + index % 2 * 290, y + 170 + index / 2 * 14, pair.desc);
+            font(key_font_size);
+            mes(x + 248 + index % 2 * 290, y + 169 + index / 2 * 14, pair.key);
+            ++index;
+        }
+    }
+
+    // Section "Info"
+    {
+        display_topic(
+            i18n::s.get("core.locale.ui.manual.keys.info.title"),
+            x + 18,
+            y + 256);
+
+        std::vector<KeyDescPair> keys{
+            {key_charainfo,
+             i18n::s.get("core.locale.ui.manual.keys.info.chara")},
+            {key_msglog, i18n::s.get("core.locale.ui.manual.keys.info.log")},
+            {key_journal,
+             i18n::s.get("core.locale.ui.manual.keys.info.journal")},
+            {key_material,
+             i18n::s.get("core.locale.ui.manual.keys.info.material")},
+            {key_help, i18n::s.get("core.locale.ui.manual.keys.info.help")},
+            {key_trait, i18n::s.get("core.locale.ui.manual.keys.info.feat")},
+        };
+
+        int index = 0;
+        for (const auto& pair : keys)
+        {
+            font(desc_font_size);
+            mes(x + 38 + index % 2 * 290, y + 284 + index / 2 * 14, pair.desc);
+            font(key_font_size);
+            mes(x + 248 + index % 2 * 290, y + 283 + index / 2 * 14, pair.key);
+            ++index;
+        }
+    }
+
+    // Section "Other"
+    {
+        display_topic(
+            i18n::s.get("core.locale.ui.manual.keys.other.title"),
+            x + 18,
+            y + 328);
+
+        std::vector<KeyDescPair> keys{
+            {key_save, i18n::s.get("core.locale.ui.manual.keys.other.save")},
+            {key_close, i18n::s.get("core.locale.ui.manual.keys.other.close")},
+            {key_pray, i18n::s.get("core.locale.ui.manual.keys.other.pray")},
+            {key_give, i18n::s.get("core.locale.ui.manual.keys.other.give")},
+            {key_offer, i18n::s.get("core.locale.ui.manual.keys.other.offer")},
+        };
+
+        int index = 0;
+        for (const auto& pair : keys)
+        {
+            font(desc_font_size);
+            mes(x + 38 + index % 2 * 290, y + 356 + index / 2 * 14, pair.desc);
+            font(key_font_size);
+            mes(x + 248 + index % 2 * 290, y + 355 + index / 2 * 14, pair.key);
+            ++index;
+        }
+    }
+
+    // Misc.
+    // TODO: support key bindings!
+    const auto misc_keys = u8"F9 "s +
+        i18n::s.get("core.locale.ui.manual.keys.other.hide_interface") +
+        u8"  F11 " +
+        i18n::s.get("core.locale.ui.manual.keys.other.export_chara_sheet") +
+        u8"  F12 " + i18n::s.get("core.locale.ui.manual.keys.other.console");
+    font(desc_font_size);
+    mes(x + 38, y + 408, misc_keys);
 }
 
 

--- a/src/elona/ui/ui_menu_game_help.hpp
+++ b/src/elona/ui/ui_menu_game_help.hpp
@@ -17,7 +17,6 @@ protected:
     virtual void draw();
     virtual optional<UIMenuGameHelp::ResultType> on_key(const std::string& key);
 
-    void _remove_parenthesis_around_keys();
     void _draw_key_list();
     void _draw_regular_pages();
     void _draw_window();

--- a/src/elona/ui/ui_menu_game_help.hpp
+++ b/src/elona/ui/ui_menu_game_help.hpp
@@ -22,6 +22,31 @@ protected:
     void _draw_window();
     void _draw_navigation_menu();
     void _draw_background_vignette(int id, int type);
+
+private:
+    struct GameHelp
+    {
+        void load(const fs::path& filepath);
+
+
+        const std::vector<std::string>& section_headings() const
+        {
+            return _section_headings;
+        }
+
+
+        const std::vector<std::string> get_section(size_t index) const
+        {
+            return _sections.at(index);
+        }
+
+
+    private:
+        std::vector<std::vector<std::string>> _sections;
+        std::vector<std::string> _section_headings;
+    };
+
+    GameHelp _help;
 };
 } // namespace ui
 } // namespace elona

--- a/src/elona/ui/ui_menu_game_help.hpp
+++ b/src/elona/ui/ui_menu_game_help.hpp
@@ -18,8 +18,9 @@ protected:
     virtual optional<UIMenuGameHelp::ResultType> on_key(const std::string& key);
 
     void _remove_parenthesis_around_keys();
-    void _update_key_list();
-    void _update_regular_pages();
+    void _draw_key_list();
+    void _draw_regular_pages();
+    void _draw_window();
     void _draw_navigation_menu();
     void _draw_background_vignette(int id, int type);
 };


### PR DESCRIPTION
# Related Issues

Close #1173.


# Summary

Fix game help text being blurred by drawing background every time.


# Screenshot

![image](https://user-images.githubusercontent.com/36858341/51423042-bdb56100-1bfc-11e9-8d6e-27b91d208f7c.png)


# TODO

- [x] It causes serious performance hit. The help window was slow before, but the change may make it even slower!
  - Performance is improved at some degree. The bottleneck is `gmes()` function, but it is difficult to optimize it because the function is also used in other places.
  - At least in my machine, the performance hit has been resolved in Japanese mode. In English mode, `gmes()` still slows down the performance.