### PR TITLE
Add mod list to main menu

### DIFF
--- a/runtime/data/script/kernel/data.lua
+++ b/runtime/data/script/kernel/data.lua
@@ -4,7 +4,7 @@ data.by_legacy = {}
 data.types = {}
 
 function data:define_type(name, validate)
-   local instance_id = _ENV["_MOD_NAME"] .. "." .. name
+   local instance_id = _ENV["_MOD_ID"] .. "." .. name
 
    if self.types[instance_id] then
       error("duplicate type definition of " .. instance_id)
@@ -41,7 +41,7 @@ function data:add(array)
          error("missing id or type: id=" .. (id or 'nil') .. " type=" .. (data_type or 'nil'))
       end
 
-      local instance_id = _ENV["_MOD_NAME"] .. "." .. id
+      local instance_id = _ENV["_MOD_ID"] .. "." .. id
 
 
       local validator = self.types[data_type]

--- a/runtime/data/script/kernel/handle.lua
+++ b/runtime/data/script/kernel/handle.lua
@@ -185,7 +185,7 @@ function Handle.create_handle(cpp_ref, kind, uuid)
       return nil
    end
 
-   -- print("CREATE " .. cpp_ref.index .. " " .. uuid)
+   -- print("CREATE " .. kind .. " " .. cpp_ref.index .. " " .. uuid)
 
    local handle = {
       __uuid = uuid,
@@ -298,7 +298,6 @@ end
 
 function Handle.merge_handles(kind, handles_)
    for index, handle in pairs(handles_) do
-
       if handle ~= nil then
          if handles_by_index[kind][index] ~= nil then
             error("Attempt to overwrite handle " .. kind .. ":" .. adjusted_index, 2)

--- a/runtime/data/script/kernel/serial.lua
+++ b/runtime/data/script/kernel/serial.lua
@@ -19,7 +19,10 @@ local function resolve_handles(data, seen)
    end
 end
 
-Serial.save = serpent.dump
+Serial.save = function(s)
+   local dump = serpent.dump(s)
+   return dump
+end
 
 function Serial.load(dump)
    local ok, data = serpent.load(dump)

--- a/runtime/locale/en/main_menu.hcl
+++ b/runtime/locale/en/main_menu.hcl
@@ -44,10 +44,15 @@ locale {
                 download = "Download Mods"
             }
             no_readme = "(No README available.)"
-            name = "Name"
-            author = "Author"
-            version = "Version"
-            description = "Description"
+
+            info {
+                title = "Information"
+                name = "Name"
+                id = "ID"
+                author = "Author"
+                version = "Version"
+                description = "Description"
+            }
 
             download {
                 failed = "Could not download mod list."
@@ -58,7 +63,6 @@ locale {
                 info = "[Mod Info]"
                 download = "[Switch To Download]"
                 installed = "[Switch To Installed]"
-                readme_page = "[Change README page]"
             }
         }
     }

--- a/runtime/locale/en/main_menu.hcl
+++ b/runtime/locale/en/main_menu.hcl
@@ -39,6 +39,13 @@ locale {
         }
 
         mods {
+            title = "Installed Mods"
+            hint_readme_page = "[Change README page]"
+            no_readme = "(No README available.)"
+            name = "Name"
+            author = "Author"
+            version = "Version"
+            description = "Description"
         }
     }
 }

--- a/runtime/locale/en/main_menu.hcl
+++ b/runtime/locale/en/main_menu.hcl
@@ -6,6 +6,7 @@ locale {
             incarnate = "Incarnate an Adventurer"
             about = "About"
             options = "Options"
+            mods = "Mods"
             exit = "Exit"
         }
 
@@ -35,6 +36,9 @@ locale {
 
         about_changelog {
             title = "Changelogs"
+        }
+
+        mods {
         }
     }
 }

--- a/runtime/locale/en/main_menu.hcl
+++ b/runtime/locale/en/main_menu.hcl
@@ -39,13 +39,27 @@ locale {
         }
 
         mods {
-            title = "Installed Mods"
-            hint_readme_page = "[Change README page]"
+            title {
+                installed = "Installed Mods"
+                download = "Download Mods"
+            }
             no_readme = "(No README available.)"
             name = "Name"
             author = "Author"
             version = "Version"
             description = "Description"
+
+            download {
+                failed = "Could not download mod list."
+            }
+
+            hint {
+                toggle = "[Enable/Disable]"
+                info = "[Mod Info]"
+                download = "[Switch To Download]"
+                installed = "[Switch To Installed]"
+                readme_page = "[Change README page]"
+            }
         }
     }
 }

--- a/runtime/locale/jp/main_menu.hcl
+++ b/runtime/locale/jp/main_menu.hcl
@@ -6,6 +6,7 @@ locale {
             incarnate = "冒険者の引継ぎ"
             about = "このゲームについて"
             options = "設定の変更"
+            mods = "MODリスト"
             exit = "終了"
         }
 
@@ -35,6 +36,9 @@ locale {
 
         about_changelog {
             title = "更新履歴"
+        }
+
+        mods {
         }
     }
 }

--- a/runtime/locale/jp/main_menu.hcl
+++ b/runtime/locale/jp/main_menu.hcl
@@ -39,6 +39,13 @@ locale {
         }
 
         mods {
+            title = "インストール済みのMOD"
+            hint_readme_page = "[READMEページ切替]"
+            no_readme = "(READMEはありません)"
+            name = "名前"
+            author = "作者"
+            version = "バージョン"
+            description = "説明文"
         }
     }
 }

--- a/runtime/locale/jp/main_menu.hcl
+++ b/runtime/locale/jp/main_menu.hcl
@@ -39,13 +39,27 @@ locale {
         }
 
         mods {
-            title = "インストール済みのMOD"
-            hint_readme_page = "[READMEページ切替]"
+            title {
+                installed = "インストール済みのMOD"
+                download = "MODダウンロード"
+            }
             no_readme = "(READMEはありません)"
             name = "名前"
             author = "作者"
             version = "バージョン"
             description = "説明文"
+
+            download {
+                failed = "MODリストのダウンロードに失敗しました。"
+            }
+
+            hint {
+                toggle = "[有効/無効にする]"
+                info = "[MODの情報]"
+                download = "[ダウンロード]"
+                installed = "[インストール済み]"
+                readme_page = "[READMEページ切替]"
+            }
         }
     }
 }

--- a/runtime/locale/jp/main_menu.hcl
+++ b/runtime/locale/jp/main_menu.hcl
@@ -44,10 +44,15 @@ locale {
                 download = "MODダウンロード"
             }
             no_readme = "(READMEはありません)"
-            name = "名前"
-            author = "作者"
-            version = "バージョン"
-            description = "説明文"
+
+            info {
+                title = "情報"
+                id = "ID"
+                name = "名前"
+                author = "作者"
+                version = "バージョン"
+                description = "説明文"
+            }
 
             download {
                 failed = "MODリストのダウンロードに失敗しました。"
@@ -58,7 +63,6 @@ locale {
                 info = "[MODの情報]"
                 download = "[ダウンロード]"
                 installed = "[インストール済み]"
-                readme_page = "[READMEページ切替]"
             }
         }
     }

--- a/runtime/locale/jp/main_menu.hcl
+++ b/runtime/locale/jp/main_menu.hcl
@@ -41,7 +41,7 @@ locale {
         mods {
             title {
                 installed = "インストール済みのMOD"
-                download = "MODダウンロード"
+                download = "MODのダウンロード"
             }
             no_readme = "(READMEはありません)"
 

--- a/runtime/mod/core/mod.hcl
+++ b/runtime/mod/core/mod.hcl
@@ -1,5 +1,6 @@
 mod {
-    name = "core"
+    id = "core"
+    name = "Core Content"
     author = "KI, Ruin0x11"
     version = "0.2.6"
     license = "MIT"

--- a/runtime/mod/core/mod.hcl
+++ b/runtime/mod/core/mod.hcl
@@ -2,5 +2,6 @@ mod {
     name = "core"
     author = "KI, Ruin0x11"
     version = "0.2.6"
+    license = "MIT"
     description = "Base game content. Currently, the game cannot be run without this mod."
 }

--- a/src/elona/config/config.cpp
+++ b/src/elona/config/config.cpp
@@ -495,16 +495,16 @@ Config& Config::instance()
     return the_instance;
 }
 
-void Config::load_def(std::istream& is, const std::string& mod_name)
+void Config::load_def(std::istream& is, const std::string& mod_id)
 {
-    def.load(is, "[input stream]", mod_name);
-    mod_names_.emplace(mod_name);
+    def.load(is, "[input stream]", mod_id);
+    mod_ids_.emplace(mod_id);
 }
 
-void Config::load_def(const fs::path& config_def_path, const std::string& mod_name)
+void Config::load_def(const fs::path& config_def_path, const std::string& mod_id)
 {
-    def.load(config_def_path, mod_name);
-    mod_names_.emplace(mod_name);
+    def.load(config_def_path, mod_id);
+    mod_ids_.emplace(mod_id);
 }
 
 void Config::load_defaults(bool preload)
@@ -557,7 +557,7 @@ void Config::load(std::istream& is, const std::string& hcl_file, bool preload)
 
     for (const auto& pair : conf.as<hcl::Object>())
     {
-        const auto& mod_name = pair.first;
+        const auto& mod_id = pair.first;
         const auto& mod_section = pair.second;
 
         if (!mod_section.is<hcl::Object>())
@@ -565,7 +565,7 @@ void Config::load(std::istream& is, const std::string& hcl_file, bool preload)
             continue;
         }
 
-        visit_object(mod_section.as<hcl::Object>(), mod_name, hcl_file, preload);
+        visit_object(mod_section.as<hcl::Object>(), mod_id, hcl_file, preload);
     }
 }
 

--- a/src/elona/config/config.hpp
+++ b/src/elona/config/config.hpp
@@ -28,8 +28,8 @@ public:
     }
     ~Config() = default;
 
-    void load_def(std::istream& is, const std::string& mod_name);
-    void load_def(const fs::path& config_def_path, const std::string& mod_name);
+    void load_def(std::istream& is, const std::string& mod_id);
+    void load_def(const fs::path& config_def_path, const std::string& mod_id);
     void load(std::istream&, const std::string&, bool);
     void save();
 
@@ -105,9 +105,9 @@ public:
 
     bool is_test = false; // testing use only
 
-    const std::unordered_set<std::string>& get_mod_names()
+    const std::unordered_set<std::string>& get_mod_ids()
     {
-        return mod_names_;
+        return mod_ids_;
     }
 
     bool is_visible(const std::string& key) const
@@ -272,7 +272,7 @@ private:
     tsl::ordered_map<std::string, std::function<hcl::Value(void)>> getters_;
     tsl::ordered_map<std::string, std::function<void(const hcl::Value&)>>
         setters_;
-    std::unordered_set<std::string> mod_names_;
+    std::unordered_set<std::string> mod_ids_;
 };
 
 

--- a/src/elona/config/create_config_screen.cpp
+++ b/src/elona/config/create_config_screen.cpp
@@ -142,17 +142,17 @@ void ConfigScreenCreator::add_keybindings_section()
 
 void ConfigScreenCreator::add_mod_configs_section()
 {
-    const auto& mod_names = config_.get_mod_names();
+    const auto& mod_ids = config_.get_mod_ids();
 
     // Only add the section if there is at least one mod other than "core".
-    if (mod_names.size() <= 1)
+    if (mod_ids.size() <= 1)
     {
         return;
     }
 
     // Add the menu.
     int w = menu_width;
-    int h = menu_height + (menu_item_height * (mod_names.size() - 1));
+    int h = menu_height + (menu_item_height * (mod_ids.size() - 1));
     int mod_menu_index = result_.size();
     result_.emplace_back(std::make_unique<ConfigMenu>(
         i18n::s.get("core.locale.config.menu.mods.name"),
@@ -162,25 +162,25 @@ void ConfigScreenCreator::add_mod_configs_section()
 
     bool found_mods = false;
 
-    for (const auto& mod_name : mod_names)
+    for (const auto& mod_id : mod_ids)
     {
-        if (mod_name == "core")
+        if (mod_id == "core")
         {
             continue;
         }
 
-        auto found_items = visit_mod_config(mod_name);
+        auto found_items = visit_mod_config(mod_id);
 
         if (found_items)
         {
             found_mods = true;
 
-            I18NKey locale_key = mod_name + ".locale.config.menu";
-            int submenu_index = config_key_to_submenu_index_[mod_name];
+            I18NKey locale_key = mod_id + ".locale.config.menu";
+            int submenu_index = config_key_to_submenu_index_[mod_id];
 
             result_.at(mod_menu_index)
                 ->items.emplace_back(std::make_unique<ConfigMenuItemSection>(
-                    mod_name, locale_key, submenu_index));
+                    mod_id, locale_key, submenu_index));
         }
     }
 
@@ -211,11 +211,11 @@ void ConfigScreenCreator::visit_toplevel()
     add_mod_configs_section();
 }
 
-bool ConfigScreenCreator::visit_mod_config(const std::string& mod_name)
+bool ConfigScreenCreator::visit_mod_config(const std::string& mod_id)
 {
-    I18NKey locale_key = mod_name + ".locale.config.menu";
+    I18NKey locale_key = mod_id + ".locale.config.menu";
 
-    return visit_section_children(mod_name, locale_key);
+    return visit_section_children(mod_id, locale_key);
 }
 
 bool ConfigScreenCreator::visit_section_children(

--- a/src/elona/config/create_config_screen.hpp
+++ b/src/elona/config/create_config_screen.hpp
@@ -28,9 +28,9 @@ public:
 
 private:
     void visit_toplevel();
-    bool visit_mod_config(const std::string& mod_name);
+    bool visit_mod_config(const std::string& mod_id);
     bool visit_section_children(
-        const std::string& mod_name,
+        const std::string& mod_id,
         const I18NKey& locale_key);
     bool visit_section(const SpecKey& current_key, const I18NKey& locale_key);
     bool visit_config_item(

--- a/src/elona/elonacore.cpp
+++ b/src/elona/elonacore.cpp
@@ -4063,6 +4063,11 @@ TurnResult exit_map()
     int previous_map = game_data.current_map;
     int previous_dungeon_level = game_data.current_dungeon_level;
     int fixstart = 0;
+
+    ELONA_LOG("map") << "exit_map levelexitby begin " << levelexitby << " cur "
+                     << game_data.current_map << " cur_level "
+                     << game_data.current_dungeon_level;
+
     game_data.left_minutes_of_executing_quest = 0;
     game_data.rogue_boss_encountered = 0;
     if (map_data.type == mdata_t::MapType::player_owned)
@@ -4434,6 +4439,8 @@ TurnResult exit_map()
     {
         // This map should be saved.
         save_map_local_data();
+
+        ELONA_LOG("map") << "exit_map save local";
     }
     else
     {
@@ -4456,12 +4463,14 @@ TurnResult exit_map()
                 --npcmemory(1, cnt.id);
             }
         }
+
+        ELONA_LOG("map") << "exit_map clear temporary";
     }
 
     bool map_changed = game_data.current_map != previous_map ||
         game_data.current_dungeon_level != previous_dungeon_level;
 
-    ELONA_LOG("map") << "exit_map levelexitby " << levelexitby << " cur "
+    ELONA_LOG("map") << "exit_map levelexitby end " << levelexitby << " cur "
                      << game_data.current_map << " cur_level "
                      << game_data.current_dungeon_level << " prev "
                      << previous_map << " prev_level "

