### PR TITLE
Fix prompt not clearing key repeat state

### DIFF
--- a/src/elona/input_prompt.cpp
+++ b/src/elona/input_prompt.cpp
@@ -20,6 +20,8 @@ int Prompt::query(int x, int y, int width)
     cs = 0;
     cs_bk = -1;
 
+    snail::Input::instance().clear_pressed_keys_and_modifiers();
+
     _replace_null_keys_from_key_select();
     _draw_keys_and_background(x, y, width);
 


### PR DESCRIPTION

# Related Issues

Close #1225.


# Summary

Prompt did not clear key repeat state. As a result, when you cast Return
spell by pressing [b] in the spell menu, the second town in the prompt
was immediately selected.