### PR TITLE
Fix returning prompt

### DIFF
--- a/runtime/locale/en/magic.hcl
+++ b/runtime/locale/en/magic.hcl
@@ -329,7 +329,7 @@ locale {
 
         escape {
             cancel = "The air around you gradually loses power."
-            during_quest = "Returning while taking a quest if forbidden. Are you sure you want to return?"
+            during_quest = "Returning while taking a quest is forbidden. Are you sure you want to return?"
             begin = "The air around you becomes charged."
             lord_may_disappear = "The lord of the dungeon might disappear if you escape now."
         }

--- a/runtime/locale/en/misc.hcl
+++ b/runtime/locale/en/misc.hcl
@@ -180,7 +180,7 @@ locale {
         no_target_around = "You look around and find nothing."
 
         return {
-            forbidden = "Returning while taking a quest if forbidden. Are you sure you want to return?"
+            forbidden = "Returning while taking a quest is forbidden. Are you sure you want to return?"
             no_location = "You don't know any location you can return to"
             where_do_you_want_to_go = "Where do you want to go?"
             air_becomes_charged = "The air around you becomes charged."

--- a/src/elona/elonacore.cpp
+++ b/src/elona/elonacore.cpp
@@ -6203,7 +6203,7 @@ void try_to_return()
     if (stat == 1)
     {
         txt(i18n::s.get("core.locale.misc.return.forbidden"));
-        if (yes_or_no(promptx, prompty, 160) == 0)
+        if (yes_or_no(promptx, prompty, 160) != 0)
         {
             update_screen();
             return;


### PR DESCRIPTION
# Related Issues

Close #1178.
#1140

# Summary

- Fix typo: "if forbidden" -> "is forbidden".
- Fix the response to the prompt "Returning while taking a quest is forbidden. Are you sure to return?" being wrongly handled.
  - The prompt is also shown when you *escape* during an escort quest, but the result is dealt with correctly.