### PR TITLE
Fix mojibake in error message if filepath contains multibyte characters

### DIFF
--- a/src/elona/config/config.cpp
+++ b/src/elona/config/config.cpp
@@ -379,7 +379,7 @@ void load_config(const fs::path& hcl_file)
         "core.config.font.quality", &convert_and_set_requested_font_quality);
 
     std::ifstream ifs{hcl_file.native()};
-    conf.load(ifs, hcl_file.string(), false);
+    conf.load(ifs, filepathutil::to_utf8_path(hcl_file), false);
 
     if (Config::instance().run_wait < 1)
     {
@@ -443,7 +443,7 @@ void initialize_config_preload(const fs::path& hcl_file)
 
     std::ifstream ifs{
         hcl_file.native()};
-    conf.load(ifs, hcl_file.string(), true);
+    conf.load(ifs, filepathutil::to_utf8_path(hcl_file), true);
 
     snail::android::set_navigation_bar_visibility(
         !conf.get<bool>("core.config.android.hide_navigation"));

--- a/src/elona/lua_env/mod_manifest.cpp
+++ b/src/elona/lua_env/mod_manifest.cpp
@@ -67,7 +67,8 @@ static std::unordered_set<std::string> _read_dependencies(
 ModManifest ModManifest::load(const fs::path& path)
 {
     auto parsed = hclutil::load(path);
-    const auto& value = hclutil::skip_sections(parsed, {"mod"}, path.string());
+    const auto& value = hclutil::skip_sections(
+        parsed, {"mod"}, filepathutil::to_utf8_path(path));
 
     std::string mod_name = _read_mod_name(value, path);
     fs::path mod_path = path.parent_path();


### PR DESCRIPTION
# Summary

To build error message, `boost::fiilesystem::path::string()` function was used before, but this function is not appropriate for this case. Because Windows encodes filepath in UTF16, `path::string()` function, which returns `std::string`, i.e., a sequence of `char`, cannot represents native filepath on Windows (UTF16), required 2 bytes to encode. If the filepath contains multibyte characters, `path::string()` attempts to encode its native form in *system-dependent encoding*. For example, if your Windows is running in Japanese language, `path::string()` returns CP932 (codepage 932, Japanese legacy encoding) string. The encoding is incompatible with UTF8, so cannot be concatenated with UTF8 text which Elona foobar mainly uses. This commit fixes the bug to use `filepathutil::to_utf8_path()` function instead. The function encodes native filepath (UTF8 or UTF16) to UTF8, safely joined to `u8` literal strings and others.