### PR TITLE
Implement version-based mod dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,7 @@ else()
       src/tests/keybind_key_names.cpp
       src/tests/keybind_manager.cpp
       src/tests/keybind_serializer.cpp
+      src/tests/semver.cpp
       src/tests/serialization.cpp
       )
 

--- a/runtime/profile/_/mod/kiroku/mod.hcl
+++ b/runtime/profile/_/mod/kiroku/mod.hcl
@@ -4,5 +4,7 @@ mod {
     version = "0.0.1"
     description = "Adds an item which displays the total number of creatures the player has killed."
 
-    dependencies = ["core"]
+    dependencies = {
+        core = "*"
+    }
 }

--- a/src/elona/lua_env/mod_manifest.cpp
+++ b/src/elona/lua_env/mod_manifest.cpp
@@ -6,7 +6,10 @@ namespace elona
 namespace lua
 {
 
-static std::string _read_mod_name(const hcl::Value& value, const fs::path& path)
+namespace
+{
+
+std::string _read_mod_name(const hcl::Value& value, const fs::path& path)
 {
     std::string result;
 
@@ -26,31 +29,77 @@ static std::string _read_mod_name(const hcl::Value& value, const fs::path& path)
     return result;
 }
 
-static std::unordered_set<std::string> _read_dependencies(
+
+
+semver::Version _read_mod_version(const hcl::Value& value, const fs::path& path)
+{
+    // TODO: Clean up, as with lua::ConfigTable
+    const hcl::Value* object = value.find("version");
+    if (!object)
+    {
+        return semver::Version{};
+    }
+
+    if (object->is<std::string>())
+    {
+        if (const auto result =
+                semver::Version::parse(object->as<std::string>()))
+        {
+            return result.right();
+        }
+        else
+        {
+            throw std::runtime_error{result.left()};
+        }
+    }
+    else
+    {
+        throw std::runtime_error(
+            filepathutil::to_utf8_path(path) +
+            ": Missing \"name\" in mod manifest");
+    }
+}
+
+
+
+ModManifest::Dependencies _read_dependencies(
     const hcl::Value& value,
     const fs::path& path)
 {
-    std::unordered_set<std::string> result;
+    ModManifest::Dependencies result;
 
     const hcl::Value* object = value.find("dependencies");
     if (object)
     {
-        if (object->is<hcl::List>())
+        if (object->is<hcl::Object>())
         {
-            auto dependencies = object->as<hcl::List>();
+            const auto& dependencies = object->as<hcl::Object>();
 
-            for (const auto& value : dependencies)
+            for (const auto& kvp : dependencies)
             {
-                if (value.is<std::string>())
+                hcl::Value mod;
+                hcl::Value version;
+                std::tie(mod, version) = kvp;
+
+                if (mod.is<std::string>() && version.is<std::string>())
                 {
-                    result.insert(value.as<std::string>());
+                    if (const auto req = semver::VersionRequirement::parse(
+                            version.as<std::string>()))
+                    {
+                        result.emplace(mod.as<std::string>(), req.right());
+                    }
+                    else
+                    {
+                        throw std::runtime_error(
+                            filepathutil::to_utf8_path(path) + ": " +
+                            req.left());
+                    }
                 }
                 else
                 {
                     throw std::runtime_error(
                         filepathutil::to_utf8_path(path) +
-                        ": \"dependencies\" field must be a list of "
-                        "strings.");
+                        ": \"dependencies\" field must be an object.");
                 }
             }
         }
@@ -58,12 +107,16 @@ static std::unordered_set<std::string> _read_dependencies(
         {
             throw std::runtime_error(
                 filepathutil::to_utf8_path(path) +
-                ": \"dependencies\" field must be a list of strings.");
+                ": \"dependencies\" field must be an object.");
         }
     }
 
     return result;
 }
+
+} // namespace
+
+
 
 ModManifest ModManifest::load(const fs::path& path)
 {
@@ -71,11 +124,12 @@ ModManifest ModManifest::load(const fs::path& path)
     const auto& value = hclutil::skip_sections(
         parsed, {"mod"}, filepathutil::to_utf8_path(path));
 
-    std::string mod_name = _read_mod_name(value, path);
-    fs::path mod_path = path.parent_path();
-    auto dependencies = _read_dependencies(value, path);
+    const auto mod_name = _read_mod_name(value, path);
+    const auto version = _read_mod_version(value, path);
+    const auto mod_path = path.parent_path();
+    const auto dependencies = _read_dependencies(value, path);
 
-    return ModManifest{mod_name, mod_path, dependencies};
+    return ModManifest{mod_name, version, mod_path, dependencies};
 }
 
 } // namespace lua

--- a/src/elona/lua_env/mod_manifest.hpp
+++ b/src/elona/lua_env/mod_manifest.hpp
@@ -1,7 +1,11 @@
 #pragma once
-#include <unordered_set>
+
+#include <unordered_map>
 #include "../filesystem.hpp"
 #include "../optional.hpp"
