### PR TITLE
Add macro API and related input/map APIs for pathfinding

### DIFF
--- a/doc/examples/life.lua
+++ b/doc/examples/life.lua
@@ -58,13 +58,13 @@ local function run_life()
       for y = 1, Map.width() do
          for x = 1, Map.height() do
             local tile
-            if Store.map_local.grid[x][y] == 1 and Map.can_access(x, y) then
+            if Store.map_local.grid[x][y] == 1 and Map.is_blocked(x, y) then
                tile = Map.generate_tile(Enums.TileKind.Wall)
             else
                tile = Map.generate_tile(Enums.TileKind.Room)
             end
             Map.set_tile(x, y, tile)
-            Map.set_tile_memory(x, y, tile)
+            Map.set_memory(x, y, tile)
          end
       end
       Store.map_local.grid = evolve(grid)

--- a/doc/topics/README.md
+++ b/doc/topics/README.md
@@ -62,7 +62,7 @@ local function run_life()
       for y = 1, Map.width() do
          for x = 1, Map.height() do
             local tile
-            if Store.map_local.grid[x][y] == 1 and Map.can_access(x, y) then
+            if Store.map_local.grid[x][y] == 1 and Map.is_blocked(x, y) then
                tile = Map.generate_tile("Wall")
             else
                tile = Map.generate_tile("Room")
@@ -112,16 +112,16 @@ Next we iterate over every x-y pair in the map. Since there is only ever one map
 
 ```
             local tile
-            if Store.map_local.grid[x][y] == 1 and Map.can_access(x, y) then
+            if Store.map_local.grid[x][y] == 1 and Map.is_blocked(x, y) then
                tile = Map.generate_tile(Enums.TileKind.Wall)
             else
                tile = Map.generate_tile(Enums.TileKind.Room)
             end
             Map.set_tile(x, y, tile)
-            Map.set_tile_memory(x, y, tile)
+            Map.set_memory(x, y, tile)
 ```
 
-Here is where we make use of the `Map` module to modify the map. You can read the documentation for `Map.can_access`, `Map.generate_tile` and `Map.set_tile` elsewhere in the docs. Essentially, if the simulation reports a cell with value 1, we set that square to a wall tile, else to a floor tile. We also make sure to set the player's memory of that tile so they can see it even if it's out of field of view.
+Here is where we make use of the `Map` module to modify the map. You can read the documentation for `Map.is_blocked`, `Map.generate_tile` and `Map.set_tile` elsewhere in the docs. Essentially, if the simulation reports a cell with value 1, we set that square to a wall tile, else to a floor tile. We also make sure to set the player's memory of that tile so they can see it even if it's out of field of view.
 
 We also use the enum type `TileKind` here. Some functions take enums to denote one of several different states an object can be in, like the curse state of an object (`Blessed`, `None`, `Cursed`, or `Doomed`). These will typically be found inside the `Enum` module. You also can pass the name of the enum itself without using the `Enums` table (like `Map.generate_tile("Wall")`), to avoid having to `require` `Enums` all the time.
 