--- a/src/elona/filesystem.cpp
+++ b/src/elona/filesystem.cpp
@@ -143,14 +143,14 @@ fs::path path(const std::string& str)
 fs::path resolve_path_for_mod(const std::string& mod_local_path)
 {
     // TODO: standardize mod naming convention.
-    std::regex mod_name_regex("^__([a-zA-Z0-9_]+)__/(.*)");
+    std::regex mod_id_regex("^__([a-zA-Z0-9_]+)__/(.*)");
     std::smatch match;
-    std::string mod_name, rest;
+    std::string mod_id, rest;
 
-    if (std::regex_match(mod_local_path, match, mod_name_regex) &&
+    if (std::regex_match(mod_local_path, match, mod_id_regex) &&
         match.size() == 3)
     {
-        mod_name = match.str(1);
+        mod_id = match.str(1);
         rest = match.str(2);
     }
     else
@@ -158,13 +158,13 @@ fs::path resolve_path_for_mod(const std::string& mod_local_path)
         throw std::runtime_error("Invalid filepath syntax: " + mod_local_path);
     }
 
-    if (mod_name == "BUILTIN")
+    if (mod_id == "BUILTIN")
     {
         return dir::exe() / rest;
     }
     else
     {
-        return dir::for_mod(mod_name) / rest;
+        return dir::for_mod(mod_id) / rest;
     }
 }
 

--- a/src/elona/i18n.cpp
+++ b/src/elona/i18n.cpp
@@ -28,12 +28,12 @@ void Store::init(const std::vector<Store::Location>& locations)
 
     for (const auto& loc : locations)
     {
-        locale_dir_table[loc.mod_name] = loc.locale_dir;
-        load(loc.locale_dir, loc.mod_name);
+        locale_dir_table[loc.mod_id] = loc.locale_dir;
+        load(loc.locale_dir, loc.mod_id);
     }
 }
 
-void Store::load(const fs::path& path, const std::string& mod_name)
+void Store::load(const fs::path& path, const std::string& mod_id)
 {
     for (const auto& entry :
          filesystem::dir_entries(path, filesystem::DirEntryRange::Type::file))
@@ -46,14 +46,14 @@ void Store::load(const fs::path& path, const std::string& mod_name)
                 filepathutil::make_preferred_path_in_utf8(entry.path())};
         }
 
-        load(ifs, filepathutil::to_utf8_path(entry.path()), mod_name);
+        load(ifs, filepathutil::to_utf8_path(entry.path()), mod_id);
     }
 }
 
 void Store::load(
     std::istream& is,
     const std::string& hcl_file,
-    const std::string& mod_name)
+    const std::string& mod_id)
 {
     const hcl::Value& value = hclutil::load(is, hcl_file);
 
@@ -64,7 +64,7 @@ void Store::load(
 
     const hcl::Value locale = value["locale"];
 
-    visit_object(locale.as<hcl::Object>(), mod_name + ".locale", hcl_file);
+    visit_object(locale.as<hcl::Object>(), mod_id + ".locale", hcl_file);
 }
 
 void Store::visit_object(

--- a/src/elona/i18n.hpp
+++ b/src/elona/i18n.hpp
@@ -495,14 +495,14 @@ public:
 
     struct Location
     {
-        Location(fs::path locale_dir, std::string mod_name)
+        Location(fs::path locale_dir, std::string mod_id)
             : locale_dir(locale_dir)
-            , mod_name(mod_name)
+            , mod_id(mod_id)
         {
         }
 
         fs::path locale_dir;
-        std::string mod_name;
+        std::string mod_id;
     };
 
     void init(const std::vector<Store::Location>&);
@@ -760,9 +760,9 @@ public:
     }
 
 
-    const fs::path& get_locale_dir(const std::string& mod_name)
+    const fs::path& get_locale_dir(const std::string& mod_id)
     {
-        return locale_dir_table[mod_name];
+        return locale_dir_table[mod_id];
     }
 
 
@@ -791,7 +791,7 @@ private:
 
     std::set<I18NKey> unknown_keys;
 
-    // Key: mod name.
+    // Key: mod ID.
     // Value: locale directory.
     std::unordered_map<std::string, fs::path> locale_dir_table;
 };

--- a/src/elona/init.cpp
+++ b/src/elona/init.cpp
@@ -1,4 +1,5 @@
 #include "init.hpp"
+
 #include "../snail/touch_input.hpp"
 #include "adventurer.hpp"
 #include "area.hpp"

--- a/src/elona/init.cpp
+++ b/src/elona/init.cpp
@@ -760,7 +760,8 @@ void init()
 
     quickpage = 1;
 
-    show_loading_screen();
+    // TODO: Show each time mods are reloaded.
+    // show_loading_screen();
 }
 
 } // namespace elona

--- a/src/elona/init.cpp
+++ b/src/elona/init.cpp
@@ -207,7 +207,7 @@ void initialize_i18n()
             const auto locale_path = entry.path() / "locale" / language;
             if (fs::exists(locale_path))
             {
-                locations.emplace_back(locale_path, manifest.name);
+                locations.emplace_back(locale_path, manifest.id);
             }
         }
     }
@@ -707,7 +707,7 @@ void initialize_config_defs()
             const auto config_def_path = entry.path() / "config_def.hcl";
             if (fs::exists(config_def_path))
             {
-                Config::instance().load_def(config_def_path, manifest.name);
+                Config::instance().load_def(config_def_path, manifest.id);
             }
         }
     }

--- a/src/elona/lua_env/api_manager.cpp
+++ b/src/elona/lua_env/api_manager.cpp
@@ -120,7 +120,7 @@ sol::table APIManager::bind(LuaEnv& lua)
                 return result;
             },
 
-            // If no mod name is provided, assume it is "core".
+            // If no mod ID is provided, assume it is "core".
             [&lua](const std::string& module) {
                 sol::optional<sol::table> result = sol::nullopt;
                 result = lua.get_api_manager().try_find_api("core", module);

--- a/src/elona/lua_env/api_manager.hpp
+++ b/src/elona/lua_env/api_manager.hpp
@@ -71,7 +71,7 @@ public:
     /***
      * Adds a new API from the return value of a mod's init.lua file.
      * It would then be accessable by calling
-     * Elona.require("mod_name", "api_table").
+     * Elona.require("mod_id", "api_table").
      */
     void add_api(const std::string& module_namespace, sol::table& module_table);
 

--- a/src/elona/lua_env/console.cpp
+++ b/src/elona/lua_env/console.cpp
@@ -108,7 +108,6 @@ void Console::init_environment()
     auto core = _lua->get_api_manager().get_core_api_table();
     _console_mod =
         _lua->get_mod_manager().create_mod(_namespace_console, none, false);
-    _console_mod->enabled = true;
 
     // Automatically import APIs from "core" into the environment.
     for (const auto& kvp : core)

--- a/src/elona/lua_env/console.cpp
+++ b/src/elona/lua_env/console.cpp
@@ -1,7 +1,10 @@
 #include "console.hpp"
+
 #include <regex>
 #include <sstream>
+
 #include <boost/algorithm/string/predicate.hpp>
+
 #include "../../snail/application.hpp"
 #include "../../snail/blend_mode.hpp"
 #include "../../snail/input.hpp"
@@ -105,6 +108,7 @@ void Console::init_environment()
     auto core = _lua->get_api_manager().get_core_api_table();
     _console_mod =
         _lua->get_mod_manager().create_mod(_namespace_console, none, false);
+    _console_mod->enabled = true;
 
     // Automatically import APIs from "core" into the environment.
     for (const auto& kvp : core)

--- a/src/elona/lua_env/console.cpp
+++ b/src/elona/lua_env/console.cpp
@@ -60,7 +60,7 @@ constexpr int max_scrollback_count = 1000;
 
 constexpr const char* _lua_var_commands = u8"COMMANDS";
 constexpr const char* _namespace_builtin = u8"_BUILTIN_";
-constexpr const char* _namespace_console = u8"_CONSOLE_";
+constexpr const char* _console_mod_id = u8"_CONSOLE_";
 
 
 
@@ -107,7 +107,7 @@ void Console::init_environment()
 {
     auto core = _lua->get_api_manager().get_core_api_table();
     _console_mod =
-        _lua->get_mod_manager().create_mod(_namespace_console, none, false);
+        _lua->get_mod_manager().create_mod(_console_mod_id, none, false);
 
     // Automatically import APIs from "core" into the environment.
     for (const auto& kvp : core)
@@ -577,11 +577,11 @@ void Console::grab_input()
 
 
 void Console::register_(
-    const std::string& mod_name,
+    const std::string& mod_id,
     const std::string& name,
     sol::protected_function callback)
 {
-    _env()["__USH__"]["register"](mod_name, name, callback);
+    _env()["__USH__"]["register"](mod_id, name, callback);
 }
 
 
@@ -596,7 +596,7 @@ sol::object Console::run(const std::string& cmdline)
 void Console::_init_builtin_lua_functions()
 {
     // Table for built-in Lua functions.
-    sol::table funcs = _command_table()["_BUILTIN_"];
+    sol::table funcs = _command_table()[_namespace_builtin];
 
     auto inspect = lua->get_state()->script_file(filepathutil::to_utf8_path(
         filesystem::dir::data() / "script" / "kernel" / "inspect.lua"));
@@ -634,7 +634,7 @@ void Console::_init_builtin_lua_functions()
         range::transform(
             _lua->get_mod_manager().calculate_loading_order(),
             std::back_inserter(mods),
-            [](const auto& mod_name) { return mod_name; });
+            [](const auto& mod_id) { return mod_id; });
         range::sort(mods);
 
         sol::table ret = _env().create();

--- a/src/elona/lua_env/console.hpp
+++ b/src/elona/lua_env/console.hpp
@@ -24,12 +24,12 @@ struct ModInfo;
  *
  * All console commands and Lua functions are performed in an isolated
  * environment (mod "console"), so that no side-effect happends to the game.
- * Commands have own "namespace", usually the mod name where the command is
+ * Commands have own "namespace", usually the mod ID where the command is
  * registered. There are two special namespaces, "_BUILTIN_" and "_CONSOLE_".
  * "_BUILTIN_" is, you know, a namespace for all built-in commands defined from
- * C++ code, "console.cpp". "_CONSOLE_" is a namespace for user-defined
- * commands which are defined via the console. Registered commands are stored
- * in "COMMANDS" table. You can access any commands like this
+ * C++ code, "console.cpp". "_CONSOLE_" is a namespace for user-defined commands
+ * which are defined via the console. Registered commands are stored in
+ * "COMMANDS" table. You can access any commands like this
  * "COMMANDS[namespace][command_name]" in Lua mode.
  */
 class Console
@@ -55,7 +55,7 @@ public:
 
 
     void register_(
-        const std::string& mod_name,
+        const std::string& mod_id,
         const std::string& name,
         sol::protected_function callback);
 

--- a/src/elona/lua_env/data_manager.cpp
+++ b/src/elona/lua_env/data_manager.cpp
@@ -1,4 +1,8 @@
 #include "data_manager.hpp"
+
+#include "../../util/natural_order_comparator.hpp"
+#include "../log.hpp"
+#include "api_manager.hpp"
 #include "mod_manager.hpp"
 
 
@@ -60,7 +64,7 @@ void DataManager::init_from_mods()
     for (const auto& mod_name :
          _lua->get_mod_manager().calculate_loading_order())
     {
-        const auto& mod = _lua->get_mod_manager().get_mod(mod_name);
+        const auto& mod = _lua->get_mod_manager().get_enabled_mod(mod_name);
         _init_from_mod(*mod);
     }
 

--- a/src/elona/lua_env/data_manager.cpp
+++ b/src/elona/lua_env/data_manager.cpp
@@ -40,7 +40,7 @@ void DataManager::_init_from_mod(ModInfo& mod)
         // outside of a mod environment. To determine which mod is adding new
         // types/data in the data chunk, it has to be set on the global Lua
         // state temporarily during the data loading process.
-        _lua->get_state()->set("_MOD_NAME", mod.manifest.name);
+        _lua->get_state()->set("_MOD_ID", mod.manifest.id);
 
         const auto data_script = *mod.manifest.path / "data.lua";
         if (fs::exists(data_script))
@@ -67,7 +67,7 @@ void DataManager::init_from_mods()
         _init_from_mod(*mod);
     }
 
-    _lua->get_state()->set("_MOD_NAME", sol::lua_nil);
+    _lua->get_state()->set("_MOD_ID", sol::lua_nil);
 
     // Prevent modifications to the 'data' table.
     sol::table metatable = _data.storage().create_with(

--- a/src/elona/lua_env/data_manager.cpp
+++ b/src/elona/lua_env/data_manager.cpp
@@ -61,10 +61,9 @@ void DataManager::_init_from_mod(ModInfo& mod)
 
 void DataManager::init_from_mods()
 {
-    for (const auto& mod_name :
-         _lua->get_mod_manager().calculate_loading_order())
+    for (const auto& mod_id : _lua->get_mod_manager().calculate_loading_order())
     {
-        const auto& mod = _lua->get_mod_manager().get_enabled_mod(mod_name);
+        const auto& mod = _lua->get_mod_manager().get_enabled_mod(mod_id);
         _init_from_mod(*mod);
     }
 

--- a/src/elona/lua_env/export_manager.hpp
+++ b/src/elona/lua_env/export_manager.hpp
@@ -32,7 +32,7 @@ public:
      * inside the API tables returned by mods. They will then be
      * accessable by the id
      *
-     * "exports:<mod_name>.<namespaces>.<...>"
+     * "exports:<mod_id>.<namespaces>.<...>"
      *
      * corresponding to the nested table layout of the Exports table.
      */
@@ -40,7 +40,7 @@ public:
 
     /***
      * Obtains a Lua callback where name is like
-     * "exports:<mod_name>.<namespaces>", if it exists.
+     * "exports:<mod_id>.<namespaces>", if it exists.
      */
     optional<WrappedFunction> get_exported_function(
         const std::string& name) const;

--- a/src/elona/lua_env/lua_api/lua_api_console.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_console.cpp
@@ -14,16 +14,16 @@ namespace lua
  *
  * Registers a new console command.
  *
- * @tparam string mod_name the mod's name where the command is defined.
+ * @tparam string mod_id the mod's id where the command is defined.
  * @tparam string name the command name.
  * @tparam function callback the command itself.
  */
 void LuaApiConsole::register_(
-    const std::string& mod_name,
+    const std::string& mod_id,
     const std::string& name,
     sol::protected_function callback)
 {
-    lua->get_console().register_(mod_name, name, callback);
+    lua->get_console().register_(mod_id, name, callback);
 }
 
 

--- a/src/elona/lua_env/lua_api/lua_api_console.hpp
+++ b/src/elona/lua_env/lua_api/lua_api_console.hpp
@@ -19,7 +19,7 @@ namespace LuaApiConsole
 {
 
 void register_(
-    const std::string& mod_name,
+    const std::string& mod_id,
     const std::string& name,
     sol::protected_function callback);
 

--- a/src/elona/lua_env/lua_env.cpp
+++ b/src/elona/lua_env/lua_env.cpp
@@ -1,4 +1,5 @@
 #include "lua_env.hpp"
+
 #include "../config/config.hpp"
 #include "api_manager.hpp"
 #include "console.hpp"
@@ -79,6 +80,7 @@ void LuaEnv::clear()
     event_mgr->clear();
     mod_mgr->clear_mod_stores();
     data_mgr->clear();
+    handle_mgr->clear_all_handles();
     lua_->collect_garbage();
 }
 

--- a/src/elona/lua_env/mod_manager.cpp
+++ b/src/elona/lua_env/mod_manager.cpp
@@ -56,17 +56,6 @@ void ModManager::load_mods(const fs::path& mod_dir)
     load_scanned_mods();
 }
 
-void ModManager::unload_mods()
-{
-    if (stage_ != ModLoadingStage::all_mods_loaded)
-    {
-        throw std::runtime_error("Mods have not been loaded.");
-    }
-
-    mods_ = ModStorageType();
-    stage_ = ModLoadingStage::not_started;
-}
-
 void ModManager::load_mods(
     const fs::path& mod_dir,
     const std::vector<fs::path> additional_mod_paths)
@@ -83,6 +72,17 @@ void ModManager::load_mods(
     }
     load_lua_support_libraries();
     load_scanned_mods();
+}
+
+void ModManager::unload_mods()
+{
+    if (stage_ != ModLoadingStage::all_mods_loaded)
+    {
+        return;
+    }
+
+    mods_ = ModStorageType();
+    stage_ = ModLoadingStage::not_started;
 }
 
 

--- a/src/elona/lua_env/mod_manager.cpp
+++ b/src/elona/lua_env/mod_manager.cpp
@@ -422,20 +422,10 @@ std::vector<std::string> ModManager::calculate_loading_order()
 {
     TopologicalSorter<std::string> sorter;
 
-    // For checking mods with more than one version enabled.
-    std::unordered_set<std::string> checked_mods;
-
     for (const auto& pair : this->enabled_mods())
     {
         const auto& mod = pair.second;
         sorter.add(mod->manifest.id);
-
-        if (checked_mods.find(mod->manifest.id) != checked_mods.end())
-        {
-            throw std::runtime_error(
-                "Mod '" + mod->manifest.id +
-                "' has more than one version enabled.");
-        }
 
         for (const auto& pair : mod->manifest.dependencies)
         {

--- a/src/elona/lua_env/mod_manager.cpp
+++ b/src/elona/lua_env/mod_manager.cpp
@@ -252,18 +252,7 @@ void ModManager::clear_map_local_stores()
     for (auto&& pair : this->enabled_mods())
     {
         auto& mod = pair.second;
-        lua_->get_state()->safe_script(
-            R"(
-local function clear(t)
-    for key, _ in pairs(t) do
-        t[key] = nil
-    end
-end
-if Store then
-    clear(Store.map)
-end
-)",
-            mod->env);
+        lua_->get_state()->safe_script(R"(Store.map = {})", mod->env);
     }
 }
 
@@ -272,18 +261,7 @@ void ModManager::clear_global_stores()
     for (auto&& pair : this->enabled_mods())
     {
         auto& mod = pair.second;
-        lua_->get_state()->safe_script(
-            R"(
-local function clear(t)
-    for key, _ in pairs(t) do
-        t[key] = nil
-    end
-end
-if Store then
-    clear(Store.global)
-end
-)",
-            mod->env);
+        lua_->get_state()->safe_script(R"(Store.global = {})", mod->env);
     }
 }
 