+#include "../semver.hpp"
+
+
 
 namespace elona
 {
@@ -10,14 +14,18 @@ namespace lua
 
 struct ModManifest
 {
+    using Dependencies =
+        std::unordered_map<std::string, semver::VersionRequirement>;
+
     /**
      * Loads a mod manifest from a mod.hcl file.
      */
     static ModManifest load(const fs::path& path);
 
     std::string name;
+    semver::Version version;
     optional<fs::path> path;
-    std::unordered_set<std::string> dependencies;
+    Dependencies dependencies;
 };
 
 } // namespace lua

--- a/src/elona/semver.hpp
+++ b/src/elona/semver.hpp
@@ -1,0 +1,443 @@
+#pragma once
+
+#include <cassert>
+#include <regex>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include "../util/either.hpp"
+#include "../util/range.hpp"
+#include "../util/strutil.hpp"
+
+
+
+namespace elona
+{
+
+// This module is named "SemVer", but it does not follow The Semantic Versioning
+// strictly.
+namespace semver
+{
+
+struct VersionRequirement;
+
+
+
+struct Version
+{
+    static constexpr int unspecified = -1;
+
+
+
+    int major;
+    int minor;
+    int patch;
+
+
+
+    constexpr Version()
+        : Version(0, 1, 0)
+    {
+    }
+
+
+
+    // Constructor without validation.
+    explicit constexpr Version(int major, int minor, int patch)
+        : major(major)
+        , minor(minor)
+        , patch(patch)
+    {
+    }
+
+
+
+    static either::either<std::string, Version> parse(const std::string& str)
+    {
+        if (const auto result = _parse_internal(str))
+        {
+            if (result.right()._is_incomplete())
+            {
+                return either::either<std::string, Version>::left_of(
+                    u8"Minor and patch version must be specified: " + str);
+            }
+            else
+            {
+                return result;
+            }
+        }
+        else
+        {
+            return result;
+        }
+    }
+
+
+
+    // E.g., "1.2.3"
+    std::string to_string() const
+    {
+        auto ret = std::to_string(major);
+        if (minor != unspecified)
+        {
+            ret += "." + std::to_string(minor);
+        }
+        if (patch != unspecified)
+        {
+            ret += "." + std::to_string(patch);
+        }
+        return ret;
+    }
+
+
+
+    // E.g., 1.2.3 => 10203
+    constexpr int to_integer() const
+    {
+        return major * 100 * 100 + minor * 100 + patch;
+    }
+
+
+
+    constexpr Version next_major() const
+    {
+        return Version{major + 1, 0, 0};
+    }
+
+
+
+    constexpr Version next_minor() const
+    {
+        return Version{major, minor + 1, 0};
+    }
+
+
+
+    constexpr Version next_patch() const
+    {
+        return Version{major, minor, patch + 1};
+    }
+
+
+
+#define ELONA_SEMVER_DEFINE_COMPARATOR(op) \
+    constexpr bool operator op(const Version& other) const \
+    { \
+        return to_integer() op other.to_integer(); \
+    }
+
+    ELONA_SEMVER_DEFINE_COMPARATOR(==)
+    ELONA_SEMVER_DEFINE_COMPARATOR(!=)
+    ELONA_SEMVER_DEFINE_COMPARATOR(<)
+    ELONA_SEMVER_DEFINE_COMPARATOR(<=)
+    ELONA_SEMVER_DEFINE_COMPARATOR(>)
+    ELONA_SEMVER_DEFINE_COMPARATOR(>=)
+
+#undef ELONA_SEMVER_DEFINE_COMPARATOR
+
+
+
+private:
+    friend VersionRequirement;
+
+
+
+    // Factory method with validation. This method allows incomplete version.
+    static either::either<std::string, Version> _parse_internal(
+        const std::string& str)
+    {
+        using Result = either::either<std::string, Version>;
+
+        std::regex pattern{u8R"(([0-9]+)(?:\.([0-9]+)(?:\.([0-9]+))?)?)"};
+        std::smatch match;
+        if (const auto matched = std::regex_match(str, match, pattern))
+        {
+            int major, minor, patch;
+            try
+            {
+                major = std::stoi(match[1]);
+                minor = match[2].matched ? std::stoi(match[2]) : unspecified;
+                patch = match[3].matched ? std::stoi(match[3]) : unspecified;
+            }
+            catch (std::out_of_range&)
+            {
+                return Result::left_of(u8"Too large number: " + str);
+            }
+
+            if (major == 0 && minor == 0 && patch == 0)
+            {
+                return Result::left_of(u8"Version '0.0.0' is invalid.");
+            }
+            // For the upper limit, see to_integer().
+            if (100 <= major || 100 <= minor || 100 <= patch)
+            {
+                return Result::left_of(
+                    u8"Each number must be less than 100: " + str);
+            }
+
+            return Result::right_of(Version{major, minor, patch});
+        }
+        else
+        {
+            return Result::left_of(u8"Invalid format: " + str);
+        }
+    }
+
+
+
+    constexpr bool _is_complete() const
+    {
+        return minor != unspecified && patch != unspecified;
+    }
+
+
+    constexpr bool _is_incomplete() const
+    {
+        return !_is_complete();
+    }
+};
+
+
+
+struct VersionRequirement
+{
+private:
+    struct OneVersionRequirement
+    {
+        enum class Operator
+        {
+            match_any,
+            equal,
+            not_equal,
+            less_than,
+            less_than_or_equal,
+            greater_than,
+            greater_than_or_equal,
+        };
+
+
+
+        static either::either<std::string, OneVersionRequirement> parse(
+            std::string str)
+        {
+            using Result = either::either<std::string, OneVersionRequirement>;
+
+            range::remove_erase(str, ' ');
+
+            if (str.empty() || str == "*")
+            {
+                return Result::right_of(
+                    OneVersionRequirement{Operator::match_any, Version{}});
+            }
+
+            std::string version_str;
+            Operator op;
+            if (strutil::starts_with(str, u8"!="))
+            {
+                version_str = str.substr(2);
+                op = Operator::not_equal;
+            }
+            else if (strutil::starts_with(str, u8"=="))
+            {
+                version_str = str.substr(2);
+                op = Operator::equal;
+            }
+            else if (strutil::starts_with(str, u8"="))
+            {
+                version_str = str.substr(1);
+                op = Operator::equal;
+            }
+            else if (strutil::starts_with(str, u8"<="))
+            {
+                version_str = str.substr(2);
+                op = Operator::less_than_or_equal;
+            }
+            else if (strutil::starts_with(str, u8"<"))
+            {
+                version_str = str.substr(1);
+                op = Operator::less_than;
+            }
+            else if (strutil::starts_with(str, u8">="))
+            {
+                version_str = str.substr(2);
+                op = Operator::greater_than_or_equal;
+            }
+            else if (strutil::starts_with(str, u8">"))
+            {
+                version_str = str.substr(1);
+                op = Operator::greater_than;
+            }
+            else
+            {
+                version_str = str;
+                op = Operator::equal;
+            }
+
+            // Call Version::_parse_internal() instead of Version::parse() to
+            // allow incomplete version.
+            if (const auto version = Version::_parse_internal(version_str))
+            {
+                return Result::right_of(
+                    OneVersionRequirement{op, version.right()});
+            }
+            else
+            {
+                return Result::left_of(version.left());
+            }
+        }
+
+
+
+        bool is_satisfied(const Version& lhs) const
+        {
+            assert(lhs._is_complete());
+
+            switch (_operator)
+            {
+            case Operator::match_any: return true;
+            case Operator::equal: return _equal(lhs, _rhs);
+            case Operator::not_equal: return !_equal(lhs, _rhs);
+            case Operator::less_than: return _less_than(lhs, _rhs);
+            case Operator::less_than_or_equal:
+                return _less_than(lhs, _rhs) || _equal(lhs, _rhs);
+            case Operator::greater_than:
+                return !_less_than(lhs, _rhs) && !_equal(lhs, _rhs);
+            case Operator::greater_than_or_equal: return !_less_than(lhs, _rhs);
+            default: assert(0); return false;
+            }
+        }
+
+
+
+        std::string to_string() const
+        {
+            switch (_operator)
+            {
+            case Operator::match_any: return "*";
+            case Operator::equal: return "= " + _rhs.to_string();
+            case Operator::not_equal: return "!= " + _rhs.to_string();
+            case Operator::less_than: return "< " + _rhs.to_string();
+            case Operator::less_than_or_equal: return "<= " + _rhs.to_string();
+            case Operator::greater_than: return "> " + _rhs.to_string();
+            case Operator::greater_than_or_equal:
+                return ">= " + _rhs.to_string();
+            default: assert(0); return "";
+            }
+        }
+
+
+
+    private:
+        Operator _operator;
+        Version _rhs;
+
+
+
+        OneVersionRequirement(Operator op, const Version& version)
+            : _operator(op)
+            , _rhs(version)
+        {
+        }
+
+
+
+        static bool _equal(const Version& lhs, const Version& rhs)
+        {
+            if (lhs.major != rhs.major)
+                return false;
+            if (rhs.minor != Version::unspecified && lhs.minor != rhs.minor)
+                return false;
+            if (rhs.patch != Version::unspecified && lhs.patch != rhs.patch)
+                return false;
+            return true;
+        }
+
+
+
+        static bool _less_than(const Version& lhs, const Version& rhs)
+        {
+            if (lhs.major < rhs.major)
+                return true;
+            if (lhs.major > rhs.major)
+                return false;
+            if (rhs.minor == Version::unspecified)
+                return false;
+            if (lhs.minor < rhs.minor)
+                return true;
+            if (lhs.minor > rhs.minor)
+                return false;
+            if (rhs.patch == Version::unspecified)
+                return false;
+            return lhs.patch < rhs.patch;
+        }
+    };
+
+
+
+public:
+    explicit VersionRequirement(
+        const std::vector<OneVersionRequirement>& requirements)
+        : _requirements(requirements)
+    {
+    }
+
+
+
+    static either::either<std::string, VersionRequirement> parse(
+        const std::string& str)
+    {
+        using Result = either::either<std::string, VersionRequirement>;
+
+        std::vector<OneVersionRequirement> requirements;
+        for (const auto& req_str : strutil::split(str, ','))
+        {
+            if (const auto req = OneVersionRequirement::parse(req_str))
+            {
+                requirements.push_back(req.right());
+            }
+            else
+            {
+                return Result::left_of(req.left());
+            }
+        }
+
+        return Result::right_of(VersionRequirement{requirements});
+    }
+
+
+
+    bool is_satisfied(const Version& version) const
+    {
+        return std::all_of(
+            std::begin(_requirements),
+            std::end(_requirements),
+            [&](const auto& req) { return req.is_satisfied(version); });
+    }
+
+
+
+    std::string to_string() const
+    {
+        std::string result;
+        for (const auto& r : _requirements)
+        {
+            if (result.empty())
+            {
+                result += r.to_string();
+            }
+            else
+            {
+                result += ", " + r.to_string();
+            }
+        }
+        return result;
+    }
+
+
+
+private:
+    std::vector<OneVersionRequirement> _requirements;
+};
+
+} // namespace semver
+} // namespace elona

