### PR TITLE
Fix being unable to run in a certain configuration

### DIFF
--- a/src/elona/keybind/input_context.cpp
+++ b/src/elona/keybind/input_context.cpp
@@ -174,7 +174,7 @@ optional<std::string> InputContext::_check_movement_action(
     {
         // Has to be modified globally, since scroll speed is determined by
         // keybd_wait. See @ref ui_scroll_screen()
-        keybd_wait = 100000;
+        keybd_wait = 100000 + keybd_wait % 100;
         if (keywait == 0)
         {
             keywait = 1;
@@ -287,7 +287,7 @@ std::string InputContext::_delay_movement_action(
     {
         if ((modifiers & snail::ModKey::shift) != snail::ModKey::shift)
         {
-            keybd_wait = 1000;
+            keybd_wait = 1000 + keybd_wait % 100;
         }
     }
 


### PR DESCRIPTION
# Bug

You cannot run even when you press Shift key in a certain configuration:

Condition:
- scroll: Yes
- scroll when running: No
- running wait: 3 wait

This bug also occurs in vanilla. The original bug report was posted to [MMAh's development thread](http://jbbs.shitaraba.net/bbs/read.cgi/game/58103/1551181700/29).


# Summary

`keybd_wait` was fixed to 100,000 when you press shift key. Since 100,000 is
not a multiple of 3, the if condition which determines whether you are
about to run or not, `keybd_wait % run_wait == 0`, is always false.

With this change, `keybd_wait` will be incremented properly.

Because the cause is that 100,000 is not a multiple of 3, this bug can be reproduced with other prime number like 7 wait.