### PR TITLE
Fix casino card glitch

### DIFF
--- a/runtime/mod/core/data/asset.lua
+++ b/runtime/mod/core/data/asset.lua
@@ -378,8 +378,8 @@ data:add_multi(
       {
          id = "card_suit",
          source = "interface",
-         x = 864,
-         y = 533,
+         x = 192,
+         y = 672,
          width = 24,
          height = 32,
          count_x = 5,
@@ -389,8 +389,8 @@ data:add_multi(
       {
          id = "card_rank",
          source = "interface",
-         x = 864,
-         y = 565,
+         x = 312,
+         y = 672,
          width = 24,
          height = 32,
          count_x = 13,

--- a/src/elona/casino_card.cpp
+++ b/src/elona/casino_card.cpp
@@ -363,13 +363,13 @@ int opencard2(int card_index, int player_id)
 
 int trashcard(int card_index)
 {
+    gmode(2);
     for (int cnt = 0; cnt < 21; ++cnt)
     {
         draw(
             "card_pile",
             card_at_cardcontrol(3, card_index) - 8,
             card_at_cardcontrol(4, card_index) - 8);
-        gmode(2);
         if (cnt == 20)
         {
             redraw();


### PR DESCRIPTION
# Related Issues

Close #1177.


# Summary

- Fix #1177. Move card assets to other coordinate.
- Fix this glitch:

Screenshot A (before the commit)

![image](https://user-images.githubusercontent.com/36858341/57982807-fe2acb80-7a84-11e9-9c79-90705856e327.png)


Screenshot B (after the commit)

![image](https://user-images.githubusercontent.com/36858341/57982745-7e046600-7a84-11e9-9574-625ab6ac0815.png)

When you feel bad feeling about the card, you can change it. The trashed card (3rd one) in "Screenshot A" has small black garbage at the corners. The 5th card which is about to be trashed in "Screenshot B" does not.