--- a/src/elona/semver.hpp
+++ b/src/elona/semver.hpp
@@ -9,6 +9,19 @@
 #include "../util/range.hpp"
 #include "../util/strutil.hpp"
 
+// A GNU system header defines these two macro named "major" and "minor". To
+// avoid breackage of semver::Version's fields, save and undefine the two here.
+// cf.
+// https://stackoverflow.com/questions/22240973/major-and-minor-macros-defined-in-sys-sysmacros-h-pulled-in-by-iterator
+#if defined(major) || defined(minor)
+#define ELONA_MAJOR_AND_MINOR_MACRO_DEFINED // for restoring
+// Both Clang and GCC support this pragma
+#pragma push_macro("major")
+#pragma push_macro("minor")
+#undef major
+#undef minor
+#endif
+
 
 
 namespace elona
@@ -441,3 +454,12 @@ private:
 
 } // namespace semver
 } // namespace elona
+
+
+
+#ifdef ELONA_MAJOR_AND_MINOR_MACRO_DEFINED
+// Restore undefined macros. See also the top of this file.
+#pragma pop_macro("major")
+#pragma pop_macro("minor")
+#undef ELONA_MAJOR_AND_MINOR_MACRO_DEFINED
+#endif

--- a/src/tests/data/registry/chara/mod.hcl
+++ b/src/tests/data/registry/chara/mod.hcl
@@ -1,4 +1,4 @@
 mod {
     name = "chara"
-    dependencies = ["core"]
+    dependencies = { core = "*" }
 }

