### PR TITLE
Fix flickering on house designing

### DIFF
--- a/src/elona/elonacore.cpp
+++ b/src/elona/elonacore.cpp
@@ -5331,7 +5331,7 @@ TurnResult step_into_gate()
 
 int target_position(bool target_chara)
 {
-    if (tlocinitx != 0 || tlocinity != 0)
+    if (tlocinitx != 0 || tlocinity != 0 || homemapmode == 1)
     {
         tlocx = tlocinitx;
         tlocy = tlocinity;
@@ -5634,7 +5634,7 @@ int target_position(bool target_chara)
                 snd("core.cursor1");
             }
             scposval = 0;
-            if (tlocinitx == 0 && tlocinity == 0)
+            if (tlocinitx == 0 && tlocinity == 0 && homemapmode != 1)
             {
                 update_screen();
             }


### PR DESCRIPTION
# Summary

When you move your cursor to (0, 0) in the current map on housing,
the top right tile flickers, and the position of the highlighting square
moves to the cell you are standing.

It also occurs in vanilla.

The solution is very ad-hoc, but it works.