### PR TITLE
Fix various text error

### DIFF
--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -677,7 +677,7 @@ void continuous_action_sex()
         {
             txt(i18n::s.get(
                 "core.locale.activity.sex.spare_life",
-                i18n::s.get("core.locale.ui.sex2", cdata[tc].sex),
+                i18n::s.get_enum("core.locale.ui.sex2", cdata[tc].sex),
                 cdata[tc]));
         }
         cdata[cc].continuous_action.finish();

--- a/src/elona/elonacore.cpp
+++ b/src/elona/elonacore.cpp
@@ -5903,7 +5903,7 @@ int find_enemy_target()
     {
         if (cc == 0)
         {
-            i18n::s.get("core.locale.action.ranged.no_target");
+            txt(i18n::s.get("core.locale.action.ranged.no_target"));
             update_screen();
         }
         return 0;
@@ -8367,7 +8367,7 @@ int do_magic_attempt()
             {
                 if (is_in_fov(cdata[cc]))
                 {
-                    txt(i18n::s.get("core.locale.misc.shakes_head"));
+                    txt(i18n::s.get("core.locale.misc.shakes_head", cdata[cc]));
                 }
                 return 1;
             }


### PR DESCRIPTION
# Related issues

#1315 

# Summary


- Fix 'You find no target.' not shown.
- Add missing argument to `locale.misc.shakes_head`.
- Fix wrong function: `i18n::s.get` -> `i18n::s.get_enum`.