--- a/src/tests/data/registry/chara_defaults/mod.hcl
+++ b/src/tests/data/registry/chara_defaults/mod.hcl
@@ -1,4 +1,4 @@
 mod {
     name = "chara_defaults"
-    dependencies = ["core"]
+    dependencies = { core = "*" }
 }

--- a/src/tests/data/registry/chara_duplicate_key/mod.hcl
+++ b/src/tests/data/registry/chara_duplicate_key/mod.hcl
@@ -1,4 +1,4 @@
 mod {
     name = "chara_duplicate_key"
-    dependencies = ["core"]
+    dependencies = { core = "*" }
 }

--- a/src/tests/data/registry/chara_invalid_enum/mod.hcl
+++ b/src/tests/data/registry/chara_invalid_enum/mod.hcl
@@ -1,4 +1,4 @@
 mod {
     name = "chara_invalid_enum"
-    dependencies = ["core"]
+    dependencies = { core = "*" }
 }

--- a/src/tests/data/registry/chara_portrait/mod.hcl
+++ b/src/tests/data/registry/chara_portrait/mod.hcl
@@ -1,5 +1,5 @@
 mod {
     name = "chara_portrait"
     description = "Test complex portrait settings."
-    dependencies = ["core"]
+    dependencies = { core = "*" }
 }

--- a/src/tests/data/registry/item/mod.hcl
+++ b/src/tests/data/registry/item/mod.hcl
@@ -1,4 +1,4 @@
 mod {
     name = "item"
-    dependencies = ["core"]
+    dependencies = { core = "*" }
 }

