### PR TITLE
Refactor autosaving: remove global flag, instead call function

### DIFF
--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -19,6 +19,7 @@
 #include "map_cell.hpp"
 #include "message.hpp"
 #include "optional.hpp"
+#include "save.hpp"
 #include "status_ailment.hpp"
 #include "ui.hpp"
 #include "variables.hpp"
@@ -1687,9 +1688,7 @@ void spot_digging()
                             txt(
                                 i18n::s.get("core.locale.common.something_is_"
                                             "put_on_the_ground"));
-                            autosave = 1 *
-                                (game_data.current_map !=
-                                 mdata_t::MapId::show_house);
+                            save_set_autosave();
                             inv[cnt].modify_number(-1);
                             break;
                         }

--- a/src/elona/casino.cpp
+++ b/src/elona/casino.cpp
@@ -18,8 +18,11 @@
 #include "menu.hpp"
 #include "message.hpp"
 #include "random.hpp"
+#include "save.hpp"
 #include "ui.hpp"
 #include "variables.hpp"
+
+
 
 namespace elona
 {
@@ -990,7 +993,7 @@ bool casino_blackjack()
     stake = rtval;
     winrow = 0;
     cardround = 0;
-    autosave = 1 * (game_data.current_map != mdata_t::MapId::show_house);
+    save_set_autosave();
     for (int cnt = 0;; ++cnt)
     {
         screenupdate = -1;

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -2582,7 +2582,7 @@ TurnResult do_use_command()
             }
         }
         chara_vanquish(tc);
-        autosave = 1 * (game_data.current_map != mdata_t::MapId::show_house);
+        save_set_autosave();
         chara_gain_skill_exp(cdata.player(), 151, 1200);
         randomize();
         screenupdate = -1;
@@ -3475,8 +3475,7 @@ TurnResult do_get_command()
                     : 0);
             if (feat(2) == 40)
             {
-                autosave =
-                    1 * (game_data.current_map != mdata_t::MapId::show_house);
+                save_set_autosave();
             }
             refresh_burden_state();
             return TurnResult::turn_end;

--- a/src/elona/elonacore.cpp
+++ b/src/elona/elonacore.cpp
@@ -4324,8 +4324,7 @@ TurnResult exit_map()
             area_data[game_data.current_map].type != mdata_t::MapType::field &&
             game_data.current_map != mdata_t::MapId::show_house)
         {
-            autosave =
-                1 * (game_data.current_map != mdata_t::MapId::show_house);
+            save_set_autosave();
         }
         if (map_data.type != mdata_t::MapType::world_map)
         {
@@ -5048,14 +5047,13 @@ void supply_income()
                     income(1)),
                 Message::color{ColorIndex::orange});
         }
-        autosave = 1 * (game_data.current_map != mdata_t::MapId::show_house);
+        save_set_autosave();
     }
     if (game_data.date.day == 1)
     {
         if (cdata.player().level > 5)
         {
-            autosave =
-                1 * (game_data.current_map != mdata_t::MapId::show_house);
+            save_set_autosave();
             p = -1;
             for (const auto& cnt : items(-1))
             {
@@ -7266,7 +7264,7 @@ void sleep_start()
     }
     msg_halt();
     play_music();
-    autosave = 1 * (game_data.current_map != mdata_t::MapId::show_house);
+    save_set_autosave();
     if (area_data[game_data.current_map].id == mdata_t::MapId::shop)
     {
         update_shop();
@@ -10112,7 +10110,7 @@ void open_box()
     }
     snd("core.ding2");
     txt(i18n::s.get("core.locale.action.open.goods", inv[ri]));
-    autosave = 1 * (game_data.current_map != mdata_t::MapId::show_house);
+    save_set_autosave();
     inv[ri].param1 = 0;
     if (inv[ri].id == 284)
     {
@@ -11592,7 +11590,7 @@ void create_harvested_item()
     {
         flttypemajor = choice(fsetplantartifact);
         fixlv = Quality::miracle;
-        autosave = 1 * (game_data.current_map != mdata_t::MapId::show_house);
+        save_set_autosave();
     }
     if (feat(2) == 36)
     {

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -32,6 +32,7 @@
 #include "message.hpp"
 #include "quest.hpp"
 #include "random.hpp"
+#include "save.hpp"
 #include "status_ailment.hpp"
 #include "trait.hpp"
 #include "ui.hpp"
@@ -809,7 +810,7 @@ bool _magic_1117()
     }
     snd("core.ding2");
     txt(i18n::s.get("core.locale.magic.create_material.apply", s(0)));
-    autosave = 1 * (game_data.current_map != mdata_t::MapId::show_house);
+    save_set_autosave();
     for (int cnt = 0,
              cnt_end = (rnd(3) + 3 + (efstatus == CurseState::blessed) * 6);
          cnt < cnt_end;
@@ -1317,7 +1318,7 @@ bool _magic_1104()
         obvious = 0;
         return true;
     }
-    autosave = 1 * (game_data.current_map != mdata_t::MapId::show_house);
+    save_set_autosave();
     return true;
 }
 
@@ -1421,7 +1422,7 @@ bool _magic_1105()
         }
     }
     chara_refresh(tc);
