### PR TITLE
Improve console output

### DIFF
--- a/runtime/data/script/kernel/ush.lua
+++ b/runtime/data/script/kernel/ush.lua
@@ -13,9 +13,25 @@ function ush.init(environment)
 
    -- echo
    ush.register('_BUILTIN_', 'echo', function(...)
-      -- TODO do not use inspect
-      local x = ...
-      E.print(E.COMMANDS._BUILTIN_.inspect(x))
+      local function do_echo(x, indent)
+         if type(x) == 'table' then
+            for k, v in pairs(x) do
+               if type(k) ~= 'number' or k < 1 or #x < k then
+                  E.print(('  '):rep(indent) .. tostring(k))
+               end
+               do_echo(v, indent + 1)
+            end
+         else
+            E.print(('  '):rep(indent) .. tostring(x))
+         end
+      end
+
+      local args = {...}
+      if #args == 1 then
+         do_echo(args[1], -1)
+      else
+         do_echo(args, -1)
+      end
       return nil
    end)
 
@@ -38,7 +54,7 @@ function ush.run(cmdline)
    local ast = parse(cmdline)
    E.RESULT = execute(ast, E)
    if E.RESULT ~= nil then
-      E.print(tostring(E.RESULT))
+      E.COMMANDS._BUILTIN_.echo(E.RESULT)
    end
    return E.RESULT
 end

--- a/runtime/data/script/kernel/ush/execute.lua
+++ b/runtime/data/script/kernel/ush/execute.lua
@@ -94,10 +94,13 @@ function Executor:_look_up_command(command_name)
    -- Do "Did you mean?" suggestion.
    local did_you_mean = {}
    local calculator = jarowinkler.DefaultCalculator.new()
-   for _, cmd in ipairs(commands) do
-      local distance = calculator:distance(command_name, has_namespace and cmd.full_name or cmd.name)
-      if distance >= _did_you_mean_threshold then
-         did_you_mean[#did_you_mean+1] = {distance = distance, command_name = full_name}
+   for namespace, command_table in pairs(self.E.COMMANDS) do
+      for name, _ in pairs(command_table) do
+         local full_name = namespace .. '.' .. name
+         local distance = calculator:distance(command_name, has_namespace and full_name or name)
+         if distance >= _did_you_mean_threshold then
+            did_you_mean[#did_you_mean+1] = {distance = distance, command_name = full_name}
+         end
       end
    end
    table.sort(did_you_mean, function(a, b) return a.distance < b.distance end)

--- a/src/elona/lua_env/console.cpp
+++ b/src/elona/lua_env/console.cpp
@@ -610,11 +610,11 @@ void Console::_init_builtin_lua_functions()
         print(ss.str());
     };
 
-    funcs["hello_world"] = [this]() { print(u8"Hello, World!"); };
+    funcs["hello_world"] = []() { return "Hello, World!"; };
 
     funcs["lua"] = [this]() {
         _in_lua_mode = true;
-        print(u8"Lua mode activated");
+        print(u8"Lua mode activated.");
     };
 
     funcs["exit_lua"] = [this]() {
@@ -651,7 +651,7 @@ void Console::_init_builtin_lua_functions()
 
         game_data.wizard = 1;
         cdatan(1, 0) = "*Debug*";
-        print("Wizard mode activated");
+        print("Wizard mode activated.");
         print("Please get on Ylva Express on Platform 9 ¾.");
     };
 
@@ -680,7 +680,7 @@ void Console::_init_builtin_lua_functions()
         debug::voldemort = false;
         game_data.wizard = 0;
         cdatan(1, 0) = random_title(RandomTitleType::character);
-        print("Wizard mode inactivated");
+        print("Wizard mode inactivated.");
         print("I am perfectly normal, thank you very much.");
     };
 


### PR DESCRIPTION

# Related Issues

#983 


# Summary

- Don't output quotation when the result is string.
- Don't call `inspect()` for tables, and output them in more human-friendly way.
- Fix "Did you mean?" feature not working.
- Add missing period.