--- a/src/tests/semver.cpp
+++ b/src/tests/semver.cpp
@@ -1,0 +1,203 @@
+#include "../thirdparty/catch2/catch.hpp"
+
+#include "../elona/semver.hpp"
+
+#include "tests.hpp"
+
+using SemVer = elona::semver::Version;
+using SemVerRequirement = elona::semver::VersionRequirement;
+
+
+
+TEST_CASE("Test valid version", "[SemVer]")
+{
+    REQUIRE_SOME(SemVer::parse("0.1.0"));
+    REQUIRE_SOME(SemVer::parse("1.0.0"));
+    REQUIRE_SOME(SemVer::parse("10.99.42"));
+}
+
+
+
+TEST_CASE("Test invalid version", "[SemVer]")
+{
+    REQUIRE_NONE(SemVer::parse(""));
+    REQUIRE_NONE(SemVer::parse("lomias"));
+    REQUIRE_NONE(SemVer::parse("0.0.0"));
+    REQUIRE_NONE(SemVer::parse("-2.0.0"));
+    REQUIRE_NONE(SemVer::parse("1.0"));
+    REQUIRE_NONE(SemVer::parse("1"));
+    REQUIRE_NONE(SemVer::parse("100.0.0"));
+    REQUIRE_NONE(SemVer::parse("1000.0.0"));
+    REQUIRE_NONE(SemVer::parse("1000000000000000000000000"));
+}
+
+
+
+TEST_CASE("Test SemVer::to_string()", "[SemVer]")
+{
+    REQUIRE(SemVer(1, 2, 3).to_string() == "1.2.3");
+    REQUIRE(SemVer(99, 88, 77).to_string() == "99.88.77");
+}
+
+
+
+TEST_CASE("Test SemVer::to_integer()", "[SemVer]")
+{
+    REQUIRE(SemVer(1, 2, 3).to_integer() == 10203);
+    REQUIRE(SemVer(99, 88, 77).to_integer() == 998877);
+}
+
+
+
+TEST_CASE("Test version comparison", "[SemVer]")
+{
+    REQUIRE(SemVer(1, 2, 3) == SemVer(1, 2, 3));
+    REQUIRE(SemVer(1, 2, 3) != SemVer(0, 2, 3));
+    REQUIRE(SemVer(1, 2, 3) != SemVer(1, 0, 3));
+    REQUIRE(SemVer(1, 2, 3) != SemVer(1, 2, 0));
+    REQUIRE(SemVer(1, 2, 3) > SemVer(1, 2, 2));
+    REQUIRE(SemVer(1, 2, 3) > SemVer(1, 1, 4));
+    REQUIRE(SemVer(1, 2, 3) > SemVer(0, 3, 4));
+    REQUIRE(SemVer(1, 2, 3) >= SemVer(1, 2, 3));
+    REQUIRE(SemVer(1, 2, 3) >= SemVer(1, 2, 2));
+    REQUIRE(SemVer(1, 2, 3) >= SemVer(1, 1, 4));
+    REQUIRE(SemVer(1, 2, 3) >= SemVer(0, 3, 4));
+}
+
+
+
+TEST_CASE("Test valid version requirement", "[SemVer]")
+{
+    REQUIRE_SOME(SemVerRequirement::parse(""));
+    REQUIRE_SOME(SemVerRequirement::parse(" "));
+    REQUIRE_SOME(SemVerRequirement::parse("*"));
+    REQUIRE_SOME(SemVerRequirement::parse("=0.1.0"));
+    REQUIRE_SOME(SemVerRequirement::parse("0.1.0"));
+    REQUIRE_SOME(SemVerRequirement::parse("=0.1"));
+    REQUIRE_SOME(SemVerRequirement::parse("0.1"));
+    REQUIRE_SOME(SemVerRequirement::parse("=0"));
+    REQUIRE_SOME(SemVerRequirement::parse("0"));
+    REQUIRE_SOME(SemVerRequirement::parse("==   99.10"));
+    REQUIRE_SOME(SemVerRequirement::parse("  !=   1.0.10  "));
+    REQUIRE_SOME(SemVerRequirement::parse("> 1.2.3"));
+    REQUIRE_SOME(SemVerRequirement::parse(">= 1.2.3"));
+    REQUIRE_SOME(SemVerRequirement::parse("< 1.2.3"));
+    REQUIRE_SOME(SemVerRequirement::parse("<= 1.2.3"));
+    REQUIRE_SOME(SemVerRequirement::parse(">= 1.2, < 1.3"));
+    REQUIRE_SOME(SemVerRequirement::parse(">= 1.2, < 1.3, != 1.2.4"));
+    REQUIRE_SOME(SemVerRequirement::parse(",,,,,"));
+}
+
+
+
+TEST_CASE("Test invalid version requirement", "[SemVer]")
+{
+    REQUIRE_NONE(SemVerRequirement::parse("larnneire"));
+    REQUIRE_NONE(SemVerRequirement::parse("\t\n"));
+    REQUIRE_NONE(SemVerRequirement::parse("0.0.0"));
+    REQUIRE_NONE(SemVerRequirement::parse("@ 1.2.3"));
+    REQUIRE_NONE(SemVerRequirement::parse("~ 1.2.3"));
+    REQUIRE_NONE(SemVerRequirement::parse("+ 1.2.3"));
+    REQUIRE_NONE(SemVerRequirement::parse("> 100.999.1000"));
+    REQUIRE_NONE(SemVerRequirement::parse("1.0.0, xxx"));
+    REQUIRE_NONE(SemVerRequirement::parse("1000000000000000000000000"));
+}
+
+
+
+TEST_CASE("Test SemVerRequirement::to_string()", "[SemVer]")
+{
+#define REQUIRE_(lhs, rhs) \
+    REQUIRE(SemVerRequirement::parse(lhs).right().to_string() == rhs)
+
+    REQUIRE_("", "*");
+    REQUIRE_(" ", "*");
+    REQUIRE_("*", "*");
+    REQUIRE_("=0.1.0", "= 0.1.0");
+    REQUIRE_("0.1.0", "= 0.1.0");
+    REQUIRE_("=0.1", "= 0.1");
+    REQUIRE_("0.1", "= 0.1");
+    REQUIRE_("=0", "= 0");
+    REQUIRE_("0", "= 0");
+    REQUIRE_("==   99.10", "= 99.10");
+    REQUIRE_("  !=   1.0.10  ", "!= 1.0.10");
+    REQUIRE_("> 1.2.3", "> 1.2.3");
+    REQUIRE_(">= 1.2.3", ">= 1.2.3");
+    REQUIRE_("< 1.2.3", "< 1.2.3");
+    REQUIRE_("<= 1.2.3", "<= 1.2.3");
+    REQUIRE_(">= 1.2, < 1.3", ">= 1.2, < 1.3");
+    REQUIRE_(">= 1.2, < 1.3, != 1.2.4", ">= 1.2, < 1.3, != 1.2.4");
+    REQUIRE_(",,,,,", "*, *, *, *, *, *");
+
+#undef REQUIRE_
+}
+
+
+
+TEST_CASE("Test SemVerRequirement::is_satisfied()", "[SemVer]")
+{
+#define REQUIRE_(req_str, ver_str) \
+    REQUIRE(SemVerRequirement::parse(req_str).right().is_satisfied( \
+        SemVer::parse(ver_str).right()))
+#define REQUIRE_FALSE_(req_str, ver_str) \
+    REQUIRE_FALSE(SemVerRequirement::parse(req_str).right().is_satisfied( \
+        SemVer::parse(ver_str).right()))
+
+    REQUIRE_("*", "0.0.1");
+    REQUIRE_("*", "1.2.3");
+    REQUIRE_("*", "10.0.0");
+    REQUIRE_("= 0.1.0", "0.1.0");
+    REQUIRE_FALSE_("= 0.1.0", "0.1.1");
+
+    REQUIRE_("= 0.1", "0.1.0");
+    REQUIRE_("= 0.1", "0.1.99");
+    REQUIRE_FALSE_("= 0.1", "0.2.0");
+
+    REQUIRE_("= 0", "0.0.1");
+    REQUIRE_("= 0", "0.99.0");
+    REQUIRE_FALSE_("= 0", "1.0.0");
+
+    REQUIRE_("!= 1.0.10", "1.0.11");
+    REQUIRE_FALSE_("!= 1.0.10", "1.0.10");
+
+    REQUIRE_("> 1.2.3", "1.2.4");
+    REQUIRE_("> 1.2.3", "1.3.2");
+    REQUIRE_("> 1.2.3", "1.3.2");
+    REQUIRE_FALSE_("> 1.2.3", "1.2.3");
+    REQUIRE_FALSE_("> 1.2.3", "1.1.3");
+
+    REQUIRE_(">= 1.2.3", "1.2.4");
+    REQUIRE_(">= 1.2.3", "1.3.2");
+    REQUIRE_(">= 1.2.3", "1.3.2");
+    REQUIRE_(">= 1.2.3", "1.2.3");
+    REQUIRE_FALSE_(">= 1.2.3", "1.1.3");
+
+    REQUIRE_("< 1.2", "1.1.0");
+    REQUIRE_("< 1.2", "1.1.55");
+    REQUIRE_FALSE_("< 1.2", "1.2.0");
+    REQUIRE_FALSE_("< 1.2", "1.2.10");
+    REQUIRE_FALSE_("< 1.2", "1.3.0");
+    REQUIRE_FALSE_("< 1.2", "2.0.0");
+
+    REQUIRE_("<= 1.2", "1.1.0");
+    REQUIRE_("<= 1.2", "1.1.55");
+    REQUIRE_("<= 1.2", "1.2.0");
+    REQUIRE_("<= 1.2", "1.2.10");
+    REQUIRE_FALSE_("<= 1.2", "1.3.0");
+    REQUIRE_FALSE_("<= 1.2", "2.0.0");
+
+    REQUIRE_(">= 1.2, < 1.3", "1.2.10");
+    REQUIRE_FALSE_(">= 1.2, < 1.3", "1.3.0");
+
+    REQUIRE_(">= 1.2, < 1.3, != 1.2.4", "1.2.0");
+    REQUIRE_(">= 1.2, < 1.3, != 1.2.4", "1.2.7");
+    REQUIRE_FALSE_(">= 1.2, < 1.3, != 1.2.4", "1.2.4");
+    REQUIRE_FALSE_(">= 1.2, < 1.3, != 1.2.4", "1.3.0");
+    REQUIRE_FALSE_(">= 1.2, < 1.3, != 1.2.4", "3.0.0");
+
+    REQUIRE_("= 1.0.0, *", "1.0.0");
+    REQUIRE_FALSE_("= 1.0.0, *", "1.2.3");
+
+#undef REQUIRE_
+#undef REQUIRE_FALSE_
+}