--- a/src/elona/lua_env/mod_manager.hpp
+++ b/src/elona/lua_env/mod_manager.hpp
@@ -54,7 +54,7 @@ struct ModInfo
     ModInfo& operator=(const ModInfo&) = delete;
     ~ModInfo() = default;
 
-    sol::table get_store(StoreType store_type) const
+    sol::object get_store(StoreType store_type) const
     {
         std::string table_name;
         switch (store_type)
@@ -63,10 +63,10 @@ struct ModInfo
         case StoreType::global: table_name = "global"; break;
         }
 
-        return env["Store"][table_name].get<sol::table>();
+        return env["Store"][table_name].get<sol::object>();
     }
 
-    void set_store(StoreType store_type, sol::table data)
+    void set_store(StoreType store_type, sol::object data)
     {
         std::string table_name;
         switch (store_type)

--- a/src/elona/lua_env/mod_manifest.cpp
+++ b/src/elona/lua_env/mod_manifest.cpp
@@ -128,6 +128,7 @@ ModManifest ModManifest::load(const fs::path& path)
     const auto& value = hclutil::skip_sections(
         parsed, {"mod"}, filepathutil::to_utf8_path(path));
 
+    const auto mod_id = _read_string("id", value, path);
     const auto mod_name = _read_string("name", value, path);
     const auto mod_author = _read_string("author", value, path);
     const auto mod_description = _read_string("description", value, path);
@@ -136,7 +137,8 @@ ModManifest ModManifest::load(const fs::path& path)
     const auto mod_path = path.parent_path();
     const auto dependencies = _read_dependencies(value, path);
 
-    return ModManifest{mod_name,
+    return ModManifest{mod_id,
+                       mod_name,
                        mod_author,
                        mod_description,
                        mod_license,

--- a/src/elona/lua_env/mod_manifest.cpp
+++ b/src/elona/lua_env/mod_manifest.cpp
@@ -1,4 +1,5 @@
 #include "mod_manifest.hpp"
+
 #include "../hcl.hpp"
 
 namespace elona
@@ -9,12 +10,15 @@ namespace lua
 namespace
 {
 
-std::string _read_mod_name(const hcl::Value& value, const fs::path& path)
+std::string _read_string(
+    const std::string key,
+    const hcl::Value& value,
+    const fs::path& path)
 {
     std::string result;
 
     // TODO: Clean up, as with lua::ConfigTable
-    const hcl::Value* object = value.find("name");
+    const hcl::Value* object = value.find(key);
     if (object && object->is<std::string>())
     {
         result = object->as<std::string>();
@@ -22,8 +26,8 @@ std::string _read_mod_name(const hcl::Value& value, const fs::path& path)
     else
     {
         throw std::runtime_error(
-            filepathutil::to_utf8_path(path) +
-            ": Missing \"name\" in mod manifest");
+            filepathutil::to_utf8_path(path) + ": Missing \"" + key +
+            "\" in mod manifest");
     }
 
     return result;
@@ -56,7 +60,7 @@ semver::Version _read_mod_version(const hcl::Value& value, const fs::path& path)
     {
         throw std::runtime_error(
             filepathutil::to_utf8_path(path) +
-            ": Missing \"name\" in mod manifest");
+            ": Missing \"version\" in mod manifest");
     }
 }
 
@@ -124,12 +128,21 @@ ModManifest ModManifest::load(const fs::path& path)
     const auto& value = hclutil::skip_sections(
         parsed, {"mod"}, filepathutil::to_utf8_path(path));
 
-    const auto mod_name = _read_mod_name(value, path);
+    const auto mod_name = _read_string("name", value, path);
+    const auto mod_author = _read_string("author", value, path);
+    const auto mod_description = _read_string("description", value, path);
+    const auto mod_license = _read_string("license", value, path);
     const auto version = _read_mod_version(value, path);
     const auto mod_path = path.parent_path();
     const auto dependencies = _read_dependencies(value, path);
 
-    return ModManifest{mod_name, version, mod_path, dependencies};
+    return ModManifest{mod_name,
+                       mod_author,
+                       mod_description,
+                       mod_license,
+                       version,
+                       mod_path,
+                       dependencies};
 }
 
 } // namespace lua

--- a/src/elona/lua_env/mod_manifest.hpp
+++ b/src/elona/lua_env/mod_manifest.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <unordered_map>
+
 #include "../filesystem.hpp"
 #include "../optional.hpp"
 #include "../semver.hpp"
@@ -23,6 +24,9 @@ struct ModManifest
     static ModManifest load(const fs::path& path);
 
     std::string name;
+    std::string author;
+    std::string description;
+    std::string license;
     semver::Version version;
     optional<fs::path> path;
     Dependencies dependencies;

--- a/src/elona/lua_env/mod_manifest.hpp
+++ b/src/elona/lua_env/mod_manifest.hpp
@@ -23,6 +23,7 @@ struct ModManifest
      */
     static ModManifest load(const fs::path& path);
 
+    std::string id;
     std::string name;
     std::string author;
     std::string description;

--- a/src/elona/lua_env/mod_serializer.hpp
+++ b/src/elona/lua_env/mod_serializer.hpp
@@ -87,10 +87,10 @@ public:
 
         for (const auto& pair : mod_mgr.enabled_mods())
         {
-            std::string mod_name = pair.second->manifest.name;
+            std::string mod_id = pair.second->manifest.id;
             semver::Version mod_version = pair.second->manifest.version;
 
-            putit_archive(mod_name);
+            putit_archive(mod_id);
             putit_archive(mod_version);
 
             sol::table data = pair.second->get_store(store_type);
@@ -98,7 +98,7 @@ public:
 
             ELONA_LOG("lua.mod")
                 << "Saved " << get_store_name(store_type) << " store data for "
-                << mod_name << " " << mod_version.to_string();
+                << mod_id << " " << mod_version.to_string();
         }
     }
 
