### PR TITLE
Don't render particles of rain and hard rain's effect at (0, 0)

### DIFF
--- a/src/elona/ui.cpp
+++ b/src/elona/ui.cpp
@@ -109,23 +109,30 @@ void render_weather_effect_rain()
          ++i)
     {
         auto&& particle = particles[i];
-        const auto brightness = rnd(100);
-        line(
-            particle.x,
-            particle.y,
-            particle.x + i % 2 + 1,
-            particle.y + i % 3 + 1,
-            {static_cast<uint8_t>(70 + brightness),
-             static_cast<uint8_t>(100 + brightness),
-             static_cast<uint8_t>(150 + brightness)});
+
+        if (particle != Position{0, 0})
+        {
+            const auto brightness = rnd(100);
+            // Draw.
+            line(
+                particle.x,
+                particle.y,
+                particle.x + i % 2 + 1,
+                particle.y + i % 3 + 1,
+                {static_cast<uint8_t>(70 + brightness),
+                 static_cast<uint8_t>(100 + brightness),
+                 static_cast<uint8_t>(150 + brightness)});
+        }
 
         if (particle == Position{0, 0})
         {
+            // Create new particle.
             particle.x = rnd(windoww);
             particle.y = rnd(windowh - inf_verh) - 6;
         }
         else
         {
+            // Update position.
             particle.x += 2;
             particle.y += 16 + i % 8;
             if (particle.y > windowh - inf_verh - 4)
@@ -153,23 +160,30 @@ void render_weather_effect_hard_rain()
          ++i)
     {
         auto&& particle = particles[i];
-        const auto brightness = rnd(100);
-        line(
-            particle.x,
-            particle.y,
-            particle.x + i % 2 + 1,
-            particle.y + i % 5 + 4,
-            {static_cast<uint8_t>(70 + brightness),
-             static_cast<uint8_t>(100 + brightness),
-             static_cast<uint8_t>(150 + brightness)});
+
+        if (particle != Position{0, 0})
+        {
+            const auto brightness = rnd(100);
+            // Draw.
+            line(
+                particle.x,
+                particle.y,
+                particle.x + i % 2 + 1,
+                particle.y + i % 5 + 4,
+                {static_cast<uint8_t>(70 + brightness),
+                 static_cast<uint8_t>(100 + brightness),
+                 static_cast<uint8_t>(150 + brightness)});
+        }
 
         if (particle == Position{0, 0})
         {
+            // Create new particle.
             particle.x = rnd(windoww);
             particle.y = rnd(windowh - inf_verh) - 6;
         }
         else
         {
+            // Update position.
             ++particle.x;
             particle.y += 24 + i % 8;
             if (particle.y > windowh - inf_verh - 9)


### PR DESCRIPTION
# Related Issues

#1289 

![image](https://user-images.githubusercontent.com/36858341/58100682-12073680-7c19-11e9-86f8-e5ac3f2dd190.png)

There are several rain at the the top left (0, 0). This pull request is fixing it.

# Summary

Same as the change of b7a7cedb6cde0562dbaed984ab9637361e27dc4a