--- a/src/util/either.hpp
+++ b/src/util/either.hpp
@@ -1,0 +1,183 @@
+#pragma once
+
+#include <boost/optional.hpp>
+#include <boost/variant.hpp>
+
+
+
+namespace either
+{
+
+namespace detail
+{
+
+template <typename T>
+struct left_holder
+{
+    T value;
+};
+
+
+
+template <typename T>
+struct right_holder
+{
+    T value;
+};
+
+} // namespace detail
+
+
+
+template <typename T>
+detail::left_holder<T> left(T&& value)
+{
+    return {std::forward<T>(value)};
+}
+
+
+
+template <typename T>
+detail::right_holder<T> right(T&& value)
+{
+    return {std::forward<T>(value)};
+}
+
+
+
+template <typename Left, typename Right>
+struct either
+    : public boost::
+          variant<detail::left_holder<Left>, detail::right_holder<Right>>
+{
+private:
+    using left_holder = detail::left_holder<Left>;
+    using right_holder = detail::right_holder<Right>;
+
+    using base_type = boost::variant<left_holder, right_holder>;
+
+
+
+public:
+    enum class which_type
+    {
+        left,
+        right,
+    };
+
+
+    using left_type = Left;
+    using right_type = Right;
+
+
+
+    either(const left_holder& value)
+        : base_type(value)
+    {
+    }
+
+
+
+    either(left_holder&& value)
+        : base_type(value)
+    {
+    }
+
+
+
+    either(const right_holder& value)
+        : base_type(value)
+    {
+    }
+
+
+
+    either(right_holder&& value)
+        : base_type(value)
+    {
+    }
+
+
+
+    static either left_of(const left_type& left)
+    {
+        return either(left_holder{left});
+    }
+
+
+
+    static either left_of(left_type&& left)
+    {
+        return either(left_holder{std::move(left)});
+    }
+
+
+
+    static either right_of(const right_type& right)
+    {
+        return either(right_holder{right});
+    }
+
+
+
+    static either right_of(right_type&& right)
+    {
+        return either(right_holder{std::move(right)});
+    }
+
+
+
+    which_type which() const
+    {
+        return base_type::which() == 0 ? which_type::left : which_type::right;
+    }
+
+
+
+    bool is_left() const
+    {
+        return which() == which_type::left;
+    }
+
+
+
+    bool is_right() const
+    {
+        return which() == which_type::right;
+    }
+
+
+
+    explicit operator bool() const
+    {
+        return is_right();
+    }
+
+
+
+    left_type& left()
+    {
+        return boost::get<left_holder>(*this).value;
+    }
+
+
+    const left_type& left() const
+    {
+        return boost::get<left_holder>(*this).value;
+    }
+
+
+
+    right_type& right()
+    {
+        return boost::get<right_holder>(*this).value;
+    }
+
+
+    const right_type& right() const
+    {
+        return boost::get<right_holder>(*this).value;
+    }
+};
+
+} // namespace either

