### PR TITLE
Fix Makefile.win

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -1,20 +1,20 @@
 # Change this variable to point to your Boost installation.
-BOOST_DIR := E:\build\SDK\boost_1_66_0
+BOOST_DIR = E:\build\SDK\boost_1_66_0
 
-BIN_DIR := bin
+BIN_DIR = bin
 
-BOOST_ROOT := $(BOOST_INCLUDEDIR)
-BOOST_INCLUDEDIR := $(BOOST_DIR)
-BOOST_LIBRARYDIR := $(BOOST_INCLUDEDIR)\lib64-msvc-14.1
-CMAKE_ARGS := \
+BOOST_ROOT = $(BOOST_INCLUDEDIR)
+BOOST_INCLUDEDIR = $(BOOST_DIR)
+BOOST_LIBRARYDIR = $(BOOST_INCLUDEDIR)\lib64-msvc-14.1
+CMAKE_ARGS = \
         -DBOOST_ROOT="$(BOOST_ROOT)" \
         -DBOOST_INCLUDEDIR="$(BOOST_INCLUDEDIR)" \
         -DBOOST_LIBRARYDIR="$(BOOST_LIBRARYDIR)" \
-        -G "Visual Studio 15 2017 Win64"
-		$(CMAKE_ARGS)
+        -G "Visual Studio 15 2017 Win64" \
+        $(CMAKE_ARGS)
 
 # Utilities
-MKDIR := mkdir
+MKDIR = mkdir
 
 
 .PHONY: FORCE
@@ -101,3 +101,5 @@ putit: FORCE # Generate serializers for save data.
 
 
 rebuild: clean build FORCE # Clean and build Elona.
+
+FORCE:


### PR DESCRIPTION
# Summary

Fixes broken build.

- Variable flavor (:=) is not supported in nmake.
- Add missing backslash for line continuation.
- Add empty build rule for FORCE because nmake does not allow undefined
  rule.
