### PR TITLE
Simplify config menu hierarchy

### DIFF
--- a/src/elona/config/create_config_screen.cpp
+++ b/src/elona/config/create_config_screen.cpp
@@ -264,11 +264,21 @@ void ConfigScreenCreator::add_mod_configs_section()
             found_mods = true;
 
             I18NKey locale_key = mod_id + ".locale.config.menu";
-            int submenu_index = config_key_to_submenu_index_[mod_id];
+
+            std::string id = mod_id;
+            const auto& children = config_.get_def().get_children(mod_id);
+            if (children.size() == 1)
+            {
+                // If the mod has only one section, expand the section into
+                // "Mod Settings" submenu.
+                id += "." + children.front();
+            }
+
+            int submenu_index = config_key_to_submenu_index_[id];
 
             result_.at(mod_menu_index)
                 ->items.emplace_back(std::make_unique<ConfigMenuItemSection>(
-                    mod_id, locale_key, submenu_index));
+                    id, locale_key, submenu_index));
         }
     }
 

--- a/src/elona/config/create_config_screen.cpp
+++ b/src/elona/config/create_config_screen.cpp
@@ -1,18 +1,96 @@
 #include "create_config_screen.hpp"
+#include <string>
+#include <unordered_map>
+#include "../../util/natural_order_comparator.hpp"
+#include "../../util/range.hpp"
 #include "../spec.hpp"
 #include "config_def.hpp"
 #include "config_menu.hpp"
 
+
+
 namespace elona
 {
+
+namespace
+{
+
+using SpecKey = std::string;
+using I18NKey = std::string;
+
+
+
+class ConfigScreenCreator
+{
+public:
+    ConfigScreenCreator(Config& config)
+        : config_(config)
+    {
+    }
+
+    ConfigScreen create();
+
+private:
+    void visit_toplevel();
+    bool visit_mod_config(const std::string& mod_id);
+    bool visit_section_children(
+        const std::string& mod_id,
+        const I18NKey& locale_key);
+    bool visit_section(const SpecKey& current_key, const I18NKey& locale_key);
+    bool visit_config_item(
+        const SpecKey& current_key,
+        const I18NKey& locale_key);
+
+    void add_keybindings_section();
+    void add_mod_configs_section();
+
+    void add_menu(
+        const SpecKey& key,
+        const I18NKey& menu_name_key,
+        int width,
+        int submenu);
+    void add_submenu(
+        const SpecKey& key,
+        const I18NKey& menu_name_key,
+        int width,
+        int submenu);
+
+    void add_item_yesno(
+        const SpecKey& key,
+        const I18NKey& locale_key,
+        bool default_value);
+    void add_item_integer(
+        const SpecKey& key,
+        const I18NKey& locale_key,
+        int default_value);
+    void add_item_choice(
+        const SpecKey& key,
+        const I18NKey& locale_key,
+        const std::string& default_value);
+    void add_item_section(
+        const SpecKey& key,
+        const I18NKey& locale_key,
+        const std::string section_name,
+        int submenu_index);
+
+    std::vector<std::string> get_sorted_mod_list();
+
+    Config& config_;
+    ConfigScreen result_;
+    std::unordered_map<std::string, int> config_key_to_submenu_index_;
+    int menu_index_;
+};
+
+
 
 constexpr int menu_width = 370;
 constexpr int submenu_width = 440;
 constexpr int menu_height = 165;
 constexpr int menu_item_height = 19;
 
-// Functions for adding items to the config screen.
 
+
+// Functions for visiting/building the config menu.
 void ConfigScreenCreator::add_menu(
     const SpecKey& key,
     const I18NKey& menu_name_key,
@@ -26,6 +104,8 @@ void ConfigScreenCreator::add_menu(
         i18n::s.get(menu_name_key), w, h, submenu));
 }
 
+
+
 void ConfigScreenCreator::add_submenu(
     const SpecKey& key,
     const I18NKey& menu_name_key,
@@ -38,6 +118,7 @@ void ConfigScreenCreator::add_submenu(
     result_.emplace_back(std::make_unique<ConfigMenuSubmenu>(
         i18n::s.get(menu_name_key), w, h, submenu));
 }
+
 
 
 void ConfigScreenCreator::add_item_yesno(
@@ -67,6 +148,8 @@ void ConfigScreenCreator::add_item_yesno(
             key, locale_key, default_value, yes_text, no_text));
 }
 
+
+
 void ConfigScreenCreator::add_item_integer(
     const SpecKey& key,
     const I18NKey& locale_key,
@@ -79,6 +162,8 @@ void ConfigScreenCreator::add_item_integer(
         ->items.emplace_back(std::make_unique<ConfigMenuItemInteger>(
             key, locale_key, default_value, min, max, "${_1}"));
 }
+
+
 
 void ConfigScreenCreator::add_item_choice(
     const SpecKey& key,
@@ -104,6 +189,8 @@ void ConfigScreenCreator::add_item_choice(
             key, locale_key, default_value, choices, translate_variants));
 }
 
+
+
 void ConfigScreenCreator::add_item_section(
     const SpecKey& key,
     const I18NKey& locale_key,
@@ -125,7 +212,6 @@ void ConfigScreenCreator::add_item_section(
 }
 
 
-// Functions for visiting/building the config menu.
 
 void ConfigScreenCreator::add_keybindings_section()
 {
@@ -140,9 +226,11 @@ void ConfigScreenCreator::add_keybindings_section()
         menu_index_));
 }
 
