### PR TITLE
 Add @noluadoc directive to suppress unnecessary document generation

### DIFF
--- a/doc/api/chara.luadoc
+++ b/doc/api/chara.luadoc
@@ -29,6 +29,12 @@ function count() end
 --  @function player
 function player() end
 
+--- Returns the character at the given index.
+--  @treturn[1] LuaCharacter
+--  @treturn[2] nil
+--  @function get
+function get(index) end
+
 --- Attempts to create a randomly generated character at a given position.
 --  Returns the character if creation succeeded, nil otherwise.
 --  @tparam LuaPosition position (const) position to create the character at

--- a/doc/api/classes/LuaMapGenerator.luadoc
+++ b/doc/api/classes/LuaMapGenerator.luadoc
@@ -1,73 +1,95 @@
---- A class used in map generation.
--- @classmod LuaMapGenerator
+--- Enumerations for various data types. All enum variants take the
+--  name of the variant as a string for its value. This means that
+--  anywhere an enum value is required, you can pass a string with its
+--  name instead of using the <code>Enums</code> table.
+--  @classmod LuaEnums
 
---- Gets the world map tile the player was standing on when they entered the map being generated.
--- @treturn num the tile ID
+--- Gets the world map tile the player was standing on when they entered the map
+--  being generated.
+--  @treturn num the tile ID
+--  @function stood_world_map_tile
 function stood_world_map_tile() end
 
---- Returns true if the map is being generated for the first time, across all regenerations.
--- @treturn bool
+--- Returns true if the map is being generated for the first time, across all
+--  regenerations.
+--  @treturn bool
+--  @function is_first_generation
 function is_first_generation() end
 
 --- Returns true if the current dungeon level is the deepest in this map.
--- @return bool
+--  @treturn bool
+--  @function is_deepest_level
 function is_deepest_level() end
 
 --- Creates a blank map of the specified size.
--- @tparam num width
--- @tparam num height
+--  @tparam num width
+--  @tparam num height
+--  @function create
 function create(width, height) end
 
 --- Loads a custom map with the given name.
--- @tparam string map_name
-function load_custom(map_name) end
+--  @tparam string map_name
+--  @function load_custom
+function load_custom(name) end
 
 --- Generates a random nefia (dungeon).
+--  @function generate_nefia
 function generate_nefia() end
 
 --- Sets the created map's name.
--- @tparam string name
+--  @tparam string name
+--  @function set_name
 function set_name(name) end
 
 --- Initializes the created map's tileset.
--- @tparam num tileset_id
-function set_tileset(tileset_id) end
+--  @tparam num tileset_id
+--  @function set_tileset
+function set_tileset(tileset) end
 
 --- Sets the position of the stairs up in the created map.
--- @tparam num x
--- @tparam num y
+--  @tparam num x
+--  @tparam num y
+--  @function set_stair_up_pos
 function set_stair_up_pos(x, y) end
 
 --- Sets the position of the stairs down in the created map.
--- @tparam num x
--- @tparam num y
+--  @tparam num x
+--  @tparam num y
+--  @function set_stair_down_pos
 function set_stair_down_pos(x, y) end
 
 --- Sets the created map's entrance type.
--- @tparam Enums.EntranceType type
+--  @tparam Enums.EntranceType type
+--  @function set_entrance_type
 function set_entrance_type(type) end
 
 --- Sets the created map's no aggro refresh flag. If true, characters
---- will not have their enemy_id and hate reset after map
---- initialization. Set this flag to true if you change the "enemy_id"
---- or "hate" fields of any characters in the generation function.
--- @tparam bool flag
+--  will not have their enemy_id and hate reset after map
+--  initialization. Set this flag to true if you change the "enemy_id"
+--  or "hate" fields of any characters in the generation function.
+--  @tparam bool flag
+--  @function set_no_aggro_refresh
 function set_no_aggro_refresh(flag) end
 
 --- Sets the position of the player based on the entrance type.
+--  @function place_player
 function place_player() end
 
 --- Sets the position of the player to the given coordinates and
