### PR TITLE
Add menu for installed mods

### DIFF
--- a/runtime/data/script/kernel/handle.lua
+++ b/runtime/data/script/kernel/handle.lua
@@ -185,7 +185,7 @@ function Handle.create_handle(cpp_ref, kind, uuid)
       return nil
    end
 
-   -- print("CREATE " .. cpp_ref.index .. " " .. uuid)
+   -- print("CREATE " .. kind .. " " .. cpp_ref.index .. " " .. uuid)
 
    local handle = {
       __uuid = uuid,
@@ -298,7 +298,6 @@ end
 
 function Handle.merge_handles(kind, handles_)
    for index, handle in pairs(handles_) do
-
       if handle ~= nil then
          if handles_by_index[kind][index] ~= nil then
             error("Attempt to overwrite handle " .. kind .. ":" .. adjusted_index, 2)

--- a/runtime/data/script/kernel/serial.lua
+++ b/runtime/data/script/kernel/serial.lua
@@ -19,7 +19,10 @@ local function resolve_handles(data, seen)
    end
 end
 
-Serial.save = serpent.dump
+Serial.save = function(s)
+   local dump = serpent.dump(s)
+   return dump
+end
 
 function Serial.load(dump)
    local ok, data = serpent.load(dump)

--- a/runtime/locale/en/main_menu.hcl
+++ b/runtime/locale/en/main_menu.hcl
@@ -39,6 +39,13 @@ locale {
         }
 
         mods {
+            title = "Installed Mods"
+            hint_readme_page = "[Change README page]"
+            no_readme = "(No README available.)"
+            name = "Name"
+            author = "Author"
+            version = "Version"
+            description = "Description"
         }
     }
 }

--- a/runtime/locale/en/main_menu.hcl
+++ b/runtime/locale/en/main_menu.hcl
@@ -6,6 +6,7 @@ locale {
             incarnate = "Incarnate an Adventurer"
             about = "About"
             options = "Options"
+            mods = "Mods"
             exit = "Exit"
         }
 
@@ -35,6 +36,9 @@ locale {
 
         about_changelog {
             title = "Changelogs"
+        }
+
+        mods {
         }
     }
 }

--- a/runtime/locale/jp/main_menu.hcl
+++ b/runtime/locale/jp/main_menu.hcl
@@ -6,6 +6,7 @@ locale {
             incarnate = "冒険者の引継ぎ"
             about = "このゲームについて"
             options = "設定の変更"
+            mods = "MODリスト"
             exit = "終了"
         }
 
@@ -35,6 +36,9 @@ locale {
 
         about_changelog {
             title = "更新履歴"
+        }
+
+        mods {
         }
     }
 }

--- a/runtime/locale/jp/main_menu.hcl
+++ b/runtime/locale/jp/main_menu.hcl
@@ -39,6 +39,13 @@ locale {
         }
 
         mods {
+            title = "インストール済みのMOD"
+            hint_readme_page = "[READMEページ切替]"
+            no_readme = "(READMEはありません)"
+            name = "名前"
+            author = "作者"
+            version = "バージョン"
+            description = "説明文"
         }
     }
 }

--- a/runtime/profile/_/mod/core/mod.hcl
+++ b/runtime/profile/_/mod/core/mod.hcl
@@ -2,5 +2,6 @@ mod {
     name = "core"
     author = "KI, Ruin0x11"
     version = "0.2.6"
+    license = "MIT"
     description = "Base game content. Currently, the game cannot be run without this mod."
 }

--- a/src/elona/elonacore.cpp
+++ b/src/elona/elonacore.cpp
@@ -4063,6 +4063,11 @@ TurnResult exit_map()
     int previous_map = game_data.current_map;
     int previous_dungeon_level = game_data.current_dungeon_level;
     int fixstart = 0;
+
+    ELONA_LOG("map") << "exit_map levelexitby begin " << levelexitby << " cur "
+                     << game_data.current_map << " cur_level "
+                     << game_data.current_dungeon_level;
+
     game_data.left_minutes_of_executing_quest = 0;
     game_data.rogue_boss_encountered = 0;
     if (map_data.type == mdata_t::MapType::player_owned)
@@ -4434,6 +4439,8 @@ TurnResult exit_map()
     {
         // This map should be saved.
         save_map_local_data();
+
+        ELONA_LOG("map") << "exit_map save local";
     }
     else
     {
@@ -4456,12 +4463,14 @@ TurnResult exit_map()
                 --npcmemory(1, cnt.id);
             }
         }
+
+        ELONA_LOG("map") << "exit_map clear temporary";
     }
 
     bool map_changed = game_data.current_map != previous_map ||
         game_data.current_dungeon_level != previous_dungeon_level;
 
-    ELONA_LOG("map") << "exit_map levelexitby " << levelexitby << " cur "
+    ELONA_LOG("map") << "exit_map levelexitby end " << levelexitby << " cur "
                      << game_data.current_map << " cur_level "
                      << game_data.current_dungeon_level << " prev "
                      << previous_map << " prev_level "

--- a/src/elona/init.cpp
+++ b/src/elona/init.cpp
@@ -1,4 +1,5 @@
 #include "init.hpp"
+
 #include "../snail/touch_input.hpp"
 #include "adventurer.hpp"
 #include "area.hpp"

--- a/src/elona/lua_env/console.cpp
+++ b/src/elona/lua_env/console.cpp
@@ -108,7 +108,6 @@ void Console::init_environment()
     auto core = _lua->get_api_manager().get_core_api_table();
     _console_mod =
         _lua->get_mod_manager().create_mod(_namespace_console, none, false);
-    _console_mod->enabled = true;
 
     // Automatically import APIs from "core" into the environment.
     for (const auto& kvp : core)

--- a/src/elona/lua_env/console.cpp
+++ b/src/elona/lua_env/console.cpp
@@ -1,7 +1,10 @@
 #include "console.hpp"
+
 #include <regex>
 #include <sstream>
+
 #include <boost/algorithm/string/predicate.hpp>
+
 #include "../../snail/application.hpp"
 #include "../../snail/blend_mode.hpp"
 #include "../../snail/input.hpp"
@@ -105,6 +108,7 @@ void Console::init_environment()
     auto core = _lua->get_api_manager().get_core_api_table();
     _console_mod =
         _lua->get_mod_manager().create_mod(_namespace_console, none, false);
+    _console_mod->enabled = true;
 
     // Automatically import APIs from "core" into the environment.
     for (const auto& kvp : core)

