### PR TITLE
Fix snow field not generated

### DIFF
--- a/src/elona/initialize_map_types.cpp
+++ b/src/elona/initialize_map_types.cpp
@@ -2264,33 +2264,16 @@ static void _init_map_fields()
     }
 
     mdatan(0) = "";
-    if (4 <= game_data.stood_world_map_tile &&
-        game_data.stood_world_map_tile < 9)
+
+    switch (map_get_field_type())
     {
-        _init_map_fields_forest();
-    }
-    if (264 <= game_data.stood_world_map_tile &&
-        game_data.stood_world_map_tile < 363)
-    {
-        _init_map_fields_sea();
-    }
-    if (9 <= game_data.stood_world_map_tile &&
-        game_data.stood_world_map_tile < 13)
-    {
-        _init_map_fields_grassland();
-    }
-    if (13 <= game_data.stood_world_map_tile &&
-        game_data.stood_world_map_tile < 17)
-    {
-        _init_map_fields_desert();
-    }
-    if (chip_data[game_data.stood_world_map_tile].kind == 4)
-    {
-        _init_map_fields_snow_field();
-    }
-    if (mdatan(0) == ""s)
-    {
-        _init_map_fields_plain_field();
+    case FieldMapType::plain_field: _init_map_fields_plain_field(); break;
+    case FieldMapType::forest: _init_map_fields_forest(); break;
+    case FieldMapType::sea: _init_map_fields_sea(); break;
+    case FieldMapType::grassland: _init_map_fields_grassland(); break;
+    case FieldMapType::desert: _init_map_fields_desert(); break;
+    case FieldMapType::snow_field: _init_map_fields_snow_field(); break;
+    default: assert(0); break;
     }
 
     map_placeplayer();

--- a/src/elona/mapgen.cpp
+++ b/src/elona/mapgen.cpp
@@ -3654,35 +3654,33 @@ void map_tileset(int tileset_type)
     }
     if (tileset_type == 4)
     {
-        tile_default = 0;
-        tile_fog = 528;
-        if (4 <= game_data.stood_world_map_tile &&
-            game_data.stood_world_map_tile < 9)
+        switch (map_get_field_type())
         {
+        case FieldMapType::plain_field:
+            tile_default = 0;
+            tile_fog = 528;
+            break;
+        case FieldMapType::forest:
             tile_default = 7;
             tile_fog = 528;
-        }
-        if (264 <= game_data.stood_world_map_tile &&
-            game_data.stood_world_map_tile < 363)
-        {
+            break;
+        case FieldMapType::sea:
             tile_default = 12;
-        }
-        if (9 <= game_data.stood_world_map_tile &&
-            game_data.stood_world_map_tile < 13)
-        {
             tile_fog = 528;
+            break;
+        case FieldMapType::grassland:
             tile_default = 3;
-        }
-        if (13 <= game_data.stood_world_map_tile &&
-            game_data.stood_world_map_tile < 17)
-        {
-            tile_fog = 531;
+            tile_fog = 528;
+            break;
+        case FieldMapType::desert:
             tile_default = 19;
-        }
-        if (chip_data[game_data.stood_world_map_tile].kind == 4)
-        {
-            tile_fog = 532;
+            tile_fog = 531;
+            break;
+        case FieldMapType::snow_field:
             tile_default = 45;
+            tile_fog = 532;
+            break;
+        default: assert(0); break;
         }
     }
 }
@@ -3785,5 +3783,37 @@ void map_initcustom(const std::string& map_filename)
 }
 
 
+
+FieldMapType map_get_field_type()
+{
+    const auto T = game_data.stood_world_map_tile;
+
+    if (4 <= T && T < 9)
+    {
+        return FieldMapType::forest;
+    }
+    else if (264 <= T && T < 363)
+    {
+        return FieldMapType::sea;
+    }
+    else if (9 <= T && T < 13)
+    {
+        return FieldMapType::grassland;
+    }
+    else if (13 <= T && T < 17)
+    {
+        return FieldMapType::desert;
+    }
+    else if (
+        (26 <= T && T <= 32) || (568 <= T && T <= 570) ||
+        (198 <= T && T <= 230))
+    {
+        return FieldMapType::snow_field;
+    }
+    else
+    {
+        return FieldMapType::plain_field;
+    }
+}
 
 } // namespace elona

--- a/src/elona/mapgen.hpp
+++ b/src/elona/mapgen.hpp
@@ -30,4 +30,18 @@ int initialize_random_nefia_rdtype3();
 int initialize_quest_map_party();
 void initialize_home_mdata();
 
+
+
+enum class FieldMapType
+{
+    plain_field,
+    forest,
+    sea,
+    grassland,
+    desert,
+    snow_field,
+};
+
+FieldMapType map_get_field_type();
+
 } // namespace elona


### PR DESCRIPTION
# Related Issues

Close #1303 


# Summary

Change the way to check whether you are standing on snow tile or not (see `map_get_field_type` function). It is dirty solution, but works at least now. It should be rewritten in a better way in the future.