+
+
 void ConfigScreenCreator::add_mod_configs_section()
 {
-    const auto& mod_ids = config_.get_mod_ids();
+    const auto& mod_ids = get_sorted_mod_list();
 
     // Only add the section if there is at least one mod other than "core".
     if (mod_ids.size() <= 1)
@@ -193,6 +281,8 @@ void ConfigScreenCreator::add_mod_configs_section()
     }
 }
 
+
+
 void ConfigScreenCreator::visit_toplevel()
 {
     menu_index_ = 0;
@@ -211,12 +301,16 @@ void ConfigScreenCreator::visit_toplevel()
     add_mod_configs_section();
 }
 
+
+
 bool ConfigScreenCreator::visit_mod_config(const std::string& mod_id)
 {
     I18NKey locale_key = mod_id + ".locale.config.menu";
 
     return visit_section_children(mod_id, locale_key);
 }
+
+
 
 bool ConfigScreenCreator::visit_section_children(
     const std::string& current_key,
@@ -228,7 +322,7 @@ bool ConfigScreenCreator::visit_section_children(
     I18NKey menu_name_key = locale_key + ".name";
 
     // Ignore this section if it contains no items.
-    if (config_.get_def().get_children(current_key).size() == 0)
+    if (config_.get_def().get_children(current_key).empty())
     {
         return false;
     }
@@ -270,6 +364,8 @@ bool ConfigScreenCreator::visit_section_children(
     return found_items;
 }
 
+
+
 bool ConfigScreenCreator::visit_section(
     const SpecKey& current_key,
     const I18NKey& locale_key)
@@ -291,7 +387,7 @@ bool ConfigScreenCreator::visit_section(
         return false;
     }
     // Ignore this section if it contains no items.
-    if (config_.get_def().get_children(current_key).size() == 0)
+    if (config_.get_def().get_children(current_key).empty())
     {
         return false;
     }
@@ -323,6 +419,8 @@ bool ConfigScreenCreator::visit_section(
 
     return found_items;
 }
+
+
 
 bool ConfigScreenCreator::visit_config_item(
     const SpecKey& current_key,
@@ -382,11 +480,27 @@ bool ConfigScreenCreator::visit_config_item(
 }
 
 
+
+std::vector<std::string> ConfigScreenCreator::get_sorted_mod_list()
+{
+    const auto& mods = config_.get_mod_ids();
+    std::vector<std::string> ret{std::begin(mods), std::end(mods)};
+
+    range::sort(ret, lib::natural_order_comparator{});
+
+    return ret;
+}
+
+
+
 ConfigScreen ConfigScreenCreator::create()
 {
     visit_toplevel();
     return std::move(result_);
 }
+
+} // namespace
+
 
 
 ConfigScreen create_config_screen()

--- a/src/elona/config/create_config_screen.hpp
+++ b/src/elona/config/create_config_screen.hpp
@@ -1,79 +1,16 @@
 #pragma once
 
 #include <memory>
-#include <string>
-#include <unordered_map>
 #include <vector>
+
+
 
 namespace elona
 {
-using SpecKey = std::string;
-using I18NKey = std::string;
 
-class Config;
-class ConfigDef;
 class ConfigMenu;
-
 using ConfigScreen = std::vector<std::unique_ptr<ConfigMenu>>;
 
-class ConfigScreenCreator
-{
-public:
-    ConfigScreenCreator(Config& config)
-        : config_(config)
-    {
-    }
-
-    ConfigScreen create();
-
-private:
-    void visit_toplevel();
-    bool visit_mod_config(const std::string& mod_id);
-    bool visit_section_children(
-        const std::string& mod_id,
-        const I18NKey& locale_key);
-    bool visit_section(const SpecKey& current_key, const I18NKey& locale_key);
-    bool visit_config_item(
-        const SpecKey& current_key,
-        const I18NKey& locale_key);
-
-    void add_keybindings_section();
-    void add_mod_configs_section();
-
-    void add_menu(
-        const SpecKey& key,
-        const I18NKey& menu_name_key,
-        int width,
-        int submenu);
-    void add_submenu(
-        const SpecKey& key,
-        const I18NKey& menu_name_key,
-        int width,
-        int submenu);
-
-    void add_item_yesno(
-        const SpecKey& key,
-        const I18NKey& locale_key,
-        bool default_value);
-    void add_item_integer(
-        const SpecKey& key,
-        const I18NKey& locale_key,
-        int default_value);
-    void add_item_choice(
-        const SpecKey& key,
-        const I18NKey& locale_key,
-        const std::string& default_value);
-    void add_item_section(
-        const SpecKey& key,
-        const I18NKey& locale_key,
-        const std::string section_name,
-        int submenu_index);
-
-    Config& config_;
-    ConfigScreen result_;
-    std::unordered_map<std::string, int> config_key_to_submenu_index_;
-    int menu_index_;
-};
-
 ConfigScreen create_config_screen();
+
 } // namespace elona


### PR DESCRIPTION
# Related Issues

Close #1260 


# Summary

- ~~Remove "Mod Settings" submenu.~~
- ~~Instead, expand each menu to top level.~~
- Sort mods by name (ascending).
- Expand mod config if the mod has only one section.
  - If the mod has only one section, the number of Enter keys you need to type decrease by 1.


# Screenshot

```hcl
# mod/hoge/config_def.hcl
config {
    game {
        type = "section"
        options = {
            aaa = true
        }
    }
}
```

![image](https://user-images.githubusercontent.com/36858341/58960035-45cd8900-87e1-11e9-8468-0905a5479998.png)
![image](https://user-images.githubusercontent.com/36858341/58960048-4c5c0080-87e1-11e9-9557-4eafa328a1be.png)
![image](https://user-images.githubusercontent.com/36858341/58960054-4e25c400-87e1-11e9-9b9a-3aee1f4ebb01.png)