--- a/src/elona/CMakeLists.txt
+++ b/src/elona/CMakeLists.txt
@@ -142,6 +142,7 @@ set(ELONA_SOURCES
   keybind/keybind_deserializer.cpp
   keybind/keybind_manager.cpp
   keybind/keybind_serializer.cpp
+  keybind/macro_action_queue.cpp
 
   pic_loader/pic_loader.cpp
   pic_loader/tinted_buffers.cpp

--- a/src/elona/elonacore.cpp
+++ b/src/elona/elonacore.cpp
@@ -5329,7 +5329,7 @@ TurnResult step_into_gate()
 
 
 
-int target_position()
+int target_position(bool target_chara)
 {
     if (tlocinitx != 0 || tlocinity != 0)
     {
@@ -5349,26 +5349,30 @@ int target_position()
     else
     {
         scposval = 1;
-        if (cdata.player().enemy_id == 0)
+
+        if (target_chara)
         {
-            find_enemy_target();
-        }
-        build_target_list();
-        if (listmax == 0)
-        {
-            txt(i18n::s.get("core.locale.misc.no_target_around"));
-        }
-        for (int cnt = 0, cnt_end = (listmax); cnt < cnt_end; ++cnt)
-        {
-            if (list(0, cnt) == 0)
+            if (cdata.player().enemy_id == 0)
             {
-                continue;
+                find_enemy_target();
             }
-            if (list(0, cnt) == cdata.player().enemy_id)
+            build_target_list();
+            if (listmax == 0)
             {
-                tlocx = cdata[list(0, cnt)].position.x;
-                tlocy = cdata[list(0, cnt)].position.y;
-                break;
+                txt(i18n::s.get("core.locale.misc.no_target_around"));
+            }
+            for (int cnt = 0, cnt_end = (listmax); cnt < cnt_end; ++cnt)
+            {
+                if (list(0, cnt) == 0)
+                {
+                    continue;
+                }
+                if (list(0, cnt) == cdata.player().enemy_id)
+                {
+                    tlocx = cdata[list(0, cnt)].position.x;
+                    tlocy = cdata[list(0, cnt)].position.y;
+                    break;
+                }
             }
         }
     }

--- a/src/elona/initialize_map.cpp
+++ b/src/elona/initialize_map.cpp
@@ -1337,6 +1337,9 @@ init_map_after_refresh:
     }
     if (mode == 3)
     {
+        lua::lua->get_event_manager()
+            .run_callbacks<lua::EventKind::map_initialized>();
+
         mode = 0;
         if (mapsubroutine == 0)
         {

--- a/src/elona/initialize_map.cpp
+++ b/src/elona/initialize_map.cpp
@@ -1337,9 +1337,6 @@ init_map_after_refresh:
     }
     if (mode == 3)
     {
-        lua::lua->get_event_manager()
-            .run_callbacks<lua::EventKind::map_initialized>();
-
         mode = 0;
         if (mapsubroutine == 0)
         {

--- a/src/elona/keybind/input_context.hpp
+++ b/src/elona/keybind/input_context.hpp
@@ -4,6 +4,8 @@
 namespace elona
 {
 
+class MacroActionQueue;
+
 class InputContext
 {
 public:
@@ -55,6 +57,8 @@ private:
      */
     void _add_actions_from_category(ActionCategory category);
 
+    bool _is_valid_action(const std::string& action_id);
+
     bool _matches(
         const std::string& action_id,
         snail::Key key,
@@ -76,6 +80,9 @@ private:
         KeyWaitDelay delay_type);
 
     bool _delay_normal_action(const Keybind& keybind);
+
+    optional<std::string> _handle_macro_action(
+        MacroActionQueue& macro_action_queue);
 
 
     std::set<std::string> _available_actions;

--- a/src/elona/keybind/macro_action_queue.cpp
+++ b/src/elona/keybind/macro_action_queue.cpp
@@ -1,0 +1,11 @@
+#include "macro_action_queue.hpp"
+
+namespace elona
+{
+namespace keybind
+{
+
+MacroActionQueue macro_action_queue;
+
+}
+} // namespace elona

--- a/src/elona/keybind/macro_action_queue.hpp
+++ b/src/elona/keybind/macro_action_queue.hpp
@@ -1,0 +1,59 @@
+#pragma once
+#include <queue>
+#include <string>
+
+namespace elona
+{
+
+/**
+ * Queue of keybind actions that are executed first before any user input is
+ * queried. It is used by the mod macro system to programmatically send inputs
+ * to the game.
+ */
+class MacroActionQueue
+{
+    using Action = std::string;
+
+    const std::string default_action = "";
+
+public:
+    void push(const Action& action)
+    {
+        _queue.push(action);
+    }
+
+    void clear()
+    {
+        while (!empty())
+        {
+            pop();
+        }
+    }
+
+    bool empty()
+    {
+        return _queue.empty();
+    }
+
+    Action pop()
+    {
+        if (empty())
+        {
+            return default_action;
+        }
+
+        Action result = _queue.front();
+        _queue.pop();
+        return result;
+    }
+
+private:
+    std::queue<Action> _queue;
+};
+
+namespace keybind
+{
+extern MacroActionQueue macro_action_queue;
+}
+
+} // namespace elona

--- a/src/elona/lua_env/lua_api/lua_api_input.hpp
+++ b/src/elona/lua_env/lua_api/lua_api_input.hpp
@@ -58,6 +58,23 @@ void start_dialog_with_data(LuaCharacterHandle, const std::string&);
 
 sol::optional<LuaCharacterHandle> choose_ally(const EnumString&);
 
+void enqueue_macro(const std::string&);
+void enqueue_macro_table(sol::table);
+
+void clear_macro_queue();
+
+void ignore_keywait();
+
+sol::optional<Position> prompt_position(const std::string&);
+sol::optional<Position> prompt_position_with_initial(
+    const std::string&,
+    const Position&);
+sol::optional<Position>
+prompt_position_with_initial_xy(const std::string&, int, int);
+
+bool any_key_pressed();
+
+
 void bind(sol::table&);
 }; // namespace LuaApiInput
 

--- a/src/elona/lua_env/lua_api/lua_api_map.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_map.cpp
@@ -1,9 +1,11 @@
 #include "lua_api_map.hpp"
 #include "../../area.hpp"
+#include "../../character.hpp"
 #include "../../data/types/type_map.hpp"
 #include "../../lua_env/enums/enums.hpp"
 #include "../../map.hpp"
 #include "../../map_cell.hpp"
+#include "../interface.hpp"
 
 namespace elona
 {
@@ -13,7 +15,8 @@ namespace lua
 /**
  * @luadoc
  *
- * Returns the current map's width. This is only valid until the map changes.
+ * Returns the current map's width. This is only valid until the map
+ * changes.
  * @treturn num the current map's width in tiles
  */
 int LuaApiMap::width()
@@ -24,7 +27,8 @@ int LuaApiMap::width()
 /**
  * @luadoc
  *
- * Returns the current map's height. This is only valid until the map changes.
+ * Returns the current map's height. This is only valid until the map
+ * changes.
  * @treturn num the current map's height in tiles
  */
 int LuaApiMap::height()
@@ -91,7 +95,7 @@ bool LuaApiMap::is_overworld()
  * @luadoc
  *
  * Checks if a position is inside the map. It might be blocked by something.
- * @tparam LuaPosition position (const) the map position
+ * @tparam LuaPosition position
  * @treturn bool true if the position is inside the map.
  */
 bool LuaApiMap::valid(const Position& position)
@@ -101,52 +105,61 @@ bool LuaApiMap::valid(const Position& position)
 
 bool LuaApiMap::valid_xy(int x, int y)
 {
-    if (LuaApiMap::is_overworld())
-    {
-        return false;
-    }
-    if (x < 0 || y < 0 || x >= LuaApiMap::width() || y >= LuaApiMap::height())
-    {
-        return false;
-    }
-
-    return elona::cell_data.at(x, y).chip_id_actual != 0;
+    return x >= 0 && y >= 0 && x < LuaApiMap::width() &&
+        y < LuaApiMap::height();
 }
 
 /**
  * @luadoc
  *
- * Checks if a position is accessable by walking.
- * @tparam LuaPosition position (const) the map position
- * @treturn bool true if the position is accessable by walking
+ * Returns true if the map tile at the given position is solid.
+ * @tparam LuaPosition position
+ * @treturn bool
  */
-bool LuaApiMap::can_access(const Position& position)
+bool LuaApiMap::is_solid(const Position& position)
 {
-    return LuaApiMap::can_access_xy(position.x, position.y);
+    return LuaApiMap::is_solid_xy(position.x, position.y);
 }
 
-bool LuaApiMap::can_access_xy(int x, int y)
+bool LuaApiMap::is_solid_xy(int x, int y)
 {
     if (LuaApiMap::is_overworld())
     {
-        return false;
+        return true;
     }
+    if (!LuaApiMap::valid_xy(x, y))
+    {
+        return true;
+    }
+
+    return elona::chipm(7, elona::cell_data.at(x, y).chip_id_actual) & 4;
+}
+
+/**
+ * @luadoc
+ *
+ * Checks if a position is blocked and cannot be reached by walking.
+ * @tparam LuaPosition position
+ * @treturn bool
+ */
+bool LuaApiMap::is_blocked(const Position& position)
+{
+    return LuaApiMap::is_blocked_xy(position.x, position.y);
+}
+
+bool LuaApiMap::is_blocked_xy(int x, int y)
+{
+    if (LuaApiMap::is_overworld())
+    {
+        return true;
+    }
+    if (!LuaApiMap::valid_xy(x, y))
+    {
+        return true;
+    }
+
     elona::cell_check(x, y);
-    return cellaccess != 0;
-}
-
-/**
- * @luadoc
- *
- * Given a position, returns a position that is bounded within the current map.
- * @tparam LuaPosition position (const) the map position
- * @treturn LuaPosition the bounded position
- */
-Position LuaApiMap::bound_within(const Position& position)
-{
-    int x = clamp(position.x, 0, map_data.width - 1);
-    int y = clamp(position.y, 0, map_data.height - 1);
-    return Position{x, y};
+    return cellaccess == 0;
 }
 
 /**
@@ -158,8 +171,8 @@ Position LuaApiMap::bound_within(const Position& position)
  */
 Position LuaApiMap::random_pos()
 {
-    return LuaApiMap::bound_within(Position{elona::rnd(map_data.width - 1),
-                                            elona::rnd(map_data.height - 1)});
+    return Position{elona::rnd(map_data.width - 1),
+                    elona::rnd(map_data.height - 1)};
 }
 
 /**
@@ -181,9 +194,162 @@ int LuaApiMap::generate_tile(const EnumString& tile_kind)
 /**
  * @luadoc
  *
+ * Gets the tile type of a tile position.
+ * @tparam LuaPosition position
+ * @treturn num
+ */
+int LuaApiMap::get_tile(const Position& position)
+{
+    return LuaApiMap::get_tile_xy(position.x, position.y);
+}
+
+int LuaApiMap::get_tile_xy(int x, int y)
+{
+    if (LuaApiMap::is_overworld())
+    {
+        return -1;
+    }
+    if (!LuaApiMap::valid_xy(x, y))
+    {
+        return -1;
+    }
+
+    return elona::cell_data.at(x, y).chip_id_actual;
+}
+
+/**
+ * @luadoc
+ *
+ * Gets the player's memory of a tile position.
+ * @tparam LuaPosition position
+ * @treturn num
+ */
+int LuaApiMap::get_memory(const Position& position)
+{
+    return LuaApiMap::get_memory_xy(position.x, position.y);
+}
+
+int LuaApiMap::get_memory_xy(int x, int y)
+{
+    if (LuaApiMap::is_overworld())
+    {
+        return -1;
+    }
+    if (!LuaApiMap::valid_xy(x, y))
+    {
+        return -1;
+    }
+
+    return elona::cell_data.at(x, y).chip_id_memory;
+}
+
+/**
+ * @luadoc
+ *
+ * Returns a table containing map feature information at the given tile
+ * position.
+ * - id: Feature id.
+ * - param1: Extra parameter.
+ * - param2: Extra parameter.
+ * - param3: Extra parameter. (unused)
+ * @tparam LuaPosition position
+ * @treturn table
+ */
+sol::table LuaApiMap::get_feat(const Position& position)
+{
+    return LuaApiMap::get_feat_xy(position.x, position.y);
+}
+
+sol::table LuaApiMap::get_feat_xy(int x, int y)
+{
+    if (LuaApiMap::is_overworld())
+    {
+        return lua::create_table();
+    }
+    if (!LuaApiMap::valid_xy(x, y))
+    {
+        return lua::create_table();
+    }
+
+    auto feats = elona::cell_data.at(x, y).feats;
+
+    auto id = feats % 1000;
+    auto param1 = feats / 1000 % 100;
+    auto param2 = feats / 100000 % 100;
+    auto param3 = feats / 10000000;
+
+    return lua::create_table(
+        "id", id, "param1", param1, "param2", param2, "param3", param3);
+}
+
+/**
+ * @luadoc
+ *
+ * Returns the ID of the map effect at the given position.
+ * @tparam LuaPosition position
+ * @treturn num
+ */
+int LuaApiMap::get_mef(const Position& position)
+{
+    return LuaApiMap::get_mef_xy(position.x, position.y);
+}
+
+int LuaApiMap::get_mef_xy(int x, int y)
+{
+    if (LuaApiMap::is_overworld())
+    {
+        return 0;
+    }
+    if (!LuaApiMap::valid_xy(x, y))
+    {
+        return 0;
+    }
+
+    int index_plus_one = cell_data.at(x, y).mef_index_plus_one;
+
+    if (index_plus_one == 0)
+    {
+        return 0;
+    }
+
+    return mef(0, index_plus_one - 1);
+}
+
+/**
+ * @luadoc
+ *
+ * Gets the character standing at a tile position.
+ * @tparam LuaPosition position
+ * @treturn[opt] LuaCharacter
+ */
+sol::optional<LuaCharacterHandle> LuaApiMap::get_chara(const Position& position)
+{
+    return LuaApiMap::get_chara_xy(position.x, position.y);
+}
+
+sol::optional<LuaCharacterHandle> LuaApiMap::get_chara_xy(int x, int y)
+{
+    if (!LuaApiMap::valid_xy(x, y))
+    {
+        return sol::nullopt;
+    }
+
+    int index_plus_one = cell_data.at(x, y).chara_index_plus_one;
+
+    if (index_plus_one == 0)
+    {
+        return sol::nullopt;
+    }
+
+    return lua::handle(cdata[index_plus_one - 1]);
+}
+
+/**
+ * @luadoc
+ *
  * Sets a tile of the current map. Only checks if the position is valid, not
  * things like blocking objects.
- * @tparam LuaPosition position (const) the map position
+ * @tparam LuaPosition position
  * @tparam num id the tile ID to set
  * @usage Map.set_tile(10, 10, Map.generate_tile(Enums.TileKind.Room))
  */
@@ -211,16 +377,16 @@ void LuaApiMap::set_tile_xy(int x, int y, int id)
  * @luadoc
  *
  * Sets the player's memory of a tile position to the given tile kind.
- * @tparam LuaPosition position (const) the map position
+ * @tparam LuaPosition position
  * @tparam num id the tile ID to set
- * @usage Map.set_tile_memory(10, 10, Map.generate_tile(Enums.TileKind.Room))
+ * @usage Map.set_memory(10, 10, Map.generate_tile(Enums.TileKind.Room))
  */
-void LuaApiMap::set_tile_memory(const Position& position, int id)
+void LuaApiMap::set_memory(const Position& position, int id)
 {
-    LuaApiMap::set_tile_memory_xy(position.x, position.y, id);
+    LuaApiMap::set_memory_xy(position.x, position.y, id);
 }
 
-void LuaApiMap::set_tile_memory_xy(int x, int y, int id)
+void LuaApiMap::set_memory_xy(int x, int y, int id)
 {
     if (LuaApiMap::is_overworld())
     {
@@ -284,17 +450,29 @@ void LuaApiMap::bind(sol::table& api_table)
     api_table.set_function(
         "valid", sol::overload(LuaApiMap::valid, LuaApiMap::valid_xy));
     api_table.set_function(
-        "can_access",
-        sol::overload(LuaApiMap::can_access, LuaApiMap::can_access_xy));
-    LUA_API_BIND_FUNCTION(api_table, LuaApiMap, bound_within);
+        "is_solid", sol::overload(LuaApiMap::is_solid, LuaApiMap::is_solid_xy));
+    api_table.set_function(
+        "is_blocked",
+        sol::overload(LuaApiMap::is_blocked, LuaApiMap::is_blocked_xy));
     LUA_API_BIND_FUNCTION(api_table, LuaApiMap, random_pos);
     LUA_API_BIND_FUNCTION(api_table, LuaApiMap, generate_tile);
     api_table.set_function(
+        "get_tile", sol::overload(LuaApiMap::get_tile, LuaApiMap::get_tile_xy));
+    api_table.set_function(
+        "get_memory",
+        sol::overload(LuaApiMap::get_memory, LuaApiMap::get_memory_xy));
+    api_table.set_function(
+        "get_feat", sol::overload(LuaApiMap::get_feat, LuaApiMap::get_feat_xy));
+    api_table.set_function(
+        "get_mef", sol::overload(LuaApiMap::get_mef, LuaApiMap::get_mef_xy));
+    api_table.set_function(
+        "get_chara",
+        sol::overload(LuaApiMap::get_chara, LuaApiMap::get_chara_xy));
+    api_table.set_function(
         "set_tile", sol::overload(LuaApiMap::set_tile, LuaApiMap::set_tile_xy));
     api_table.set_function(
-        "set_tile_memory",
-        sol::overload(
-            LuaApiMap::set_tile_memory, LuaApiMap::set_tile_memory_xy));
+        "set_memory",
+        sol::overload(LuaApiMap::set_memory, LuaApiMap::set_memory_xy));
     api_table.set_function(
         "set_feat", sol::overload(LuaApiMap::set_feat, LuaApiMap::set_feat_xy));
     api_table.set_function(

--- a/src/elona/lua_env/lua_api/lua_api_map.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_map.cpp
@@ -132,7 +132,7 @@ bool LuaApiMap::is_solid_xy(int x, int y)
         return true;
     }
 
-    return elona::chipm(7, elona::cell_data.at(x, y).chip_id_actual) & 4;
+    return elona::chip_data.for_cell(x, y).effect & 4;
 }
 
 /**

--- a/src/elona/lua_env/lua_api/lua_api_map.hpp
+++ b/src/elona/lua_env/lua_api/lua_api_map.hpp
@@ -31,20 +31,36 @@ bool is_overworld();
 bool valid(const Position&);
 bool valid_xy(int, int);
 
-bool can_access(const Position&);
-bool can_access_xy(int, int);
+bool is_solid(const Position&);
+bool is_solid_xy(int, int);
 
-Position bound_within(const Position&);
+bool is_blocked(const Position&);
+bool is_blocked_xy(int, int);
 
 Position random_pos();
 
 int generate_tile(const EnumString&);
 
+int get_tile(const Position&);
+int get_tile_xy(int, int);
+
+int get_memory(const Position&);
+int get_memory_xy(int, int);
+
+sol::table get_feat(const Position&);
+sol::table get_feat_xy(int, int);
+
+int get_mef(const Position&);
+int get_mef_xy(int, int);
+
+sol::optional<LuaCharacterHandle> get_chara(const Position&);
+sol::optional<LuaCharacterHandle> get_chara_xy(int, int);
+
 void set_tile(const Position&, int);
 void set_tile_xy(int, int, int);
 
-void set_tile_memory(const Position&, int);
-void set_tile_memory_xy(int, int, int);
+void set_memory(const Position&, int);
+void set_memory_xy(int, int, int);
 
 void set_feat(const Position&, int, int, int);
 void set_feat_xy(int, int, int, int, int);

--- a/src/elona/lua_env/lua_class/lua_class_character.cpp
+++ b/src/elona/lua_env/lua_class/lua_class_character.cpp
@@ -500,6 +500,36 @@ void LuaCharacter::switch_religion(Character& self, const std::string& god_id)
     elona::switch_religion();
 }
 
+/**
+ * @luadoc
+ *
+ * Returns the duration of an ailment on this character.
+ * @tparam StatusAilment ailment
+ * @treturn num
+ */
+int LuaCharacter::get_ailment(Character& self, const EnumString& ailment)
+{
+    StatusAilment ailment_value =
+        LuaEnums::StatusAilmentTable.ensure_from_string(ailment);
+
+    switch (ailment_value)
+    {
+    case StatusAilment::blinded: return self.blind;
+    case StatusAilment::confused: return self.confused;
+    case StatusAilment::paralyzed: return self.paralyzed;
+    case StatusAilment::poisoned: return self.poisoned;
+    case StatusAilment::sleep: return self.sleep;
+    case StatusAilment::fear: return self.fear;
+    case StatusAilment::dimmed: return self.dimmed;
+    case StatusAilment::bleeding: return self.bleeding;
+    case StatusAilment::drunk: return self.drunk;
+    case StatusAilment::insane: return self.insane;
+    case StatusAilment::sick: return self.sick;
+    }
+
+    return 0;
+}
+
 void LuaCharacter::bind(sol::state& lua)
 {
     auto LuaCharacter = lua.create_simple_usertype<Character>();
@@ -829,6 +859,7 @@ void LuaCharacter::bind(sol::state& lua)
         "move_to",
         sol::overload(&LuaCharacter::move_to, &LuaCharacter::move_to_xy));
     LuaCharacter.set("switch_religion", &LuaCharacter::switch_religion);
+    LuaCharacter.set("get_ailment", &LuaCharacter::get_ailment);
 
     auto key = Character::lua_type();
     lua.set_usertype(key, LuaCharacter);

--- a/src/elona/lua_env/lua_class/lua_class_character.hpp
+++ b/src/elona/lua_env/lua_class/lua_class_character.hpp
@@ -73,6 +73,8 @@ void move_to_xy(Character&, int, int);
 
 void switch_religion(Character&, const std::string&);
 
+int get_ailment(Character&, const EnumString&);
+
 
 void bind(sol::state&);
 } // namespace LuaCharacter

--- a/src/elona/mapgen.cpp
+++ b/src/elona/mapgen.cpp
@@ -1585,6 +1585,7 @@ void generate_debug_map()
     map_data.max_crowd_density = map_data.width * map_data.height / 100;
     map_data.tileset = 3;
     map_data.user_map_flag = 0;
+    map_data.type = static_cast<int>(mdata_t::MapType::dungeon);
     map_initialize();
 
     for (int y = 0; y < map_data.height; ++y)

--- a/src/elona/variables.hpp
+++ b/src/elona/variables.hpp
@@ -770,7 +770,7 @@ int key_direction(const std::string& action);
 
 // Querying input
 int ask_direction();
-int target_position();
+int target_position(bool target_chara = true);
 int prompt_magic_location();
 int prompt_really_attack();
 

--- a/src/tests/lua/map.lua
+++ b/src/tests/lua/map.lua
@@ -25,14 +25,13 @@ lrun("test Map.valid", function()
 end)
 
 lrun("test Map.is_blocked", function()
-
         Testing.start_in_debug_map()
 
         local pos = LuaPosition.new(5, 5)
-        lequal(Map.is_blocked(pos), true)
-        lequal(Map.is_blocked(pos.x, pos.y), true)
-
-        Map.set_tile(5, 5, Map.generate_tile(Enums.TileKind.Wall))
         lequal(Map.is_blocked(pos), false)
         lequal(Map.is_blocked(pos.x, pos.y), false)
+
+        Map.set_tile(5, 5, Map.generate_tile(Enums.TileKind.Wall))
+        lequal(Map.is_blocked(pos), true)
+        lequal(Map.is_blocked(pos.x, pos.y), true)
 end)

--- a/src/tests/lua/map.lua
+++ b/src/tests/lua/map.lua
@@ -24,15 +24,15 @@ lrun("test Map.valid", function()
         lequal(Map.valid(-1, 0), false)
 end)
 
-lrun("test Map.can_access", function()
+lrun("test Map.is_blocked", function()
 
         Testing.start_in_debug_map()
 
         local pos = LuaPosition.new(5, 5)
-        lequal(Map.can_access(pos), true)
-        lequal(Map.can_access(pos.x, pos.y), true)
+        lequal(Map.is_blocked(pos), true)
+        lequal(Map.is_blocked(pos.x, pos.y), true)
 
         Map.set_tile(5, 5, Map.generate_tile(Enums.TileKind.Wall))
-        lequal(Map.can_access(pos), false)
-        lequal(Map.can_access(pos.x, pos.y), false)
+        lequal(Map.is_blocked(pos), false)
+        lequal(Map.is_blocked(pos.x, pos.y), false)
 end)


### PR DESCRIPTION
# Summary
- Add some APIs needed for pathfinding. With this, mods implementing autoexplore can be created.
- Remove `Map.bound_within`.
- Replace `Map.can_access` with `Map.is_blocked`.