### PR TITLE
Fix strange item's subcategory

### DIFF
--- a/runtime/mod/core/data/item.hcl
+++ b/runtime/mod/core/data/item.hcl
@@ -6456,7 +6456,7 @@
         level = 1
         fltselect = 0
         category = 57000
-        subcategory = 99999
+        subcategory = 57004
         rarity = 1000000
         coefficient = 100
         light = 0
@@ -21892,7 +21892,7 @@
         level = 1
         fltselect = 3
         category = 57000
-        subcategory = 57004
+        subcategory = 99999
         rarity = 1000000
         coefficient = 100
         light = 0
@@ -23462,7 +23462,7 @@
         level = 1
         fltselect = 3
         category = 57000
-        subcategory = 57004
+        subcategory = 99999
         rarity = 1000000
         coefficient = 100
         light = 0


### PR DESCRIPTION
# Related Issues

Close #1259


# Summary

strawberry: 99999 (others) -> 57004 (fruits)
hero_cheese: 57004 (fruits) -> 99999 (others)
rabbit_tail: 57004 (fruits) -> 99999 (others)


The bug report was originally reported to MMAh, and MMAh fixed other items' subcategory as well, but I don't change them other than the above three.

cf. https://twitter.com/ki_foobar/status/1121405431203545088