---- updates the entrance type accordingly.
--- @tparam num x
--- @tparam num y
-function place_player(x, y) end
+--  updates the entrance type accordingly.
+--  @tparam num x
+--  @tparam num y
+--  @function place_player_xy
+function place_player_xy(x, y) end
 
 --- Creates new quests for the characters in the created map if necessary.
+--  @function update_quests_in_map
 function update_quests_in_map() end
 
 --- Marks all characters in this map as being enemies and quest targets.
+--  @function mark_quest_targets
 function mark_quest_targets() end
 
 --- Initializes this map as a world map,
+--  @function initialize_world_map
 function initialize_world_map() end

--- a/doc/api/item.luadoc
+++ b/doc/api/item.luadoc
@@ -31,3 +31,36 @@ function itemname(item, number, use_article) end
 --  @treturn[2] nil
 --  @function create
 function create(position, id, number) end
+
+--- Retrieves the player's memory of an item type.
+--  @tparam num type
+--  @tparam string id
+--  @function memory
+function memory(type, id) end
+
+--- Stacks an item in the inventory indicated. The item will no longer be valid
+--  for use.
+--  @tparam num inventory_id
+--  @tparam LuaItem handle
+--  @treturn[1] LuaItem The modified item stack on success
+--  @treturn[2] nil
+--  @function stack
+function stack(inventory_id, handle) end
+
+--- Returns the trading rate of a cargo item.
+--  @tparam LuaItem handle A cargo item
+--  @treturn num
+--  @function trade_rate
+function trade_rate(handle) end
+
+--- Tries to find an item in the player's inventory, the ground, or both.
+--  @tparam string item_id The item ID to find.
+--  @tparam ItemFindLocation location Where to search for the item.
+--  @function find
+function find(item_id, location) end
+
+--- Returns the string representation of a weight value.
+--  @tparam num weight The weight value
+--  @treturn string
+--  @function weight_string
+function weight_string(weight) end

--- a/doc/api/registry.luadoc
+++ b/doc/api/registry.luadoc
@@ -1,13 +1,18 @@
---- Functions for working with the data registry. The registry is set
---- of immutable Lua tables for storing semi-structured data, like
---- character or item definitions. It can be expanded by modders to
---- contain new data types.
+--- Functions for retrieving arbitrary game data.
 --  @usage local Registry = Elona.require("Registry")
 module "Registry"
 
---- Gets the root table for a datatype, if it exists.
--- @tparam string mod_name name of the mod where the data type is declared
--- @tparam string datatype_name name of the datatype
--- @treturn[1] table the registry table containing data definitions
--- @treturn[2] nil
-function get_table(mod_name, datatype_name) end
+--- Get the data table for the prototype ID.
+--  @tparam string prototype_id a namespaced prototype ID.
+--  @treturn[1] table the table which stores data.
+--  @treturn[2] nil if not found.
+--  @function get_table
+function get_table(prototype_id) end
+
+--- Get new ID by legacy ID.
+--  @tparam string prototype_id a namespaced prototype ID.
+--  @tparam num legacy_id a legacy data ID.
+--  @treturn[1] string the corresponding new ID.
+--  @treturn[2] nil if not found.
+--  @function get_id_by_legacy
+function get_id_by_legacy(prototype_id, legacy_id) end

--- a/src/elona/lua_env/lua_api/lua_api.cpp
+++ b/src/elona/lua_env/lua_api/lua_api.cpp
@@ -1,3 +1,4 @@
+// @noluadoc
 #include "lua_api.hpp"
 
 #include "lua_api_animation.cpp"

--- a/src/elona/lua_env/lua_class/lua_class.cpp
+++ b/src/elona/lua_env/lua_class/lua_class.cpp
@@ -1,3 +1,4 @@
+// @noluadoc
 #include "lua_class.hpp"
 
 #include "lua_class_ability.hpp"


### PR DESCRIPTION
# Related Issues

Close #ISSUE.


# Summary


According to the actual behavior, Rust's clang module may expand `#include` macros before analysis. As a result, files which do not have `@luadoc` magic comment (namely `lua_api/lua_api.cpp` and `lua_class/lua_class.cpp`) were not skipped, and unnecessary luadoc files
were generated. This commit adds `@noluadoc` directive to explicitly state this file does not have any documentation and prevent unnecessary luadoc files from being generated.