-    autosave = 1 * (game_data.current_map != mdata_t::MapId::show_house);
+    save_set_autosave();
     return true;
 }
 
@@ -1539,7 +1540,7 @@ bool _magic_1119()
         }
     }
     chara_refresh(tc);
-    autosave = 1 * (game_data.current_map != mdata_t::MapId::show_house);
+    save_set_autosave();
     return true;
 }
 
@@ -1615,7 +1616,7 @@ bool _magic_1113()
     }
     if (cdata[tc].index == 0)
     {
-        autosave = 1 * (game_data.current_map != mdata_t::MapId::show_house);
+        save_set_autosave();
     }
     return true;
 }
@@ -2441,7 +2442,7 @@ bool _magic_49(int efcibk)
     objfix = 0;
     ci = efcibk;
     inv[ci].modify_number(-1);
-    autosave = 1 * (game_data.current_map != mdata_t::MapId::show_house);
+    save_set_autosave();
     return true;
 }
 
@@ -2825,8 +2826,7 @@ bool _magic_1140()
         MenuResult result = ctrl_inventory();
         if (result.succeeded)
         {
-            autosave =
-                1 * (game_data.current_map != mdata_t::MapId::show_house);
+            save_set_autosave();
             animeload(8, cc);
             if (!is_cursed(efstatus))
             {
@@ -2902,7 +2902,7 @@ bool _magic_1132(int& fltbk, int& valuebk)
     }
     if (f == 1)
     {
-        autosave = 1 * (game_data.current_map != mdata_t::MapId::show_house);
+        save_set_autosave();
         animeload(8, cc);
         fltbk = the_item_db[inv[ci].id]->category;
         valuebk = calcitemvalue(ci, 0);

--- a/src/elona/proc_event.cpp
+++ b/src/elona/proc_event.cpp
@@ -21,6 +21,7 @@
 #include "quest.hpp"
 #include "random.hpp"
 #include "random_event.hpp"
+#include "save.hpp"
 #include "ui.hpp"
 #include "variables.hpp"
 
@@ -209,7 +210,7 @@ void proc_event()
             cdata.player().position.y,
             rnd(3) + 2);
         txt(i18n::s.get("core.locale.common.something_is_put_on_the_ground"));
-        autosave = 1 * (game_data.current_map != mdata_t::MapId::show_house);
+        save_set_autosave();
         break;
     case 29:
     {
@@ -358,7 +359,7 @@ void proc_event()
         cdata.player().gold -= cdata.player().gold / 3;
         decfame(0, 10);
         chara_refresh(0);
-        autosave = 1 * (game_data.current_map != mdata_t::MapId::show_house);
+        save_set_autosave();
         break;
     case 20:
         damage_hp(cdata[evdata1(evnum - (evnum != 0) * 1)], 9999, -11);

--- a/src/elona/quest.cpp
+++ b/src/elona/quest.cpp
@@ -16,7 +16,10 @@
 #include "mef.hpp"
 #include "message.hpp"
 #include "random.hpp"
+#include "save.hpp"
 #include "variables.hpp"
+
+
 
 namespace elona
 {
@@ -1496,7 +1499,7 @@ void quest_complete()
     }
     quest_data[rq].id = 0;
     quest_data[rq].progress = 0;
-    autosave = 1 * (game_data.current_map != mdata_t::MapId::show_house);
+    save_set_autosave();
 }
 
 } // namespace elona