@@ -114,20 +114,20 @@ public:
 
         for (unsigned i = 0; i < mod_count; i++)
         {
-            std::string mod_name;
+            std::string mod_id;
             semver::Version mod_version;
 
-            putit_archive(mod_name);
+            putit_archive(mod_id);
             putit_archive(mod_version);
 
-            auto mod = mod_mgr.get_enabled_mod_optional(mod_name);
+            auto mod = mod_mgr.get_enabled_mod_optional(mod_id);
             if (!mod)
             {
                 // Skip this piece of data.
                 ELONA_WARN("lua.mod")
                     << "WARNING: skipping mod store loading as mod "
                        "wasn't loaded: "
-                    << mod_name;
+                    << mod_id;
 
                 std::string raw_data;
                 putit_archive(raw_data);
@@ -136,7 +136,7 @@ public:
             }
             ELONA_LOG("lua.mod")
                 << "Loaded " << get_store_name(store_type) << " store data for "
-                << mod_name << " " << mod_version.to_string();
+                << mod_id << " " << mod_version.to_string();
 
             sol::table data = _lua->get_state()->create_table();
             load(data, putit_archive);

--- a/src/elona/lua_env/mod_serializer.hpp
+++ b/src/elona/lua_env/mod_serializer.hpp
@@ -82,12 +82,12 @@ public:
     {
         const auto& mod_mgr = _lua->get_mod_manager();
 
-        unsigned mod_count = static_cast<unsigned>(mod_mgr.count());
+        unsigned mod_count = static_cast<unsigned>(mod_mgr.enabled_mod_count());
         putit_archive(mod_count);
 
-        for (const auto& pair : mod_mgr)
+        for (const auto& pair : mod_mgr.enabled_mods())
         {
-            std::string mod_name = pair.first;
+            std::string mod_name = pair.second->manifest.name;
             semver::Version mod_version = pair.second->manifest.version;
 
             putit_archive(mod_name);
@@ -120,7 +120,7 @@ public:
             putit_archive(mod_name);
             putit_archive(mod_version);
 
-            auto mod = mod_mgr.get_mod_optional(mod_name);
+            auto mod = mod_mgr.get_enabled_mod_optional(mod_name);
             if (!mod)
             {
                 // Skip this piece of data.

--- a/src/elona/main_menu.cpp
+++ b/src/elona/main_menu.cpp
@@ -1260,11 +1260,6 @@ MainMenuResult main_menu_about_credits()
 MainMenuResult main_menu_mods()
 {
     ui::UIMenuMods().show();
-#if 0
-    lua::lua->get_mod_manager()->unload_mods();
-    lua::lua->get_mod_manager()->load_mods(filesystem::dir::mods());
-    show_loading_screen();
-#endif
     return MainMenuResult::main_title_menu;
 }
 

--- a/src/elona/main_menu.hpp
+++ b/src/elona/main_menu.hpp
@@ -13,6 +13,7 @@ enum class MainMenuResult
     main_menu_about_changelogs,
     main_menu_about_license,
     main_menu_about_credits,
+    main_menu_mods,
     character_making_select_race,
     character_making_select_sex,
     character_making_select_sex_looped,
@@ -40,5 +41,6 @@ MainMenuResult main_menu_about();
 MainMenuResult main_menu_about_changelogs();
 MainMenuResult main_menu_about_license();
 MainMenuResult main_menu_about_credits();
+MainMenuResult main_menu_mods();
 
 } // namespace elona

--- a/src/elona/save.cpp
+++ b/src/elona/save.cpp
@@ -1,4 +1,5 @@
 #include "save.hpp"
+
 #include "audio.hpp"
 #include "character_status.hpp"
 #include "ctrl_file.hpp"

--- a/src/elona/semver.hpp
+++ b/src/elona/semver.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <cassert>
+
 #include <regex>
 #include <stdexcept>
 #include <string>
 #include <vector>
+
 #include "../util/either.hpp"
 #include "../util/range.hpp"
 #include "../util/strutil.hpp"
@@ -463,7 +465,6 @@ private:
 
 } // namespace semver
 } // namespace elona
-
 
 
 #ifdef ELONA_MAJOR_AND_MINOR_MACRO_DEFINED

--- a/src/elona/spec.cpp
+++ b/src/elona/spec.cpp
@@ -14,19 +14,19 @@ namespace elona
 namespace spec
 {
 
-void Object::load(const fs::path& path, const std::string& mod_name)
+void Object::load(const fs::path& path, const std::string& mod_id)
 {
     std::ifstream ifs(path.native());
-    load(ifs, filepathutil::to_utf8_path(path), mod_name);
+    load(ifs, filepathutil::to_utf8_path(path), mod_id);
 }
 
 void Object::load(
     std::istream& is,
     const std::string& hcl_file,
-    const std::string& mod_name)
+    const std::string& mod_id)
 {
     hcl::ParseResult parseResult = hcl::parse(is);
-    std::string top_level_key = mod_name;
+    std::string top_level_key = mod_id;
 
     if (!parseResult.valid())
     {

--- a/src/elona/spec.hpp
+++ b/src/elona/spec.hpp
@@ -146,11 +146,11 @@ public:
     }
     ~Object() = default;
 
-    void load(const fs::path& path, const std::string& mod_name);
+    void load(const fs::path& path, const std::string& mod_id);
     void load(
         std::istream& is,
         const std::string& hcl_file,
-        const std::string& mod_name);
+        const std::string& mod_id);
 
     const_iterator begin() const
     {

--- a/src/elona/std.cpp
+++ b/src/elona/std.cpp
@@ -6,12 +6,10 @@
 #include <regex>
 #include <sstream>
 
-
 #include "../snail/android.hpp"
 #include "../snail/application.hpp"
 #include "../snail/hsp.hpp"
 #include "../snail/window.hpp"
-
 #include "../util/fps_counter.hpp"
 #include "../util/strutil.hpp"
 #include "config/config.hpp"

--- a/src/elona/testing.cpp
+++ b/src/elona/testing.cpp
@@ -1,7 +1,10 @@
 #include "testing.hpp"
+
 #include <sstream>
+
 #include "../version.hpp"
 #include "config/config.hpp"
+#include "ctrl_file.hpp"
 #include "data/types/type_item.hpp"
 #include "data/types/type_music.hpp"
 #include "data/types/type_sound.hpp"
@@ -41,7 +44,7 @@ fs::path get_mods_path()
 
 void load_previous_savefile()
 {
-    elona::testing::reset_state();
+    testing::reset_state();
     // This file was saved directly after the dialog at the start of the game.
     elona::playerid = "sav_foobar_test";
     filesystem::dir::set_base_save_directory(filesystem::path(save_dir));
@@ -54,19 +57,29 @@ void load_previous_savefile()
 
 void save_reset_and_reload()
 {
-    filesystem::dir::set_base_save_directory(filesystem::path(save_dir));
-    save_game();
-    elona::testing::reset_state();
-    elona::firstturn = 1;
-    load_save_data();
+    testing::save();
+    testing::reset_state();
+    testing::load();
 }
 
 void save_and_reload()
 {
+    testing::save();
+    testing::load();
+}
+
+void save()
+{
     filesystem::dir::set_base_save_directory(filesystem::path(save_dir));
     save_game();
+}
+
+void load()
+{
     elona::firstturn = 1;
     load_save_data();
+    elona::mode = 3;
+    initialize_map();
 }
 
 void load_translations(const std::string& hcl)
@@ -108,6 +121,10 @@ void start_in_map(int map, int level)
 
     elona::playerid = player_id;
     fs::remove_all(filesystem::dir::save(player_id));
+    fs::remove_all(filesystem::dir::tmp());
+    fs::create_directory(filesystem::dir::tmp());
+    writeloadedbuff_clear();
+    Save::instance().clear();
 
     game_data.current_map = map;
     game_data.current_dungeon_level = level;
@@ -181,6 +198,10 @@ void post_run()
 {
     filesystem::dir::set_base_save_directory(filesystem::path(save_dir));
     fs::remove_all(filesystem::dir::save(player_id));
+    fs::remove_all(filesystem::dir::tmp());
+    writeloadedbuff_clear();
+    Save::instance().clear();
+    fs::create_directory(filesystem::dir::tmp());
     finish_elona();
 }
 

--- a/src/elona/testing.hpp
+++ b/src/elona/testing.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <functional>
+
 #include "filesystem.hpp"
 
 namespace elona
@@ -23,6 +24,9 @@ void reset_state();
 
 void save_reset_and_reload();
 void save_and_reload();
+
+void save();
+void load();
 
 /***
  * Loads a pre-prepared savefile to test save breakages between

--- a/src/elona/ui/ui_menu_keybindings.cpp
+++ b/src/elona/ui/ui_menu_keybindings.cpp
@@ -40,7 +40,7 @@ static std::string _action_category_to_name(ActionCategory category)
 }
 
 static std::string _get_localized_action_name(
-    const std::string& mod_name,
+    const std::string& mod_id,
     const std::string& action_id,
     ActionCategory action_category)
 {
@@ -56,20 +56,19 @@ static std::string _get_localized_action_name(
         {
             action_index_plus_1 -= 10;
         }
-        localized_name = i18n::s.get(mod_name + ".locale.keybind.shortcut") +
+        localized_name = i18n::s.get(mod_id + ".locale.keybind.shortcut") +
             std::to_string(action_index_plus_1);
         break;
     }
     case ActionCategory::selection:
     {
         const auto action_index_plus_1 = keybind_index_number(action_id) + 1;
-        localized_name = i18n::s.get(mod_name + ".locale.keybind.select") +
+        localized_name = i18n::s.get(mod_id + ".locale.keybind.select") +
             std::to_string(action_index_plus_1);
         break;
     }
     default:
-        localized_name =
-            i18n::s.get(mod_name + ".locale.keybind."s + action_id);
+        localized_name = i18n::s.get(mod_id + ".locale.keybind."s + action_id);
         break;
     }
 
@@ -120,9 +119,9 @@ static void _load_keybindings()
             const auto& action_id = pair->second;
             const auto& keybind_config = keybind_manager.binding(pair->second);
 
-            const auto mod_name = "core"s;
-            std::string localized_name = _get_localized_action_name(
-                mod_name, action_id, action_category);
+            const auto mod_id = "core"s;
+            std::string localized_name =
+                _get_localized_action_name(mod_id, action_id, action_category);
 
             _push_keybind_entry(action_id, localized_name, keybind_config);
         }
@@ -408,10 +407,9 @@ private:
     void _print_conflict(std::ostream& out, const std::string& action_id)
     {
         const auto category = keybind::actions.at(action_id).category;
-        const auto mod_name = "core";
+        const auto mod_id = "core";
         out << "  " << _action_category_to_name(category) << ": "
-            << _get_localized_action_name(mod_name, action_id, category)
-            << "\n";
+            << _get_localized_action_name(mod_id, action_id, category) << "\n";
     }
 
 

--- a/src/elona/ui/ui_menu_mod_info.cpp
+++ b/src/elona/ui/ui_menu_mod_info.cpp
@@ -1,0 +1,252 @@
+#include "ui_menu_mod_info.hpp"
+
+#include "../../util/fileutil.hpp"
+#include "../../util/strutil.hpp"
+#include "../audio.hpp"
+#include "../draw.hpp"
+#include "../i18n.hpp"
+#include "../lua_env/mod_manager.hpp"
+
+
+
+namespace elona
+{
+namespace ui
+{
+
+static int _wrap_text(std::string& text, int max_line_length)
+{
+    std::string rest{text};
+    text.clear();
+    int n{};
+
+    while (1)
+    {
+        const auto len = rest.size();
+        if (int(len) < max_line_length)
+        {
+            text += rest;
+            return n;
+        }
+        size_t byte_length = 0;
+        size_t width_length = 0;
+        while (width_length <= len)
+        {
+            const auto bytes = strutil::byte_count(rest[byte_length]);
+            const auto char_width = bytes == 1 ? 1 : 2;
+
+            byte_length += bytes;
+            width_length += char_width;
+
+            if (int(width_length) > max_line_length)
+            {
+                text += rest.substr(0, byte_length) + '\n';
+                ++n;
+                if (rest.size() > byte_length)
+                {
+                    rest = rest.substr(byte_length);
+                }
+                else
+                {
+                    rest = "";
+                }
+                break;
+            }
+        }
+    }
+}
+
+bool UIMenuModInfo::init()
+{
+    key_list(0) = key_enter;
+    keyrange = 0;
+    pagesize = 1;
+    listmax = 0;
+
+    _build_description();
+
+    return true;
+}
+
+void UIMenuModInfo::_build_description()
+{
+    _readme_pages.clear();
+    _desc_page = 0;
+
+    auto readme_path =
+        filesystem::dir::for_mod(_desc.manifest.id) / "README.txt";
+    if (!fs::exists(readme_path))
+    {
+        // TODO
+        _readme_pages.push_back(
+            i18n::s.get("core.locale.main_menu.mods.no_readme"));
+        return;
+    }
+
+    std::vector<std::string> description_lines;
+    range::copy(
+        fileutil::read_by_line(readme_path),
+        std::back_inserter(description_lines));
+
+    if (description_lines.empty())
+    {
+        // TODO
+        _readme_pages.push_back(
+            i18n::s.get("core.locale.main_menu.mods.no_readme"));
+        return;
+    }
+
+    const size_t text_width = 90 - 2;
+    constexpr size_t lines_per_page = 15;
+
+    for (auto&& line : description_lines)
+    {
+        _wrap_text(line, text_width);
+    }
+    size_t line_count = 0;
+    for (const auto& lines : description_lines)
+    {
+        if (lines == "")
+        {
+            _readme_pages.back() += '\n';
+        }
+        for (const auto& line : strutil::split_lines(lines))
+        {
+            if (line_count == 0)
+            {
+                _readme_pages.push_back(line + '\n');
+            }
+            else
+            {
+                _readme_pages.back() += line + '\n';
+            }
+            ++line_count;
+            if (line_count == lines_per_page)
+            {
+                line_count = 0;
+            }
+        }
+    }
+
+    listmax = _readme_pages.size();
+}
+
+
+
+void UIMenuModInfo::update()
+{
+    pagemax = (listmax - 1) / pagesize;
+    if (page < 0)
+        page = pagemax;
+    else if (page > pagemax)
+        page = 0;
+}
+
+
+
+void UIMenuModInfo::_draw_mod_page()
+{
+    display_topic(
+        i18n::s.get("core.locale.main_menu.mods.info.title"), wx + 30, wy + 36);
+
+    int y = wy + 60;
+
+    gmes(
+        "<b>" + i18n::s.get("core.locale.main_menu.mods.info.id") + ":<def> " +
+            _desc.manifest.id,
+        wx + 30,
+        y,
+        488,
+        {30, 30, 30},
+        false);
+    gmes(
+        "<b>" + i18n::s.get("core.locale.main_menu.mods.info.author") +
+            ":<def> " + _desc.manifest.author,
+        wx + 30,
+        y + 16,
+        488,
+        {30, 30, 30},
+        false);
+    gmes(
+        "<b>" + i18n::s.get("core.locale.main_menu.mods.info.version") +
+            ":<def> " + _desc.manifest.version.to_string(),
+        wx + 30,
+        y + 32,
+        488,
+        {30, 30, 30},
+        false);
+    gmes(
+        "<b>" + i18n::s.get("core.locale.main_menu.mods.info.description") +
+            ":<def> " + _desc.manifest.description,
+        wx + 30,
+        y + 48,
+        488,
+        {30, 30, 30},
+        false);
+
+    window2(wx + 30 + 498 - 4, y - 36 - 4, 128 + 8, 128 + 8, 1, 1);
+    boxf(wx + 30 + 498, y - 36, 128, 128, {0, 0, 0});
+    mes(wx + 30 + 498 + 32 + 6, y - 36 + 64 - 7, "(image)", {255, 255, 255});
+
+    display_topic("README", wx + 30, wy + 160);
+
+    font(14 - en * 2);
+    mes(wx + 30, wy + 184, _readme_pages.at(page));
+}
+
+
+
+void UIMenuModInfo::_draw_window()
+{
+    ui_display_window(
+        _desc.manifest.name,
+        strhint2 + strhint3b,
+        (windoww - 700) / 2 + inf_screenx,
+        winposy(500) - 10,
+        700,
+        500);
+}
+
+
+
+void UIMenuModInfo::draw()
+{
+    _draw_window();
+    _draw_mod_page();
+}
+
+
+
+optional<UIMenuModInfo::ResultType> UIMenuModInfo::on_key(
+    const std::string& action)
+{
+    // Page changes
+    if (action == "next_page")
+    {
+        if (pagemax != 0)
+        {
+            snd("core.pop1");
+            page++;
+            set_reupdate();
+        }
+    }
+    if (action == "previous_page")
+    {
+        if (pagemax != 0)
+        {
+            snd("core.pop1");
+            page--;
+            set_reupdate();
+        }
+    }
+
+    // Closing menu
+    if (action == "cancel")
+    {
+        return UIMenuModInfo::ResultType::finish();
+    }
+    return none;
+}
+
+} // namespace ui
+} // namespace elona

--- a/src/elona/ui/ui_menu_mod_info.cpp
+++ b/src/elona/ui/ui_menu_mod_info.cpp
@@ -14,48 +14,6 @@ namespace elona
 namespace ui
 {
 
-static int _wrap_text(std::string& text, int max_line_length)
-{
-    std::string rest{text};
-    text.clear();
-    int n{};
-
-    while (1)
-    {
-        const auto len = rest.size();
-        if (int(len) < max_line_length)
-        {
-            text += rest;
-            return n;
-        }
-        size_t byte_length = 0;
-        size_t width_length = 0;
-        while (width_length <= len)
-        {
-            const auto bytes = strutil::byte_count(rest[byte_length]);
-            const auto char_width = bytes == 1 ? 1 : 2;
-
-            byte_length += bytes;
-            width_length += char_width;
-
-            if (int(width_length) > max_line_length)
-            {
-                text += rest.substr(0, byte_length) + '\n';
-                ++n;
-                if (rest.size() > byte_length)
-                {
-                    rest = rest.substr(byte_length);
-                }
-                else
-                {
-                    rest = "";
-                }
-                break;
-            }
-        }
-    }
-}
-
 bool UIMenuModInfo::init()
 {
     key_list(0) = key_enter;
@@ -93,7 +51,7 @@ void UIMenuModInfo::_build_description()
 
         for (auto&& line : description_lines)
         {
-            _wrap_text(line, text_width);
+            strutil::wrap_text(line, text_width);
         }
         size_t line_count = 0;
         for (const auto& lines : description_lines)

--- a/src/elona/ui/ui_menu_mod_info.cpp
+++ b/src/elona/ui/ui_menu_mod_info.cpp
@@ -74,61 +74,66 @@ void UIMenuModInfo::_build_description()
     _desc_page = 0;
 
     auto readme_path =
-        filesystem::dir::for_mod(_desc.manifest.id) / "README.txt";
+        filesystem::dir::for_mod(_desc.manifest.id) / "README.md";
+
     if (!fs::exists(readme_path))
     {
-        // TODO
         _readme_pages.push_back(
             i18n::s.get("core.locale.main_menu.mods.no_readme"));
-        return;
     }
-
-    std::vector<std::string> description_lines;
-    range::copy(
-        fileutil::read_by_line(readme_path),
-        std::back_inserter(description_lines));
-
-    if (description_lines.empty())
+    else
     {
-        // TODO
-        _readme_pages.push_back(
-            i18n::s.get("core.locale.main_menu.mods.no_readme"));
-        return;
-    }
+        std::vector<std::string> description_lines;
+        range::copy(
+            fileutil::read_by_line(readme_path),
+            std::back_inserter(description_lines));
 
-    const size_t text_width = 90 - 2;
-    constexpr size_t lines_per_page = 15;
+        const size_t text_width = 90 - 2;
+        constexpr size_t lines_per_page = 15;
 
-    for (auto&& line : description_lines)
-    {
-        _wrap_text(line, text_width);
-    }
-    size_t line_count = 0;
-    for (const auto& lines : description_lines)
-    {
-        if (lines == "")
+        for (auto&& line : description_lines)
         {
-            _readme_pages.back() += '\n';
+            _wrap_text(line, text_width);
         }
-        for (const auto& line : strutil::split_lines(lines))
+        size_t line_count = 0;
+        for (const auto& lines : description_lines)
         {
-            if (line_count == 0)
+            if (lines == "")
             {
-                _readme_pages.push_back(line + '\n');
+                _readme_pages.back() += '\n';
             }
-            else
+            for (const auto& line : strutil::split_lines(lines))
             {
-                _readme_pages.back() += line + '\n';
+                if (line_count == 0)
+                {
+                    _readme_pages.push_back(line + '\n');
+                }
+                else
+                {
+                    _readme_pages.back() += line + '\n';
+                }
+                ++line_count;
+                if (line_count == lines_per_page)
+                {
+                    line_count = 0;
+                }
             }
-            ++line_count;
-            if (line_count == lines_per_page)
-            {
-                line_count = 0;
-            }
+        }
+
+        if (description_lines.empty())
+        {
+            _readme_pages.push_back(
+                i18n::s.get("core.locale.main_menu.mods.no_readme"));
         }
     }
 
     listmax = _readme_pages.size();
+
+    auto image_path = filesystem::dir::for_mod(_desc.manifest.id) / "image.png";
+    if (fs::exists(image_path))
+    {
+        _mod_image = snail::Image{image_path};
+    }
 }
 
 
@@ -156,7 +161,7 @@ void UIMenuModInfo::_draw_mod_page()
             _desc.manifest.id,
         wx + 30,
         y,
-        488,
+        570,
         {30, 30, 30},
         false);
     gmes(
@@ -164,7 +169,7 @@ void UIMenuModInfo::_draw_mod_page()
             ":<def> " + _desc.manifest.author,
         wx + 30,
         y + 16,
-        488,
+        570,
         {30, 30, 30},
         false);
     gmes(
@@ -172,7 +177,7 @@ void UIMenuModInfo::_draw_mod_page()
             ":<def> " + _desc.manifest.version.to_string(),
         wx + 30,
         y + 32,
-        488,
+        570,
         {30, 30, 30},
         false);
     gmes(
@@ -180,13 +185,19 @@ void UIMenuModInfo::_draw_mod_page()
             ":<def> " + _desc.manifest.description,
         wx + 30,
         y + 48,
-        488,
+        570,
         {30, 30, 30},
         false);
 
-    window2(wx + 30 + 498 - 4, y - 36 - 4, 128 + 8, 128 + 8, 1, 1);
-    boxf(wx + 30 + 498, y - 36, 128, 128, {0, 0, 0});
-    mes(wx + 30 + 498 + 32 + 6, y - 36 + 64 - 7, "(image)", {255, 255, 255});
+    auto image_x = wx + 30 + 578;
+    auto image_y = wy + 30;
+    window2(image_x - 4, image_y - 4, 48 + 8, 48 + 8, 1, 1);
+
+    if (_mod_image)
+    {
+        auto& renderer = snail::Application::instance().get_renderer();
+        renderer.render_image(*_mod_image, image_x, image_y, 48, 48);
+    }
 
     display_topic("README", wx + 30, wy + 160);
 
@@ -202,7 +213,7 @@ void UIMenuModInfo::_draw_window()
         _desc.manifest.name,
         strhint2 + strhint3b,
         (windoww - 700) / 2 + inf_screenx,
-        winposy(500) - 10,
+        winposy(480, 1),
         700,
         500);
 }

--- a/src/elona/ui/ui_menu_mod_info.hpp
+++ b/src/elona/ui/ui_menu_mod_info.hpp
@@ -1,0 +1,34 @@
+#pragma once
+#include "../lua_env/mod_manifest.hpp"
+#include "ui_menu.hpp"
+#include "ui_menu_mods.hpp"
+namespace elona
+{
+namespace ui
+{
+class UIMenuModInfo : public UIMenu<DummyResult>
+{
+public:
+    UIMenuModInfo(const ModDescription& desc)
+        : _desc(desc)
+    {
+    }
+
+protected:
+    virtual bool init();
+    virtual void update();
+    virtual void draw();
+    virtual optional<UIMenuModInfo::ResultType> on_key(const std::string& key);
+
+    void _build_description();
+    void _draw_mod_page();
+    void _draw_window();
+
+private:
+    const ModDescription& _desc;
+    std::vector<std::string> _readme_pages;
+
+    size_t _desc_page;
+};
+} // namespace ui
+} // namespace elona

--- a/src/elona/ui/ui_menu_mod_info.hpp
+++ b/src/elona/ui/ui_menu_mod_info.hpp
@@ -2,6 +2,12 @@
 #include "../lua_env/mod_manifest.hpp"
 #include "ui_menu.hpp"
 #include "ui_menu_mods.hpp"
+
+namespace snail
+{
+class Image;
+}
+
 namespace elona
 {
 namespace ui
@@ -27,6 +33,7 @@ protected:
 private:
     const ModDescription& _desc;
     std::vector<std::string> _readme_pages;
+    optional<snail::Image> _mod_image;
 
     size_t _desc_page;
 };

--- a/src/elona/ui/ui_menu_mods.cpp
+++ b/src/elona/ui/ui_menu_mods.cpp
@@ -35,9 +35,9 @@ bool UIMenuMods::init()
 
     for (const auto& mod : lua::lua->get_mod_manager().all_mods())
     {
-        const auto& name = mod->second->manifest.name;
+        const auto& name = mod->second->manifest.id;
 
-        if (lua::ModManager::mod_name_is_reserved(name))
+        if (lua::ModManager::mod_id_is_reserved(name))
             continue;
 
         ModDescription mod_desc{
@@ -61,7 +61,7 @@ optional<ModDescription> UIMenuMods::_find_enabled_mod(const std::string& name)
 {
     for (const auto& desc : _mod_descriptions)
     {
-        if (desc.enabled && desc.manifest.name == name)
+        if (desc.enabled && desc.manifest.id == name)
             return desc;
     }
     return none;
@@ -150,7 +150,7 @@ void UIMenuMods::_draw_mod_list()
 
         cs_list(
             cs == cnt,
-            desc.manifest.name,
+            desc.manifest.id,
             wx + 84,
             wy + 66 + cnt * 19 - 1,
             0,

--- a/src/elona/ui/ui_menu_mods.cpp
+++ b/src/elona/ui/ui_menu_mods.cpp
@@ -148,9 +148,6 @@ void UIMenuMods::_draw_key(int cnt, int index)
 
 void UIMenuMods::_draw_window()
 {
-    int y;
-    y = winposy(466) - 24;
-
     auto hint = ""s + key_enter + " " +
         i18n::s.get("core.locale.main_menu.mods.hint.toggle") + "  " +
         key_identify + " " +
@@ -182,7 +179,7 @@ void UIMenuMods::_draw_window()
         title,
         strhint2 + strhint3b + hint,
         (windoww - 730) / 2 + inf_screenx,
-        y,
+        winposy(510, 1),
         730,
         530);
 

--- a/src/elona/ui/ui_menu_mods.cpp
+++ b/src/elona/ui/ui_menu_mods.cpp
@@ -1,0 +1,325 @@
+#include "ui_menu_mods.hpp"
+
+#include "../../util/fileutil.hpp"
+#include "../../util/strutil.hpp"
+#include "../audio.hpp"
+#include "../draw.hpp"
+#include "../i18n.hpp"
+#include "../lua_env/mod_manager.hpp"
+
+
+
+namespace elona
+{
+namespace ui
+{
+
+bool UIMenuMods::init()
+{
+    snd("core.pop2");
+    listmax = 0;
+    page = 0;
+    pagesize = 18;
+    cs = 0;
+    cc = 0;
+    cs_bk = -1;
+    page_bk = 0;
+    cs_bk2 = 0;
+
+    asset_load("void");
+    ::draw("void", 0, 0, windoww, windowh);
+    load_background_variants(2);
+    gsel(0);
+    gmode(0);
+    gcopy(4, 0, 0, windoww, windowh, 0, 0);
+    gmode(2);
+
+    for (const auto& mod : lua::lua->get_mod_manager().all_mods())
+    {
+        if (mod->second->manifest.name == "_CONSOLE_")
+            continue;
+
+        ModDescription mod_desc{mod->second->manifest.name + "(" +
+                                    mod->second->manifest.version.to_string() +
+                                    ")",
+                                mod->second->manifest,
+                                mod->second->enabled};
+
+        mod_descriptions.emplace_back(mod_desc);
+        listmax++;
+    }
+
+    windowshadow = 1;
+
+    update();
+
+    return true;
+}
+
+
+
+void UIMenuMods::_draw_mod_page()
+{
+    const auto& desc = mod_descriptions.at(pagesize * page + cs);
+
+    display_topic(desc.display_name, wx + 206, wy + 36);
+
+    font(14 - en * 2);
+    int y = wy + 60;
+
+    gmes(
+        "<b>Name<def>: " + desc.manifest.name,
+        wx + 216,
+        y,
+        380,
+        {30, 30, 30},
+        false);
+    gmes(
+        "<b>Author:<def> " + desc.manifest.author,
+        wx + 216,
+        y + 16,
+        380,
+        {30, 30, 30},
+        false);
+    gmes(
+        "<b>Version:<def> " + desc.manifest.version.to_string(),
+        wx + 216,
+        y + 32,
+        380,
+        {30, 30, 30},
+        false);
+    gmes(
+        "<b>Description:<def> " + desc.manifest.description,
+        wx + 216,
+        y + 48,
+        380,
+        {30, 30, 30},
+        false);
+
+    window2(wx + 216 + 386 + 12 - 4, y - 36 - 4, 128 + 8, 128 + 8, 1, 1);
+    boxf(wx + 216 + 386 + 12, y - 36, 128, 128, {0, 0, 0});
+
+    display_topic("Description", wx + 206, wy + 160);
+
+    y = wy + 184;
+
+    auto readme_path =
+        filesystem::dir::for_mod(desc.manifest.name) / "README.md";
+    if (fs::exists(readme_path))
+    {
+        std::vector<std::string> credits_text_lines;
+        range::copy(
+            fileutil::read_by_line(readme_path),
+            std::back_inserter(credits_text_lines));
+        const size_t text_width = 75 - 28;
+        constexpr size_t lines_per_page = 16;
+
+        for (auto&& line : credits_text_lines)
+        {
+            // talk_conv only accepts single line text, so you need to split by
+            // line.
+            talk_conv(line, text_width);
+        }
+        size_t line_count = 0;
+        for (const auto& lines : credits_text_lines)
+        {
+            if (lines == "")
+            {
+                y = gmes(lines, wx + 216, y, 510, {30, 30, 30}, false).y;
+            }
+            for (const auto& line : strutil::split_lines(lines))
+            {
+                const auto ny =
+                    gmes(line, wx + 216, y, 510, {30, 30, 30}, false).y;
+                ++line_count;
+                if (line_count == lines_per_page)
+                {
+                    return;
+                    line_count = 0;
+                }
+                y = ny;
+            }
+        }
+    }
+    else
+    {
+        gmes(
+            "(No description available.)",
+            wx + 216,
+            y,
+            510,
+            {30, 30, 30},
+            false);
+    }
+}
+
+
+
+void UIMenuMods::_draw_navigation_menu()
+{
+    font(14 - en * 2);
+    cs_listbk();
+    for (int cnt = 0, cnt_end = (pagesize); cnt < cnt_end; ++cnt)
+    {
+        p = pagesize * page + cnt;
+        if (p >= listmax)
+        {
+            break;
+        }
+        const auto& desc = mod_descriptions.at(p);
+        snail::Color color = {0, 0, 0};
+        if (desc.enabled)
+        {
+            color = {0, 0, 255};
+        }
+
+        cs_list(
+            cs == cnt,
+            desc.display_name,
+            wx + 66,
+            wy + 66 + cnt * 19 - 1,
+            0,
+            color);
+    }
+
+    if (keyrange != 0)
+    {
+        cs_bk = cs;
+    }
+}
+
+
+
+void UIMenuMods::_draw_background_vignette(int id, int type)
+{
+    cmbg = id;
+    x = ww / 5 * 2;
+    y = wh - 80;
+    gmode(2, 50);
+    gcopy_c(
+        type,
+        cmbg % 4 * 180,
+        cmbg / 4 % 2 * 300,
+        180,
+        300,
+        wx + ww / 4,
+        wy + wh / 2,
+        x,
+        y);
+    gmode(2);
+}
+
+
+
+void UIMenuMods::update()
+{
+    cs_bk = -1;
+    pagemax = (listmax - 1) / pagesize;
+    if (page < 0)
+        page = pagemax;
+    else if (page > pagemax)
+        page = 0;
+
+    _redraw = true;
+}
+
+
+
+void UIMenuMods::_draw_window()
+{
+    int y;
+    if (mode == 1)
+    {
+        y = winposy(496, 1);
+    }
+    else
+    {
+        y = winposy(496) - 24;
+    }
+    ui_display_window(
+        u8"Mod List",
+        strhint2 + strhint3b,
+        (windoww - 780) / 2 + inf_screenx,
+        y,
+        780,
+        580);
+    display_topic(i18n::s.get("core.locale.ui.manual.topic"), wx + 34, wy + 36);
+
+    _draw_background_vignette(page % 5, 2);
+    keyrange = 0;
+
+    // Moves and refresh cursor
+    for (int cnt = 0, cnt_end = (pagesize); cnt < cnt_end; ++cnt)
+    {
+        p = pagesize * page + cnt;
+        if (p >= listmax)
+            break;
+        key_list(cnt) = key_select(cnt);
+        ++keyrange;
+        display_key(wx + 38, wy + 66 + cnt * 19 - 2, cnt);
+    }
+
+    _draw_mod_page();
+}
+
+
+
+void UIMenuMods::draw()
+{
+    if (_redraw)
+    {
+        _draw_window();
+        _draw_navigation_menu();
+        _redraw = false;
+    }
+}
+
+
+
+optional<UIMenuMods::ResultType> UIMenuMods::on_key(const std::string& action)
+{
+    // Key selection
+    if (auto selected = get_selected_index_this_page())
+    {
+        cs = *selected;
+        snd("core.ok1");
+        auto& desc = mod_descriptions.at(pagesize * page + cs_bk);
+        desc.enabled = !desc.enabled;
+        set_reupdate();
+    }
+
+    if (cs != cs_bk)
+    {
+        set_reupdate();
+    }
+
+    // Page changes
+    if (action == "next_page")
+    {
+        if (pagemax != 0)
+        {
+            snd("core.pop1");
+            ++page;
+            set_reupdate();
+        }
+    }
+    if (action == "previous_page")
+    {
+        if (pagemax != 0)
+        {
+            snd("core.pop1");
+            --page;
+            set_reupdate();
+        }
+    }
+
+    // Closing menu
+    if (action == "cancel")
+    {
+        return UIMenuMods::ResultType::finish();
+    }
+    return none;
+}
+
+} // namespace ui
+} // namespace elona

--- a/src/elona/ui/ui_menu_mods.cpp
+++ b/src/elona/ui/ui_menu_mods.cpp
@@ -36,14 +36,16 @@ bool UIMenuMods::init()
 
     for (const auto& mod : lua::lua->get_mod_manager().all_mods())
     {
-        if (mod->second->manifest.name == "_CONSOLE_")
+        const auto& name = mod->second->manifest.name;
+
+        if (lua::ModManager::mod_name_is_reserved(name))
             continue;
 
-        ModDescription mod_desc{mod->second->manifest.name + "(" +
-                                    mod->second->manifest.version.to_string() +
-                                    ")",
-                                mod->second->manifest,
-                                mod->second->enabled};
+        ModDescription mod_desc{
+            name + "(" + mod->second->manifest.version.to_string() + ")",
+            mod->second->manifest,
+            static_cast<bool>(
+                lua::lua->get_mod_manager().get_enabled_version(name))};
 
         mod_descriptions.emplace_back(mod_desc);
         listmax++;
@@ -56,6 +58,17 @@ bool UIMenuMods::init()
     return true;
 }
 
+
+optional<UIMenuMods::ModDescription> UIMenuMods::_find_enabled_mod(
+    const std::string& name)
+{
+    for (const auto& desc : mod_descriptions)
+    {
+        if (desc.enabled && desc.manifest.name == name)
+            return desc;
+    }
+    return none;
+}
 
 
 void UIMenuMods::_draw_mod_page()

--- a/src/elona/ui/ui_menu_mods.cpp
+++ b/src/elona/ui/ui_menu_mods.cpp
@@ -14,48 +14,6 @@ namespace elona
 namespace ui
 {
 
-static int _wrap_text(std::string& text, int max_line_length)
-{
-    std::string rest{text};
-    text.clear();
-    int n{};
-
-    while (1)
-    {
-        const auto len = rest.size();
-        if (int(len) < max_line_length)
-        {
-            text += rest;
-            return n;
-        }
-        size_t byte_length = 0;
-        size_t width_length = 0;
-        while (width_length <= len)
-        {
-            const auto bytes = strutil::byte_count(rest[byte_length]);
-            const auto char_width = bytes == 1 ? 1 : 2;
-
-            byte_length += bytes;
-            width_length += char_width;
-
-            if (int(width_length) > max_line_length)
-            {
-                text += rest.substr(0, byte_length) + '\n';
-                ++n;
-                if (rest.size() > byte_length)
-                {
-                    rest = rest.substr(byte_length);
-                }
-                else
-                {
-                    rest = "";
-                }
-                break;
-            }
-        }
-    }
-}
-
 bool UIMenuMods::init()
 {
     snd("core.pop2");
@@ -70,7 +28,6 @@ bool UIMenuMods::init()
 
     asset_load("void");
     ::draw("void", 0, 0, windoww, windowh);
-    load_background_variants(2);
     gsel(0);
     gmode(0);
     gcopy(4, 0, 0, windoww, windowh, 0, 0);
@@ -84,7 +41,6 @@ bool UIMenuMods::init()
             continue;
 
         ModDescription mod_desc{
-            name + "(" + mod->second->manifest.version.to_string() + ")",
             mod->second->manifest,
             static_cast<bool>(
                 lua::lua->get_mod_manager().get_enabled_version(name))};
@@ -101,8 +57,7 @@ bool UIMenuMods::init()
 }
 
 
-optional<UIMenuMods::ModDescription> UIMenuMods::_find_enabled_mod(
-    const std::string& name)
+optional<ModDescription> UIMenuMods::_find_enabled_mod(const std::string& name)
 {
     for (const auto& desc : _mod_descriptions)
     {
@@ -110,178 +65,6 @@ optional<UIMenuMods::ModDescription> UIMenuMods::_find_enabled_mod(
             return desc;
     }
     return none;
-}
-
-void UIMenuMods::_build_description()
-{
-    _description_pages.clear();
-    _desc_page = 0;
-
-    const auto& desc = _mod_descriptions.at(pagesize * page + cs);
-
-    auto readme_path =
-        filesystem::dir::for_mod(desc.manifest.name) / "README.txt";
-    if (!fs::exists(readme_path))
-    {
-        // TODO
-        _description_pages.push_back(
-            i18n::s.get("core.locale.main_menu.mods.no_readme"));
-        return;
-    }
-
-    std::vector<std::string> description_lines;
-    range::copy(
-        fileutil::read_by_line(readme_path),
-        std::back_inserter(description_lines));
-
-    if (description_lines.empty())
-    {
-        // TODO
-        _description_pages.push_back(
-            i18n::s.get("core.locale.main_menu.mods.no_readme"));
-        return;
-    }
-
-    const size_t text_width = 70;
-    constexpr size_t lines_per_page = 20;
-
-    for (auto&& line : description_lines)
-    {
-        _wrap_text(line, text_width);
-    }
-    size_t line_count = 0;
-    for (const auto& lines : description_lines)
-    {
-        if (lines == "")
-        {
-            _description_pages.back() += '\n';
-        }
-        for (const auto& line : strutil::split_lines(lines))
-        {
-            if (line_count == 0)
-            {
-                _description_pages.push_back(line + '\n');
-            }
-            else
-            {
-                _description_pages.back() += line + '\n';
-            }
-            ++line_count;
-            if (line_count == lines_per_page)
-            {
-                line_count = 0;
-            }
-        }
-    }
-}
-
-
-void UIMenuMods::_draw_mod_page()
-{
-    const auto& desc = _mod_descriptions.at(pagesize * page + cs);
-
-    display_topic(desc.display_name, wx + 206, wy + 36);
-
-    int y = wy + 60;
-
-    gmes(
-        "<b>" + i18n::s.get("core.locale.main_menu.mods.name") + ":<def> " +
-            desc.manifest.name,
-        wx + 216,
-        y,
-        380,
-        {30, 30, 30},
-        false);
-    gmes(
-        "<b>" + i18n::s.get("core.locale.main_menu.mods.author") + ":<def> " +
-            desc.manifest.author,
-        wx + 216,
-        y + 16,
-        380,
-        {30, 30, 30},
-        false);
-    gmes(
-        "<b>" + i18n::s.get("core.locale.main_menu.mods.version") + ":<def> " +
-            desc.manifest.version.to_string(),
-        wx + 216,
-        y + 32,
-        380,
-        {30, 30, 30},
-        false);
-    gmes(
-        "<b>" + i18n::s.get("core.locale.main_menu.mods.description") +
-            ":<def> " + desc.manifest.description,
-        wx + 216,
-        y + 48,
-        380,
-        {30, 30, 30},
-        false);
-
-    window2(wx + 216 + 386 + 12 - 4, y - 36 - 4, 128 + 8, 128 + 8, 1, 1);
-    boxf(wx + 216 + 386 + 12, y - 36, 128, 128, {0, 0, 0});
-    mes(wx + 216 + 366 + 64 + 6, y - 36 + 64 - 7, "(image)", {255, 255, 255});
-
-    display_topic(
-        "README (" + std::to_string(_desc_page + 1) + "/" +
-            _description_pages.size() + ")",
-        wx + 206,
-        wy + 160);
-
-    font(14 - en * 2);
-    mes(wx + 216, wy + 184, _description_pages.at(_desc_page));
-}
-
-
-
-void UIMenuMods::_draw_navigation_menu()
-{
-    font(14 - en * 2);
-    cs_listbk();
-    for (int cnt = 0, cnt_end = (pagesize); cnt < cnt_end; ++cnt)
-    {
-        p = pagesize * page + cnt;
-        if (p >= listmax)
-        {
-            break;
-        }
-        const auto& desc = _mod_descriptions.at(p);
-        snail::Color color = {0, 0, 0};
-        if (desc.enabled)
-        {
-            color = {0, 0, 255};
-        }
-
-        auto name = desc.display_name;
-        cutname(name, 17);
-
-        cs_list(cs == cnt, name, wx + 66, wy + 66 + cnt * 19 - 1, 0, color);
-    }
-
-    if (keyrange != 0)
-    {
-        cs_bk = cs;
-    }
-}
-
-
-
-void UIMenuMods::_draw_background_vignette(int id, int type)
-{
-    cmbg = id;
-    x = ww / 5 * 2;
-    y = wh - 80;
-    gmode(2, 50);
-    gcopy_c(
-        type,
-        cmbg % 4 * 180,
-        cmbg / 4 % 2 * 300,
-        180,
-        300,
-        wx + ww / 4,
-        wy + wh / 2,
-        x,
-        y);
-    gmode(2);
 }
 
 
@@ -294,11 +77,6 @@ void UIMenuMods::update()
     else if (page > pagemax)
         page = 0;
 
-    if (page_bk != page || cs_bk != cs)
-    {
-        _build_description();
-    }
-
     cs_bk = -1;
     page_bk = page;
 
@@ -307,42 +85,86 @@ void UIMenuMods::update()
 
 
 
+void UIMenuMods::_draw_key(int cnt, int index)
+{
+    if (cnt % 2 == 0)
+    {
+        boxf(wx + 57, wy + 66 + cnt * 19, 640, 18, {12, 14, 16, 16});
+    }
+
+    display_key(wx + 58, wy + 66 + cnt * 19 - 2, cnt);
+}
+
+
+
 void UIMenuMods::_draw_window()
 {
     int y;
-    if (mode == 1)
-    {
-        y = winposy(496, 1);
-    }
-    else
-    {
-        y = winposy(496) - 24;
-    }
+    y = winposy(466) - 24;
     ui_display_window(
         i18n::s.get("core.locale.main_menu.mods.title"),
         strhint2 + strhint3b + " " + key_prev + ","s + key_next + " " +
             i18n::s.get("core.locale.main_menu.mods.hint_readme_page"),
-        (windoww - 780) / 2 + inf_screenx,
+        (windoww - 730) / 2 + inf_screenx,
         y,
-        780,
-        580);
-    display_topic(i18n::s.get("core.locale.ui.manual.topic"), wx + 34, wy + 36);
-
-    _draw_background_vignette(page % 5, 2);
-    keyrange = 0;
+        730,
+        530);
 
     // Moves and refresh cursor
+    keyrange = 0;
     for (int cnt = 0, cnt_end = (pagesize); cnt < cnt_end; ++cnt)
     {
-        p = pagesize * page + cnt;
-        if (p >= listmax)
+        int index = pagesize * page + cnt;
+        if (index >= listmax)
             break;
         key_list(cnt) = key_select(cnt);
         ++keyrange;
-        display_key(wx + 38, wy + 66 + cnt * 19 - 2, cnt);
+        _draw_key(cnt, index);
     }
 
-    _draw_mod_page();
+    display_topic(
+        i18n::s.get("core.locale.main_menu.mods.name"), wx + 46, wy + 36);
+    display_topic(
+        i18n::s.get("core.locale.main_menu.mods.version"), wx + 255, wy + 36);
+}
+
+
+
+void UIMenuMods::_draw_mod_list()
+{
+    font(14 - en * 2);
+    cs_listbk();
+    for (int cnt = 0, cnt_end = (pagesize); cnt < cnt_end; ++cnt)
+    {
+        int index = pagesize * page + cnt;
+        if (index >= listmax)
+        {
+            break;
+        }
+        const auto& desc = _mod_descriptions.at(index);
+        snail::Color text_color = {0, 0, 0};
+        if (desc.enabled)
+        {
+            text_color = {0, 0, 255};
+        }
+
+        cs_list(
+            cs == cnt,
+            desc.manifest.name,
+            wx + 84,
+            wy + 66 + cnt * 19 - 1,
+            0,
+            text_color);
+        mes(wx + 270,
+            wy + 66 + cnt * 19 - 1,
+            desc.manifest.version.to_string(),
+            {0, 0, 0});
+    }
+
+    if (keyrange != 0)
+    {
+        cs_bk = cs;
+    }
 }
 
 
@@ -352,7 +174,7 @@ void UIMenuMods::draw()
     if (_redraw)
     {
         _draw_window();
-        _draw_navigation_menu();
+        _draw_mod_list();
         _redraw = false;
     }
 }
@@ -399,24 +221,6 @@ optional<UIMenuMods::ResultType> UIMenuMods::on_key(const std::string& action)
         {
             snd("core.pop1");
             --page;
-            set_reupdate();
-        }
-    }
-    if (action == "next_menu")
-    {
-        if (_description_pages.size() != 0)
-        {
-            snd("core.pop1");
-            _desc_page = (_desc_page + 1) % _description_pages.size();
-            set_reupdate();
-        }
-    }
-    if (action == "previous_menu")
-    {
-        if (_description_pages.size() != 0)
-        {
-            snd("core.pop1");
-            _desc_page = (_desc_page - 1) % _description_pages.size();
             set_reupdate();
         }
     }

--- a/src/elona/ui/ui_menu_mods.cpp
+++ b/src/elona/ui/ui_menu_mods.cpp
@@ -7,6 +7,7 @@
 #include "../i18n.hpp"
 #include "../lua_env/mod_manager.hpp"
 #include "simple_prompt.hpp"
+#include "ui_menu_mod_info.hpp"
 
 
 
@@ -198,9 +199,11 @@ void UIMenuMods::_draw_window()
     }
 
     display_topic(
-        i18n::s.get("core.locale.main_menu.mods.name"), wx + 46, wy + 36);
+        i18n::s.get("core.locale.main_menu.mods.info.name"), wx + 46, wy + 36);
     display_topic(
-        i18n::s.get("core.locale.main_menu.mods.version"), wx + 255, wy + 36);
+        i18n::s.get("core.locale.main_menu.mods.info.version"),
+        wx + 255,
+        wy + 36);
 }
 
 
@@ -301,8 +304,22 @@ optional<UIMenuMods::ResultType> UIMenuMods::on_key(const std::string& action)
     }
     if (action == "identify")
     {
+        const auto& desc = _mod_descriptions.at(pagesize * page + cs);
+
         int cs_prev = cs;
-        cs = cs_prev;
+        int page_prev = page;
+        int listmax_prev = listmax;
+        int pagesize_prev = pagesize;
+
+        lib::scope_guard restore([&]() {
+            cs = cs_prev;
+            page_prev = page;
+            listmax = listmax_prev;
+            pagesize = pagesize_prev;
+        });
+
+        UIMenuModInfo(desc).show();
+
         set_reupdate();
     }
     if (action == "switch_mode")

--- a/src/elona/ui/ui_menu_mods.hpp
+++ b/src/elona/ui/ui_menu_mods.hpp
@@ -8,6 +8,13 @@ namespace ui
 class UIMenuMods : public UIMenu<DummyResult>
 {
 public:
+    struct ModDescription
+    {
+        std::string display_name;
+        lua::ModManifest manifest;
+        bool enabled;
+    };
+
     UIMenuMods()
     {
     }
@@ -18,18 +25,13 @@ protected:
     virtual void draw();
     virtual optional<UIMenuMods::ResultType> on_key(const std::string& key);
 
+    optional<ModDescription> _find_enabled_mod(const std::string& name);
     void _draw_mod_page();
     void _draw_window();
     void _draw_navigation_menu();
     void _draw_background_vignette(int id, int type);
 
 private:
-    struct ModDescription
-    {
-        std::string display_name;
-        lua::ModManifest manifest;
-        bool enabled;
-    };
     std::vector<ModDescription> mod_descriptions;
 
     bool _redraw;

--- a/src/elona/ui/ui_menu_mods.hpp
+++ b/src/elona/ui/ui_menu_mods.hpp
@@ -24,6 +24,7 @@ protected:
     virtual void draw();
     virtual optional<UIMenuMods::ResultType> on_key(const std::string& key);
 
+    void _load_mods();
     optional<ModDescription> _find_enabled_mod(const std::string& name);
     void _draw_key(int cnt, int index);
     void _draw_mod_list();
@@ -34,6 +35,7 @@ private:
     std::vector<std::string> _description_pages;
 
     bool _redraw;
+    bool _is_download;
 };
 } // namespace ui
 } // namespace elona

--- a/src/elona/ui/ui_menu_mods.hpp
+++ b/src/elona/ui/ui_menu_mods.hpp
@@ -5,16 +5,15 @@ namespace elona
 {
 namespace ui
 {
+struct ModDescription
+{
+    lua::ModManifest manifest;
+    bool enabled;
+};
+
 class UIMenuMods : public UIMenu<DummyResult>
 {
 public:
-    struct ModDescription
-    {
-        std::string display_name;
-        lua::ModManifest manifest;
-        bool enabled;
-    };
-
     UIMenuMods()
     {
     }
@@ -26,18 +25,15 @@ protected:
     virtual optional<UIMenuMods::ResultType> on_key(const std::string& key);
 
     optional<ModDescription> _find_enabled_mod(const std::string& name);
-    void _build_description();
-    void _draw_mod_page();
+    void _draw_key(int cnt, int index);
+    void _draw_mod_list();
     void _draw_window();
-    void _draw_navigation_menu();
-    void _draw_background_vignette(int id, int type);
 
 private:
     std::vector<ModDescription> _mod_descriptions;
     std::vector<std::string> _description_pages;
 
     bool _redraw;
-    size_t _desc_page;
 };
 } // namespace ui
 } // namespace elona

--- a/src/elona/ui/ui_menu_mods.hpp
+++ b/src/elona/ui/ui_menu_mods.hpp
@@ -1,0 +1,38 @@
+#pragma once
+#include "../lua_env/mod_manifest.hpp"
+#include "ui_menu.hpp"
+namespace elona
+{
+namespace ui
+{
+class UIMenuMods : public UIMenu<DummyResult>
+{
+public:
+    UIMenuMods()
+    {
+    }
+
+protected:
+    virtual bool init();
+    virtual void update();
+    virtual void draw();
+    virtual optional<UIMenuMods::ResultType> on_key(const std::string& key);
+
+    void _draw_mod_page();
+    void _draw_window();
+    void _draw_navigation_menu();
+    void _draw_background_vignette(int id, int type);
+
+private:
+    struct ModDescription
+    {
+        std::string display_name;
+        lua::ModManifest manifest;
+        bool enabled;
+    };
+    std::vector<ModDescription> mod_descriptions;
+
+    bool _redraw;
+};
+} // namespace ui
+} // namespace elona

--- a/src/elona/ui/ui_menu_mods.hpp
+++ b/src/elona/ui/ui_menu_mods.hpp
@@ -26,15 +26,18 @@ protected:
     virtual optional<UIMenuMods::ResultType> on_key(const std::string& key);
 
     optional<ModDescription> _find_enabled_mod(const std::string& name);
+    void _build_description();
     void _draw_mod_page();
     void _draw_window();
     void _draw_navigation_menu();
     void _draw_background_vignette(int id, int type);
 
 private:
-    std::vector<ModDescription> mod_descriptions;
+    std::vector<ModDescription> _mod_descriptions;
+    std::vector<std::string> _description_pages;
 
     bool _redraw;
+    size_t _desc_page;
 };
 } // namespace ui
 } // namespace elona

--- a/src/elona/ui_menus.cpp
+++ b/src/elona/ui_menus.cpp
@@ -25,6 +25,7 @@
 #include "ui/ui_menu_keybindings.cpp"
 #include "ui/ui_menu_materials.cpp"
 #include "ui/ui_menu_message_log.cpp"
+#include "ui/ui_menu_mod_info.cpp"
 #include "ui/ui_menu_mods.cpp"
 #include "ui/ui_menu_npc_tone.cpp"
 #include "ui/ui_menu_quest_board.cpp"

--- a/src/elona/ui_menus.cpp
+++ b/src/elona/ui_menus.cpp
@@ -25,6 +25,7 @@
 #include "ui/ui_menu_keybindings.cpp"
 #include "ui/ui_menu_materials.cpp"
 #include "ui/ui_menu_message_log.cpp"
+#include "ui/ui_menu_mods.cpp"
 #include "ui/ui_menu_npc_tone.cpp"
 #include "ui/ui_menu_quest_board.cpp"
 #include "ui/ui_menu_scene.cpp"

--- a/src/tests/data/mods/test_export_keys/mod.hcl
+++ b/src/tests/data/mods/test_export_keys/mod.hcl
@@ -1,4 +1,5 @@
 mod {
+    id = "test_export_keys"
     name = "test_export_keys"
     author = "Ruin0x11"
     version = "0.1.0"

--- a/src/tests/data/mods/test_export_keys/mod.hcl
+++ b/src/tests/data/mods/test_export_keys/mod.hcl
@@ -1,3 +1,7 @@
 mod {
     name = "test_export_keys"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
 }

--- a/src/tests/data/mods/test_i18n_a/mod.hcl
+++ b/src/tests/data/mods/test_i18n_a/mod.hcl
@@ -1,3 +1,7 @@
 mod {
     name = "test_i18n_a"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
 }

--- a/src/tests/data/mods/test_i18n_a/mod.hcl
+++ b/src/tests/data/mods/test_i18n_a/mod.hcl
@@ -1,4 +1,5 @@
 mod {
+    id = "test_i18n_a"
     name = "test_i18n_a"
     author = "Ruin0x11"
     version = "0.1.0"

--- a/src/tests/data/mods/test_i18n_b/mod.hcl
+++ b/src/tests/data/mods/test_i18n_b/mod.hcl
@@ -1,3 +1,7 @@
 mod {
     name = "test_i18n_b"
+    version = "0.1.0"
+    author = "Ruin0x11"
+    description = "Test mod."
+    license = "MIT"
 }

--- a/src/tests/data/mods/test_i18n_b/mod.hcl
+++ b/src/tests/data/mods/test_i18n_b/mod.hcl
@@ -1,4 +1,5 @@
 mod {
+    id = "test_i18n_b"
     name = "test_i18n_b"
     version = "0.1.0"
     author = "Ruin0x11"

--- a/src/tests/data/mods/test_require/mod.hcl
+++ b/src/tests/data/mods/test_require/mod.hcl
@@ -1,4 +1,5 @@
 mod {
+    id = "test_require"
     name = "test_require"
     author = "Ruin0x11"
     version = "0.1.0"

--- a/src/tests/data/mods/test_require/mod.hcl
+++ b/src/tests/data/mods/test_require/mod.hcl
@@ -1,3 +1,7 @@
 mod {
     name = "test_require"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
 }

--- a/src/tests/data/mods/test_require_chunks/mod.hcl
+++ b/src/tests/data/mods/test_require_chunks/mod.hcl
@@ -1,4 +1,5 @@
 mod {
+    id = "test_require_chunks"
     name = "test_require_chunks"
     author = "Ruin0x11"
     version = "0.1.0"

--- a/src/tests/data/mods/test_require_chunks/mod.hcl
+++ b/src/tests/data/mods/test_require_chunks/mod.hcl
@@ -1,3 +1,7 @@
 mod {
     name = "test_require_chunks"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
 }

--- a/src/tests/data/registry/chara/mod.hcl
+++ b/src/tests/data/registry/chara/mod.hcl
@@ -1,4 +1,5 @@
 mod {
+    id = "chara"
     name = "chara"
     author = "Ruin0x11"
     version = "0.1.0"

--- a/src/tests/data/registry/chara/mod.hcl
+++ b/src/tests/data/registry/chara/mod.hcl
@@ -1,4 +1,8 @@
 mod {
     name = "chara"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
     dependencies = { core = "*" }
 }

--- a/src/tests/data/registry/chara_defaults/mod.hcl
+++ b/src/tests/data/registry/chara_defaults/mod.hcl
@@ -1,4 +1,8 @@
 mod {
     name = "chara_defaults"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
     dependencies = { core = "*" }
 }

--- a/src/tests/data/registry/chara_defaults/mod.hcl
+++ b/src/tests/data/registry/chara_defaults/mod.hcl
@@ -1,4 +1,5 @@
 mod {
+    id = "chara_defaults"
     name = "chara_defaults"
     author = "Ruin0x11"
     version = "0.1.0"

--- a/src/tests/data/registry/chara_duplicate_key/mod.hcl
+++ b/src/tests/data/registry/chara_duplicate_key/mod.hcl
@@ -1,4 +1,5 @@
 mod {
+    id = "chara_duplicate_key"
     name = "chara_duplicate_key"
     author = "Ruin0x11"
     version = "0.1.0"

--- a/src/tests/data/registry/chara_duplicate_key/mod.hcl
+++ b/src/tests/data/registry/chara_duplicate_key/mod.hcl
@@ -1,4 +1,8 @@
 mod {
     name = "chara_duplicate_key"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
     dependencies = { core = "*" }
 }

--- a/src/tests/data/registry/chara_invalid_enum/mod.hcl
+++ b/src/tests/data/registry/chara_invalid_enum/mod.hcl
@@ -1,4 +1,5 @@
 mod {
+    id = "chara_invalid_enum"
     name = "chara_invalid_enum"
     author = "Ruin0x11"
     version = "0.1.0"

--- a/src/tests/data/registry/chara_invalid_enum/mod.hcl
+++ b/src/tests/data/registry/chara_invalid_enum/mod.hcl
@@ -1,4 +1,8 @@
 mod {
     name = "chara_invalid_enum"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
     dependencies = { core = "*" }
 }

--- a/src/tests/data/registry/chara_portrait/mod.hcl
+++ b/src/tests/data/registry/chara_portrait/mod.hcl
@@ -1,4 +1,5 @@
 mod {
+    id = "chara_portrait"
     name = "chara_portrait"
     author = "KI"
     version = "0.1.0"

--- a/src/tests/data/registry/chara_portrait/mod.hcl
+++ b/src/tests/data/registry/chara_portrait/mod.hcl
@@ -1,5 +1,8 @@
 mod {
     name = "chara_portrait"
+    author = "KI"
+    version = "0.1.0"
+    license = "MIT"
     description = "Test complex portrait settings."
     dependencies = { core = "*" }
 }

--- a/src/tests/data/registry/invalid/mod.hcl
+++ b/src/tests/data/registry/invalid/mod.hcl
@@ -1,3 +1,7 @@
 mod {
     name = "invalid"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
 }

--- a/src/tests/data/registry/invalid/mod.hcl
+++ b/src/tests/data/registry/invalid/mod.hcl
@@ -1,4 +1,5 @@
 mod {
+    id = "invalid"
     name = "invalid"
     author = "Ruin0x11"
     version = "0.1.0"

--- a/src/tests/data/registry/item/mod.hcl
+++ b/src/tests/data/registry/item/mod.hcl
@@ -1,4 +1,5 @@
 mod {
+    id = "item"
     name = "item"
     author = "Ruin0x11"
     version = "0.1.0"

--- a/src/tests/data/registry/item/mod.hcl
+++ b/src/tests/data/registry/item/mod.hcl
@@ -1,4 +1,8 @@
 mod {
     name = "item"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
     dependencies = { core = "*" }
 }

--- a/src/tests/data/registry/putit/mod.hcl
+++ b/src/tests/data/registry/putit/mod.hcl
@@ -1,3 +1,7 @@
 mod {
     name = "putit"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
 }

--- a/src/tests/data/registry/putit/mod.hcl
+++ b/src/tests/data/registry/putit/mod.hcl
@@ -1,4 +1,5 @@
 mod {
+    id = "putit"
     name = "putit"
     author = "Ruin0x11"
     version = "0.1.0"

--- a/src/tests/data/registry/putit_b/mod.hcl
+++ b/src/tests/data/registry/putit_b/mod.hcl
@@ -1,4 +1,5 @@
 mod {
+    id = "putit_b"
     name = "putit_b"
     author = "Ruin0x11"
     version = "0.1.0"

--- a/src/tests/data/registry/putit_b/mod.hcl
+++ b/src/tests/data/registry/putit_b/mod.hcl
@@ -1,3 +1,7 @@
 mod {
     name = "putit_b"
+    author = "Ruin0x11"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
 }

--- a/src/tests/lua_callbacks.cpp
+++ b/src/tests/lua_callbacks.cpp
@@ -1,6 +1,3 @@
-#include "../thirdparty/catch2/catch.hpp"
-#include "../thirdparty/sol2/sol.hpp"
-
 #include "../elona/character.hpp"
 #include "../elona/dmgheal.hpp"
 #include "../elona/filesystem.hpp"
@@ -10,6 +7,8 @@
 #include "../elona/lua_env/mod_manager.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/catch2/catch.hpp"
+#include "../thirdparty/sol2/sol.hpp"
 #include "tests.hpp"
 
 using namespace elona::testing;
@@ -35,7 +34,7 @@ Event.register("core.character_created", my_chara_created_handler)
     int idx = elona::rc;
     REQUIRE(idx != -1);
     elona::lua::lua->get_mod_manager()
-        .get_mod("test_chara_created")
+        .get_enabled_mod("test_chara_created")
         ->env.set("idx", idx);
 
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
@@ -65,7 +64,7 @@ Event.register("core.character_damaged", my_chara_hurt_handler)
     REQUIRE(elona::chara_create(-1, PUTIT_PROTO_ID, 4, 8));
     int idx = elona::rc;
     elona::lua::lua->get_mod_manager()
-        .get_mod("test_chara_hurt")
+        .get_enabled_mod("test_chara_hurt")
         ->env.set("idx", idx);
 
     elona::damage_hp(cdata[idx], 4, -1);
@@ -97,7 +96,7 @@ Event.register("core.character_removed", my_chara_removed_handler)
     REQUIRE(elona::chara_create(-1, PUTIT_PROTO_ID, 4, 8));
     int idx = elona::rc;
     elona::lua::lua->get_mod_manager()
-        .get_mod("test_chara_removed")
+        .get_enabled_mod("test_chara_removed")
         ->env.set("idx", idx);
 
     testing::invalidate_chara(cdata[idx]);
@@ -127,7 +126,7 @@ Event.register("core.character_killed", my_chara_killed_handler)
     int idx = elona::rc;
     elona::Character& chara = elona::cdata[idx];
     elona::lua::lua->get_mod_manager()
-        .get_mod("test_chara_killed")
+        .get_enabled_mod("test_chara_killed")
         ->env.set("idx", idx);
 
     elona::damage_hp(cdata[idx], chara.max_hp + 1, -11);
@@ -209,7 +208,7 @@ Event.register("core.character_removed", my_chara_removed_handler)
     int idx = elona::rc;
     elona::Character& chara = elona::cdata[idx];
     elona::lua::lua->get_mod_manager()
-        .get_mod("test_special_chara_killed")
+        .get_enabled_mod("test_special_chara_killed")
         ->env.set("idx", idx);
 
     // Give this character a role besides a townsperson.
@@ -244,7 +243,7 @@ Event.register("core.character_refreshed", my_chara_refreshed_handler)
     REQUIRE(elona::chara_create(-1, PUTIT_PROTO_ID, 4, 8));
     int idx = elona::rc;
     elona::lua::lua->get_mod_manager()
-        .get_mod("test_chara_refreshed")
+        .get_enabled_mod("test_chara_refreshed")
         ->env.set("idx", idx);
 
     elona::chara_refresh(idx);
@@ -275,7 +274,7 @@ Event.register("core.item_created", my_item_created_handler)
     int idx = elona::ci;
     REQUIRE(idx != -1);
     elona::lua::lua->get_mod_manager()
-        .get_mod("test_item_created")
+        .get_enabled_mod("test_item_created")
         ->env.set("idx", idx);
 
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(

--- a/src/tests/lua_exports.cpp
+++ b/src/tests/lua_exports.cpp
@@ -1,5 +1,3 @@
-#include "../thirdparty/catch2/catch.hpp"
-
 #include "../elona/filesystem.hpp"
 #include "../elona/lua_env/export_manager.hpp"
 #include "../elona/lua_env/handle_manager.hpp"
@@ -7,6 +5,7 @@
 #include "../elona/lua_env/mod_manager.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/catch2/catch.hpp"
 #include "tests.hpp"
 #include "util.hpp"
 
@@ -108,7 +107,7 @@ return {
     REQUIRE_NOTHROW(function->call(handle));
 
     elona::lua::lua->get_mod_manager()
-        .get_mod("test_registry_chara_callback")
+        .get_enabled_mod("test_registry_chara_callback")
         ->env.set("index", elona::rc);
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_registry_chara_callback",

--- a/src/tests/lua_handles.cpp
+++ b/src/tests/lua_handles.cpp
@@ -1,6 +1,3 @@
-#include "../thirdparty/catch2/catch.hpp"
-#include "../thirdparty/sol2/sol.hpp"
-
 #include "../elona/character.hpp"
 #include "../elona/item.hpp"
 #include "../elona/itemgen.hpp"
@@ -9,6 +6,8 @@
 #include "../elona/lua_env/mod_manager.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/catch2/catch.hpp"
+#include "../thirdparty/sol2/sol.hpp"
 #include "tests.hpp"
 
 using namespace elona::testing;
@@ -185,7 +184,7 @@ TEST_CASE("Test invalid references to handles in store table", "[Lua: Handles]")
 
         REQUIRE_NOTHROW(mod_mgr.load_mod_from_script("test", ""));
 
-        mod_mgr.get_mod("test")->env.set("chara", handle);
+        mod_mgr.get_enabled_mod("test")->env.set("chara", handle);
         REQUIRE_NOTHROW(
             mod_mgr.run_in_mod("test", "Store.global.charas = {[0]=chara}"));
 
@@ -202,7 +201,7 @@ TEST_CASE("Test invalid references to handles in store table", "[Lua: Handles]")
 
         REQUIRE_NOTHROW(mod_mgr.load_mod_from_script("test2", ""));
 
-        mod_mgr.get_mod("test2")->env.set("item", handle);
+        mod_mgr.get_enabled_mod("test2")->env.set("item", handle);
         REQUIRE_NOTHROW(
             mod_mgr.run_in_mod("test2", "Store.global.items = {[0]=item}"));
 
@@ -229,7 +228,7 @@ local chara = Chara.create(0, 0, "core.putit")
 idx = chara.index
 Store.global.charas = {[0]=chara}
 )"));
-        int idx = mod_mgr.get_mod("test_invalid_chara")->env["idx"];
+        int idx = mod_mgr.get_enabled_mod("test_invalid_chara")->env["idx"];
 
         testing::invalidate_chara(elona::cdata[idx]);
 
@@ -244,7 +243,7 @@ local item = Item.create(0, 0, "core.putitoro", 3)
 idx = item.index
 Store.global.items = {[0]=items}
 )"));
-        int idx = mod_mgr.get_mod("test_invalid_item")->env["idx"];
+        int idx = mod_mgr.get_enabled_mod("test_invalid_item")->env["idx"];
 
         testing::invalidate_item(elona::inv[idx]);
 
@@ -270,7 +269,7 @@ TEST_CASE(
 
         REQUIRE_NOTHROW(mod_mgr.load_mod_from_script(
             "test_chara_arg", "Store.global.charas = {}"));
-        mod_mgr.get_mod("test_chara_arg")->env.set("chara", handle);
+        mod_mgr.get_enabled_mod("test_chara_arg")->env.set("chara", handle);
 
         REQUIRE_NOTHROW(mod_mgr.run_in_mod("test_chara_arg", R"(
 Store.global.charas[0] = chara
@@ -293,7 +292,7 @@ print(Chara.is_ally(Store.global.charas[0]))
 
         REQUIRE_NOTHROW(mod_mgr.load_mod_from_script(
             "test_item_arg", "Store.global.items = {}"));
-        mod_mgr.get_mod("test_item_arg")->env.set("item", handle);
+        mod_mgr.get_enabled_mod("test_item_arg")->env.set("item", handle);
 
         REQUIRE_NOTHROW(mod_mgr.run_in_mod("test_item_arg", R"(
 Store.global.items[0] = item

--- a/src/tests/lua_mods.cpp
+++ b/src/tests/lua_mods.cpp
@@ -264,7 +264,7 @@ assert(a == nil)
 
 static void _create_mod(
     elona::lua::LuaEnv& lua,
-    const std::string& name,
+    const std::string& id,
     const std::unordered_map<std::string, std::string> deps)
 {
     elona::lua::ModManifest::Dependencies deps_(deps.size());
@@ -284,7 +284,7 @@ static void _create_mod(
     }
 
     elona::lua::ModManifest manifest;
-    manifest.name = name;
+    manifest.id = id;
     manifest.dependencies = deps_;
     lua.get_mod_manager().create_mod(manifest, false);
 };

--- a/src/tests/lua_mods.cpp
+++ b/src/tests/lua_mods.cpp
@@ -16,7 +16,7 @@
 
 using namespace elona::testing;
 
-TEST_CASE("Test that _MOD_NAME is defined", "[Lua: Mods]")
+TEST_CASE("Test that _MOD_ID is defined", "[Lua: Mods]")
 {
     elona::lua::LuaEnv lua;
     auto& mod_mgr = lua.get_mod_manager();
@@ -25,7 +25,7 @@ TEST_CASE("Test that _MOD_NAME is defined", "[Lua: Mods]")
     REQUIRE_NOTHROW(mod_mgr.load_mod_from_script("my_mod", ""));
 
     REQUIRE_NOTHROW(
-        mod_mgr.run_in_mod("my_mod", R"(assert(_MOD_NAME == "my_mod"))"));
+        mod_mgr.run_in_mod("my_mod", R"(assert(_MOD_ID == "my_mod"))"));
 }
 
 TEST_CASE("Test that globals cannot be overwritten", "[Lua: Mods]")
@@ -36,13 +36,13 @@ TEST_CASE("Test that globals cannot be overwritten", "[Lua: Mods]")
 
     REQUIRE_NOTHROW(mod_mgr.load_mod_from_script("my_mod", "", true));
 
-    REQUIRE_THROWS(mod_mgr.run_in_mod("my_mod", R"(_MOD_NAME = "dood")"));
+    REQUIRE_THROWS(mod_mgr.run_in_mod("my_mod", R"(_MOD_ID = "dood")"));
     REQUIRE_THROWS(mod_mgr.run_in_mod("my_mod", R"(dood = "dood")"));
     REQUIRE_THROWS(mod_mgr.run_in_mod("my_mod", R"(function dood() end)"));
     REQUIRE_THROWS(mod_mgr.run_in_mod("my_mod", R"(Elona = "dood")"));
     REQUIRE_THROWS(mod_mgr.run_in_mod("my_mod", R"(Store = "dood")"));
     REQUIRE_NOTHROW(
-        mod_mgr.run_in_mod("my_mod", R"(assert(_MOD_NAME == "my_mod"))"));
+        mod_mgr.run_in_mod("my_mod", R"(assert(_MOD_ID == "my_mod"))"));
 }
 
 TEST_CASE("Test that sandboxing removes unsafe functions", "[Lua: Mods]")

--- a/src/tests/lua_mods.cpp
+++ b/src/tests/lua_mods.cpp
@@ -1,6 +1,3 @@
-#include "../thirdparty/catch2/catch.hpp"
-#include "../thirdparty/sol2/sol.hpp"
-
 #include "../elona/character.hpp"
 #include "../elona/dmgheal.hpp"
 #include "../elona/filesystem.hpp"
@@ -13,6 +10,8 @@
 #include "../elona/lua_env/mod_manager.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/catch2/catch.hpp"
+#include "../thirdparty/sol2/sol.hpp"
 #include "tests.hpp"
 
 using namespace elona::testing;
@@ -104,7 +103,8 @@ TEST_CASE("Test usage of store in mod", "[Lua: Mods]")
 
     REQUIRE_NOTHROW(
         mod_mgr.run_in_mod("test", "assert(Store.global.thing == 1)"));
-    int thing = mod_mgr.get_mod("test")->store_global["thing"].get<int>();
+    int thing =
+        mod_mgr.get_enabled_mod("test")->store_global["thing"].get<int>();
     REQUIRE(thing == 1);
 }
 

--- a/src/tests/lua_serialization.cpp
+++ b/src/tests/lua_serialization.cpp
@@ -1,6 +1,3 @@
-#include "../thirdparty/catch2/catch.hpp"
-#include "../thirdparty/sol2/sol.hpp"
-
 #include "../elona/character.hpp"
 #include "../elona/filesystem.hpp"
 #include "../elona/item.hpp"
@@ -12,6 +9,8 @@
 #include "../elona/lua_env/mod_manager.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/catch2/catch.hpp"
+#include "../thirdparty/sol2/sol.hpp"
 #include "tests.hpp"
 
 using namespace elona::testing;
@@ -174,7 +173,15 @@ Store.map.val = "hoge"
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_serial_reload", "assert(Store.map.val == \"hoge\")"));
 
-    save_and_reload();
+    save();
+
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().run_in_mod("test_serial_reload", R"(
+Store.global.val = 0
+Store.map.val = ""
+)"));
+
+    load();
 
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_serial_reload", "assert(Store.global.val == 42)"));
@@ -185,21 +192,25 @@ Store.map.val = "hoge"
 
 TEST_CASE("Test preservation of handles across reloads", "[Lua: Serialization]")
 {
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
+        "test_serial_handle_reload", ""));
+
     start_in_debug_map();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_serial_handle_reload", R"(
 local Chara = Elona.require("Chara")
+local Item = Elona.require("Item")
 local Item = Elona.require("Item")
 
 Store.global.chara = Chara.create(4, 8, "core.putit")
 Store.global.item = Item.create(4, 8, "core.putitoro", 0)
 Store.map.chara = Chara.create(4, 8, "core.putit")
 Store.map.item = Item.create(4, 8, "core.putitoro", 0)
-)"));
+        )"));
 
-    auto mod =
-        elona::lua::lua->get_mod_manager().get_mod("test_serial_handle_reload");
+    auto mod = elona::lua::lua->get_mod_manager().get_enabled_mod(
+        "test_serial_handle_reload");
     std::string uuid_chara_global = mod->get_store(
         elona::lua::ModInfo::StoreType::global)["chara"]["__uuid"];
     std::string uuid_item_global = mod->get_store(
@@ -209,7 +220,17 @@ Store.map.item = Item.create(4, 8, "core.putitoro", 0)
     std::string uuid_item_map =
         mod->get_store(elona::lua::ModInfo::StoreType::map)["item"]["__uuid"];
 
-    save_and_reload();
+    save();
+
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
+        "test_serial_handle_reload", R"(
+Store.global.chara = 0
+Store.global.item = 0
+Store.map.chara = 0
+Store.map.item = 0
+        )"));
+
+    load();
 
     mod->env.set("uuid_chara_global", uuid_chara_global);
     mod->env.set("uuid_item_global", uuid_item_global);
@@ -238,9 +259,12 @@ TEST_CASE(
     "Test preservation of handles across map changes",
     "[Lua: Serialization]")
 {
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
+        "test_serial_handle_map_change", ""));
+
     start_in_debug_map();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_serial_handle_map_change", R"(
 local Chara = Elona.require("Chara")
 
@@ -248,9 +272,10 @@ Store.global.chara = Chara.create(4, 8, "core.putit")
 Store.global.chara_local = Chara.create(4, 8, "core.putit")
 
 Store.global.chara:recruit_as_ally()
+Store.global.it = 0
 )"));
 
-    auto mod = elona::lua::lua->get_mod_manager().get_mod(
+    auto mod = elona::lua::lua->get_mod_manager().get_enabled_mod(
         "test_serial_handle_map_change");
     auto store = mod->get_store(elona::lua::ModInfo::StoreType::global);
     std::string uuid_chara = store["chara"]["__uuid"];
@@ -259,29 +284,29 @@ Store.global.chara:recruit_as_ally()
     mod->env.set("uuid_chara", uuid_chara);
     mod->env.set("uuid_chara_local", uuid_chara_local);
 
-    run_in_temporary_map(6, 1, [&mod, uuid_chara]() {
+    run_in_temporary_map(6, 1, [uuid_chara]() {
         REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
             "test_serial_handle_map_change", R"(
 assert(Store.global.chara.__uuid == uuid_chara)
 assert(Store.global.chara_local.__uuid == uuid_chara_local)
-            )"));
+)"));
         REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
             "test_serial_handle_map_change", R"(
 assert(Store.global.chara:is_valid())
 assert(not Store.global.chara_local:is_valid())
-            )"));
+)"));
     });
 
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_serial_handle_map_change", R"(
 assert(Store.global.chara.__uuid == uuid_chara)
 assert(Store.global.chara_local.__uuid == uuid_chara_local)
-            )"));
+)"));
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_serial_handle_map_change", R"(
 assert(Store.global.chara:is_valid())
-assert(not Store.global.chara_local:is_valid())
-            )"));
+assert(Store.global.chara_local:is_valid())
+)"));
 }
 
 
@@ -289,9 +314,12 @@ TEST_CASE(
     "Test preservation of map local handles across map changes",
     "[Lua: Serialization]")
 {
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
+        "test_serial_handle_map_change_local", ""));
+
     start_in_debug_map();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_serial_handle_map_change_local", R"(
 local Chara = Elona.require("Chara")
 local Item = Elona.require("Item")
@@ -300,18 +328,18 @@ Store.map.chara = Chara.create(4, 8, "core.putit")
 Store.map.item = Item.create(4, 8, "core.putitoro", 0)
 )"));
 
-    auto mod = elona::lua::lua->get_mod_manager().get_mod(
+    auto mod = elona::lua::lua->get_mod_manager().get_enabled_mod(
         "test_serial_handle_map_change_local");
     auto store = mod->get_store(elona::lua::ModInfo::StoreType::map);
     std::string uuid_chara = store["chara"]["__uuid"];
     std::string uuid_item = store["item"]["__uuid"];
 
-    run_in_temporary_map(6, 1, [&mod, uuid_chara, uuid_item]() {
+    run_in_temporary_map(6, 1, [uuid_chara, uuid_item]() {
         REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
             "test_serial_handle_map_change_local", R"(
 assert(Store.map.chara == nil)
 assert(Store.map.item == nil)
-            )"));
+)"));
     });
 
     mod->env.set("uuid_chara", uuid_chara);
@@ -321,12 +349,12 @@ assert(Store.map.item == nil)
         "test_serial_handle_map_change_local", R"(
 assert(Store.map.chara.__uuid == uuid_chara)
 assert(Store.map.item.__uuid == uuid_item)
-            )"));
+)"));
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_serial_handle_map_change_local", R"(
 assert(Store.map.chara:is_valid())
 assert(Store.map.item:is_valid())
-            )"));
+)"));
 }
 
 
@@ -342,11 +370,50 @@ t[1] = t
 Store.global.t = t
 )"));
 
-    save_and_reload();
+    save();
 
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_serial_recursive", R"(
-            assert(type(Store.global.t) == "table")
-            assert(type(Store.global.t[1]) == "table")
-            )"));
+Store.global.t = {}
+)"));
+
+    load();
+
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
+        "test_serial_recursive", R"(
+assert(type(Store.global.t) == "table")
+assert(type(Store.global.t[1]) == "table")
+)"));
+}
+
+
+TEST_CASE("Test that disabled mods are not serialized", "[Lua: Serialization]")
+{
+    start_in_debug_map();
+
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
+        "test_serial_disabled", R"(
+Store.global.val = 42
+)"));
+
+    save();
+
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
+        "test_serial_disabled", R"(
+Store.global.val = 0
+)"));
+
+    elona::lua::lua->get_mod_manager()
+        .get_enabled_mod("test_serial_disabled")
+        ->enabled = false;
+
+    load();
+
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
+        "test_serial_disabled", ""));
+
+    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
+        "test_serial_disabled", R"(
+assert(Store.global.val == nil)
+)"));
 }

--- a/src/tests/lua_serialization.cpp
+++ b/src/tests/lua_serialization.cpp
@@ -403,9 +403,7 @@ Store.global.val = 42
 Store.global.val = 0
 )"));
 
-    elona::lua::lua->get_mod_manager()
-        .get_enabled_mod("test_serial_disabled")
-        ->enabled = false;
+    elona::lua::lua->get_mod_manager().disable_mod("test_serial_disabled");
 
     load();
 

--- a/src/tests/lua_serialization.cpp
+++ b/src/tests/lua_serialization.cpp
@@ -73,12 +73,12 @@ TEST_CASE("Test that globals aren't reset", "[Lua: Serialization]")
 
     REQUIRE_NOTHROW(lua.get_mod_manager().load_mod_from_script("test", ""));
     REQUIRE_NOTHROW(lua.get_mod_manager().run_in_mod(
-        "test", R"(assert(_MOD_NAME == "test"))"));
+        "test", R"(assert(_MOD_ID == "test"))"));
 
     lua.get_mod_manager().clear_mod_stores();
 
     REQUIRE_NOTHROW(lua.get_mod_manager().run_in_mod(
-        "test", R"(assert(_MOD_NAME == "test"))"));
+        "test", R"(assert(_MOD_ID == "test"))"));
 }
 
 TEST_CASE(

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -5,6 +5,7 @@
 
 #ifdef ELONA_OS_WINDOWS
 #include <crtdbg.h>
+
 #include <windows>
 // Prevent assertion dialogs from appearing on Windows, hanging CI test runs
 int WindowsCrtReportHook(int reportType, char* message, int* returnValue)

--- a/src/tests/tests.hpp
+++ b/src/tests/tests.hpp
@@ -6,6 +6,6 @@
 // macros for boost::optional results
 #define REQUIRE_SOME(x) REQUIRE(static_cast<bool>(x) == true)
 #define REQUIRE_NONE(x) REQUIRE(static_cast<bool>(x) == false)
-#define REQUIRE_IN_MOD(mod_name, assertion) \
+#define REQUIRE_IN_MOD(mod_id, assertion) \
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod( \
-        mod_name, "assert(assertion)"));
+        mod_id, "assert(assertion)"));

--- a/src/tests/util.cpp
+++ b/src/tests/util.cpp
@@ -108,14 +108,14 @@ void invalidate_chara(Character& chara)
 
 void register_lua_function(
     lua::LuaEnv& lua,
-    std::string mod_name,
+    std::string mod_id,
     std::string callback_signature,
     std::string callback_body)
 {
     lua.get_mod_manager().load_mods(filesystem::dir::mod());
 
     REQUIRE_NOTHROW(lua.get_mod_manager().load_mod_from_script(
-        mod_name,
+        mod_id,
         "\
 local Exports = {}\
 \

--- a/src/tests/util.hpp
+++ b/src/tests/util.hpp
@@ -26,16 +26,16 @@ void invalidate_item(Item&);
 /**
  * Registers a single callback in a mod.
 
- * This can only be called once per mod name.
+ * This can only be called once per mod ID.
  *
  * @param lua Lua environment for mod
- * @param mod_name the mod's name
+ * @param mod_id the mod's id
  * @param callback_signature "my_callback(arg)"
  * @param callback_body "return arg + 42"
  */
 void register_lua_function(
     lua::LuaEnv& lua,
-    std::string mod_name,
+    std::string mod_id,
     std::string callback_signature,
     std::string callback_body);
 

--- a/src/util/strutil.hpp
+++ b/src/util/strutil.hpp
@@ -295,4 +295,53 @@ inline size_t utf8_cut_index(
     return current_byte;
 }
 
+
+/**
+ * Wraps text in a language-agnostic manner. Instead of relying on
+ * language-specific rules, it wraps text based on character width, determined
+ * by codepoint. All 1-byte characters count as width 1, and every other
+ * character is width 2.
+ */
+inline int wrap_text(std::string& text, int max_line_length)
+{
+    std::string rest{text};
+    text.clear();
+    int n{};
+
+    while (1)
+    {
+        const auto len = rest.size();
+        if (int(len) < max_line_length)
+        {
+            text += rest;
+            return n;
+        }
+        size_t byte_length = 0;
+        size_t width_length = 0;
+        while (width_length <= len)
+        {
+            const auto bytes = strutil::byte_count(rest[byte_length]);
+            const auto char_width = bytes == 1 ? 1 : 2;
+
+            byte_length += bytes;
+            width_length += char_width;
+
+            if (int(width_length) > max_line_length)
+            {
+                text += rest.substr(0, byte_length) + '\n';
+                ++n;
+                if (rest.size() > byte_length)
+                {
+                    rest = rest.substr(byte_length);
+                }
+                else
+                {
+                    rest = "";
+                }
+                break;
+            }
+        }
+    }
+}
+
 } // namespace strutil


### PR DESCRIPTION
# Summary
- Adds a menu to the title screen to view installed mods. It's only one part of the feature to integrate the mod system with the UI. It shows the description in a separate window.
- Adds a few more metadata fields to `mod.hcl`.
- Renames references of "mod name" to "mod ID", and add a `name` field to the mod manifest for the display name of a mod.
- Adds a field in the mod manager to enable/disable mods. Currently all mods are enabled (as before).

![2019-05-03-222135_800x600_scrot](https://user-images.githubusercontent.com/6700637/57174352-7beaa800-6df2-11e9-81e7-0b730c7b5864.png)
![2019-05-03-222637_800x600_scrot](https://user-images.githubusercontent.com/6700637/57174364-886f0080-6df2-11e9-8576-e3a93afcb6f1.png)
