### PR TITLE
Rename Character::does_not_search_enemy -> is_not_attacked_by_enemy

### DIFF
--- a/src/elona/data/types/type_character.hpp
+++ b/src/elona/data/types/type_character.hpp
@@ -66,7 +66,7 @@
     ELONA_CHARACTER_DEFINE_FLAG_ACCESSOR(is_lord_of_dungeon, 976) \
     ELONA_CHARACTER_DEFINE_FLAG_ACCESSOR(has_own_name, 977) \
     ELONA_CHARACTER_DEFINE_FLAG_ACCESSOR(is_pregnant, 978) \
-    ELONA_CHARACTER_DEFINE_FLAG_ACCESSOR(does_not_search_enemy, 979) \
+    ELONA_CHARACTER_DEFINE_FLAG_ACCESSOR(is_not_attacked_by_enemy, 979) \
     ELONA_CHARACTER_DEFINE_FLAG_ACCESSOR(is_contracting_with_reaper, 980) \
     ELONA_CHARACTER_DEFINE_FLAG_ACCESSOR(needs_refreshing_status, 981) \
     ELONA_CHARACTER_DEFINE_FLAG_ACCESSOR(visited_just_now, 982) \

--- a/src/elona/elonacore.cpp
+++ b/src/elona/elonacore.cpp
@@ -11864,7 +11864,7 @@ int new_ally_joins()
     cdata[rc].original_relationship = 10;
     cdata[rc].character_role = 0;
     cdata[rc].is_quest_target() = false;
-    cdata[rc].does_not_search_enemy() = false;
+    cdata[rc].is_not_attacked_by_enemy() = false;
     cdata[rc].is_hung_on_sand_bag() = false;
     cdata[rc].is_temporary() = false;
     cdata[rc].only_christmas() = false;

--- a/src/elona/initialize_map_types.cpp
+++ b/src/elona/initialize_map_types.cpp
@@ -2453,7 +2453,7 @@ static void _init_map_puppy_cave()
             {
                 flt();
                 chara_create(-1, 225, -3, 0);
-                cdata[rc].does_not_search_enemy() = true;
+                cdata[rc].is_not_attacked_by_enemy() = true;
             }
         }
     }

--- a/src/elona/talk_unique.cpp
+++ b/src/elona/talk_unique.cpp
@@ -605,7 +605,7 @@ void _lomias_release_putits()
         flt();
         chara_create(
             -1, 3, cdata.player().position.x, cdata.player().position.y);
-        cdata[rc].does_not_search_enemy() = true;
+        cdata[rc].is_not_attacked_by_enemy() = true;
     }
     flt();
     itemcreate(-1, 68, cdata.player().position.x, cdata.player().position.y, 0);

--- a/src/elona/turn_sequence.cpp
+++ b/src/elona/turn_sequence.cpp
@@ -583,7 +583,7 @@ label_2689_internal:
                 {
                     if (cdata[c].relationship > -3)
                     {
-                        if (cdata[c].does_not_search_enemy() == 0)
+                        if (!cdata[c].is_not_attacked_by_enemy())
                         {
                             f = 1;
                             break;
@@ -594,7 +594,7 @@ label_2689_internal:
                 {
                     if (cdata[c].original_relationship <= -3)
                     {
-                        if (cdata[c].does_not_search_enemy() == 0)
+                        if (!cdata[c].is_not_attacked_by_enemy())
                         {
                             f = 1;
                             break;
@@ -604,7 +604,7 @@ label_2689_internal:
             }
             if (f)
             {
-                if (cdata[cc].does_not_search_enemy() == 0)
+                if (!cdata[cc].is_not_attacked_by_enemy())
                 {
                     cdata[cc].enemy_id = c;
                     cdata[cc].hate = 30;


### PR DESCRIPTION
# Summary

The previous name did not express correct meaning. The creature who has
the flag will not be attacked by others. E.g., putits Lomias releases,
\<Poppy\>.