--- a/src/elona/lua_env/data_manager.cpp
+++ b/src/elona/lua_env/data_manager.cpp
@@ -1,4 +1,5 @@
 #include "data_manager.hpp"
+
 #include "../../util/natural_order_comparator.hpp"
 #include "../log.hpp"
 #include "api_manager.hpp"
@@ -164,7 +165,7 @@ void DataManager::init_from_mods()
     for (const auto& mod_name :
          _lua->get_mod_manager().calculate_loading_order())
     {
-        const auto& mod = _lua->get_mod_manager().get_mod(mod_name);
+        const auto& mod = _lua->get_mod_manager().get_enabled_mod(mod_name);
         _init_from_mod(*mod);
     }
 

--- a/src/elona/lua_env/lua_env.cpp
+++ b/src/elona/lua_env/lua_env.cpp
@@ -1,4 +1,5 @@
 #include "lua_env.hpp"
+
 #include "../config/config.hpp"
 #include "api_manager.hpp"
 #include "console.hpp"
@@ -79,6 +80,7 @@ void LuaEnv::clear()
     event_mgr->clear();
     mod_mgr->clear_mod_stores();
     data_mgr->clear();
+    handle_mgr->clear_all_handles();
     lua_->collect_garbage();
 }
 

--- a/src/elona/lua_env/mod_manifest.cpp
+++ b/src/elona/lua_env/mod_manifest.cpp
@@ -1,4 +1,5 @@
 #include "mod_manifest.hpp"
+
 #include "../hcl.hpp"
 
 namespace elona
@@ -9,12 +10,15 @@ namespace lua
 namespace
 {
 
-std::string _read_mod_name(const hcl::Value& value, const fs::path& path)
+std::string _read_string(
+    const std::string key,
+    const hcl::Value& value,
+    const fs::path& path)
 {
     std::string result;
 
     // TODO: Clean up, as with lua::ConfigTable
-    const hcl::Value* object = value.find("name");
+    const hcl::Value* object = value.find(key);
     if (object && object->is<std::string>())
     {
         result = object->as<std::string>();
@@ -22,8 +26,8 @@ std::string _read_mod_name(const hcl::Value& value, const fs::path& path)
     else
     {
         throw std::runtime_error(
-            filepathutil::to_utf8_path(path) +
-            ": Missing \"name\" in mod manifest");
+            filepathutil::to_utf8_path(path) + ": Missing \"" + key +
+            "\" in mod manifest");
     }
 
     return result;
@@ -56,7 +60,7 @@ semver::Version _read_mod_version(const hcl::Value& value, const fs::path& path)
     {
         throw std::runtime_error(
             filepathutil::to_utf8_path(path) +
-            ": Missing \"name\" in mod manifest");
+            ": Missing \"version\" in mod manifest");
     }
 }
 
@@ -124,12 +128,21 @@ ModManifest ModManifest::load(const fs::path& path)
     const auto& value = hclutil::skip_sections(
         parsed, {"mod"}, filepathutil::to_utf8_path(path));
 
-    const auto mod_name = _read_mod_name(value, path);
+    const auto mod_name = _read_string("name", value, path);
+    const auto mod_author = _read_string("author", value, path);
+    const auto mod_description = _read_string("description", value, path);
+    const auto mod_license = _read_string("license", value, path);
     const auto version = _read_mod_version(value, path);
     const auto mod_path = path.parent_path();
     const auto dependencies = _read_dependencies(value, path);
 
-    return ModManifest{mod_name, version, mod_path, dependencies};
+    return ModManifest{mod_name,
+                       mod_author,
+                       mod_description,
+                       mod_license,
+                       version,
+                       mod_path,
+                       dependencies};
 }
 
 } // namespace lua

--- a/src/elona/lua_env/mod_manifest.hpp
+++ b/src/elona/lua_env/mod_manifest.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <unordered_map>
+
 #include "../filesystem.hpp"
 #include "../optional.hpp"
 #include "../semver.hpp"
@@ -23,6 +24,9 @@ struct ModManifest
     static ModManifest load(const fs::path& path);
 
     std::string name;
+    std::string author;
+    std::string description;
+    std::string license;
     semver::Version version;
     optional<fs::path> path;
     Dependencies dependencies;

--- a/src/elona/lua_env/mod_serializer.hpp
+++ b/src/elona/lua_env/mod_serializer.hpp
@@ -82,12 +82,12 @@ public:
     {
         const auto& mod_mgr = _lua->get_mod_manager();
 
-        unsigned mod_count = static_cast<unsigned>(mod_mgr.count());
+        unsigned mod_count = static_cast<unsigned>(mod_mgr.enabled_mod_count());
         putit_archive(mod_count);
 
-        for (const auto& pair : mod_mgr)
+        for (const auto& pair : mod_mgr.enabled_mods())
         {
-            std::string mod_name = pair.first;
+            std::string mod_name = pair.second->manifest.name;
             semver::Version mod_version = pair.second->manifest.version;
 
             putit_archive(mod_name);
@@ -120,7 +120,7 @@ public:
             putit_archive(mod_name);
             putit_archive(mod_version);
 
-            auto mod = mod_mgr.get_mod_optional(mod_name);
+            auto mod = mod_mgr.get_enabled_mod_optional(mod_name);
             if (!mod)
             {
                 // Skip this piece of data.

--- a/src/elona/main_menu.cpp
+++ b/src/elona/main_menu.cpp
@@ -1260,11 +1260,6 @@ MainMenuResult main_menu_about_credits()
 MainMenuResult main_menu_mods()
 {
     ui::UIMenuMods().show();
-#if 0
-    lua::lua->get_mod_manager()->unload_mods();
-    lua::lua->get_mod_manager()->load_mods(filesystem::dir::mods());
-    show_loading_screen();
-#endif
     return MainMenuResult::main_title_menu;
 }
 

--- a/src/elona/main_menu.hpp
+++ b/src/elona/main_menu.hpp
@@ -13,6 +13,7 @@ enum class MainMenuResult
     main_menu_about_changelogs,
     main_menu_about_license,
     main_menu_about_credits,
+    main_menu_mods,
     character_making_select_race,
     character_making_select_sex,
     character_making_select_sex_looped,
@@ -40,5 +41,6 @@ MainMenuResult main_menu_about();
 MainMenuResult main_menu_about_changelogs();
 MainMenuResult main_menu_about_license();
 MainMenuResult main_menu_about_credits();
+MainMenuResult main_menu_mods();
 
 } // namespace elona

--- a/src/elona/save.cpp
+++ b/src/elona/save.cpp
@@ -1,4 +1,5 @@
 #include "save.hpp"
+
 #include "audio.hpp"
 #include "character_status.hpp"
 #include "ctrl_file.hpp"

--- a/src/elona/semver.hpp
+++ b/src/elona/semver.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <cassert>
+
 #include <regex>
 #include <stdexcept>
 #include <string>
 #include <vector>
+
 #include "../util/either.hpp"
 #include "../util/range.hpp"
 #include "../util/strutil.hpp"
@@ -463,7 +465,6 @@ private:
 
 } // namespace semver
 } // namespace elona
