### PR TITLE
Avoid unnecessary migration

### DIFF
--- a/src/elona/save_update.cpp
+++ b/src/elona/save_update.cpp
@@ -2208,6 +2208,14 @@ void _update_save_data_10(const fs::path& save_dir)
              filesystem::DirEntryRange::Type::file,
              std::regex{u8R"(shop.*\.s2)"}))
     {
+        if (fs::exists(
+                save_dir /
+                ("mod_" + filepathutil::to_utf8_path(entry.path().filename()))))
+        {
+            // This file is saved in new format. Skipping.
+            continue;
+        }
+
         // Open file.
         std::ifstream fin{entry.path().native(), std::ios::binary};
         putit::BinaryIArchive iar{fin};
@@ -2351,6 +2359,14 @@ void _update_save_data_10(const fs::path& save_dir)
              filesystem::DirEntryRange::Type::file,
              std::regex{u8R"(shop.*\.s2)"}))
     {
+        if (fs::exists(
+                save_dir /
+                ("mod_" + filepathutil::to_utf8_path(entry.path().filename()))))
+        {
+            // Has already existed. Skipping.
+            continue;
+        }
+
         std::ifstream fin{entry.path().native(), std::ios::binary};
         putit::BinaryIArchive iar{fin};
 


### PR DESCRIPTION
# Related Issues

![image](https://user-images.githubusercontent.com/36858341/58181697-36314900-7ce7-11e9-9af1-286f0d846cb2.png)

v0.4.0's save cannot be update to the latest (v0.4.1) properly.


# Summary

Because update from v8 to v9 and from v9 to v10 were not applied to
shop*.s2, in update from v10 to v11, these files were migrated. However,
shop*.s2 files which were saved in Elona foobar v0.4.0 as valid format
do not require extra migration. As a result, unnecessary migration for
these files broke them and caused errors. Since this commit, foobar
checks whether the corresponding mod_*.s2 files exist and the shop*.s2
file requires migration or not. If not, foobar skips the file.