--- a/src/util/either.hpp
+++ b/src/util/either.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
-#include <boost/optional.hpp>
 #include <boost/variant.hpp>
 
 
 
+/**
+ * Utility module for safe error handling.
+ * It is highly inspired by Haskell's Data.Either.
+ */
 namespace either
 {
 
@@ -29,6 +32,7 @@ struct right_holder
 
 
 
+/// Make a left value.
 template <typename T>
 detail::left_holder<T> left(T&& value)
 {
@@ -37,6 +41,7 @@ detail::left_holder<T> left(T&& value)
 
 
 
+/// Make a right value.
 template <typename T>
 detail::right_holder<T> right(T&& value)
 {
@@ -45,6 +50,13 @@ detail::right_holder<T> right(T&& value)
 
 
 
+/**
+ * Represents either left or right.
+ * Typically, left means failure, and right means success. It is because right
+ * is *right*.
+ * The template parameters, Left and Right, are wrapped by left_holder and
+ * right_holder because boost::variant cannot take the same type.
+ */
 template <typename Left, typename Right>
 struct either
     : public boost::
@@ -71,6 +83,7 @@ public:
 
 
 
+    /// Constructs with the left value.
     either(const left_holder& value)
         : base_type(value)
     {
@@ -78,6 +91,7 @@ public:
 
 
 
+    /// Move-constructs with the left value.
     either(left_holder&& value)
         : base_type(value)
     {
@@ -85,6 +99,7 @@ public:
 
 
 
+    /// Constructs with the right value.
     either(const right_holder& value)
         : base_type(value)
     {
@@ -92,6 +107,7 @@ public:
 
 
 
+    /// Move-constructs with the right value.
     either(right_holder&& value)
         : base_type(value)
     {
@@ -99,6 +115,7 @@ public:
 
 
 
+    /// Factory method to build a left value.
     static either left_of(const left_type& left)
     {
         return either(left_holder{left});
@@ -106,6 +123,7 @@ public:
 
 
 
+    /// Factory method to build a left value.
     static either left_of(left_type&& left)
     {
         return either(left_holder{std::move(left)});
@@ -113,6 +131,7 @@ public:
 
 
 
+    /// Factory method to build a right value.
     static either right_of(const right_type& right)
     {
         return either(right_holder{right});
@@ -120,6 +139,7 @@ public:
 
 
 
+    /// Factory method to build a right value.
     static either right_of(right_type&& right)
     {
         return either(right_holder{std::move(right)});
@@ -127,6 +147,7 @@ public:
 
 
 
+    /// Get which type the either has.
     which_type which() const
     {
         return base_type::which() == 0 ? which_type::left : which_type::right;
@@ -148,6 +169,7 @@ public:
 
 
 
+    /// Return true if it is right; otherwise false.
     explicit operator bool() const
     {
         return is_right();
@@ -155,12 +177,14 @@ public:
 
 
 
+    /// Get the left value.
     left_type& left()
     {
         return boost::get<left_holder>(*this).value;
     }
 
 
+    /// Get the left value.
     const left_type& left() const
     {
         return boost::get<left_holder>(*this).value;
@@ -168,12 +192,14 @@ public:
 
 
 
+    /// Get the right value.
     right_type& right()
     {
         return boost::get<right_holder>(*this).value;
     }
 
 
+    /// Get the right value.
     const right_type& right() const
     {
         return boost::get<right_holder>(*this).value;

--- a/src/util/range.hpp
+++ b/src/util/range.hpp
@@ -9,11 +9,12 @@ namespace range
 {
 
 template <typename Range, typename Predicate>
-auto count_if(Range&& range, Predicate predicate)
+auto count_if(Range&& range, Predicate&& predicate)
 {
     using std::begin;
     using std::end;
-    return std::count_if(begin(range), end(range), predicate);
+    return std::count_if(
+        begin(range), end(range), std::forward<Predicate>(predicate));
 }
 
 
@@ -29,21 +30,23 @@ auto distance(Range&& range)
 
 
 template <typename Range, typename Predicate>
-bool all_of(Range&& range, Predicate predicate)
+bool all_of(Range&& range, Predicate&& predicate)
 {
     using std::begin;
     using std::end;
-    return std::all_of(begin(range), end(range), predicate);
+    return std::all_of(
+        begin(range), end(range), std::forward<Predicate>(predicate));
 }
 
 
 
 template <typename Range, typename Predicate>
-bool any_of(Range&& range, Predicate predicate)
+bool any_of(Range&& range, Predicate&& predicate)
 {
     using std::begin;
     using std::end;
-    return std::any_of(begin(range), end(range), predicate);
+    return std::any_of(
+        begin(range), end(range), std::forward<Predicate>(predicate));
 }
 
 
@@ -89,11 +92,12 @@ auto find(Range&& range, const T& value)
 
 
 template <typename Range, typename Predicate>
-auto find_if(Range&& range, Predicate predicate)
+auto find_if(Range&& range, Predicate&& predicate)
 {
     using std::begin;
     using std::end;
-    return std::find_if(begin(range), end(range), predicate);
+    return std::find_if(
+        begin(range), end(range), std::forward<Predicate>(predicate));
 }
 
 
@@ -134,6 +138,31 @@ void sort(Range&& range, Comparator less)
     using std::begin;
     using std::end;
     std::sort(begin(range), end(range), less);
+}
+
+
+
+// https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Erase-Remove
+template <typename Range, typename T>
+void remove_erase(Range& range, const T& element)
+{
+    using std::begin;
+    using std::end;
+    range.erase(std::remove(begin(range), end(range), element), end(range));
+}
+
+
+
+// https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Erase-Remove
+template <typename Range, typename Predicate>
+void remove_erase_if(Range& range, Predicate&& predicate)
+{
+    using std::begin;
+    using std::end;
+    range.erase(
+        std::remove_if(
+            begin(range), end(range), std::forward<Predicate>(predicate)),
+        end(range));
 }
 
 


### PR DESCRIPTION
# Summary

Introduced version-based mod dependencies. Detailed specification is inspired by Ruby Gemfile's format and Semantic Versioning. However, it is not exactly the same as either Gemfile or Semantic Versioning.


## Specifications

*Version* consists of tree parts, major, minor, and patch. E.g., `1.0.0`, `3.1.4`, `10.20.30`. Each part must be positive, and less than 100.

*Version requirement* is a pair of *operator* and version. Operator specifies matching algorithm, for example, `Operator::any`, `Operator::equal`, and `Operator::less_than`.


> Example:
>
> Assumes that the version is `2.3.4`. The version satisfies these requirements:
> - `*` and `` (empty string).
> - `= 2.3.4`.
> - `= 2.3`.
> - `< 3`
> - `< 2.4`
> - `>= 2`
> - `> 2.3.1`
> - `> 2.2.0, != 2.3.1`
> - `>= 2.2.0, < 2.5`