### PR TITLE
Decreate resource usage of help screen

### DIFF
--- a/src/elona/ui/ui_menu_game_help.cpp
+++ b/src/elona/ui/ui_menu_game_help.cpp
@@ -280,6 +280,8 @@ void UIMenuGameHelp::update()
         page = pagemax;
     else if (page > pagemax)
         page = 0;
+
+    _redraw = true;
 }
 
 
@@ -328,8 +330,12 @@ void UIMenuGameHelp::_draw_window()
 
 void UIMenuGameHelp::draw()
 {
-    _draw_window();
-    _draw_navigation_menu();
+    if (_redraw)
+    {
+        _draw_window();
+        _draw_navigation_menu();
+        _redraw = false;
+    }
 }
 
 
@@ -344,6 +350,11 @@ optional<UIMenuGameHelp::ResultType> UIMenuGameHelp::on_key(
         snd("core.ok1");
         page_bk = page;
         cs_bk2 = cs;
+        set_reupdate();
+    }
+
+    if (cs != cs_bk)
+    {
         set_reupdate();
     }
 

--- a/src/elona/ui/ui_menu_game_help.hpp
+++ b/src/elona/ui/ui_menu_game_help.hpp
@@ -47,6 +47,7 @@ private:
     };
 
     GameHelp _help;
+    bool _redraw;
 };
 } // namespace ui
 } // namespace elona


### PR DESCRIPTION
# Related Issues

#1224.

# Summary
Now it will only be redrawn if a page update happens. This could be generalized to other menus also.