--- a/src/elona/save.cpp
+++ b/src/elona/save.cpp
@@ -1,7 +1,7 @@
 #include "save.hpp"
-
 #include "audio.hpp"
 #include "character_status.hpp"
+#include "config/config.hpp"
 #include "ctrl_file.hpp"
 #include "draw.hpp"
 #include "i18n.hpp"
@@ -14,6 +14,15 @@
 
 namespace elona
 {
+
+namespace
+{
+
+bool will_autosave = false;
+
+}
+
+
 
 void load_save_data()
 {
@@ -121,6 +130,30 @@ void save_game()
     ctrl_file(FileOperation2::global_write, save_dir);
     Save::instance().clear();
     ELONA_LOG("save") << "Save end:" << playerid;
+}
+
+
+
+void save_set_autosave()
+{
+    will_autosave = true;
+}
+
+
+
+void save_autosave_if_needed()
+{
+    if (will_autosave)
+    {
+        will_autosave = false;
+        if (!game_data.wizard &&
+            game_data.current_map != mdata_t::MapId::show_house &&
+            game_data.current_map != mdata_t::MapId::pet_arena &&
+            Config::instance().autosave)
+        {
+            do_save_game();
+        }
+    }
 }
 
 } // namespace elona

--- a/src/elona/save.hpp
+++ b/src/elona/save.hpp
@@ -9,4 +9,9 @@ void load_save_data();
 void do_save_game();
 void save_game();
 
+// Will autosave in the next PC's turn.
+void save_set_autosave();
+// Autosave if save_set_autosave() was called.
+void save_autosave_if_needed();
+
 } // namespace elona

--- a/src/elona/turn_sequence.cpp
+++ b/src/elona/turn_sequence.cpp
@@ -1360,16 +1360,7 @@ TurnResult pc_turn(bool advance_time)
                 }
             }
         }
-        if (autosave)
-        {
-            autosave = 0;
-            if (game_data.wizard == 0 &&
-                game_data.current_map != mdata_t::MapId::pet_arena &&
-                Config::instance().autosave)
-            {
-                do_save_game();
-            }
-        }
+        save_autosave_if_needed();
         if (autoturn == 1)
         {
             autoturn = 0;

--- a/src/elona/variables.hpp
+++ b/src/elona/variables.hpp
@@ -338,7 +338,6 @@ ELONA_EXTERN(int attacknum);
 ELONA_EXTERN(int attackrange);
 ELONA_EXTERN(int attackskill);
 ELONA_EXTERN(int atxspot);
-ELONA_EXTERN(int autosave);
 ELONA_EXTERN(int body);
 ELONA_EXTERN(int bonus);
 ELONA_EXTERN(int camera);

--- a/src/elona/wish.cpp
+++ b/src/elona/wish.cpp
@@ -20,13 +20,13 @@
 #include "network.hpp"
 #include "optional.hpp"
 #include "random.hpp"
+#include "save.hpp"
 #include "variables.hpp"
 
 
 
 namespace
 {
-
 
 template <typename T, typename Similarity = int>
 class BySimilaritySelector
@@ -770,7 +770,7 @@ bool process_wish()
 
     txt(i18n::s.get("core.locale.wish.your_wish", inputlog(0)));
 
-    autosave = 1 * (game_data.current_map != mdata_t::MapId::show_house);
+    save_set_autosave();
 
     log_copy_observer = std::make_unique<LogCopyObserver>();
     subscribe_log(log_copy_observer.get());


### PR DESCRIPTION
# Summary


```cpp
autosave = 1 * (game_data.current_map != mdata_t::MapId::show_house)
```

Replace this line which appeared many times with single function call. Also remove a global flag, `autosave`.