-
 
 
 #ifdef ELONA_MAJOR_AND_MINOR_MACRO_DEFINED

--- a/src/elona/std.cpp
+++ b/src/elona/std.cpp
@@ -6,12 +6,10 @@
 #include <regex>
 #include <sstream>
 
-
 #include "../snail/android.hpp"
 #include "../snail/application.hpp"
 #include "../snail/hsp.hpp"
 #include "../snail/window.hpp"
-
 #include "../util/fps_counter.hpp"
 #include "../util/strutil.hpp"
 #include "config/config.hpp"

--- a/src/elona/testing.cpp
+++ b/src/elona/testing.cpp
@@ -1,7 +1,10 @@
 #include "testing.hpp"
+
 #include <sstream>
+
 #include "../version.hpp"
 #include "config/config.hpp"
+#include "ctrl_file.hpp"
 #include "data/types/type_item.hpp"
 #include "data/types/type_music.hpp"
 #include "data/types/type_sound.hpp"
@@ -41,7 +44,7 @@ fs::path get_mods_path()
 
 void load_previous_savefile()
 {
-    elona::testing::reset_state();
+    testing::reset_state();
     // This file was saved directly after the dialog at the start of the game.
     elona::playerid = "sav_foobar_test";
     filesystem::dir::set_base_save_directory(filesystem::path(save_dir));
@@ -54,19 +57,29 @@ void load_previous_savefile()
 
 void save_reset_and_reload()
 {
-    filesystem::dir::set_base_save_directory(filesystem::path(save_dir));
-    save_game();
-    elona::testing::reset_state();
-    elona::firstturn = 1;
-    load_save_data();
+    testing::save();
+    testing::reset_state();
+    testing::load();
 }
 
 void save_and_reload()
 {
+    testing::save();
+    testing::load();
+}
+
+void save()
+{
     filesystem::dir::set_base_save_directory(filesystem::path(save_dir));
     save_game();
+}
+
+void load()
+{
     elona::firstturn = 1;
     load_save_data();
+    elona::mode = 3;
+    initialize_map();
 }
 
 void load_translations(const std::string& hcl)
@@ -108,6 +121,10 @@ void start_in_map(int map, int level)
 
     elona::playerid = player_id;
     fs::remove_all(filesystem::dir::save(player_id));
+    fs::remove_all(filesystem::dir::tmp());
+    fs::create_directory(filesystem::dir::tmp());
+    writeloadedbuff_clear();
+    Save::instance().clear();
 
     game_data.current_map = map;
     game_data.current_dungeon_level = level;
@@ -178,6 +195,10 @@ void post_run()
 {
     filesystem::dir::set_base_save_directory(filesystem::path(save_dir));
     fs::remove_all(filesystem::dir::save(player_id));
+    fs::remove_all(filesystem::dir::tmp());
+    writeloadedbuff_clear();
+    Save::instance().clear();
+    fs::create_directory(filesystem::dir::tmp());
     finish_elona();
 }
 

--- a/src/elona/testing.hpp
+++ b/src/elona/testing.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <functional>
+
 #include "filesystem.hpp"
 
 namespace elona
@@ -23,6 +24,9 @@ void reset_state();
 
 void save_reset_and_reload();
 void save_and_reload();
+
+void save();
+void load();
 
 /***
  * Loads a pre-prepared savefile to test save breakages between

--- a/src/elona/ui/ui_menu_mods.cpp
+++ b/src/elona/ui/ui_menu_mods.cpp
@@ -1,0 +1,325 @@
+#include "ui_menu_mods.hpp"
+
+#include "../../util/fileutil.hpp"
+#include "../../util/strutil.hpp"
+#include "../audio.hpp"
+#include "../draw.hpp"
+#include "../i18n.hpp"
+#include "../lua_env/mod_manager.hpp"
+
+
+
+namespace elona
+{
+namespace ui
+{
+
+bool UIMenuMods::init()
+{
+    snd("core.pop2");
+    listmax = 0;
+    page = 0;
+    pagesize = 18;
+    cs = 0;
+    cc = 0;
+    cs_bk = -1;
+    page_bk = 0;
+    cs_bk2 = 0;
+
+    asset_load("void");
+    ::draw("void", 0, 0, windoww, windowh);
+    load_background_variants(2);
+    gsel(0);
+    gmode(0);
+    gcopy(4, 0, 0, windoww, windowh, 0, 0);
+    gmode(2);
+
+    for (const auto& mod : lua::lua->get_mod_manager().all_mods())
+    {
+        if (mod->second->manifest.name == "_CONSOLE_")
+            continue;
+
+        ModDescription mod_desc{mod->second->manifest.name + "(" +
+                                    mod->second->manifest.version.to_string() +
+                                    ")",
+                                mod->second->manifest,
+                                mod->second->enabled};
+
+        mod_descriptions.emplace_back(mod_desc);
+        listmax++;
+    }
+
+    windowshadow = 1;
+
+    update();
+
+    return true;
+}
+
+
+
+void UIMenuMods::_draw_mod_page()
+{
+    const auto& desc = mod_descriptions.at(pagesize * page + cs);
+
+    display_topic(desc.display_name, wx + 206, wy + 36);
+
+    font(14 - en * 2);
+    int y = wy + 60;
+
+    gmes(
+        "<b>Name<def>: " + desc.manifest.name,
+        wx + 216,
+        y,
+        380,
+        {30, 30, 30},
+        false);
+    gmes(
+        "<b>Author:<def> " + desc.manifest.author,
+        wx + 216,
+        y + 16,
+        380,
+        {30, 30, 30},
+        false);
+    gmes(
+        "<b>Version:<def> " + desc.manifest.version.to_string(),
+        wx + 216,
+        y + 32,
+        380,
+        {30, 30, 30},
+        false);
+    gmes(
+        "<b>Description:<def> " + desc.manifest.description,
+        wx + 216,
+        y + 48,
+        380,
+        {30, 30, 30},
+        false);
+
+    window2(wx + 216 + 386 + 12 - 4, y - 36 - 4, 128 + 8, 128 + 8, 1, 1);
+    boxf(wx + 216 + 386 + 12, y - 36, 128, 128, {0, 0, 0});
+
+    display_topic("Description", wx + 206, wy + 160);
+
+    y = wy + 184;
+
+    auto readme_path =
+        filesystem::dir::for_mod(desc.manifest.name) / "README.md";
+    if (fs::exists(readme_path))
+    {
+        std::vector<std::string> credits_text_lines;
+        range::copy(
+            fileutil::read_by_line(readme_path),
+            std::back_inserter(credits_text_lines));
+        const size_t text_width = 75 - 28;
+        constexpr size_t lines_per_page = 16;
+
+        for (auto&& line : credits_text_lines)
+        {
+            // talk_conv only accepts single line text, so you need to split by
+            // line.
+            talk_conv(line, text_width);
+        }
+        size_t line_count = 0;
+        for (const auto& lines : credits_text_lines)
+        {
+            if (lines == "")
+            {
+                y = gmes(lines, wx + 216, y, 510, {30, 30, 30}, false).y;
+            }
+            for (const auto& line : strutil::split_lines(lines))
+            {
+                const auto ny =
+                    gmes(line, wx + 216, y, 510, {30, 30, 30}, false).y;
+                ++line_count;
+                if (line_count == lines_per_page)
+                {
+                    return;
+                    line_count = 0;
+                }
+                y = ny;
+            }
+        }
+    }
+    else
+    {
+        gmes(
+            "(No description available.)",
+            wx + 216,
+            y,
+            510,
+            {30, 30, 30},
+            false);
+    }
+}
+
+
+
+void UIMenuMods::_draw_navigation_menu()
+{
+    font(14 - en * 2);
+    cs_listbk();
+    for (int cnt = 0, cnt_end = (pagesize); cnt < cnt_end; ++cnt)
+    {
+        p = pagesize * page + cnt;
+        if (p >= listmax)
+        {
+            break;
+        }
+        const auto& desc = mod_descriptions.at(p);
+        snail::Color color = {0, 0, 0};
+        if (desc.enabled)
+        {
+            color = {0, 0, 255};
+        }
+
+        cs_list(
+            cs == cnt,
+            desc.display_name,
+            wx + 66,
+            wy + 66 + cnt * 19 - 1,
+            0,
+            color);
+    }
+
+    if (keyrange != 0)
+    {
+        cs_bk = cs;
+    }
+}
+
+
+
+void UIMenuMods::_draw_background_vignette(int id, int type)
+{
+    cmbg = id;
+    x = ww / 5 * 2;
+    y = wh - 80;
+    gmode(2, 50);
+    gcopy_c(
+        type,
+        cmbg % 4 * 180,
+        cmbg / 4 % 2 * 300,
+        180,
+        300,
+        wx + ww / 4,
+        wy + wh / 2,
+        x,
+        y);
+    gmode(2);
+}
+
+
+
+void UIMenuMods::update()
+{
+    cs_bk = -1;
+    pagemax = (listmax - 1) / pagesize;
+    if (page < 0)
+        page = pagemax;
+    else if (page > pagemax)
+        page = 0;
+
+    _redraw = true;
+}
+
+
+
+void UIMenuMods::_draw_window()
+{
+    int y;
+    if (mode == 1)
+    {
+        y = winposy(496, 1);
+    }
+    else
+    {
+        y = winposy(496) - 24;
+    }
+    ui_display_window(
+        u8"Mod List",
+        strhint2 + strhint3b,
+        (windoww - 780) / 2 + inf_screenx,
+        y,
+        780,
+        580);
+    display_topic(i18n::s.get("core.locale.ui.manual.topic"), wx + 34, wy + 36);
+
+    _draw_background_vignette(page % 5, 2);
+    keyrange = 0;
+
+    // Moves and refresh cursor
+    for (int cnt = 0, cnt_end = (pagesize); cnt < cnt_end; ++cnt)
+    {
+        p = pagesize * page + cnt;
+        if (p >= listmax)
+            break;
+        key_list(cnt) = key_select(cnt);
+        ++keyrange;
+        display_key(wx + 38, wy + 66 + cnt * 19 - 2, cnt);
+    }
+
+    _draw_mod_page();
+}
+
+
+
+void UIMenuMods::draw()
+{
+    if (_redraw)
+    {
+        _draw_window();
+        _draw_navigation_menu();
+        _redraw = false;
+    }
+}
+
+
+
+optional<UIMenuMods::ResultType> UIMenuMods::on_key(const std::string& action)
+{
+    // Key selection
+    if (auto selected = get_selected_index_this_page())
+    {
+        cs = *selected;
+        snd("core.ok1");
+        auto& desc = mod_descriptions.at(pagesize * page + cs_bk);
+        desc.enabled = !desc.enabled;
+        set_reupdate();
+    }
+
+    if (cs != cs_bk)
+    {
+        set_reupdate();
+    }
+
+    // Page changes
+    if (action == "next_page")
+    {
+        if (pagemax != 0)
+        {
+            snd("core.pop1");
+            ++page;
+            set_reupdate();
+        }
+    }
+    if (action == "previous_page")
+    {
+        if (pagemax != 0)
+        {
+            snd("core.pop1");
+            --page;
+            set_reupdate();
+        }
+    }
+
+    // Closing menu
+    if (action == "cancel")
+    {
+        return UIMenuMods::ResultType::finish();
+    }
+    return none;
+}
+
+} // namespace ui
+} // namespace elona

--- a/src/elona/ui/ui_menu_mods.cpp
+++ b/src/elona/ui/ui_menu_mods.cpp
@@ -36,14 +36,16 @@ bool UIMenuMods::init()
 
     for (const auto& mod : lua::lua->get_mod_manager().all_mods())
     {
-        if (mod->second->manifest.name == "_CONSOLE_")
+        const auto& name = mod->second->manifest.name;
+
+        if (lua::ModManager::mod_name_is_reserved(name))
             continue;
 
-        ModDescription mod_desc{mod->second->manifest.name + "(" +
-                                    mod->second->manifest.version.to_string() +
-                                    ")",
-                                mod->second->manifest,
-                                mod->second->enabled};
+        ModDescription mod_desc{
+            name + "(" + mod->second->manifest.version.to_string() + ")",
+            mod->second->manifest,
+            static_cast<bool>(
+                lua::lua->get_mod_manager().get_enabled_version(name))};
 
         mod_descriptions.emplace_back(mod_desc);
         listmax++;
@@ -56,6 +58,17 @@ bool UIMenuMods::init()
     return true;
 }
 
+
+optional<UIMenuMods::ModDescription> UIMenuMods::_find_enabled_mod(
+    const std::string& name)
+{
+    for (const auto& desc : mod_descriptions)
+    {
+        if (desc.enabled && desc.manifest.name == name)
+            return desc;
+    }
+    return none;
+}
 
 
 void UIMenuMods::_draw_mod_page()

--- a/src/elona/ui/ui_menu_mods.hpp
+++ b/src/elona/ui/ui_menu_mods.hpp
@@ -8,6 +8,13 @@ namespace ui
 class UIMenuMods : public UIMenu<DummyResult>
 {
 public:
+    struct ModDescription
+    {
+        std::string display_name;
+        lua::ModManifest manifest;
+        bool enabled;
+    };
+
     UIMenuMods()
     {
     }
@@ -18,18 +25,13 @@ protected:
     virtual void draw();
     virtual optional<UIMenuMods::ResultType> on_key(const std::string& key);
 
+    optional<ModDescription> _find_enabled_mod(const std::string& name);
     void _draw_mod_page();
     void _draw_window();
     void _draw_navigation_menu();
     void _draw_background_vignette(int id, int type);
 
 private:
-    struct ModDescription
-    {
-        std::string display_name;
-        lua::ModManifest manifest;
-        bool enabled;
-    };
     std::vector<ModDescription> mod_descriptions;
 
     bool _redraw;

--- a/src/elona/ui/ui_menu_mods.hpp
+++ b/src/elona/ui/ui_menu_mods.hpp
@@ -1,0 +1,38 @@
+#pragma once
+#include "../lua_env/mod_manifest.hpp"
+#include "ui_menu.hpp"
+namespace elona
+{
+namespace ui
+{
+class UIMenuMods : public UIMenu<DummyResult>
+{
+public:
+    UIMenuMods()
+    {
+    }
+
+protected:
+    virtual bool init();
+    virtual void update();
+    virtual void draw();
+    virtual optional<UIMenuMods::ResultType> on_key(const std::string& key);
+
+    void _draw_mod_page();
+    void _draw_window();
+    void _draw_navigation_menu();
+    void _draw_background_vignette(int id, int type);
+
+private:
+    struct ModDescription
+    {
+        std::string display_name;
+        lua::ModManifest manifest;
+        bool enabled;
+    };
+    std::vector<ModDescription> mod_descriptions;
+
+    bool _redraw;
+};
+} // namespace ui
+} // namespace elona

--- a/src/elona/ui/ui_menu_mods.hpp
+++ b/src/elona/ui/ui_menu_mods.hpp
@@ -26,15 +26,18 @@ protected:
     virtual optional<UIMenuMods::ResultType> on_key(const std::string& key);
 
     optional<ModDescription> _find_enabled_mod(const std::string& name);
+    void _build_description();
     void _draw_mod_page();
     void _draw_window();
     void _draw_navigation_menu();
     void _draw_background_vignette(int id, int type);
 
 private:
-    std::vector<ModDescription> mod_descriptions;
+    std::vector<ModDescription> _mod_descriptions;
+    std::vector<std::string> _description_pages;
 
     bool _redraw;
+    size_t _desc_page;
 };
 } // namespace ui
 } // namespace elona

--- a/src/elona/ui_menus.cpp
+++ b/src/elona/ui_menus.cpp
@@ -25,6 +25,7 @@
 #include "ui/ui_menu_keybindings.cpp"
 #include "ui/ui_menu_materials.cpp"
 #include "ui/ui_menu_message_log.cpp"
+#include "ui/ui_menu_mods.cpp"
 #include "ui/ui_menu_npc_tone.cpp"
 #include "ui/ui_menu_quest_board.cpp"
 #include "ui/ui_menu_scene.cpp"

--- a/src/tests/data/mods/test_export_keys/mod.hcl
+++ b/src/tests/data/mods/test_export_keys/mod.hcl
@@ -1,3 +1,7 @@
 mod {
     name = "test_export_keys"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
 }

--- a/src/tests/data/mods/test_i18n_a/mod.hcl
+++ b/src/tests/data/mods/test_i18n_a/mod.hcl
@@ -1,3 +1,7 @@
 mod {
     name = "test_i18n_a"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
 }

--- a/src/tests/data/mods/test_i18n_b/mod.hcl
+++ b/src/tests/data/mods/test_i18n_b/mod.hcl
@@ -1,3 +1,7 @@
 mod {
     name = "test_i18n_b"
+    version = "0.1.0"
+    author = "Ruin0x11"
+    description = "Test mod."
+    license = "MIT"
 }

--- a/src/tests/data/mods/test_require/mod.hcl
+++ b/src/tests/data/mods/test_require/mod.hcl
@@ -1,3 +1,7 @@
 mod {
     name = "test_require"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
 }

--- a/src/tests/data/mods/test_require_chunks/mod.hcl
+++ b/src/tests/data/mods/test_require_chunks/mod.hcl
@@ -1,3 +1,7 @@
 mod {
     name = "test_require_chunks"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
 }

--- a/src/tests/data/registry/chara/mod.hcl
+++ b/src/tests/data/registry/chara/mod.hcl
@@ -1,4 +1,8 @@
 mod {
     name = "chara"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
     dependencies = { core = "*" }
 }

--- a/src/tests/data/registry/chara_defaults/mod.hcl
+++ b/src/tests/data/registry/chara_defaults/mod.hcl
@@ -1,4 +1,8 @@
 mod {
     name = "chara_defaults"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
     dependencies = { core = "*" }
 }

--- a/src/tests/data/registry/chara_duplicate_key/mod.hcl
+++ b/src/tests/data/registry/chara_duplicate_key/mod.hcl
@@ -1,4 +1,8 @@
 mod {
     name = "chara_duplicate_key"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
     dependencies = { core = "*" }
 }

--- a/src/tests/data/registry/chara_invalid_enum/mod.hcl
+++ b/src/tests/data/registry/chara_invalid_enum/mod.hcl
@@ -1,4 +1,8 @@
 mod {
     name = "chara_invalid_enum"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
     dependencies = { core = "*" }
 }

--- a/src/tests/data/registry/chara_portrait/mod.hcl
+++ b/src/tests/data/registry/chara_portrait/mod.hcl
@@ -1,5 +1,8 @@
 mod {
     name = "chara_portrait"
+    author = "KI"
+    version = "0.1.0"
+    license = "MIT"
     description = "Test complex portrait settings."
     dependencies = { core = "*" }
 }

--- a/src/tests/data/registry/invalid/mod.hcl
+++ b/src/tests/data/registry/invalid/mod.hcl
@@ -1,3 +1,7 @@
 mod {
     name = "invalid"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
 }

--- a/src/tests/data/registry/item/mod.hcl
+++ b/src/tests/data/registry/item/mod.hcl
@@ -1,4 +1,8 @@
 mod {
     name = "item"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
     dependencies = { core = "*" }
 }

--- a/src/tests/data/registry/putit/mod.hcl
+++ b/src/tests/data/registry/putit/mod.hcl
@@ -1,3 +1,7 @@
 mod {
     name = "putit"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
 }

--- a/src/tests/data/registry/putit_b/mod.hcl
+++ b/src/tests/data/registry/putit_b/mod.hcl
@@ -1,3 +1,7 @@
 mod {
     name = "putit_b"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
 }

--- a/src/tests/lua_callbacks.cpp
+++ b/src/tests/lua_callbacks.cpp
@@ -1,6 +1,3 @@
-#include "../thirdparty/catch2/catch.hpp"
-#include "../thirdparty/sol2/sol.hpp"
-
 #include "../elona/character.hpp"
 #include "../elona/dmgheal.hpp"
 #include "../elona/filesystem.hpp"
@@ -10,6 +7,8 @@
 #include "../elona/lua_env/mod_manager.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/catch2/catch.hpp"
+#include "../thirdparty/sol2/sol.hpp"
 #include "tests.hpp"
 
 using namespace elona::testing;
@@ -35,7 +34,7 @@ Event.register("core.character_created", my_chara_created_handler)
     int idx = elona::rc;
     REQUIRE(idx != -1);
     elona::lua::lua->get_mod_manager()
-        .get_mod("test_chara_created")
+        .get_enabled_mod("test_chara_created")
         ->env.set("idx", idx);
 
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
@@ -65,7 +64,7 @@ Event.register("core.character_damaged", my_chara_hurt_handler)
     REQUIRE(elona::chara_create(-1, PUTIT_PROTO_ID, 4, 8));
     int idx = elona::rc;
     elona::lua::lua->get_mod_manager()
-        .get_mod("test_chara_hurt")
+        .get_enabled_mod("test_chara_hurt")
         ->env.set("idx", idx);
 
     elona::damage_hp(cdata[idx], 4, -1);
@@ -97,7 +96,7 @@ Event.register("core.character_removed", my_chara_removed_handler)
     REQUIRE(elona::chara_create(-1, PUTIT_PROTO_ID, 4, 8));
     int idx = elona::rc;
     elona::lua::lua->get_mod_manager()
-        .get_mod("test_chara_removed")
+        .get_enabled_mod("test_chara_removed")
         ->env.set("idx", idx);
 
     testing::invalidate_chara(cdata[idx]);
@@ -127,7 +126,7 @@ Event.register("core.character_killed", my_chara_killed_handler)
     int idx = elona::rc;
     elona::Character& chara = elona::cdata[idx];
     elona::lua::lua->get_mod_manager()
-        .get_mod("test_chara_killed")
+        .get_enabled_mod("test_chara_killed")
         ->env.set("idx", idx);
 
     elona::damage_hp(cdata[idx], chara.max_hp + 1, -11);
@@ -209,7 +208,7 @@ Event.register("core.character_removed", my_chara_removed_handler)
     int idx = elona::rc;
     elona::Character& chara = elona::cdata[idx];
     elona::lua::lua->get_mod_manager()
-        .get_mod("test_special_chara_killed")
+        .get_enabled_mod("test_special_chara_killed")
         ->env.set("idx", idx);
 
     // Give this character a role besides a townsperson.
@@ -244,7 +243,7 @@ Event.register("core.character_refreshed", my_chara_refreshed_handler)
     REQUIRE(elona::chara_create(-1, PUTIT_PROTO_ID, 4, 8));
     int idx = elona::rc;
     elona::lua::lua->get_mod_manager()
-        .get_mod("test_chara_refreshed")
+        .get_enabled_mod("test_chara_refreshed")
         ->env.set("idx", idx);
 
     elona::chara_refresh(idx);
@@ -275,7 +274,7 @@ Event.register("core.item_created", my_item_created_handler)
     int idx = elona::ci;
     REQUIRE(idx != -1);
     elona::lua::lua->get_mod_manager()
-        .get_mod("test_item_created")
+        .get_enabled_mod("test_item_created")
         ->env.set("idx", idx);
 
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(

--- a/src/tests/lua_exports.cpp
+++ b/src/tests/lua_exports.cpp
@@ -1,5 +1,3 @@
-#include "../thirdparty/catch2/catch.hpp"
-
 #include "../elona/filesystem.hpp"
 #include "../elona/lua_env/export_manager.hpp"
 #include "../elona/lua_env/handle_manager.hpp"
@@ -7,6 +5,7 @@
 #include "../elona/lua_env/mod_manager.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/catch2/catch.hpp"
 #include "tests.hpp"
 #include "util.hpp"
 
@@ -108,7 +107,7 @@ return {
     REQUIRE_NOTHROW(function->call(handle));
 
     elona::lua::lua->get_mod_manager()
-        .get_mod("test_registry_chara_callback")
+        .get_enabled_mod("test_registry_chara_callback")
         ->env.set("index", elona::rc);
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_registry_chara_callback",

--- a/src/tests/lua_handles.cpp
+++ b/src/tests/lua_handles.cpp
@@ -1,6 +1,3 @@
-#include "../thirdparty/catch2/catch.hpp"
-#include "../thirdparty/sol2/sol.hpp"
-
 #include "../elona/character.hpp"
 #include "../elona/item.hpp"
 #include "../elona/itemgen.hpp"
@@ -9,6 +6,8 @@
 #include "../elona/lua_env/mod_manager.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/catch2/catch.hpp"
+#include "../thirdparty/sol2/sol.hpp"
 #include "tests.hpp"
 
 using namespace elona::testing;
@@ -185,7 +184,7 @@ TEST_CASE("Test invalid references to handles in store table", "[Lua: Handles]")
 
         REQUIRE_NOTHROW(mod_mgr.load_mod_from_script("test", ""));
 
-        mod_mgr.get_mod("test")->env.set("chara", handle);
+        mod_mgr.get_enabled_mod("test")->env.set("chara", handle);
         REQUIRE_NOTHROW(
             mod_mgr.run_in_mod("test", "Store.global.charas = {[0]=chara}"));
 
@@ -202,7 +201,7 @@ TEST_CASE("Test invalid references to handles in store table", "[Lua: Handles]")
 
         REQUIRE_NOTHROW(mod_mgr.load_mod_from_script("test2", ""));
 
-        mod_mgr.get_mod("test2")->env.set("item", handle);
+        mod_mgr.get_enabled_mod("test2")->env.set("item", handle);
         REQUIRE_NOTHROW(
             mod_mgr.run_in_mod("test2", "Store.global.items = {[0]=item}"));
 
@@ -229,7 +228,7 @@ local chara = Chara.create(0, 0, "core.putit")
 idx = chara.index
 Store.global.charas = {[0]=chara}
 )"));
-        int idx = mod_mgr.get_mod("test_invalid_chara")->env["idx"];
+        int idx = mod_mgr.get_enabled_mod("test_invalid_chara")->env["idx"];
 
         testing::invalidate_chara(elona::cdata[idx]);
 
@@ -244,7 +243,7 @@ local item = Item.create(0, 0, "core.putitoro", 3)
 idx = item.index
 Store.global.items = {[0]=items}
 )"));
-        int idx = mod_mgr.get_mod("test_invalid_item")->env["idx"];
+        int idx = mod_mgr.get_enabled_mod("test_invalid_item")->env["idx"];
 
         testing::invalidate_item(elona::inv[idx]);
 
@@ -270,7 +269,7 @@ TEST_CASE(
 
         REQUIRE_NOTHROW(mod_mgr.load_mod_from_script(
             "test_chara_arg", "Store.global.charas = {}"));
-        mod_mgr.get_mod("test_chara_arg")->env.set("chara", handle);
+        mod_mgr.get_enabled_mod("test_chara_arg")->env.set("chara", handle);
 
         REQUIRE_NOTHROW(mod_mgr.run_in_mod("test_chara_arg", R"(
 Store.global.charas[0] = chara
@@ -293,7 +292,7 @@ print(Chara.is_ally(Store.global.charas[0]))
 
         REQUIRE_NOTHROW(mod_mgr.load_mod_from_script(
             "test_item_arg", "Store.global.items = {}"));
-        mod_mgr.get_mod("test_item_arg")->env.set("item", handle);
+        mod_mgr.get_enabled_mod("test_item_arg")->env.set("item", handle);
 
         REQUIRE_NOTHROW(mod_mgr.run_in_mod("test_item_arg", R"(
 Store.global.items[0] = item

--- a/src/tests/lua_mods.cpp
+++ b/src/tests/lua_mods.cpp
@@ -1,6 +1,3 @@
-#include "../thirdparty/catch2/catch.hpp"
-#include "../thirdparty/sol2/sol.hpp"
-
 #include "../elona/character.hpp"
 #include "../elona/dmgheal.hpp"
 #include "../elona/filesystem.hpp"
@@ -13,6 +10,8 @@
 #include "../elona/lua_env/mod_manager.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/catch2/catch.hpp"
+#include "../thirdparty/sol2/sol.hpp"
 #include "tests.hpp"
 
 using namespace elona::testing;
@@ -104,7 +103,8 @@ TEST_CASE("Test usage of store in mod", "[Lua: Mods]")
 
     REQUIRE_NOTHROW(
         mod_mgr.run_in_mod("test", "assert(Store.global.thing == 1)"));
-    int thing = mod_mgr.get_mod("test")->store_global["thing"].get<int>();
+    int thing =
+        mod_mgr.get_enabled_mod("test")->store_global["thing"].get<int>();
     REQUIRE(thing == 1);
 }
 

--- a/src/tests/lua_serialization.cpp
+++ b/src/tests/lua_serialization.cpp
@@ -1,6 +1,3 @@
-#include "../thirdparty/catch2/catch.hpp"
-#include "../thirdparty/sol2/sol.hpp"
-
 #include "../elona/character.hpp"
 #include "../elona/filesystem.hpp"
 #include "../elona/item.hpp"
@@ -12,6 +9,8 @@
 #include "../elona/lua_env/mod_manager.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/catch2/catch.hpp"
+#include "../thirdparty/sol2/sol.hpp"
 #include "tests.hpp"
 
 using namespace elona::testing;
@@ -174,7 +173,15 @@ Store.map.val = "hoge"
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_serial_reload", "assert(Store.map.val == \"hoge\")"));
 
-    save_and_reload();
+    save();
+
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().run_in_mod("test_serial_reload", R"(
+Store.global.val = 0
+Store.map.val = ""
+)"));
+
+    load();
 
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_serial_reload", "assert(Store.global.val == 42)"));
@@ -185,21 +192,25 @@ Store.map.val = "hoge"
 
 TEST_CASE("Test preservation of handles across reloads", "[Lua: Serialization]")
 {
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
+        "test_serial_handle_reload", ""));
+
     start_in_debug_map();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_serial_handle_reload", R"(
 local Chara = Elona.require("Chara")
+local Item = Elona.require("Item")
 local Item = Elona.require("Item")
 
 Store.global.chara = Chara.create(4, 8, "core.putit")
 Store.global.item = Item.create(4, 8, "core.putitoro", 0)
 Store.map.chara = Chara.create(4, 8, "core.putit")
 Store.map.item = Item.create(4, 8, "core.putitoro", 0)
-)"));
+        )"));
 
-    auto mod =
-        elona::lua::lua->get_mod_manager().get_mod("test_serial_handle_reload");
+    auto mod = elona::lua::lua->get_mod_manager().get_enabled_mod(
+        "test_serial_handle_reload");
     std::string uuid_chara_global = mod->get_store(
         elona::lua::ModInfo::StoreType::global)["chara"]["__uuid"];
     std::string uuid_item_global = mod->get_store(
@@ -209,7 +220,17 @@ Store.map.item = Item.create(4, 8, "core.putitoro", 0)
     std::string uuid_item_map =
         mod->get_store(elona::lua::ModInfo::StoreType::map)["item"]["__uuid"];
 
-    save_and_reload();
+    save();
+
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
+        "test_serial_handle_reload", R"(
+Store.global.chara = 0
+Store.global.item = 0
+Store.map.chara = 0
+Store.map.item = 0
+        )"));
+
+    load();
 
     mod->env.set("uuid_chara_global", uuid_chara_global);
     mod->env.set("uuid_item_global", uuid_item_global);
@@ -238,9 +259,12 @@ TEST_CASE(
     "Test preservation of handles across map changes",
     "[Lua: Serialization]")
 {
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
+        "test_serial_handle_map_change", ""));
+
     start_in_debug_map();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_serial_handle_map_change", R"(
 local Chara = Elona.require("Chara")
 
@@ -248,9 +272,10 @@ Store.global.chara = Chara.create(4, 8, "core.putit")
 Store.global.chara_local = Chara.create(4, 8, "core.putit")
 
 Store.global.chara:recruit_as_ally()
+Store.global.it = 0
 )"));
 
-    auto mod = elona::lua::lua->get_mod_manager().get_mod(
+    auto mod = elona::lua::lua->get_mod_manager().get_enabled_mod(
         "test_serial_handle_map_change");
     auto store = mod->get_store(elona::lua::ModInfo::StoreType::global);
     std::string uuid_chara = store["chara"]["__uuid"];
@@ -259,29 +284,29 @@ Store.global.chara:recruit_as_ally()
     mod->env.set("uuid_chara", uuid_chara);
     mod->env.set("uuid_chara_local", uuid_chara_local);
 
-    run_in_temporary_map(6, 1, [&mod, uuid_chara]() {
+    run_in_temporary_map(6, 1, [uuid_chara]() {
         REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
             "test_serial_handle_map_change", R"(
 assert(Store.global.chara.__uuid == uuid_chara)
 assert(Store.global.chara_local.__uuid == uuid_chara_local)
-            )"));
+)"));
         REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
             "test_serial_handle_map_change", R"(
 assert(Store.global.chara:is_valid())
 assert(not Store.global.chara_local:is_valid())
-            )"));
+)"));
     });
 
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_serial_handle_map_change", R"(
 assert(Store.global.chara.__uuid == uuid_chara)
 assert(Store.global.chara_local.__uuid == uuid_chara_local)
-            )"));
+)"));
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_serial_handle_map_change", R"(
 assert(Store.global.chara:is_valid())
-assert(not Store.global.chara_local:is_valid())
-            )"));
+assert(Store.global.chara_local:is_valid())
+)"));
 }
 
 
@@ -289,9 +314,12 @@ TEST_CASE(
     "Test preservation of map local handles across map changes",
     "[Lua: Serialization]")
 {
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
+        "test_serial_handle_map_change_local", ""));
+
     start_in_debug_map();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_serial_handle_map_change_local", R"(
 local Chara = Elona.require("Chara")
 local Item = Elona.require("Item")
@@ -300,18 +328,18 @@ Store.map.chara = Chara.create(4, 8, "core.putit")
 Store.map.item = Item.create(4, 8, "core.putitoro", 0)
 )"));
 
-    auto mod = elona::lua::lua->get_mod_manager().get_mod(
+    auto mod = elona::lua::lua->get_mod_manager().get_enabled_mod(
         "test_serial_handle_map_change_local");
     auto store = mod->get_store(elona::lua::ModInfo::StoreType::map);
     std::string uuid_chara = store["chara"]["__uuid"];
     std::string uuid_item = store["item"]["__uuid"];
 
-    run_in_temporary_map(6, 1, [&mod, uuid_chara, uuid_item]() {
+    run_in_temporary_map(6, 1, [uuid_chara, uuid_item]() {
         REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
             "test_serial_handle_map_change_local", R"(
 assert(Store.map.chara == nil)
 assert(Store.map.item == nil)
-            )"));
+)"));
     });
 
     mod->env.set("uuid_chara", uuid_chara);
@@ -321,12 +349,12 @@ assert(Store.map.item == nil)
         "test_serial_handle_map_change_local", R"(
 assert(Store.map.chara.__uuid == uuid_chara)
 assert(Store.map.item.__uuid == uuid_item)
-            )"));
+)"));
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_serial_handle_map_change_local", R"(
 assert(Store.map.chara:is_valid())
 assert(Store.map.item:is_valid())
-            )"));
+)"));
 }
 
 
@@ -342,11 +370,50 @@ t[1] = t
 Store.global.t = t
 )"));
 
-    save_and_reload();
+    save();
 
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_serial_recursive", R"(
-            assert(type(Store.global.t) == "table")
-            assert(type(Store.global.t[1]) == "table")
-            )"));
+Store.global.t = {}
+)"));
+
+    load();
+
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
+        "test_serial_recursive", R"(
+assert(type(Store.global.t) == "table")
+assert(type(Store.global.t[1]) == "table")
+)"));
+}
+
+
+TEST_CASE("Test that disabled mods are not serialized", "[Lua: Serialization]")
+{
+    start_in_debug_map();
+
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
+        "test_serial_disabled", R"(
+Store.global.val = 42
+)"));
+
+    save();
+
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
+        "test_serial_disabled", R"(
+Store.global.val = 0
+)"));
+
+    elona::lua::lua->get_mod_manager()
+        .get_enabled_mod("test_serial_disabled")
+        ->enabled = false;
+
+    load();
+
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
+        "test_serial_disabled", ""));
+
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
+        "test_serial_disabled", R"(
+assert(Store.global.val == nil)
+)"));
 }

--- a/src/tests/lua_serialization.cpp
+++ b/src/tests/lua_serialization.cpp
@@ -403,9 +403,7 @@ Store.global.val = 42
 Store.global.val = 0
 )"));
 
-    elona::lua::lua->get_mod_manager()
-        .get_enabled_mod("test_serial_disabled")
-        ->enabled = false;
+    elona::lua::lua->get_mod_manager().disable_mod("test_serial_disabled");
 
     load();
 

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -1,9 +1,11 @@
 #define CATCH_CONFIG_RUNNER
 #include "../elona/testing.hpp"
 #include "../thirdparty/catch2/catch.hpp"
+#include "../util/backtrace.hpp"
 
 #ifdef ELONA_OS_WINDOWS
 #include <crtdbg.h>
+
 #include <windows>
 // Prevent assertion dialogs from appearing on Windows, hanging CI test runs
 int WindowsCrtReportHook(int reportType, char* message, int* returnValue)
@@ -23,6 +25,8 @@ int main(int argc, char* argv[])
     DWORD dwMode = SetErrorMode(SEM_NOGPFAULTERRORBOX);
     SetErrorMode(dwMode | SEM_NOGPFAULTERRORBOX);
 #endif
+
+    lib::setup_backtrace();
 
     srand(static_cast<unsigned int>(std::time(0)));
 


### PR DESCRIPTION
# Summary
- Adds a menu to the title screen to view installed mods. It's only one part of the feature to integrate the mod system with the UI.
- Adds a few more metadata fields to `mod.hcl`.
- Adds a field in the mod manager to enable/disable mods. Currently all mods are enabled (as before).

![2019-05-02-223740_800x600_scrot](https://user-images.githubusercontent.com/6700637/57121336-bb01f600-6d2b-11e9-9397-719f63fb3e30.png)
