### PR TITLE
Fix Input.prompt_dialog's overloads

### DIFF
--- a/src/elona/lua_env/lua_api/lua_api_input.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_input.cpp
@@ -304,7 +304,7 @@ int LuaApiInput::prompt_dialog_with_chip(
 
     if (default_index)
     {
-        chatesc = clamp(*default_index, 0, (int)choices.size() - 1);
+        chatesc = 1;
     }
     else
     {
@@ -315,7 +315,11 @@ int LuaApiInput::prompt_dialog_with_chip(
     auto result =
         talk_window_query(none, chara_image, speaker_name, text_, none);
 
-    assert(result != -1);
+    if (result == -1)
+    {
+        auto default_choice = clamp(*default_index, 0, (int)choices.size() - 1);
+        return default_choice;
+    }
 
     return result;
 }
@@ -351,7 +355,7 @@ int LuaApiInput::prompt_dialog_with_chip_impress(
 
     if (default_index)
     {
-        chatesc = clamp(*default_index, 0, (int)choices.size() - 1);
+        chatesc = 1;
     }
     else
     {
@@ -364,7 +368,11 @@ int LuaApiInput::prompt_dialog_with_chip_impress(
     auto result = talk_window_query(
         none, chara_image, speaker_name, text_, impress_interest);
 
-    assert(result != -1);
+    if (result == -1)
+    {
+        auto default_choice = clamp(*default_index, 0, (int)choices.size() - 1);
+        return default_choice;
+    }
 
     return result;
 }


### PR DESCRIPTION
# Related Issues

Close #1295.


# Summary

There are 4 overloaded `Input.prompt_dialog()`, and the implementation of `LuaApiInput::prompt_dialog_with_chip()` and `LuaApiInput::prompt_dialog_with_chip_impress()` were different from other two for some reason. Now, the four variations behave in similar ways.
