### PR TITLE
Fix .ldoc files not having a line break at the end of file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ format: FORCE # Format all C++ source files.
 	test -z "$$(git status --short)"
 
 
-docgen:
+docgen: # Generate ldoc files from C++ sources.
 	cargo run --release --manifest-path tools/docgen/Cargo.toml -- -f -o doc/api src/elona/lua_env
 
 

--- a/tools/docgen/src/main.rs
+++ b/tools/docgen/src/main.rs
@@ -349,10 +349,12 @@ impl Document {
     pub fn render<W: Write>(&self, writer: &mut W) -> io::Result<()> {
         writer.write(to_lua_comment(&self.module_comment.text).as_bytes())?;
         writer.write(self.module_comment.import_comment().as_bytes())?;
+        writer.write("\n".as_bytes())?;
 
         for comment in self.comments.iter() {
-            writer.write("\n\n".as_bytes())?;
+            writer.write("\n".as_bytes())?;
             comment.render(writer)?;
+            writer.write("\n".as_bytes())?;
         }
 
         Ok(())


### PR DESCRIPTION
# Summary

`.ldoc` files did not have a line break at the end of file before. It have generated more unnecessary diff. Fixes `tools/docgen`, and insert EOL.
