### PR TITLE
Reduce calls of Inventory::operator[]()

### DIFF
--- a/src/elona/access_item_db.cpp
+++ b/src/elona/access_item_db.cpp
@@ -1,5 +1,6 @@
 #include <unordered_map>
 #include "character.hpp"
+#include "data/types/type_item.hpp"
 #include "elona.hpp"
 #include "filesystem.hpp"
 #include "i18n.hpp"
@@ -8,29 +9,27 @@
 #include "random.hpp"
 #include "variables.hpp"
 
-#include "data/types/type_item.hpp"
 
 
 namespace elona
 {
 
-
-int access_item_db(int dbmode)
+int access_item_db(Item& item, int legacy_id, int dbmode)
 {
-    const auto info = the_item_db[dbid];
+    const auto info = the_item_db[legacy_id];
     if (info)
     {
         if (dbmode == 10 || dbmode == 3)
         {
-            inv[ci].value = info->value;
-            inv[ci].weight = info->weight;
-            inv[ci].dice_x = info->dice_x;
-            inv[ci].dice_y = info->dice_y;
-            inv[ci].hit_bonus = info->hit_bonus;
-            inv[ci].damage_bonus = info->damage_bonus;
-            inv[ci].pv = info->pv;
-            inv[ci].dv = info->dv;
-            inv[ci].material = info->material;
+            item.value = info->value;
+            item.weight = info->weight;
+            item.dice_x = info->dice_x;
+            item.dice_y = info->dice_y;
+            item.hit_bonus = info->hit_bonus;
+            item.damage_bonus = info->damage_bonus;
+            item.pv = info->pv;
+            item.dv = info->dv;
+            item.material = info->material;
             if (dbmode == 10)
                 return 0;
         }
@@ -74,53 +73,53 @@ int access_item_db(int dbmode)
     if (dbmode == 3)
     {
         // Common initialization
-        inv[ci].id = dbid;
-        inv[ci].set_number(1);
-        inv[ci].difficulty_of_identification = 0; // Default value
-        inv[ci].image = info->image;
+        item.id = legacy_id;
+        item.set_number(1);
+        item.difficulty_of_identification = 0; // Default value
+        item.image = info->image;
         fixeditemenc(0) = 0; // Default value
         reftype = info->category;
         reftypeminor = info->subcategory;
     }
 
-    switch (dbid)
+    switch (legacy_id)
     {
     case 792:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 8;
+            item.param2 = 8;
         }
         break;
     case 791:
         if (dbmode == 3)
         {
-            inv[ci].skill = 100;
+            item.skill = 100;
             fixeditemenc(0) = 57;
             fixeditemenc(1) = 300;
             fixeditemenc(2) = 61;
             fixeditemenc(3) = 200;
             fixeditemenc(4) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 790:
         if (dbmode == 3)
         {
-            inv[ci].function = 15;
+            item.function = 15;
         }
         break;
     case 789:
         if (dbmode == 3)
         {
-            inv[ci].function = 15;
+            item.function = 15;
         }
         break;
     case 788:
         if (dbmode == 3)
         {
-            inv[ci].skill = 108;
+            item.skill = 108;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -130,20 +129,20 @@ int access_item_db(int dbmode)
     case 787:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 5;
-            inv[ci].param3 = 720;
+            item.param2 = 5;
+            item.param3 = 720;
         }
         break;
     case 786:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 4;
+            item.param2 = 4;
         }
         break;
     case 785:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 1;
+            item.param2 = 1;
         }
         break;
     case 783:
@@ -156,47 +155,47 @@ int access_item_db(int dbmode)
     case 781:
         if (dbmode == 3)
         {
-            inv[ci].skill = 101;
+            item.skill = 101;
         }
         break;
     case 778:
         if (dbmode == 3)
         {
-            inv[ci].function = 44;
+            item.function = 44;
         }
         break;
     case 777:
         if (dbmode == 3)
         {
-            inv[ci].function = 26;
-            inv[ci].is_precious() = true;
-            inv[ci].has_cooldown_time() = true;
-            inv[ci].param3 = 240;
+            item.function = 26;
+            item.is_precious() = true;
+            item.has_cooldown_time() = true;
+            item.param3 = 240;
             fixlv = Quality::special;
         }
         break;
     case 776:
         if (dbmode == 3)
         {
-            inv[ci].function = 26;
-            inv[ci].is_precious() = true;
-            inv[ci].has_cooldown_time() = true;
-            inv[ci].param3 = 240;
+            item.function = 26;
+            item.is_precious() = true;
+            item.has_cooldown_time() = true;
+            item.param3 = 240;
             fixlv = Quality::special;
         }
         break;
     case 775:
         if (dbmode == 3)
         {
-            inv[ci].is_precious() = true;
-            inv[ci].param2 = 8;
+            item.is_precious() = true;
+            item.param2 = 8;
         }
         break;
     case 772:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 2000;
-            inv[ci].param3 = 32;
+            item.param1 = 2000;
+            item.param3 = 32;
         }
         break;
     case 771:
@@ -224,46 +223,46 @@ int access_item_db(int dbmode)
     case 767:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 0;
+            item.param1 = 0;
         }
         break;
     case 761:
         if (dbmode == 3)
         {
-            inv[ci].skill = 183;
+            item.skill = 183;
             fixeditemenc(0) = 60;
             fixeditemenc(1) = 100;
             fixeditemenc(2) = 0;
-            inv[ci].function = 17;
-            inv[ci].is_precious() = true;
-            inv[ci].param1 = 200;
+            item.function = 17;
+            item.is_precious() = true;
+            item.param1 = 200;
             fixlv = Quality::special;
         }
         break;
     case 760:
         if (dbmode == 3)
         {
-            inv[ci].function = 49;
-            inv[ci].is_precious() = true;
-            inv[ci].param1 = rnd(20000) + 1;
+            item.function = 49;
+            item.is_precious() = true;
+            item.param1 = rnd(20000) + 1;
             fixlv = Quality::special;
         }
         break;
     case 759:
         if (dbmode == 3)
         {
-            inv[ci].skill = 100;
+            item.skill = 100;
         }
         break;
     case 758:
         if (dbmode == 3)
         {
-            inv[ci].skill = 110;
+            item.skill = 110;
             fixeditemenc(0) = 35;
             fixeditemenc(1) = 100;
             fixeditemenc(2) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
@@ -281,43 +280,43 @@ int access_item_db(int dbmode)
             fixeditemenc(8) = 33;
             fixeditemenc(9) = 100;
             fixeditemenc(10) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 756:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 7;
+            item.param2 = 7;
         }
         break;
     case 755:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 6;
+            item.param2 = 6;
         }
         break;
     case 749:
         if (dbmode == 3)
         {
-            inv[ci].function = 48;
-            inv[ci].is_precious() = true;
+            item.function = 48;
+            item.is_precious() = true;
         }
         break;
     case 748:
         if (dbmode == 3)
         {
-            inv[ci].function = 47;
-            inv[ci].is_precious() = true;
-            inv[ci].is_showroom_only() = true;
+            item.function = 47;
+            item.is_precious() = true;
+            item.is_showroom_only() = true;
         }
         break;
     case 747:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 1;
-            inv[ci].param2 = rnd(4) + 1;
+            item.param1 = 1;
+            item.param2 = rnd(4) + 1;
         }
         if (dbmode == 13)
         {
@@ -328,51 +327,51 @@ int access_item_db(int dbmode)
     case 746:
         if (dbmode == 3)
         {
-            inv[ci].function = 30;
-            inv[ci].is_precious() = true;
-            inv[ci].has_cooldown_time() = true;
-            inv[ci].param1 = 1132;
-            inv[ci].param2 = 100;
-            inv[ci].param3 = 24;
+            item.function = 30;
+            item.is_precious() = true;
+            item.has_cooldown_time() = true;
+            item.param1 = 1132;
+            item.param2 = 100;
+            item.param3 = 24;
         }
         break;
     case 745:
         if (dbmode == 3)
         {
-            inv[ci].function = 30;
-            inv[ci].is_precious() = true;
-            inv[ci].has_cooldown_time() = true;
-            inv[ci].param1 = 1132;
-            inv[ci].param2 = 100;
-            inv[ci].param3 = 24;
+            item.function = 30;
+            item.is_precious() = true;
+            item.has_cooldown_time() = true;
+            item.param1 = 1132;
+            item.param2 = 100;
+            item.param3 = 24;
         }
         break;
     case 744:
         if (dbmode == 3)
         {
-            inv[ci].function = 30;
-            inv[ci].is_precious() = true;
-            inv[ci].has_cooldown_time() = true;
-            inv[ci].param1 = 1132;
-            inv[ci].param2 = 100;
-            inv[ci].param3 = 24;
+            item.function = 30;
+            item.is_precious() = true;
+            item.has_cooldown_time() = true;
+            item.param1 = 1132;
+            item.param2 = 100;
+            item.param3 = 24;
         }
         break;
     case 743:
         if (dbmode == 3)
         {
-            inv[ci].function = 30;
-            inv[ci].is_precious() = true;
-            inv[ci].has_cooldown_time() = true;
-            inv[ci].param1 = 1132;
-            inv[ci].param2 = 100;
-            inv[ci].param3 = 24;
+            item.function = 30;
+            item.is_precious() = true;
+            item.has_cooldown_time() = true;
+            item.param1 = 1132;
+            item.param2 = 100;
+            item.param3 = 24;
         }
         break;
     case 742:
         if (dbmode == 3)
         {
-            inv[ci].is_precious() = true;
+            item.is_precious() = true;
             fixlv = Quality::special;
         }
         if (dbmode == 13)
@@ -384,7 +383,7 @@ int access_item_db(int dbmode)
     case 741:
         if (dbmode == 3)
         {
-            inv[ci].skill = 100;
+            item.skill = 100;
             fixeditemenc(0) = 20050;
             fixeditemenc(1) = 550;
             fixeditemenc(2) = 70052;
@@ -394,8 +393,8 @@ int access_item_db(int dbmode)
             fixeditemenc(6) = 10011;
             fixeditemenc(7) = 720;
             fixeditemenc(8) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
@@ -409,15 +408,15 @@ int access_item_db(int dbmode)
             fixeditemenc(4) = 20057;
             fixeditemenc(5) = 400;
             fixeditemenc(6) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 739:
         if (dbmode == 3)
         {
-            inv[ci].skill = 107;
+            item.skill = 107;
             fixeditemenc(0) = 80002;
             fixeditemenc(1) = 400;
             fixeditemenc(2) = 70054;
@@ -431,15 +430,15 @@ int access_item_db(int dbmode)
             fixeditemenc(10) = 80003;
             fixeditemenc(11) = 350;
             fixeditemenc(12) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 738:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 6;
+            item.param2 = 6;
         }
         break;
     case 737:
@@ -463,7 +462,7 @@ int access_item_db(int dbmode)
     case 735:
         if (dbmode == 3)
         {
-            inv[ci].skill = 107;
+            item.skill = 107;
             fixeditemenc(0) = 80025;
             fixeditemenc(1) = 100;
             fixeditemenc(2) = 0;
@@ -472,14 +471,14 @@ int access_item_db(int dbmode)
     case 733:
         if (dbmode == 3)
         {
-            inv[ci].function = 45;
+            item.function = 45;
         }
         break;
     case 732:
         if (dbmode == 3)
         {
-            inv[ci].count = 3 + rnd(3) - rnd(3);
-            inv[ci].has_charge() = true;
+            item.count = 3 + rnd(3) - rnd(3);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -492,8 +491,8 @@ int access_item_db(int dbmode)
     case 731:
         if (dbmode == 3)
         {
-            inv[ci].count = 3 + rnd(3) - rnd(3);
-            inv[ci].has_charge() = true;
+            item.count = 3 + rnd(3) - rnd(3);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -506,7 +505,7 @@ int access_item_db(int dbmode)
     case 730:
         if (dbmode == 3)
         {
-            inv[ci].is_precious() = true;
+            item.is_precious() = true;
         }
         break;
     case 728:
@@ -519,29 +518,29 @@ int access_item_db(int dbmode)
             fixeditemenc(4) = 20050;
             fixeditemenc(5) = 350;
             fixeditemenc(6) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 727:
         if (dbmode == 3)
         {
-            inv[ci].skill = 168;
+            item.skill = 168;
             fixeditemenc(0) = 54;
             fixeditemenc(1) = 1000;
             fixeditemenc(2) = 20058;
             fixeditemenc(3) = 450;
             fixeditemenc(4) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 726:
         if (dbmode == 3)
         {
-            inv[ci].skill = 168;
+            item.skill = 168;
             fixeditemenc(0) = 30183;
             fixeditemenc(1) = -450;
             fixeditemenc(2) = 52;
@@ -549,15 +548,15 @@ int access_item_db(int dbmode)
             fixeditemenc(4) = 53;
             fixeditemenc(5) = 400;
             fixeditemenc(6) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 725:
         if (dbmode == 3)
         {
-            inv[ci].skill = 111;
+            item.skill = 111;
             fixeditemenc(0) = 70059;
             fixeditemenc(1) = 400;
             fixeditemenc(2) = 30183;
@@ -565,15 +564,15 @@ int access_item_db(int dbmode)
             fixeditemenc(4) = 44;
             fixeditemenc(5) = 450;
             fixeditemenc(6) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 724:
         if (dbmode == 3)
         {
-            inv[ci].is_precious() = true;
+            item.is_precious() = true;
         }
         break;
     case 723:
@@ -584,8 +583,8 @@ int access_item_db(int dbmode)
             fixeditemenc(2) = 30166;
             fixeditemenc(3) = 650;
             fixeditemenc(4) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
@@ -597,31 +596,31 @@ int access_item_db(int dbmode)
             fixeditemenc(2) = 30109;
             fixeditemenc(3) = 700;
             fixeditemenc(4) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 721:
         if (dbmode == 3)
         {
-            inv[ci].function = 43;
-            inv[ci].is_precious() = true;
-            inv[ci].has_cooldown_time() = true;
-            inv[ci].param3 = 480;
+            item.function = 43;
+            item.is_precious() = true;
+            item.has_cooldown_time() = true;
+            item.param3 = 480;
             fixlv = Quality::special;
         }
         break;
     case 720:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 200;
+            item.param1 = 200;
         }
         break;
     case 719:
         if (dbmode == 3)
         {
-            inv[ci].skill = 100;
+            item.skill = 100;
             fixeditemenc(0) = 44;
             fixeditemenc(1) = 250;
             fixeditemenc(2) = 39;
@@ -629,15 +628,15 @@ int access_item_db(int dbmode)
             fixeditemenc(4) = 33;
             fixeditemenc(5) = 100;
             fixeditemenc(6) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 718:
         if (dbmode == 3)
         {
-            inv[ci].skill = 111;
+            item.skill = 111;
             fixeditemenc(0) = 40;
             fixeditemenc(1) = 350;
             fixeditemenc(2) = 70054;
@@ -649,36 +648,36 @@ int access_item_db(int dbmode)
             fixeditemenc(8) = 30;
             fixeditemenc(9) = 500;
             fixeditemenc(10) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 717:
         if (dbmode == 3)
         {
-            inv[ci].function = 42;
+            item.function = 42;
         }
         break;
     case 716:
         if (dbmode == 3)
         {
-            inv[ci].skill = 111;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.skill = 111;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 715:
         if (dbmode == 3)
         {
-            inv[ci].function = 41;
+            item.function = 41;
         }
         break;
     case 714:
         if (dbmode == 3)
         {
-            inv[ci].skill = 111;
+            item.skill = 111;
             fixeditemenc(0) = 80024;
             fixeditemenc(1) = 100;
             fixeditemenc(2) = 0;
@@ -687,7 +686,7 @@ int access_item_db(int dbmode)
     case 713:
         if (dbmode == 3)
         {
-            inv[ci].skill = 111;
+            item.skill = 111;
             fixeditemenc(0) = 70061;
             fixeditemenc(1) = 100;
             fixeditemenc(2) = 0;
@@ -712,8 +711,8 @@ int access_item_db(int dbmode)
     case 710:
         if (dbmode == 3)
         {
-            inv[ci].count = 3 + rnd(3) - rnd(3);
-            inv[ci].has_charge() = true;
+            item.count = 3 + rnd(3) - rnd(3);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -744,13 +743,13 @@ int access_item_db(int dbmode)
     case 707:
         if (dbmode == 3)
         {
-            inv[ci].skill = 183;
+            item.skill = 183;
             fixeditemenc(0) = 49;
             fixeditemenc(1) = 100;
             fixeditemenc(2) = 0;
-            inv[ci].function = 17;
-            inv[ci].is_precious() = true;
-            inv[ci].param1 = 180;
+            item.function = 17;
+            item.is_precious() = true;
+            item.param1 = 180;
             fixlv = Quality::special;
         }
         break;
@@ -773,8 +772,8 @@ int access_item_db(int dbmode)
             fixeditemenc(4) = 41;
             fixeditemenc(5) = 100;
             fixeditemenc(6) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
@@ -790,21 +789,21 @@ int access_item_db(int dbmode)
     case 703:
         if (dbmode == 3)
         {
-            inv[ci].function = 39;
+            item.function = 39;
         }
         break;
     case 702:
         if (dbmode == 3)
         {
-            inv[ci].is_precious() = true;
-            inv[ci].param2 = 4;
+            item.is_precious() = true;
+            item.param2 = 4;
             fixlv = Quality::special;
         }
         break;
     case 701:
         if (dbmode == 3)
         {
-            inv[ci].function = 37;
+            item.function = 37;
         }
         break;
     case 700:
@@ -818,7 +817,7 @@ int access_item_db(int dbmode)
     case 699:
         if (dbmode == 3)
         {
-            inv[ci].is_precious() = true;
+            item.is_precious() = true;
         }
         break;
     case 698:
@@ -833,8 +832,8 @@ int access_item_db(int dbmode)
     case 697:
         if (dbmode == 3)
         {
-            inv[ci].count = 2 + rnd(2) - rnd(2);
-            inv[ci].has_charge() = true;
+            item.count = 2 + rnd(2) - rnd(2);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -847,8 +846,8 @@ int access_item_db(int dbmode)
     case 696:
         if (dbmode == 3)
         {
-            inv[ci].count = 2 + rnd(2) - rnd(2);
-            inv[ci].has_charge() = true;
+            item.count = 2 + rnd(2) - rnd(2);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -861,64 +860,64 @@ int access_item_db(int dbmode)
     case 695:
         if (dbmode == 3)
         {
-            inv[ci].skill = 102;
+            item.skill = 102;
             fixeditemenc(0) = 44;
             fixeditemenc(1) = 750;
             fixeditemenc(2) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 693:
         if (dbmode == 3)
         {
-            inv[ci].skill = 183;
-            inv[ci].function = 17;
-            inv[ci].param1 = 175;
+            item.skill = 183;
+            item.function = 17;
+            item.param1 = 175;
         }
         break;
     case 692:
         if (dbmode == 3)
         {
-            inv[ci].skill = 183;
-            inv[ci].function = 17;
-            inv[ci].param1 = 70;
+            item.skill = 183;
+            item.function = 17;
+            item.param1 = 70;
         }
         break;
     case 691:
         if (dbmode == 3)
         {
-            inv[ci].skill = 183;
-            inv[ci].function = 17;
-            inv[ci].param1 = 130;
+            item.skill = 183;
+            item.function = 17;
+            item.param1 = 130;
         }
         break;
     case 690:
         if (dbmode == 3)
         {
-            inv[ci].skill = 183;
-            inv[ci].function = 17;
-            inv[ci].param1 = 150;
+            item.skill = 183;
+            item.function = 17;
+            item.param1 = 150;
         }
         break;
     case 689:
         if (dbmode == 3)
         {
-            inv[ci].function = 36;
+            item.function = 36;
         }
         break;
     case 688:
         if (dbmode == 3)
         {
-            inv[ci].function = 35;
+            item.function = 35;
         }
         break;
     case 687:
         if (dbmode == 3)
         {
-            inv[ci].count = 2 + rnd(2) - rnd(2);
-            inv[ci].has_charge() = true;
+            item.count = 2 + rnd(2) - rnd(2);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -929,76 +928,76 @@ int access_item_db(int dbmode)
     case 686:
         if (dbmode == 3)
         {
-            inv[ci].function = 34;
-            inv[ci].is_precious() = true;
-            inv[ci].has_cooldown_time() = true;
-            inv[ci].param3 = 720;
+            item.function = 34;
+            item.is_precious() = true;
+            item.has_cooldown_time() = true;
+            item.param3 = 720;
             fixlv = Quality::special;
         }
         break;
     case 685:
         if (dbmode == 3)
         {
-            inv[ci].function = 33;
+            item.function = 33;
         }
         break;
     case 684:
         if (dbmode == 3)
         {
-            inv[ci].function = 32;
-            inv[ci].is_precious() = true;
+            item.function = 32;
+            item.is_precious() = true;
         }
         break;
     case 683:
         if (dbmode == 3)
         {
-            inv[ci].function = 30;
-            inv[ci].is_precious() = true;
-            inv[ci].has_cooldown_time() = true;
-            inv[ci].param1 = 1132;
-            inv[ci].param2 = 100;
-            inv[ci].param3 = 24;
+            item.function = 30;
+            item.is_precious() = true;
+            item.has_cooldown_time() = true;
+            item.param1 = 1132;
+            item.param2 = 100;
+            item.param3 = 24;
             fixlv = Quality::special;
         }
         break;
     case 682:
         if (dbmode == 3)
         {
-            inv[ci].function = 31;
-            inv[ci].is_precious() = true;
-            inv[ci].has_cooldown_time() = true;
-            inv[ci].param3 = 72;
+            item.function = 31;
+            item.is_precious() = true;
+            item.has_cooldown_time() = true;
+            item.param3 = 72;
             fixlv = Quality::special;
         }
         break;
     case 681:
         if (dbmode == 3)
         {
-            inv[ci].function = 30;
-            inv[ci].is_precious() = true;
-            inv[ci].has_cooldown_time() = true;
-            inv[ci].param1 = 404;
-            inv[ci].param2 = 400;
-            inv[ci].param3 = 8;
+            item.function = 30;
+            item.is_precious() = true;
+            item.has_cooldown_time() = true;
+            item.param1 = 404;
+            item.param2 = 400;
+            item.param3 = 8;
             fixlv = Quality::special;
         }
         break;
     case 680:
         if (dbmode == 3)
         {
-            inv[ci].function = 30;
-            inv[ci].is_precious() = true;
-            inv[ci].has_cooldown_time() = true;
-            inv[ci].param1 = 446;
-            inv[ci].param2 = 300;
-            inv[ci].param3 = 12;
+            item.function = 30;
+            item.is_precious() = true;
+            item.has_cooldown_time() = true;
+            item.param1 = 446;
+            item.param2 = 300;
+            item.param3 = 12;
             fixlv = Quality::special;
         }
         break;
     case 679:
         if (dbmode == 3)
         {
-            inv[ci].skill = 103;
+            item.skill = 103;
             fixeditemenc(0) = 39;
             fixeditemenc(1) = 350;
             fixeditemenc(2) = 80013;
@@ -1010,15 +1009,15 @@ int access_item_db(int dbmode)
             fixeditemenc(8) = 20054;
             fixeditemenc(9) = 400;
             fixeditemenc(10) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 678:
         if (dbmode == 3)
         {
-            inv[ci].skill = 101;
+            item.skill = 101;
             fixeditemenc(0) = 41;
             fixeditemenc(1) = 100;
             fixeditemenc(2) = 35;
@@ -1030,15 +1029,15 @@ int access_item_db(int dbmode)
             fixeditemenc(8) = 30185;
             fixeditemenc(9) = 600;
             fixeditemenc(10) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 677:
         if (dbmode == 3)
         {
-            inv[ci].skill = 104;
+            item.skill = 104;
             fixeditemenc(0) = 80023;
             fixeditemenc(1) = 350;
             fixeditemenc(2) = 80012;
@@ -1050,15 +1049,15 @@ int access_item_db(int dbmode)
             fixeditemenc(8) = 20056;
             fixeditemenc(9) = 150;
             fixeditemenc(10) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 676:
         if (dbmode == 3)
         {
-            inv[ci].skill = 105;
+            item.skill = 105;
             fixeditemenc(0) = 80000;
             fixeditemenc(1) = 400;
             fixeditemenc(2) = 70050;
@@ -1074,15 +1073,15 @@ int access_item_db(int dbmode)
             fixeditemenc(12) = 20052;
             fixeditemenc(13) = 250;
             fixeditemenc(14) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 675:
         if (dbmode == 3)
         {
-            inv[ci].skill = 107;
+            item.skill = 107;
             fixeditemenc(0) = 30184;
             fixeditemenc(1) = 600;
             fixeditemenc(2) = 42;
@@ -1098,15 +1097,15 @@ int access_item_db(int dbmode)
             fixeditemenc(12) = 80025;
             fixeditemenc(13) = 100;
             fixeditemenc(14) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 674:
         if (dbmode == 3)
         {
-            inv[ci].skill = 110;
+            item.skill = 110;
             fixeditemenc(0) = 80017;
             fixeditemenc(1) = 350;
             fixeditemenc(2) = 43;
@@ -1116,15 +1115,15 @@ int access_item_db(int dbmode)
             fixeditemenc(6) = 20057;
             fixeditemenc(7) = 350;
             fixeditemenc(8) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 673:
         if (dbmode == 3)
         {
-            inv[ci].skill = 108;
+            item.skill = 108;
             fixeditemenc(0) = 80014;
             fixeditemenc(1) = 200;
             fixeditemenc(2) = 80005;
@@ -1134,44 +1133,44 @@ int access_item_db(int dbmode)
             fixeditemenc(6) = 20052;
             fixeditemenc(7) = 300;
             fixeditemenc(8) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 672:
         if (dbmode == 3)
         {
-            inv[ci].function = 29;
-            inv[ci].is_precious() = true;
+            item.function = 29;
+            item.is_precious() = true;
             fixlv = Quality::special;
         }
         break;
     case 671:
         if (dbmode == 3)
         {
-            inv[ci].function = 28;
-            inv[ci].is_precious() = true;
+            item.function = 28;
+            item.is_precious() = true;
             fixlv = Quality::special;
         }
         break;
     case 670:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 7;
+            item.param1 = 7;
         }
         break;
     case 669:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 7;
+            item.param1 = 7;
         }
         break;
     case 668:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 1;
-            inv[ci].param2 = rnd(4) + 1;
+            item.param1 = 1;
+            item.param2 = rnd(4) + 1;
         }
         if (dbmode == 13)
         {
@@ -1182,26 +1181,26 @@ int access_item_db(int dbmode)
     case 667:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 7;
+            item.param2 = 7;
         }
         break;
     case 666:
         if (dbmode == 3)
         {
-            inv[ci].function = 27;
-            inv[ci].is_precious() = true;
-            inv[ci].has_cooldown_time() = true;
-            inv[ci].param3 = 120;
+            item.function = 27;
+            item.is_precious() = true;
+            item.has_cooldown_time() = true;
+            item.param3 = 120;
             fixlv = Quality::special;
         }
         break;
     case 665:
         if (dbmode == 3)
         {
-            inv[ci].function = 26;
-            inv[ci].is_precious() = true;
-            inv[ci].has_cooldown_time() = true;
-            inv[ci].param3 = 240;
+            item.function = 26;
+            item.is_precious() = true;
+            item.has_cooldown_time() = true;
+            item.param3 = 240;
             fixlv = Quality::special;
         }
         break;
@@ -1216,15 +1215,15 @@ int access_item_db(int dbmode)
     case 663:
         if (dbmode == 3)
         {
-            inv[ci].is_precious() = true;
+            item.is_precious() = true;
             fixlv = Quality::special;
         }
         break;
     case 662:
         if (dbmode == 3)
         {
-            inv[ci].is_precious() = true;
-            inv[ci].param2 = 7;
+            item.is_precious() = true;
+            item.param2 = 7;
             fixlv = Quality::special;
         }
         break;
@@ -1240,16 +1239,16 @@ int access_item_db(int dbmode)
             fixeditemenc(6) = 30182;
             fixeditemenc(7) = 200;
             fixeditemenc(8) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 660:
         if (dbmode == 3)
         {
-            inv[ci].count = 5 + rnd(5) - rnd(5);
-            inv[ci].has_charge() = true;
+            item.count = 5 + rnd(5) - rnd(5);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -1262,15 +1261,15 @@ int access_item_db(int dbmode)
     case 655:
         if (dbmode == 3)
         {
-            inv[ci].is_precious() = true;
-            inv[ci].param2 = 7;
+            item.is_precious() = true;
+            item.param2 = 7;
             fixlv = Quality::special;
         }
         break;
     case 654:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 160;
+            item.param1 = 160;
         }
         break;
     case 650:
@@ -1283,33 +1282,33 @@ int access_item_db(int dbmode)
     case 648:
         if (dbmode == 3)
         {
-            inv[ci].function = 44;
+            item.function = 44;
         }
         break;
     case 643:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 130;
+            item.param1 = 130;
         }
         break;
     case 641:
         if (dbmode == 3)
         {
-            inv[ci].is_precious() = true;
+            item.is_precious() = true;
             fixlv = Quality::special;
         }
         break;
     case 640:
         if (dbmode == 3)
         {
-            inv[ci].function = 25;
+            item.function = 25;
         }
         break;
     case 639:
         if (dbmode == 3)
         {
-            inv[ci].is_precious() = true;
-            inv[ci].param2 = 7;
+            item.is_precious() = true;
+            item.param2 = 7;
             fixlv = Quality::special;
         }
         break;
@@ -1325,26 +1324,26 @@ int access_item_db(int dbmode)
     case 637:
         if (dbmode == 3)
         {
-            inv[ci].is_precious() = true;
+            item.is_precious() = true;
             fixlv = Quality::special;
         }
         break;
     case 635:
         if (dbmode == 3)
         {
-            inv[ci].function = 24;
+            item.function = 24;
         }
         break;
     case 634:
         if (dbmode == 3)
         {
-            inv[ci].function = 23;
+            item.function = 23;
         }
         break;
     case 633:
         if (dbmode == 3)
         {
-            inv[ci].skill = 111;
+            item.skill = 111;
             fixeditemenc(0) = 70054;
             fixeditemenc(1) = 800;
             fixeditemenc(2) = 0;
@@ -1362,22 +1361,22 @@ int access_item_db(int dbmode)
     case 630:
         if (dbmode == 3)
         {
-            inv[ci].function = 21;
+            item.function = 21;
         }
         break;
     case 629:
         if (dbmode == 3)
         {
-            inv[ci].function = 20;
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.function = 20;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         break;
     case 628:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -1403,15 +1402,15 @@ int access_item_db(int dbmode)
             fixeditemenc(10) = 30161;
             fixeditemenc(11) = 300;
             fixeditemenc(12) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 626:
         if (dbmode == 3)
         {
-            inv[ci].is_precious() = true;
+            item.is_precious() = true;
         }
         if (dbmode == 15)
         {
@@ -1424,13 +1423,13 @@ int access_item_db(int dbmode)
     case 625:
         if (dbmode == 3)
         {
-            inv[ci].is_precious() = true;
+            item.is_precious() = true;
         }
         break;
     case 624:
         if (dbmode == 3)
         {
-            inv[ci].is_precious() = true;
+            item.is_precious() = true;
         }
         if (dbmode == 13)
         {
@@ -1443,7 +1442,7 @@ int access_item_db(int dbmode)
     case 623:
         if (dbmode == 3)
         {
-            inv[ci].is_precious() = true;
+            item.is_precious() = true;
         }
         if (dbmode == 13)
         {
@@ -1456,7 +1455,7 @@ int access_item_db(int dbmode)
     case 622:
         if (dbmode == 3)
         {
-            inv[ci].is_precious() = true;
+            item.is_precious() = true;
         }
         break;
     case 621:
@@ -1480,8 +1479,8 @@ int access_item_db(int dbmode)
     case 618:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 6000;
-            inv[ci].param3 = 4;
+            item.param1 = 6000;
+            item.param3 = 4;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -1491,45 +1490,45 @@ int access_item_db(int dbmode)
     case 616:
         if (dbmode == 3)
         {
-            inv[ci].is_precious() = true;
+            item.is_precious() = true;
         }
         break;
     case 615:
         if (dbmode == 3)
         {
-            inv[ci].is_precious() = true;
+            item.is_precious() = true;
         }
         break;
     case 613:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 180;
+            item.param1 = 180;
         }
         break;
     case 611:
         if (dbmode == 3)
         {
-            inv[ci].function = 8;
+            item.function = 8;
         }
         break;
     case 606:
         if (dbmode == 3)
         {
-            inv[ci].function = 15;
-            inv[ci].param1 = 225;
+            item.function = 15;
+            item.param1 = 225;
         }
         break;
     case 603:
         if (dbmode == 3)
         {
-            inv[ci].function = 44;
-            inv[ci].is_precious() = true;
+            item.function = 44;
+            item.is_precious() = true;
         }
         break;
     case 602:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 100;
+            item.param2 = 100;
         }
         if (dbmode == 15)
         {
@@ -1540,25 +1539,25 @@ int access_item_db(int dbmode)
     case 600:
         if (dbmode == 3)
         {
-            inv[ci].is_precious() = true;
+            item.is_precious() = true;
         }
         break;
     case 598:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 6;
+            item.param1 = 6;
         }
         break;
     case 597:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 6;
+            item.param1 = 6;
         }
         break;
     case 587:
         if (dbmode == 3)
         {
-            inv[ci].function = 14;
+            item.function = 14;
         }
         if (dbmode == 15)
         {
@@ -1571,15 +1570,15 @@ int access_item_db(int dbmode)
     case 583:
         if (dbmode == 3)
         {
-            inv[ci].function = 13;
-            inv[ci].param1 = 100;
+            item.function = 13;
+            item.param1 = 100;
         }
         break;
     case 582:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -1592,8 +1591,8 @@ int access_item_db(int dbmode)
     case 581:
         if (dbmode == 3)
         {
-            inv[ci].count = 6 + rnd(6) - rnd(6);
-            inv[ci].has_charge() = true;
+            item.count = 6 + rnd(6) - rnd(6);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -1605,7 +1604,7 @@ int access_item_db(int dbmode)
     case 578:
         if (dbmode == 3)
         {
-            inv[ci].function = 11;
+            item.function = 11;
         }
         break;
     case 577:
@@ -1620,7 +1619,7 @@ int access_item_db(int dbmode)
     case 576:
         if (dbmode == 3)
         {
-            inv[ci].function = 10;
+            item.function = 10;
         }
         break;
     case 574:
@@ -1635,8 +1634,8 @@ int access_item_db(int dbmode)
     case 573:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 8000;
-            inv[ci].param3 = 240;
+            item.param1 = 8000;
+            item.param3 = 240;
         }
         break;
     case 572:
@@ -1649,14 +1648,14 @@ int access_item_db(int dbmode)
     case 571:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 5;
+            item.param2 = 5;
         }
         break;
     case 570:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -1668,8 +1667,8 @@ int access_item_db(int dbmode)
     case 569:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -1682,15 +1681,15 @@ int access_item_db(int dbmode)
     case 568:
         if (dbmode == 3)
         {
-            inv[ci].count = 12 + rnd(12) - rnd(12);
-            inv[ci].has_charge() = true;
+            item.count = 12 + rnd(12) - rnd(12);
+            item.has_charge() = true;
         }
         break;
     case 567:
         if (dbmode == 3)
         {
-            inv[ci].count = 12 + rnd(12) - rnd(12);
-            inv[ci].has_charge() = true;
+            item.count = 12 + rnd(12) - rnd(12);
+            item.has_charge() = true;
         }
         break;
     case 566:
@@ -1705,8 +1704,8 @@ int access_item_db(int dbmode)
     case 565:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -1718,8 +1717,8 @@ int access_item_db(int dbmode)
     case 564:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -1732,7 +1731,7 @@ int access_item_db(int dbmode)
     case 563:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 0;
+            item.param1 = 0;
         }
         if (dbmode == 13)
         {
@@ -1743,13 +1742,13 @@ int access_item_db(int dbmode)
     case 562:
         if (dbmode == 3)
         {
-            inv[ci].function = 8;
+            item.function = 8;
         }
         break;
     case 560:
         if (dbmode == 3)
         {
-            inv[ci].is_precious() = true;
+            item.is_precious() = true;
         }
         break;
     case 559:
@@ -1790,13 +1789,13 @@ int access_item_db(int dbmode)
     case 555:
         if (dbmode == 3)
         {
-            inv[ci].function = 7;
+            item.function = 7;
         }
         break;
     case 554:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 1;
+            item.param2 = 1;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -1806,7 +1805,7 @@ int access_item_db(int dbmode)
     case 553:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 1;
+            item.param2 = 1;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -1824,8 +1823,8 @@ int access_item_db(int dbmode)
     case 551:
         if (dbmode == 3)
         {
-            inv[ci].count = 3 + rnd(3) - rnd(3);
-            inv[ci].has_charge() = true;
+            item.count = 3 + rnd(3) - rnd(3);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -1837,8 +1836,8 @@ int access_item_db(int dbmode)
     case 550:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -1860,8 +1859,8 @@ int access_item_db(int dbmode)
     case 548:
         if (dbmode == 3)
         {
-            inv[ci].count = 3 + rnd(3) - rnd(3);
-            inv[ci].has_charge() = true;
+            item.count = 3 + rnd(3) - rnd(3);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -1874,8 +1873,8 @@ int access_item_db(int dbmode)
     case 546:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -1888,8 +1887,8 @@ int access_item_db(int dbmode)
     case 545:
         if (dbmode == 3)
         {
-            inv[ci].count = 7 + rnd(7) - rnd(7);
-            inv[ci].has_charge() = true;
+            item.count = 7 + rnd(7) - rnd(7);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -1901,8 +1900,8 @@ int access_item_db(int dbmode)
     case 544:
         if (dbmode == 3)
         {
-            inv[ci].function = 6;
-            inv[ci].param1 = discsetmc();
+            item.function = 6;
+            item.param1 = discsetmc();
         }
         break;
     case 543:
@@ -1922,14 +1921,14 @@ int access_item_db(int dbmode)
     case 526:
         if (dbmode == 3)
         {
-            inv[ci].param1 = rnd(5) + 2;
-            inv[ci].param2 = choice(isetfruit);
+            item.param1 = rnd(5) + 2;
+            item.param2 = choice(isetfruit);
         }
         break;
     case 522:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 1;
+            item.param1 = 1;
         }
         if (dbmode == 13)
         {
@@ -1940,7 +1939,7 @@ int access_item_db(int dbmode)
     case 521:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 1;
+            item.param1 = 1;
         }
         if (dbmode == 13)
         {
@@ -1968,8 +1967,8 @@ int access_item_db(int dbmode)
     case 518:
         if (dbmode == 3)
         {
-            inv[ci].count = 3 + rnd(3) - rnd(3);
-            inv[ci].has_charge() = true;
+            item.count = 3 + rnd(3) - rnd(3);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -1981,8 +1980,8 @@ int access_item_db(int dbmode)
     case 517:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -2012,7 +2011,7 @@ int access_item_db(int dbmode)
     case 514:
         if (dbmode == 3)
         {
-            inv[ci].skill = 110;
+            item.skill = 110;
             fixeditemenc(0) = 80003;
             fixeditemenc(1) = 350;
             fixeditemenc(2) = 80004;
@@ -2024,21 +2023,21 @@ int access_item_db(int dbmode)
             fixeditemenc(8) = 20059;
             fixeditemenc(9) = 300;
             fixeditemenc(10) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 513:
         if (dbmode == 3)
         {
-            inv[ci].skill = 110;
+            item.skill = 110;
         }
         break;
     case 512:
         if (dbmode == 3)
         {
-            inv[ci].skill = 110;
+            item.skill = 110;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -2048,12 +2047,12 @@ int access_item_db(int dbmode)
     case 511:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 100 + rnd(200);
+            item.param1 = 100 + rnd(200);
         }
         if (dbmode == 13)
         {
             efid = 1128;
-            efp = inv[ci].param1;
+            efp = item.param1;
             read_scroll();
             return -1;
         }
@@ -2097,7 +2096,7 @@ int access_item_db(int dbmode)
     case 505:
         if (dbmode == 3)
         {
-            inv[ci].is_precious() = true;
+            item.is_precious() = true;
         }
         if (dbmode == 13)
         {
@@ -2137,25 +2136,25 @@ int access_item_db(int dbmode)
     case 499:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 7;
+            item.param2 = 7;
         }
         break;
     case 498:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 6;
+            item.param2 = 6;
         }
         break;
     case 497:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 5;
+            item.param2 = 5;
         }
         break;
     case 496:
         if (dbmode == 3)
         {
-            inv[ci].skill = 110;
+            item.skill = 110;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -2201,7 +2200,7 @@ int access_item_db(int dbmode)
     case 488:
         if (dbmode == 3)
         {
-            inv[ci].function = 9;
+            item.function = 9;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -2223,8 +2222,8 @@ int access_item_db(int dbmode)
     case 485:
         if (dbmode == 3)
         {
-            inv[ci].count = 8 + rnd(8) - rnd(8);
-            inv[ci].has_charge() = true;
+            item.count = 8 + rnd(8) - rnd(8);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -2236,8 +2235,8 @@ int access_item_db(int dbmode)
     case 484:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2250,13 +2249,13 @@ int access_item_db(int dbmode)
     case 483:
         if (dbmode == 3)
         {
-            inv[ci].skill = 109;
+            item.skill = 109;
         }
         break;
     case 482:
         if (dbmode == 3)
         {
-            inv[ci].skill = 109;
+            item.skill = 109;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -2266,8 +2265,8 @@ int access_item_db(int dbmode)
     case 481:
         if (dbmode == 3)
         {
-            inv[ci].count = 2 + rnd(2) - rnd(2);
-            inv[ci].has_charge() = true;
+            item.count = 2 + rnd(2) - rnd(2);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2280,8 +2279,8 @@ int access_item_db(int dbmode)
     case 480:
         if (dbmode == 3)
         {
-            inv[ci].count = 2 + rnd(2) - rnd(2);
-            inv[ci].has_charge() = true;
+            item.count = 2 + rnd(2) - rnd(2);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -2302,50 +2301,50 @@ int access_item_db(int dbmode)
     case 478:
         if (dbmode == 3)
         {
-            inv[ci].function = 5;
+            item.function = 5;
         }
         break;
     case 454:
         if (dbmode == 3)
         {
-            inv[ci].skill = 168;
+            item.skill = 168;
         }
         break;
     case 453:
         if (dbmode == 3)
         {
-            inv[ci].skill = 168;
+            item.skill = 168;
         }
         break;
     case 452:
         if (dbmode == 3)
         {
-            inv[ci].skill = 168;
+            item.skill = 168;
         }
         break;
     case 451:
         if (dbmode == 3)
         {
-            inv[ci].skill = 168;
+            item.skill = 168;
         }
         break;
     case 450:
         if (dbmode == 3)
         {
-            inv[ci].skill = 168;
+            item.skill = 168;
         }
         break;
     case 449:
         if (dbmode == 3)
         {
-            inv[ci].skill = 168;
+            item.skill = 168;
         }
         break;
     case 434:
         if (dbmode == 3)
         {
-            inv[ci].count = 2 + rnd(2) - rnd(2);
-            inv[ci].has_charge() = true;
+            item.count = 2 + rnd(2) - rnd(2);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2403,49 +2402,49 @@ int access_item_db(int dbmode)
     case 428:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 0;
+            item.param1 = 0;
         }
         break;
     case 427:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 7;
+            item.param2 = 7;
         }
         break;
     case 426:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 3;
+            item.param2 = 3;
         }
         break;
     case 425:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 6;
+            item.param2 = 6;
         }
         break;
     case 424:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 3;
+            item.param2 = 3;
         }
         break;
     case 423:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 4;
+            item.param2 = 4;
         }
         break;
     case 422:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 1;
+            item.param2 = 1;
         }
         break;
     case 421:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 1;
+            item.param2 = 1;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -2455,7 +2454,7 @@ int access_item_db(int dbmode)
     case 420:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 1;
+            item.param2 = 1;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -2465,7 +2464,7 @@ int access_item_db(int dbmode)
     case 419:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 1;
+            item.param2 = 1;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -2475,7 +2474,7 @@ int access_item_db(int dbmode)
     case 418:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 1;
+            item.param2 = 1;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -2485,7 +2484,7 @@ int access_item_db(int dbmode)
     case 417:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 1;
+            item.param2 = 1;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -2495,8 +2494,8 @@ int access_item_db(int dbmode)
     case 412:
         if (dbmode == 3)
         {
-            inv[ci].count = 3 + rnd(3) - rnd(3);
-            inv[ci].has_charge() = true;
+            item.count = 3 + rnd(3) - rnd(3);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -2517,8 +2516,8 @@ int access_item_db(int dbmode)
     case 410:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2531,67 +2530,67 @@ int access_item_db(int dbmode)
     case 409:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 5;
+            item.param1 = 5;
         }
         break;
     case 408:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 1;
+            item.param1 = 1;
         }
         break;
     case 407:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 2;
+            item.param1 = 2;
         }
         break;
     case 406:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 0;
+            item.param1 = 0;
         }
         break;
     case 405:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 3;
+            item.param1 = 3;
         }
         break;
     case 404:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 0;
+            item.param1 = 0;
         }
         break;
     case 403:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 3;
+            item.param1 = 3;
         }
         break;
     case 402:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 5;
+            item.param1 = 5;
         }
         break;
     case 401:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 4;
+            item.param1 = 4;
         }
         break;
     case 400:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 2;
+            item.param1 = 2;
         }
         break;
     case 399:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 1;
+            item.param1 = 1;
         }
         break;
     case 398:
@@ -2606,8 +2605,8 @@ int access_item_db(int dbmode)
     case 397:
         if (dbmode == 3)
         {
-            inv[ci].count = 5 + rnd(5) - rnd(5);
-            inv[ci].has_charge() = true;
+            item.count = 5 + rnd(5) - rnd(5);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2620,8 +2619,8 @@ int access_item_db(int dbmode)
     case 396:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2643,7 +2642,7 @@ int access_item_db(int dbmode)
     case 393:
         if (dbmode == 3)
         {
-            inv[ci].function = 3;
+            item.function = 3;
         }
         break;
     case 392:
@@ -2658,8 +2657,8 @@ int access_item_db(int dbmode)
     case 391:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -2698,8 +2697,8 @@ int access_item_db(int dbmode)
     case 387:
         if (dbmode == 3)
         {
-            inv[ci].count = 3 + rnd(3) - rnd(3);
-            inv[ci].has_charge() = true;
+            item.count = 3 + rnd(3) - rnd(3);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2712,8 +2711,8 @@ int access_item_db(int dbmode)
     case 386:
         if (dbmode == 3)
         {
-            inv[ci].count = 3 + rnd(3) - rnd(3);
-            inv[ci].has_charge() = true;
+            item.count = 3 + rnd(3) - rnd(3);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2726,8 +2725,8 @@ int access_item_db(int dbmode)
     case 385:
         if (dbmode == 3)
         {
-            inv[ci].count = 6 + rnd(6) - rnd(6);
-            inv[ci].has_charge() = true;
+            item.count = 6 + rnd(6) - rnd(6);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -2748,8 +2747,8 @@ int access_item_db(int dbmode)
     case 383:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2771,8 +2770,8 @@ int access_item_db(int dbmode)
     case 381:
         if (dbmode == 3)
         {
-            inv[ci].count = 3 + rnd(3) - rnd(3);
-            inv[ci].has_charge() = true;
+            item.count = 3 + rnd(3) - rnd(3);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2785,8 +2784,8 @@ int access_item_db(int dbmode)
     case 380:
         if (dbmode == 3)
         {
-            inv[ci].count = 3 + rnd(3) - rnd(3);
-            inv[ci].has_charge() = true;
+            item.count = 3 + rnd(3) - rnd(3);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2808,8 +2807,8 @@ int access_item_db(int dbmode)
     case 378:
         if (dbmode == 3)
         {
-            inv[ci].count = 5 + rnd(5) - rnd(5);
-            inv[ci].has_charge() = true;
+            item.count = 5 + rnd(5) - rnd(5);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2822,8 +2821,8 @@ int access_item_db(int dbmode)
     case 377:
         if (dbmode == 3)
         {
-            inv[ci].count = 8 + rnd(8) - rnd(8);
-            inv[ci].has_charge() = true;
+            item.count = 8 + rnd(8) - rnd(8);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -2853,8 +2852,8 @@ int access_item_db(int dbmode)
     case 374:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2867,8 +2866,8 @@ int access_item_db(int dbmode)
     case 373:
         if (dbmode == 3)
         {
-            inv[ci].count = 3 + rnd(3) - rnd(3);
-            inv[ci].has_charge() = true;
+            item.count = 3 + rnd(3) - rnd(3);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2890,8 +2889,8 @@ int access_item_db(int dbmode)
     case 371:
         if (dbmode == 3)
         {
-            inv[ci].count = 3 + rnd(3) - rnd(3);
-            inv[ci].has_charge() = true;
+            item.count = 3 + rnd(3) - rnd(3);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2913,8 +2912,8 @@ int access_item_db(int dbmode)
     case 369:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2936,8 +2935,8 @@ int access_item_db(int dbmode)
     case 367:
         if (dbmode == 3)
         {
-            inv[ci].count = 3 + rnd(3) - rnd(3);
-            inv[ci].has_charge() = true;
+            item.count = 3 + rnd(3) - rnd(3);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -2950,8 +2949,8 @@ int access_item_db(int dbmode)
     case 366:
         if (dbmode == 3)
         {
-            inv[ci].count = 7 + rnd(7) - rnd(7);
-            inv[ci].has_charge() = true;
+            item.count = 7 + rnd(7) - rnd(7);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -2963,8 +2962,8 @@ int access_item_db(int dbmode)
     case 365:
         if (dbmode == 3)
         {
-            inv[ci].count = 5 + rnd(5) - rnd(5);
-            inv[ci].has_charge() = true;
+            item.count = 5 + rnd(5) - rnd(5);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3017,15 +3016,15 @@ int access_item_db(int dbmode)
             fixeditemenc(10) = 20059;
             fixeditemenc(11) = 200;
             fixeditemenc(12) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 359:
         if (dbmode == 3)
         {
-            inv[ci].skill = 104;
+            item.skill = 104;
             fixeditemenc(0) = 40;
             fixeditemenc(1) = 400;
             fixeditemenc(2) = 70056;
@@ -3035,15 +3034,15 @@ int access_item_db(int dbmode)
             fixeditemenc(6) = 26;
             fixeditemenc(7) = 100;
             fixeditemenc(8) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 358:
         if (dbmode == 3)
         {
-            inv[ci].skill = 105;
+            item.skill = 105;
             fixeditemenc(0) = 80002;
             fixeditemenc(1) = 400;
             fixeditemenc(2) = 70054;
@@ -3057,8 +3056,8 @@ int access_item_db(int dbmode)
             fixeditemenc(10) = 30172;
             fixeditemenc(11) = 420;
             fixeditemenc(12) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
@@ -3082,15 +3081,15 @@ int access_item_db(int dbmode)
             fixeditemenc(14) = 24;
             fixeditemenc(15) = 100;
             fixeditemenc(16) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 356:
         if (dbmode == 3)
         {
-            inv[ci].skill = 103;
+            item.skill = 103;
             fixeditemenc(0) = 38;
             fixeditemenc(1) = 300;
             fixeditemenc(2) = 20050;
@@ -3104,8 +3103,8 @@ int access_item_db(int dbmode)
             fixeditemenc(10) = 26;
             fixeditemenc(11) = 100;
             fixeditemenc(12) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
@@ -3127,16 +3126,16 @@ int access_item_db(int dbmode)
             fixeditemenc(12) = 25;
             fixeditemenc(13) = 100;
             fixeditemenc(14) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 354:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 6000;
-            inv[ci].param3 = 4;
+            item.param1 = 6000;
+            item.param3 = 4;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -3146,8 +3145,8 @@ int access_item_db(int dbmode)
     case 353:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 6000;
-            inv[ci].param3 = 4;
+            item.param1 = 6000;
+            item.param3 = 4;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -3157,8 +3156,8 @@ int access_item_db(int dbmode)
     case 352:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 6000;
-            inv[ci].param3 = 4;
+            item.param1 = 6000;
+            item.param3 = 4;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -3168,8 +3167,8 @@ int access_item_db(int dbmode)
     case 351:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 6000;
-            inv[ci].param3 = 4;
+            item.param1 = 6000;
+            item.param3 = 4;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -3179,8 +3178,8 @@ int access_item_db(int dbmode)
     case 350:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 6000;
-            inv[ci].param3 = 4;
+            item.param1 = 6000;
+            item.param3 = 4;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -3190,8 +3189,8 @@ int access_item_db(int dbmode)
     case 349:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 6000;
-            inv[ci].param3 = 4;
+            item.param1 = 6000;
+            item.param3 = 4;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -3201,8 +3200,8 @@ int access_item_db(int dbmode)
     case 348:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 6000;
-            inv[ci].param3 = 4;
+            item.param1 = 6000;
+            item.param3 = 4;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -3212,8 +3211,8 @@ int access_item_db(int dbmode)
     case 347:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 6000;
-            inv[ci].param3 = 4;
+            item.param1 = 6000;
+            item.param3 = 4;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -3223,8 +3222,8 @@ int access_item_db(int dbmode)
     case 346:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 6000;
-            inv[ci].param3 = 4;
+            item.param1 = 6000;
+            item.param3 = 4;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -3234,8 +3233,8 @@ int access_item_db(int dbmode)
     case 345:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 6000;
-            inv[ci].param3 = 4;
+            item.param1 = 6000;
+            item.param3 = 4;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -3245,7 +3244,7 @@ int access_item_db(int dbmode)
     case 344:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 1;
+            item.param1 = 1;
         }
         if (dbmode == 13)
         {
@@ -3256,125 +3255,125 @@ int access_item_db(int dbmode)
     case 343:
         if (dbmode == 3)
         {
-            inv[ci].function = 22;
+            item.function = 22;
         }
         break;
     case 342:
         if (dbmode == 3)
         {
-            inv[ci].function = 16;
-            inv[ci].param1 = 60;
+            item.function = 16;
+            item.param1 = 60;
         }
         break;
     case 334:
         if (dbmode == 3)
         {
-            inv[ci].function = 44;
+            item.function = 44;
         }
         break;
     case 333:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 3;
+            item.param2 = 3;
         }
         break;
     case 330:
         if (dbmode == 3)
         {
-            inv[ci].function = 44;
+            item.function = 44;
         }
         break;
     case 328:
         if (dbmode == 3)
         {
-            inv[ci].function = 17;
-            inv[ci].param1 = 150;
+            item.function = 17;
+            item.param1 = 150;
         }
         break;
     case 327:
         if (dbmode == 3)
         {
-            inv[ci].function = 44;
+            item.function = 44;
         }
         break;
     case 325:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 130;
+            item.param1 = 130;
         }
         break;
     case 322:
         if (dbmode == 3)
         {
-            inv[ci].function = 19;
+            item.function = 19;
         }
         break;
     case 319:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 0;
+            item.param1 = 0;
         }
         break;
     case 310:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 130;
+            item.param1 = 130;
         }
         break;
     case 309:
         if (dbmode == 3)
         {
-            inv[ci].function = 19;
+            item.function = 19;
         }
         break;
     case 307:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 130;
+            item.param1 = 130;
         }
         break;
     case 306:
         if (dbmode == 3)
         {
-            inv[ci].function = 15;
-            inv[ci].param1 = 200;
+            item.function = 15;
+            item.param1 = 200;
         }
         break;
     case 305:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 130;
+            item.param1 = 130;
         }
         break;
     case 304:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 100;
+            item.param1 = 100;
         }
         break;
     case 303:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 120;
+            item.param1 = 120;
         }
         break;
     case 299:
         if (dbmode == 3)
         {
-            inv[ci].function = 19;
+            item.function = 19;
         }
         break;
     case 297:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 150;
+            item.param1 = 150;
         }
         break;
     case 290:
         if (dbmode == 3)
         {
-            inv[ci].count = 1 + rnd(1) - rnd(1);
-            inv[ci].has_charge() = true;
+            item.count = 1 + rnd(1) - rnd(1);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -3386,8 +3385,8 @@ int access_item_db(int dbmode)
     case 289:
         if (dbmode == 3)
         {
-            inv[ci].count = 1 + rnd(1) - rnd(1);
-            inv[ci].has_charge() = true;
+            item.count = 1 + rnd(1) - rnd(1);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3436,8 +3435,8 @@ int access_item_db(int dbmode)
     case 272:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3450,8 +3449,8 @@ int access_item_db(int dbmode)
     case 271:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3464,8 +3463,8 @@ int access_item_db(int dbmode)
     case 270:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3478,8 +3477,8 @@ int access_item_db(int dbmode)
     case 269:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3492,8 +3491,8 @@ int access_item_db(int dbmode)
     case 268:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3506,8 +3505,8 @@ int access_item_db(int dbmode)
     case 267:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3520,14 +3519,14 @@ int access_item_db(int dbmode)
     case 266:
         if (dbmode == 3)
         {
-            inv[ci].skill = 101;
+            item.skill = 101;
         }
         break;
     case 265:
         if (dbmode == 3)
         {
-            inv[ci].count = 3 + rnd(3) - rnd(3);
-            inv[ci].has_charge() = true;
+            item.count = 3 + rnd(3) - rnd(3);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3540,8 +3539,8 @@ int access_item_db(int dbmode)
     case 264:
         if (dbmode == 3)
         {
-            inv[ci].count = 3 + rnd(3) - rnd(3);
-            inv[ci].has_charge() = true;
+            item.count = 3 + rnd(3) - rnd(3);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3554,8 +3553,8 @@ int access_item_db(int dbmode)
     case 263:
         if (dbmode == 3)
         {
-            inv[ci].count = 3 + rnd(3) - rnd(3);
-            inv[ci].has_charge() = true;
+            item.count = 3 + rnd(3) - rnd(3);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3577,8 +3576,8 @@ int access_item_db(int dbmode)
     case 261:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 6000;
-            inv[ci].param3 = 6;
+            item.param1 = 6000;
+            item.param3 = 6;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -3588,28 +3587,28 @@ int access_item_db(int dbmode)
     case 260:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 7000;
-            inv[ci].param3 = 240;
+            item.param1 = 7000;
+            item.param3 = 240;
         }
         break;
     case 259:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 5000;
-            inv[ci].param3 = 24;
+            item.param1 = 5000;
+            item.param3 = 24;
         }
         break;
     case 258:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 3;
+            item.param2 = 3;
         }
         break;
     case 257:
         if (dbmode == 3)
         {
-            inv[ci].count = 5 + rnd(5) - rnd(5);
-            inv[ci].has_charge() = true;
+            item.count = 5 + rnd(5) - rnd(5);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3622,23 +3621,23 @@ int access_item_db(int dbmode)
     case 256:
         if (dbmode == 3)
         {
-            inv[ci].function = 15;
-            inv[ci].param1 = 80;
+            item.function = 15;
+            item.param1 = 80;
         }
         break;
     case 255:
         if (dbmode == 3)
         {
-            inv[ci].function = 15;
-            inv[ci].param1 = 40;
+            item.function = 15;
+            item.param1 = 40;
         }
         break;
     case 254:
         if (dbmode == 3)
         {
-            inv[ci].skill = 183;
-            inv[ci].function = 17;
-            inv[ci].param1 = 110;
+            item.skill = 183;
+            item.function = 17;
+            item.param1 = 110;
         }
         break;
     case 253:
@@ -3653,8 +3652,8 @@ int access_item_db(int dbmode)
     case 252:
         if (dbmode == 3)
         {
-            inv[ci].count = 2 + rnd(2) - rnd(2);
-            inv[ci].has_charge() = true;
+            item.count = 2 + rnd(2) - rnd(2);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3667,8 +3666,8 @@ int access_item_db(int dbmode)
     case 251:
         if (dbmode == 3)
         {
-            inv[ci].count = 3 + rnd(3) - rnd(3);
-            inv[ci].has_charge() = true;
+            item.count = 3 + rnd(3) - rnd(3);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3681,8 +3680,8 @@ int access_item_db(int dbmode)
     case 250:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3695,8 +3694,8 @@ int access_item_db(int dbmode)
     case 249:
         if (dbmode == 3)
         {
-            inv[ci].count = 5 + rnd(5) - rnd(5);
-            inv[ci].has_charge() = true;
+            item.count = 5 + rnd(5) - rnd(5);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3709,8 +3708,8 @@ int access_item_db(int dbmode)
     case 248:
         if (dbmode == 3)
         {
-            inv[ci].count = 3 + rnd(3) - rnd(3);
-            inv[ci].has_charge() = true;
+            item.count = 3 + rnd(3) - rnd(3);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3723,8 +3722,8 @@ int access_item_db(int dbmode)
     case 247:
         if (dbmode == 3)
         {
-            inv[ci].count = 2 + rnd(2) - rnd(2);
-            inv[ci].has_charge() = true;
+            item.count = 2 + rnd(2) - rnd(2);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3737,8 +3736,8 @@ int access_item_db(int dbmode)
     case 246:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -3796,31 +3795,31 @@ int access_item_db(int dbmode)
     case 235:
         if (dbmode == 3)
         {
-            inv[ci].skill = 104;
+            item.skill = 104;
         }
         break;
     case 234:
         if (dbmode == 3)
         {
-            inv[ci].skill = 102;
+            item.skill = 102;
         }
         break;
     case 233:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 3;
+            item.param2 = 3;
         }
         break;
     case 232:
         if (dbmode == 3)
         {
-            inv[ci].skill = 100;
+            item.skill = 100;
         }
         break;
     case 231:
         if (dbmode == 3)
         {
-            inv[ci].skill = 110;
+            item.skill = 110;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -3830,7 +3829,7 @@ int access_item_db(int dbmode)
     case 230:
         if (dbmode == 3)
         {
-            inv[ci].skill = 108;
+            item.skill = 108;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -3840,7 +3839,7 @@ int access_item_db(int dbmode)
     case 229:
         if (dbmode == 3)
         {
-            inv[ci].skill = 105;
+            item.skill = 105;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -3850,56 +3849,56 @@ int access_item_db(int dbmode)
     case 228:
         if (dbmode == 3)
         {
-            inv[ci].skill = 104;
+            item.skill = 104;
         }
         break;
     case 227:
         if (dbmode == 3)
         {
-            inv[ci].skill = 103;
+            item.skill = 103;
         }
         break;
     case 226:
         if (dbmode == 3)
         {
-            inv[ci].skill = 102;
+            item.skill = 102;
         }
         break;
     case 225:
         if (dbmode == 3)
         {
-            inv[ci].skill = 101;
+            item.skill = 101;
         }
         break;
     case 224:
         if (dbmode == 3)
         {
-            inv[ci].skill = 100;
+            item.skill = 100;
         }
         break;
     case 223:
         if (dbmode == 3)
         {
-            inv[ci].function = 15;
-            inv[ci].param1 = 60;
+            item.function = 15;
+            item.param1 = 60;
         }
         break;
     case 219:
         if (dbmode == 3)
         {
-            inv[ci].function = 46;
+            item.function = 46;
         }
         break;
     case 213:
         if (dbmode == 3)
         {
-            inv[ci].skill = 104;
+            item.skill = 104;
         }
         break;
     case 212:
         if (dbmode == 3)
         {
-            inv[ci].skill = 105;
+            item.skill = 105;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -3909,7 +3908,7 @@ int access_item_db(int dbmode)
     case 211:
         if (dbmode == 3)
         {
-            inv[ci].skill = 107;
+            item.skill = 107;
             fixeditemenc(0) = 80025;
             fixeditemenc(1) = 100;
             fixeditemenc(2) = 0;
@@ -3918,7 +3917,7 @@ int access_item_db(int dbmode)
     case 210:
         if (dbmode == 3)
         {
-            inv[ci].skill = 111;
+            item.skill = 111;
         }
         break;
     case 209:
@@ -3933,7 +3932,7 @@ int access_item_db(int dbmode)
     case 207:
         if (dbmode == 3)
         {
-            inv[ci].skill = 108;
+            item.skill = 108;
             fixeditemenc(0) = 80001;
             fixeditemenc(1) = 100;
             fixeditemenc(2) = 60012;
@@ -3947,15 +3946,15 @@ int access_item_db(int dbmode)
             fixeditemenc(10) = 70055;
             fixeditemenc(11) = 300;
             fixeditemenc(12) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 206:
         if (dbmode == 3)
         {
-            inv[ci].skill = 101;
+            item.skill = 101;
             fixeditemenc(0) = 80000;
             fixeditemenc(1) = 200;
             fixeditemenc(2) = 70052;
@@ -3965,8 +3964,8 @@ int access_item_db(int dbmode)
             fixeditemenc(6) = 30172;
             fixeditemenc(7) = 350;
             fixeditemenc(8) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
@@ -3982,8 +3981,8 @@ int access_item_db(int dbmode)
     case 204:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 1000;
-            inv[ci].param3 = 4;
+            item.param1 = 1000;
+            item.param3 = 4;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -3993,8 +3992,8 @@ int access_item_db(int dbmode)
     case 203:
         if (dbmode == 3)
         {
-            inv[ci].count = 8 + rnd(8) - rnd(8);
-            inv[ci].has_charge() = true;
+            item.count = 8 + rnd(8) - rnd(8);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -4006,8 +4005,8 @@ int access_item_db(int dbmode)
     case 202:
         if (dbmode == 3)
         {
-            inv[ci].count = 9 + rnd(9) - rnd(9);
-            inv[ci].has_charge() = true;
+            item.count = 9 + rnd(9) - rnd(9);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -4019,8 +4018,8 @@ int access_item_db(int dbmode)
     case 201:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 2000;
-            inv[ci].param3 = 2;
+            item.param1 = 2000;
+            item.param3 = 2;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -4030,8 +4029,8 @@ int access_item_db(int dbmode)
     case 200:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 2000;
-            inv[ci].param3 = 72;
+            item.param1 = 2000;
+            item.param3 = 72;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -4041,8 +4040,8 @@ int access_item_db(int dbmode)
     case 199:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 2000;
-            inv[ci].param3 = 72;
+            item.param1 = 2000;
+            item.param3 = 72;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -4052,8 +4051,8 @@ int access_item_db(int dbmode)
     case 198:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 2000;
-            inv[ci].param3 = 72;
+            item.param1 = 2000;
+            item.param3 = 72;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -4063,35 +4062,35 @@ int access_item_db(int dbmode)
     case 197:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 3000;
-            inv[ci].param3 = 12;
+            item.param1 = 3000;
+            item.param3 = 12;
         }
         break;
     case 196:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 3000;
-            inv[ci].param3 = 8;
+            item.param1 = 3000;
+            item.param3 = 8;
         }
         break;
     case 195:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 3000;
-            inv[ci].param3 = 12;
+            item.param1 = 3000;
+            item.param3 = 12;
         }
         break;
     case 194:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 3000;
-            inv[ci].param3 = 8;
+            item.param1 = 3000;
+            item.param3 = 8;
         }
         break;
     case 193:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 2000;
+            item.param1 = 2000;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -4101,20 +4100,20 @@ int access_item_db(int dbmode)
     case 192:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 3000;
-            inv[ci].param3 = 16;
+            item.param1 = 3000;
+            item.param3 = 16;
         }
         break;
     case 191:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 4000;
+            item.param1 = 4000;
         }
         break;
     case 190:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 2000;
+            item.param1 = 2000;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -4124,8 +4123,8 @@ int access_item_db(int dbmode)
     case 188:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 2000;
-            inv[ci].param3 = 72;
+            item.param1 = 2000;
+            item.param3 = 72;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -4135,7 +4134,7 @@ int access_item_db(int dbmode)
     case 187:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 2000;
+            item.param1 = 2000;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -4145,8 +4144,8 @@ int access_item_db(int dbmode)
     case 186:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 2000;
-            inv[ci].param3 = 72;
+            item.param1 = 2000;
+            item.param3 = 72;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -4156,8 +4155,8 @@ int access_item_db(int dbmode)
     case 185:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 2000;
-            inv[ci].param3 = 72;
+            item.param1 = 2000;
+            item.param3 = 72;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -4167,43 +4166,43 @@ int access_item_db(int dbmode)
     case 184:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 3000;
-            inv[ci].param3 = 8;
+            item.param1 = 3000;
+            item.param3 = 8;
         }
         break;
     case 183:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 3000;
-            inv[ci].param3 = 16;
+            item.param1 = 3000;
+            item.param3 = 16;
         }
         break;
     case 182:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 3000;
-            inv[ci].param3 = 12;
+            item.param1 = 3000;
+            item.param3 = 12;
         }
         break;
     case 181:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 3000;
-            inv[ci].param3 = 16;
+            item.param1 = 3000;
+            item.param3 = 16;
         }
         break;
     case 180:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 3000;
-            inv[ci].param3 = 16;
+            item.param1 = 3000;
+            item.param3 = 16;
         }
         break;
     case 179:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 2000;
-            inv[ci].param3 = 48;
+            item.param1 = 2000;
+            item.param3 = 48;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -4213,22 +4212,22 @@ int access_item_db(int dbmode)
     case 178:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 3000;
-            inv[ci].param3 = 72;
+            item.param1 = 3000;
+            item.param3 = 72;
         }
         break;
     case 177:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 3000;
-            inv[ci].param3 = 72;
+            item.param1 = 3000;
+            item.param3 = 72;
         }
         break;
     case 176:
         if (dbmode == 3)
         {
-            inv[ci].count = 8 + rnd(8) - rnd(8);
-            inv[ci].has_charge() = true;
+            item.count = 8 + rnd(8) - rnd(8);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -4240,8 +4239,8 @@ int access_item_db(int dbmode)
     case 175:
         if (dbmode == 3)
         {
-            inv[ci].count = 10 + rnd(10) - rnd(10);
-            inv[ci].has_charge() = true;
+            item.count = 10 + rnd(10) - rnd(10);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -4253,13 +4252,13 @@ int access_item_db(int dbmode)
     case 174:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 110;
+            item.param1 = 110;
         }
         break;
     case 173:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 100;
+            item.param2 = 100;
         }
         if (dbmode == 15)
         {
@@ -4270,54 +4269,54 @@ int access_item_db(int dbmode)
     case 161:
         if (dbmode == 3)
         {
-            inv[ci].function = 1;
+            item.function = 1;
         }
         break;
     case 160:
         if (dbmode == 3)
         {
-            inv[ci].function = 4;
+            item.function = 4;
         }
         break;
     case 155:
         if (dbmode == 3)
         {
-            inv[ci].function = 15;
-            inv[ci].param1 = 100;
+            item.function = 15;
+            item.param1 = 100;
         }
         break;
     case 154:
         if (dbmode == 3)
         {
-            inv[ci].function = 15;
-            inv[ci].param1 = 100;
+            item.function = 15;
+            item.param1 = 100;
         }
         break;
     case 153:
         if (dbmode == 3)
         {
-            inv[ci].function = 15;
-            inv[ci].param1 = 100;
+            item.function = 15;
+            item.param1 = 100;
         }
         break;
     case 142:
         if (dbmode == 3)
         {
-            inv[ci].function = 15;
-            inv[ci].param1 = 200;
+            item.function = 15;
+            item.param1 = 200;
         }
         break;
     case 127:
         if (dbmode == 3)
         {
-            inv[ci].function = 2;
+            item.function = 2;
         }
         break;
     case 125:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -4329,8 +4328,8 @@ int access_item_db(int dbmode)
     case 123:
         if (dbmode == 3)
         {
-            inv[ci].count = 10 + rnd(10) - rnd(10);
-            inv[ci].has_charge() = true;
+            item.count = 10 + rnd(10) - rnd(10);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -4342,8 +4341,8 @@ int access_item_db(int dbmode)
     case 122:
         if (dbmode == 3)
         {
-            inv[ci].count = 8 + rnd(8) - rnd(8);
-            inv[ci].has_charge() = true;
+            item.count = 8 + rnd(8) - rnd(8);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -4355,8 +4354,8 @@ int access_item_db(int dbmode)
     case 121:
         if (dbmode == 3)
         {
-            inv[ci].count = 8 + rnd(8) - rnd(8);
-            inv[ci].has_charge() = true;
+            item.count = 8 + rnd(8) - rnd(8);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -4368,8 +4367,8 @@ int access_item_db(int dbmode)
     case 120:
         if (dbmode == 3)
         {
-            inv[ci].count = 10 + rnd(10) - rnd(10);
-            inv[ci].has_charge() = true;
+            item.count = 10 + rnd(10) - rnd(10);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -4381,8 +4380,8 @@ int access_item_db(int dbmode)
     case 119:
         if (dbmode == 3)
         {
-            inv[ci].count = 8 + rnd(8) - rnd(8);
-            inv[ci].has_charge() = true;
+            item.count = 8 + rnd(8) - rnd(8);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -4394,8 +4393,8 @@ int access_item_db(int dbmode)
     case 118:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -4408,8 +4407,8 @@ int access_item_db(int dbmode)
     case 116:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -4422,14 +4421,14 @@ int access_item_db(int dbmode)
     case 112:
         if (dbmode == 3)
         {
-            inv[ci].function = 15;
-            inv[ci].param1 = 150;
+            item.function = 15;
+            item.param1 = 150;
         }
         break;
     case 109:
         if (dbmode == 3)
         {
-            inv[ci].param2 = 100;
+            item.param2 = 100;
         }
         if (dbmode == 15)
         {
@@ -4440,45 +4439,45 @@ int access_item_db(int dbmode)
     case 102:
         if (dbmode == 3)
         {
-            inv[ci].function = 44;
+            item.function = 44;
         }
         break;
     case 101:
         if (dbmode == 3)
         {
-            inv[ci].function = 44;
+            item.function = 44;
         }
         break;
     case 92:
         if (dbmode == 3)
         {
-            inv[ci].function = 44;
+            item.function = 44;
         }
         break;
     case 88:
         if (dbmode == 3)
         {
-            inv[ci].skill = 183;
-            inv[ci].function = 17;
-            inv[ci].param1 = 200;
+            item.skill = 183;
+            item.function = 17;
+            item.param1 = 200;
         }
         break;
     case 81:
         if (dbmode == 3)
         {
-            inv[ci].function = 44;
+            item.function = 44;
         }
         break;
     case 80:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 100;
+            item.param1 = 100;
         }
         break;
     case 77:
         if (dbmode == 3)
         {
-            inv[ci].function = 44;
+            item.function = 44;
         }
         break;
     case 76:
@@ -4511,12 +4510,12 @@ int access_item_db(int dbmode)
     case 73:
         if (dbmode == 3)
         {
-            inv[ci].skill = 100;
+            item.skill = 100;
             fixeditemenc(0) = 37;
             fixeditemenc(1) = 100;
             fixeditemenc(2) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
@@ -4568,7 +4567,7 @@ int access_item_db(int dbmode)
     case 64:
         if (dbmode == 3)
         {
-            inv[ci].skill = 100;
+            item.skill = 100;
             fixeditemenc(0) = 36;
             fixeditemenc(1) = 300;
             fixeditemenc(2) = 70059;
@@ -4582,15 +4581,15 @@ int access_item_db(int dbmode)
             fixeditemenc(10) = 20056;
             fixeditemenc(11) = 200;
             fixeditemenc(12) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 63:
         if (dbmode == 3)
         {
-            inv[ci].skill = 107;
+            item.skill = 107;
             fixeditemenc(0) = 32;
             fixeditemenc(1) = 100;
             fixeditemenc(2) = 38;
@@ -4602,27 +4601,27 @@ int access_item_db(int dbmode)
             fixeditemenc(8) = 80025;
             fixeditemenc(9) = 100;
             fixeditemenc(10) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 62:
         if (dbmode == 3)
         {
-            inv[ci].skill = 110;
+            item.skill = 110;
         }
         break;
     case 61:
         if (dbmode == 3)
         {
-            inv[ci].skill = 108;
+            item.skill = 108;
         }
         break;
     case 60:
         if (dbmode == 3)
         {
-            inv[ci].skill = 110;
+            item.skill = 110;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -4632,13 +4631,13 @@ int access_item_db(int dbmode)
     case 59:
         if (dbmode == 3)
         {
-            inv[ci].skill = 168;
+            item.skill = 168;
         }
         break;
     case 58:
         if (dbmode == 3)
         {
-            inv[ci].skill = 108;
+            item.skill = 108;
         }
         if (dbmode == 16 && dbspec == 12)
         {
@@ -4648,7 +4647,7 @@ int access_item_db(int dbmode)
     case 57:
         if (dbmode == 3)
         {
-            inv[ci].skill = 100;
+            item.skill = 100;
             fixeditemenc(0) = 39;
             fixeditemenc(1) = 400;
             fixeditemenc(2) = 25;
@@ -4658,15 +4657,15 @@ int access_item_db(int dbmode)
             fixeditemenc(6) = 20058;
             fixeditemenc(7) = 200;
             fixeditemenc(8) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
     case 56:
         if (dbmode == 3)
         {
-            inv[ci].skill = 100;
+            item.skill = 100;
             fixeditemenc(0) = 40;
             fixeditemenc(1) = 300;
             fixeditemenc(2) = 70058;
@@ -4676,8 +4675,8 @@ int access_item_db(int dbmode)
             fixeditemenc(6) = 24;
             fixeditemenc(7) = 100;
             fixeditemenc(8) = 0;
-            inv[ci].is_precious() = true;
-            inv[ci].difficulty_of_identification = 500;
+            item.is_precious() = true;
+            item.difficulty_of_identification = 500;
             fixlv = Quality::special;
         }
         break;
@@ -4747,8 +4746,8 @@ int access_item_db(int dbmode)
     case 34:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -4761,8 +4760,8 @@ int access_item_db(int dbmode)
     case 33:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -4775,8 +4774,8 @@ int access_item_db(int dbmode)
     case 32:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -4842,11 +4841,11 @@ int access_item_db(int dbmode)
     case 25:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 2;
+            item.param1 = 2;
         }
         if (dbmode == 13)
         {
-            inv[ci].param1 = 2;
+            item.param1 = 2;
             read_normal_book();
             return -1;
         }
@@ -4854,7 +4853,7 @@ int access_item_db(int dbmode)
     case 24:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 0;
+            item.param1 = 0;
         }
         if (dbmode == 13)
         {
@@ -4865,11 +4864,11 @@ int access_item_db(int dbmode)
     case 23:
         if (dbmode == 3)
         {
-            inv[ci].param1 = 1;
+            item.param1 = 1;
         }
         if (dbmode == 13)
         {
-            inv[ci].param1 = 1;
+            item.param1 = 1;
             read_normal_book();
             return -1;
         }
@@ -4877,8 +4876,8 @@ int access_item_db(int dbmode)
     case 22:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -4891,8 +4890,8 @@ int access_item_db(int dbmode)
     case 21:
         if (dbmode == 3)
         {
-            inv[ci].count = 4 + rnd(4) - rnd(4);
-            inv[ci].has_charge() = true;
+            item.count = 4 + rnd(4) - rnd(4);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -4905,8 +4904,8 @@ int access_item_db(int dbmode)
     case 20:
         if (dbmode == 3)
         {
-            inv[ci].count = 5 + rnd(5) - rnd(5);
-            inv[ci].has_charge() = true;
+            item.count = 5 + rnd(5) - rnd(5);
+            item.has_charge() = true;
         }
         if (dbmode == 13)
         {
@@ -4919,8 +4918,8 @@ int access_item_db(int dbmode)
     case 19:
         if (dbmode == 3)
         {
-            inv[ci].count = 12 + rnd(12) - rnd(12);
-            inv[ci].has_charge() = true;
+            item.count = 12 + rnd(12) - rnd(12);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -4932,8 +4931,8 @@ int access_item_db(int dbmode)
     case 18:
         if (dbmode == 3)
         {
-            inv[ci].count = 8 + rnd(8) - rnd(8);
-            inv[ci].has_charge() = true;
+            item.count = 8 + rnd(8) - rnd(8);
+            item.has_charge() = true;
         }
         if (dbmode == 14)
         {
@@ -4989,25 +4988,25 @@ int access_item_db(int dbmode)
     case 4:
         if (dbmode == 3)
         {
-            inv[ci].skill = 103;
+            item.skill = 103;
         }
         break;
     case 3:
         if (dbmode == 3)
         {
-            inv[ci].skill = 102;
+            item.skill = 102;
         }
         break;
     case 2:
         if (dbmode == 3)
         {
-            inv[ci].skill = 101;
+            item.skill = 101;
         }
         break;
     case 1:
         if (dbmode == 3)
         {
-            inv[ci].skill = 100;
+            item.skill = 100;
         }
         break;
     default: break;
@@ -5015,7 +5014,5 @@ int access_item_db(int dbmode)
 
     return 0;
 }
-
-
 
 } // namespace elona

--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -1626,73 +1626,65 @@ void spot_digging()
     txt(i18n::s.get("core.locale.activity.dig_spot.finish"));
     if (map_data.type == mdata_t::MapType::world_map)
     {
-        for (const auto& cnt : items(0))
+        for (auto&& item : inv.pc())
         {
-            if (inv[cnt].number() == 0)
+            if (item.number() == 0)
             {
                 continue;
             }
-            if (inv[cnt].id == 621)
+            if (item.id == 621 && item.param1 != 0 &&
+                item.param1 == cdata.player().position.x &&
+                item.param2 == cdata.player().position.y)
             {
-                if (inv[cnt].param1 != 0)
+                snd("core.chest1");
+                txt(i18n::s.get("core.locale.activity.dig_spot."
+                                "something_is_there"),
+                    Message::color{ColorIndex::orange});
+                msg_halt();
+                snd("core.ding2");
+                flt();
+                itemcreate(
+                    -1,
+                    622,
+                    cdata.player().position.x,
+                    cdata.player().position.y,
+                    2 + rnd(3));
+                flt();
+                itemcreate(
+                    -1,
+                    55,
+                    cdata.player().position.x,
+                    cdata.player().position.y,
+                    1 + rnd(3));
+                flt();
+                itemcreate(
+                    -1,
+                    54,
+                    cdata.player().position.x,
+                    cdata.player().position.y,
+                    rnd(10000) + 2000);
+                for (int i = 0; i < 4; ++i)
                 {
-                    if (inv[cnt].param1 == cdata.player().position.x)
+                    flt(calcobjlv(cdata.player().level + 10),
+                        calcfixlv(Quality::good));
+                    if (i == 0)
                     {
-                        if (inv[cnt].param2 == cdata.player().position.y)
-                        {
-                            snd("core.chest1");
-                            txt(i18n::s.get("core.locale.activity.dig_spot."
-                                            "something_is_there"),
-                                Message::color{ColorIndex::orange});
-                            msg_halt();
-                            snd("core.ding2");
-                            flt();
-                            itemcreate(
-                                -1,
-                                622,
-                                cdata.player().position.x,
-                                cdata.player().position.y,
-                                2 + rnd(3));
-                            flt();
-                            itemcreate(
-                                -1,
-                                55,
-                                cdata.player().position.x,
-                                cdata.player().position.y,
-                                1 + rnd(3));
-                            flt();
-                            itemcreate(
-                                -1,
-                                54,
-                                cdata.player().position.x,
-                                cdata.player().position.y,
-                                rnd(10000) + 2000);
-                            for (int cnt = 0, cnt_end = (4); cnt < cnt_end;
-                                 ++cnt)
-                            {
-                                flt(calcobjlv(cdata.player().level + 10),
-                                    calcfixlv(Quality::good));
-                                if (cnt == 0)
-                                {
-                                    fixlv = Quality::godly;
-                                }
-                                flttypemajor = choice(fsetchest);
-                                itemcreate(
-                                    -1,
-                                    0,
-                                    cdata.player().position.x,
-                                    cdata.player().position.y,
-                                    0);
-                            }
-                            txt(
-                                i18n::s.get("core.locale.common.something_is_"
-                                            "put_on_the_ground"));
-                            save_set_autosave();
-                            inv[cnt].modify_number(-1);
-                            break;
-                        }
+                        fixlv = Quality::godly;
                     }
+                    flttypemajor = choice(fsetchest);
+                    itemcreate(
+                        -1,
+                        0,
+                        cdata.player().position.x,
+                        cdata.player().position.y,
+                        0);
                 }
+                txt(
+                    i18n::s.get("core.locale.common.something_is_"
+                                "put_on_the_ground"));
+                save_set_autosave();
+                item.modify_number(-1);
+                break;
             }
         }
     }

--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -535,8 +535,7 @@ void continuous_action_perform()
                                             dbid = 55;
                                         }
                                     }
-                                    int stat = itemcreate(-1, dbid, x, y, 1);
-                                    if (stat != 0)
+                                    if (itemcreate(-1, dbid, x, y, 1))
                                     {
                                         // NOTE: may cause Lua creation
                                         // callbacks to run twice.

--- a/src/elona/adventurer.cpp
+++ b/src/elona/adventurer.cpp
@@ -15,10 +15,14 @@
 #include "text.hpp"
 #include "variables.hpp"
 
+
+
 namespace elona
 {
 
 int i_at_m145 = 0;
+
+
 
 void create_all_adventurers()
 {
@@ -74,6 +78,7 @@ void create_adventurer()
 }
 
 
+
 int advfavoriteskill(int seed)
 {
     randomize(seed);
@@ -105,6 +110,8 @@ int advfavoritestat(int seed)
     randomize();
     return i_at_m145;
 }
+
+
 
 void addnews2(const std::string& news_content, int show_message)
 {
@@ -188,6 +195,7 @@ void addnews(int news_type, int adventurer, int fame, const std::string& valn)
     }
     newsbuff += u8"\n"s;
 }
+
 
 
 void adventurer_update()
@@ -311,6 +319,7 @@ void adventurer_update()
 }
 
 
+
 int adventurer_discover_equipment()
 {
     f = 0;
@@ -350,23 +359,19 @@ int adventurer_discover_equipment()
     {
         flttypemajor = choice(fsetitem);
     }
-    int stat = itemcreate(rc, 0, -1, -1, 0);
-    if (stat == 0)
+    if (itemcreate(rc, 0, -1, -1, 0))
     {
-        return 0;
-    }
-    inv[ci].identification_state = IdentifyState::completely_identified;
-    if (inv[ci].quality >= Quality::miracle)
-    {
-        if (the_item_db[inv[ci].id]->category < 50000)
+        inv[ci].identification_state = IdentifyState::completely_identified;
+        if (inv[ci].quality >= Quality::miracle)
         {
-            addnews(1, rc, 0, itemname(ci));
+            if (the_item_db[inv[ci].id]->category < 50000)
+            {
+                addnews(1, rc, 0, itemname(ci));
+            }
         }
+        wear_most_valuable_equipment();
     }
-    wear_most_valuable_equipment();
     return 0;
 }
-
-
 
 } // namespace elona

--- a/src/elona/ai.cpp
+++ b/src/elona/ai.cpp
@@ -303,19 +303,18 @@ TurnResult proc_npc_movement_event(bool retreat)
             {
                 sell(0) = 0;
                 sell(1) = 0;
-                for (const auto& cnt : items(cc))
+                for (auto&& item : inv.for_chara(cdata[cc]))
                 {
-                    if (inv[cnt].number() == 0)
+                    if (item.number() == 0)
                     {
                         continue;
                     }
-                    int category = the_item_db[inv[cnt].id]->category;
-                    if (category == 77000)
+                    if (the_item_db[item.id]->category == 77000)
                     {
-                        p = inv[cnt].value * inv[cnt].number();
-                        sell += inv[cnt].number();
+                        p = item.value * item.number();
+                        sell += item.number();
                         sell(1) += p;
-                        inv[cnt].remove();
+                        item.remove();
                         earn_gold(cdata[cc], p);
                     }
                 }

--- a/src/elona/ai.cpp
+++ b/src/elona/ai.cpp
@@ -123,34 +123,34 @@ TurnResult ai_proc_basic()
                     {
                         tlocx = cdata[tc].position.x;
                         tlocy = cdata[tc].position.y;
-                        int stat = 0;
+                        bool success = false;
                         if (act == -9999)
                         {
                             flt();
                             flttypemajor = 52000;
-                            stat = itemcreate(
+                            success = !!itemcreate(
                                 cc, choice(isetthrowpotionminor), -1, -1, 0);
                         }
                         if (act == -9998)
                         {
                             flt();
                             flttypemajor = 52000;
-                            stat = itemcreate(
+                            success = !!itemcreate(
                                 cc, choice(isetthrowpotionmajor), -1, -1, 0);
                         }
                         if (act == -9997)
                         {
                             flt();
                             flttypemajor = 52000;
-                            stat = itemcreate(
+                            success = !!itemcreate(
                                 cc, choice(isetthrowpotiongreater), -1, -1, 0);
                         }
                         if (act == -9996)
                         {
                             flt();
-                            stat = itemcreate(cc, 698, -1, -1, 0);
+                            success = !!itemcreate(cc, 698, -1, -1, 0);
                         }
-                        if (stat == 1)
+                        if (success)
                         {
                             return do_throw_command();
                         }
@@ -765,8 +765,7 @@ label_2692_internal:
                                 flttypeminor = 52002;
                             }
                         }
-                        int stat = itemcreate(cc, 0, -1, -1, 0);
-                        if (stat == 1)
+                        if (itemcreate(cc, 0, -1, -1, 0))
                         {
                             cdata[cc].item_which_will_be_used = ci;
                         }
@@ -792,9 +791,7 @@ label_2692_internal:
                                     if (is_in_fov(cdata[game_data.fire_giant]))
                                     {
                                         flt();
-                                        int stat =
-                                            itemcreate(cc, 587, -1, -1, 0);
-                                        if (stat == 1)
+                                        if (itemcreate(cc, 587, -1, -1, 0))
                                         {
                                             tlocx = cdata[game_data.fire_giant]
                                                         .position.x;
@@ -828,8 +825,7 @@ label_2692_internal:
                                 if (found_snowman)
                                 {
                                     flt();
-                                    int stat = itemcreate(cc, 587, -1, -1, 0);
-                                    if (stat == 1)
+                                    if (itemcreate(cc, 587, -1, -1, 0))
                                     {
                                         tlocx = inv[ti].position.x;
                                         tlocy = inv[ti].position.y;
@@ -845,13 +841,12 @@ label_2692_internal:
                                         .item_appearances_actual == 0)
                                 {
                                     flt();
-                                    int stat = itemcreate(
-                                        -1,
-                                        541,
-                                        cdata[cc].position.x,
-                                        cdata[cc].position.y,
-                                        0);
-                                    if (stat == 1)
+                                    if (itemcreate(
+                                            -1,
+                                            541,
+                                            cdata[cc].position.x,
+                                            cdata[cc].position.y,
+                                            0))
                                     {
                                         snd("core.snow");
                                         txt(i18n::s.get(
@@ -865,8 +860,7 @@ label_2692_internal:
                             if (rnd(12) == 0)
                             {
                                 flt();
-                                int stat = itemcreate(cc, 587, -1, -1, 0);
-                                if (stat == 1)
+                                if (itemcreate(cc, 587, -1, -1, 0))
                                 {
                                     tlocx = cdata.player().position.x;
                                     tlocy = cdata.player().position.y;
@@ -908,8 +902,8 @@ label_2692_internal:
                     {
                         flttypeminor = 52002;
                     }
-                    int stat = itemcreate(cc, 0, -1, -1, 0);
-                    if (stat == 1 && the_item_db[inv[ci].id]->is_drinkable)
+                    if (itemcreate(cc, 0, -1, -1, 0) &&
+                        the_item_db[inv[ci].id]->is_drinkable)
                     {
                         if (inv[ci].id == 577)
                         {
@@ -963,8 +957,7 @@ label_2692_internal:
                         tlocx = cdata.player().position.x;
                         tlocy = cdata.player().position.y;
                         flt();
-                        int stat = itemcreate(cc, 698, -1, -1, 0);
-                        if (stat == 1)
+                        if (itemcreate(cc, 698, -1, -1, 0))
                         {
                             if (is_in_fov(cdata[cc]))
                             {

--- a/src/elona/blending.cpp
+++ b/src/elona/blending.cpp
@@ -1627,13 +1627,12 @@ void blending_start_attempt()
         {
             flt();
             nostack = 1;
-            int stat = itemcreate(
-                -1,
-                rpdata(0, rpid),
-                cdata.player().position.x,
-                cdata.player().position.y,
-                0);
-            if (stat != 0)
+            if (itemcreate(
+                    -1,
+                    rpdata(0, rpid),
+                    cdata.player().position.x,
+                    cdata.player().position.y,
+                    0))
             {
                 for (int cnt = 0;; ++cnt)
                 {
@@ -1834,8 +1833,7 @@ void blending_proc_on_success_events()
         {
             --game_data.holy_well_count;
             flt();
-            int stat = itemcreate(0, 516, -1, -1, 0);
-            if (stat != 0)
+            if (itemcreate(0, 516, -1, -1, 0))
             {
                 inv[ci].curse_state = CurseState::blessed;
             }

--- a/src/elona/blending.cpp
+++ b/src/elona/blending.cpp
@@ -1286,22 +1286,22 @@ int blendcheckmat(int recipe_id)
             {
                 o_at_m181 = 0;
             }
-            for (const auto& cnt : items(o_at_m181))
+            for (const auto& item : o_at_m181 == -1 ? inv.ground() : inv.pc())
             {
-                if (inv[cnt].number() <= 0)
+                if (item.number() <= 0)
                 {
                     continue;
                 }
                 if ((rpdata(2, rpid) <= 0 || step_at_m181 != 0) &&
-                    inv[cnt].own_state > 0)
+                    item.own_state > 0)
                 {
                     continue;
                 }
                 if (o_at_m181 == -1)
                 {
                     if (dist(
-                            inv[cnt].position.x,
-                            inv[cnt].position.y,
+                            item.position.x,
+                            item.position.y,
                             cdata.player().position.x,
                             cdata.player().position.y) > 4)
                     {
@@ -1310,7 +1310,7 @@ int blendcheckmat(int recipe_id)
                 }
                 if (rpdata(40 + rp_at_m181, rpid))
                 {
-                    int stat = blendcheckext(cnt, rp_at_m181);
+                    int stat = blendcheckext(item.index, rp_at_m181);
                     if (stat == 0)
                     {
                         continue;
@@ -1318,7 +1318,7 @@ int blendcheckmat(int recipe_id)
                 }
                 if (id_at_m181 < 9000)
                 {
-                    if (inv[cnt].id == id_at_m181)
+                    if (item.id == id_at_m181)
                     {
                         f_at_m181 = 1;
                         break;
@@ -1328,7 +1328,7 @@ int blendcheckmat(int recipe_id)
                 if (id_at_m181 < 10000)
                 {
                     if (instr(
-                            the_item_db[inv[cnt].id]->rffilter,
+                            the_item_db[item.id]->rffilter,
                             0,
                             u8"/"s + rfnameorg(0, (id_at_m181 - 9000)) +
                                 u8"/"s) != -1 ||
@@ -1339,7 +1339,7 @@ int blendcheckmat(int recipe_id)
                     }
                     continue;
                 }
-                if (the_item_db[inv[cnt].id]->category == id_at_m181)
+                if (the_item_db[item.id]->category == id_at_m181)
                 {
                     f_at_m181 = 1;
                     break;
@@ -1375,21 +1375,21 @@ int blendmatnum(int matcher, int step)
         {
             o_at_m182 = 0;
         }
-        for (const auto& cnt : items(o_at_m182))
+        for (const auto& item : o_at_m182 == -1 ? inv.ground() : inv.pc())
         {
-            if (inv[cnt].number() <= 0)
+            if (item.number() <= 0)
             {
                 continue;
             }
-            if ((rpdata(2, rpid) <= 0 || step != 0) && inv[cnt].own_state > 0)
+            if ((rpdata(2, rpid) <= 0 || step != 0) && item.own_state > 0)
             {
                 continue;
             }
             if (o_at_m182 == -1)
             {
                 if (dist(
-                        inv[cnt].position.x,
-                        inv[cnt].position.y,
+                        item.position.x,
+                        item.position.y,
                         cdata.player().position.x,
                         cdata.player().position.y) > 4)
                 {
@@ -1398,7 +1398,7 @@ int blendmatnum(int matcher, int step)
             }
             if (rpdata(40 + step, rpid))
             {
-                int stat = blendcheckext(cnt, step);
+                int stat = blendcheckext(item.index, step);
                 if (stat == 0)
                 {
                     continue;
@@ -1406,28 +1406,28 @@ int blendmatnum(int matcher, int step)
             }
             if (matcher < 9000)
             {
-                if (inv[cnt].id == matcher)
+                if (item.id == matcher)
                 {
-                    m_at_m182 += inv[cnt].number();
+                    m_at_m182 += item.number();
                 }
                 continue;
             }
             if (matcher < 10000)
             {
                 if (instr(
-                        the_item_db[inv[cnt].id]->rffilter,
+                        the_item_db[item.id]->rffilter,
                         0,
                         u8"/"s + rfnameorg(0, (matcher - 9000)) + u8"/"s) !=
                         -1 ||
                     matcher == 9004)
                 {
-                    m_at_m182 += inv[cnt].number();
+                    m_at_m182 += item.number();
                 }
                 continue;
             }
-            if (the_item_db[inv[cnt].id]->category == matcher)
+            if (the_item_db[item.id]->category == matcher)
             {
-                m_at_m182 += inv[cnt].number();
+                m_at_m182 += item.number();
                 continue;
             }
         }
@@ -1443,7 +1443,6 @@ int blendlist(elona_vector2<int>& result_array, int step)
     int m_at_m183 = 0;
     int o_at_m183 = 0;
     int reftype_at_m183 = 0;
-    int f_at_m183 = 0;
     id_at_m183 = rpdata(20 + step, rpid);
     m_at_m183 = 0;
     for (int cnt = 0; cnt < 2; ++cnt)
@@ -1456,35 +1455,35 @@ int blendlist(elona_vector2<int>& result_array, int step)
         {
             o_at_m183 = 0;
         }
-        for (const auto& cnt : items(o_at_m183))
+        for (const auto& item : o_at_m183 == -1 ? inv.ground() : inv.pc())
         {
             if (m_at_m183 >= 500)
             {
                 break;
             }
-            if (inv[cnt].number() <= 0)
+            if (item.number() <= 0)
             {
                 continue;
             }
-            if ((rpdata(2, rpid) <= 0 || step != 0) && inv[cnt].own_state > 0)
+            if ((rpdata(2, rpid) <= 0 || step != 0) && item.own_state > 0)
             {
                 continue;
             }
             if (o_at_m183 == -1)
             {
                 if (dist(
-                        inv[cnt].position.x,
-                        inv[cnt].position.y,
+                        item.position.x,
+                        item.position.y,
                         cdata.player().position.x,
                         cdata.player().position.y) > 4)
                 {
                     continue;
                 }
             }
-            reftype_at_m183 = the_item_db[inv[cnt].id]->category;
+            reftype_at_m183 = the_item_db[item.id]->category;
             if (rpdata(40 + step, rpid))
             {
-                int stat = blendcheckext(cnt, step);
+                int stat = blendcheckext(item.index, step);
                 if (stat == 0)
                 {
                     continue;
@@ -1492,7 +1491,7 @@ int blendlist(elona_vector2<int>& result_array, int step)
             }
             if (id_at_m183 < 9000)
             {
-                if (inv[cnt].id != id_at_m183)
+                if (item.id != id_at_m183)
                 {
                     continue;
                 }
@@ -1500,7 +1499,7 @@ int blendlist(elona_vector2<int>& result_array, int step)
             else if (id_at_m183 < 10000)
             {
                 if (instr(
-                        the_item_db[inv[cnt].id]->rffilter,
+                        the_item_db[item.id]->rffilter,
                         0,
                         u8"/"s + rfnameorg(0, (id_at_m183 - 9000)) + u8"/"s) ==
                         -1 &&
@@ -1515,22 +1514,22 @@ int blendlist(elona_vector2<int>& result_array, int step)
             }
             if (step > 0)
             {
-                f_at_m183 = cnt;
-                for (int cnt = 0, cnt_end = (step); cnt < cnt_end; ++cnt)
+                bool has_already_used = false;
+                for (int i = 0; i < step; ++i)
                 {
-                    if (rpref(10 + cnt * 2) == f_at_m183)
+                    if (rpref(10 + i * 2) == item.index)
                     {
-                        f_at_m183 = -999;
+                        has_already_used = true;
                         break;
                     }
                 }
-                if (f_at_m183 == -999)
+                if (has_already_used)
                 {
                     continue;
                 }
             }
-            result_array(0, m_at_m183) = cnt;
-            result_array(1, m_at_m183) = reftype_at_m183 * 1000 + inv[cnt].id;
+            result_array(0, m_at_m183) = item.index;
+            result_array(1, m_at_m183) = reftype_at_m183 * 1000 + item.id;
             ++m_at_m183;
         }
     }

--- a/src/elona/building.cpp
+++ b/src/elona/building.cpp
@@ -1173,30 +1173,32 @@ void show_shop_log()
             flt(list(0, cnt2), static_cast<Quality>(list(1, cnt2)));
             flttypemajor = elona::stoi(listn(0, cnt2));
             nostack = 1;
-            int stat = itemcreate(-1, 0, -1, -1, 0);
-            if (stat == 0)
+            if (itemcreate(-1, 0, -1, -1, 0))
             {
-                f = 0;
-                break;
-            }
-            if (inv[ci].value > elona::stoi(listn(1, cnt2)) * 2)
-            {
-                item_stack(-1, ci);
-                f = 1;
-                break;
-            }
-            else
-            {
-                inv[ci].remove();
-                if (cnt == 3)
+                if (inv[ci].value > elona::stoi(listn(1, cnt2)) * 2)
                 {
-                    f = 0;
+                    item_stack(-1, ci);
+                    f = 1;
                     break;
                 }
                 else
                 {
-                    continue;
+                    inv[ci].remove();
+                    if (cnt == 3)
+                    {
+                        f = 0;
+                        break;
+                    }
+                    else
+                    {
+                        continue;
+                    }
                 }
+            }
+            else
+            {
+                f = 0;
+                break;
             }
         }
         if (f == 0)
@@ -1561,8 +1563,7 @@ void update_ranch()
                     (cdatan(2, chara.index) == "core.chicken" && rnd(20) == 0))
                 {
                     ++egg_or_milk_count;
-                    int stat = itemcreate(-1, 573, x, y, 0);
-                    if (stat)
+                    if (itemcreate(-1, 573, x, y, 0))
                     {
                         inv[ci].subname = chara.id;
                         inv[ci].weight = chara.weight * 10 + 250;
@@ -1577,8 +1578,7 @@ void update_ranch()
                     (cdatan(2, chara.index) == "core.sheep" && rnd(20) == 0))
                 {
                     ++egg_or_milk_count;
-                    int stat = itemcreate(-1, 574, x, y, 0);
-                    if (stat)
+                    if (itemcreate(-1, 574, x, y, 0))
                     {
                         inv[ci].subname = chara.id;
                     }
@@ -1588,8 +1588,7 @@ void update_ranch()
                 // Shit
                 if (rnd(80) == 0)
                 {
-                    int stat = itemcreate(-1, 575, x, y, 0);
-                    if (stat)
+                    if (itemcreate(-1, 575, x, y, 0))
                     {
                         inv[ci].subname = chara.id;
                         inv[ci].weight = chara.weight * 40 + 300;

--- a/src/elona/building.cpp
+++ b/src/elona/building.cpp
@@ -117,7 +117,7 @@ void prepare_house_board_tiles()
 
 
 
-int calc_heirloom_value(Item& heirloom)
+int calc_heirloom_value(const Item& heirloom)
 {
     const auto category = the_item_db[heirloom.id]->category;
 
@@ -138,7 +138,7 @@ using ItemAndValue = std::pair<int, int>;
 
 void add_heirloom_if_valuable_enough(
     std::vector<ItemAndValue>& heirlooms,
-    Item& heirloom)
+    const Item& heirloom)
 {
     const auto category = the_item_db[heirloom.id]->category;
     if (category == 60000)
@@ -394,12 +394,12 @@ TurnResult show_house_board()
     p(0) = 0;
     p(1) = 0;
     p(2) = 0;
-    for (const auto& cnt : items(-1))
+    for (const auto& item : inv.ground())
     {
         ++p(2);
-        if (inv[cnt].number() != 0)
+        if (item.number() != 0)
         {
-            if (the_item_db[inv[cnt].id]->category != 60000)
+            if (the_item_db[item.id]->category != 60000)
             {
                 ++p;
             }
@@ -1025,54 +1025,54 @@ void show_shop_log()
     }
     mode = 6;
     dblistmax = 0;
-    for (const auto& cnt : items(-1))
+    for (const auto& item : inv.ground())
     {
-        if (inv[cnt].number() <= 0)
+        if (item.number() <= 0)
         {
             continue;
         }
-        if (inv[cnt].id == 561)
+        if (item.id == 561)
         {
             continue;
         }
-        if (inv[cnt].id == 562)
+        if (item.id == 562)
         {
             continue;
         }
-        if (inv[cnt].id == 24)
+        if (item.id == 24)
         {
             continue;
         }
-        if (inv[cnt].id == 54)
+        if (item.id == 54)
         {
             continue;
         }
-        if (inv[cnt].id == 555)
+        if (item.id == 555)
         {
             continue;
         }
-        if (inv[cnt].id == 344)
+        if (item.id == 344)
         {
             continue;
         }
-        if (inv[cnt].weight < 0)
+        if (item.weight < 0)
         {
             continue;
         }
-        if (inv[cnt].quality >= Quality::special)
+        if (item.quality >= Quality::special)
         {
             continue;
         }
-        if (inv[cnt].value < 50)
+        if (item.value < 50)
         {
             continue;
         }
-        int category = the_item_db[inv[cnt].id]->category;
+        int category = the_item_db[item.id]->category;
         if (category == 60000)
         {
             continue;
         }
-        dblist(0, dblistmax) = cnt;
+        dblist(0, dblistmax) = item.index;
         dblist(1, dblistmax) = category;
         ++dblistmax;
     }
@@ -1154,9 +1154,9 @@ void show_shop_log()
     }
     else
     {
-        for (const auto& cnt : items(-1))
+        for (auto&& item : inv.ground())
         {
-            inv[cnt].remove();
+            item.remove();
         }
     }
     mode = 6;
@@ -1266,14 +1266,14 @@ void update_shop()
             cell_data.at(cnt, y).light = 0;
         }
     }
-    for (const auto& cnt : items(-1))
+    for (const auto& item : inv.ground())
     {
-        if (inv[cnt].number() <= 0)
+        if (item.number() <= 0)
         {
             continue;
         }
-        x = inv[cnt].position.x;
-        y = inv[cnt].position.y;
+        x = item.position.x;
+        y = item.position.y;
         if (x < 0 || x >= map_data.width || y < 0 || y >= map_data.height)
         {
             continue;
@@ -1321,26 +1321,26 @@ void update_museum()
     rankorg = game_data.ranks.at(3);
     rankcur = 0;
     DIM3(dblist, 2, 800);
-    for (const auto& cnt : items(-1))
+    for (const auto& item : inv.ground())
     {
-        if (inv[cnt].number() == 0)
+        if (item.number() == 0)
         {
             continue;
         }
-        if (inv[cnt].id != 503 && inv[cnt].id != 504)
+        if (item.id != 503 && item.id != 504)
         {
             continue;
         }
         if (wpeek(
-                cell_data.at(inv[cnt].position.x, inv[cnt].position.y)
+                cell_data.at(item.position.x, item.position.y)
                     .item_appearances_actual,
-                0) != inv[cnt].image)
+                0) != item.image)
         {
             continue;
         }
-        dbid = inv[cnt].subname;
-        calc_collection_value(inv[cnt].id != 503);
-        if (inv[cnt].id == 503)
+        dbid = item.subname;
+        calc_collection_value(item.id != 503);
+        if (item.id == 503)
         {
             rankcur += rtval;
         }
@@ -1390,21 +1390,21 @@ void calc_home_rank()
     game_data.total_heirloom_value = 0;
 
     std::vector<ItemAndValue> heirlooms{heirloom_list_size};
-    for (const auto& cnt : items(-1))
+    for (const auto& item : inv.ground())
     {
-        if (inv[cnt].number() == 0)
+        if (item.number() == 0)
         {
             continue;
         }
         if (wpeek(
-                cell_data.at(inv[cnt].position.x, inv[cnt].position.y)
+                cell_data.at(item.position.x, item.position.y)
                     .item_appearances_actual,
-                0) != inv[cnt].image)
+                0) != item.image)
         {
             continue;
         }
 
-        add_heirloom_if_valuable_enough(heirlooms, inv[cnt]);
+        add_heirloom_if_valuable_enough(heirlooms, item);
     }
     size_t i{};
     for (const auto& heirloom : heirlooms)

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -925,7 +925,7 @@ int calcitemvalue(int ci, int situation)
     if (inv[ci].has_charge())
     {
         dbid = inv[ci].id;
-        access_item_db(2);
+        access_item_db(inv[ci], dbid, 2);
         if (inv[ci].count < 0)
         {
             ret = ret / 10;

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -1168,29 +1168,27 @@ int calccostreload(int owner, bool do_reload)
 {
     int cost{};
 
-    for (const auto& cnt : items(owner))
+    for (auto&& item : inv.for_chara(cdata[owner]))
     {
-        if (inv[cnt].number() == 0)
+        if (item.number() == 0)
             continue;
-        if (the_item_db[inv[cnt].id]->category != 25000)
+        if (the_item_db[item.id]->category != 25000)
             continue;
 
-        int ammo = cnt;
-        for (int cnt = 0; cnt < 15; ++cnt)
+        for (auto&& enc : item.enchantments)
         {
-            if (inv[ammo].enchantments[cnt].id == 0)
+            if (enc.id == 0)
                 break;
 
-            int enc = inv[ammo].enchantments[cnt].id;
-            if (enc / 10000 == 9)
+            if (enc.id / 10000 == 9)
             {
-                int type = enc % 10000;
-                int current = inv[ammo].enchantments[cnt].power % 1000;
-                int max = inv[ammo].enchantments[cnt].power / 1000;
+                int type = enc.id % 10000;
+                int current = enc.power % 1000;
+                int max = enc.power / 1000;
                 cost += (max - current) * (50 + type * type * 10);
                 if (do_reload)
                 {
-                    inv[ammo].enchantments[cnt].power = max * 1000 + max;
+                    enc.power = max * 1000 + max;
                 }
             }
         }
@@ -1229,13 +1227,13 @@ int calcidentifyvalue(int type)
     if (type == 1)
     {
         int need_to_identify{};
-        for (const auto& cnt : items(0))
+        for (const auto& item : inv.pc())
         {
-            if (inv[cnt].number() == 0)
+            if (item.number() == 0)
             {
                 continue;
             }
-            if (inv[cnt].identification_state !=
+            if (item.identification_state !=
                 IdentifyState::completely_identified)
             {
                 ++need_to_identify;

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -814,9 +814,9 @@ int calcattackdmg(AttackDamageCalculationMode mode)
 
 
 
-int calcmedalvalue(int ci)
+int calcmedalvalue(int item_index)
 {
-    switch (inv[ci].id)
+    switch (inv[item_index].id)
     {
     case 430: return 5;
     case 431: return 8;
@@ -843,45 +843,49 @@ int calcmedalvalue(int ci)
 
 
 
-int calcitemvalue(int ci, int situation)
+int calcitemvalue(int item_index, int situation)
 {
-    int category = the_item_db[inv[ci].id]->category;
+    int category = the_item_db[inv[item_index].id]->category;
     int ret = 0;
-    if (inv[ci].identification_state == IdentifyState::unidentified)
+    if (inv[item_index].identification_state == IdentifyState::unidentified)
     {
         if (situation == 2)
         {
-            ret = inv[ci].value * 4 / 10;
+            ret = inv[item_index].value * 4 / 10;
         }
         else
         {
             ret = cdata.player().level / 5 *
-                    ((game_data.random_seed + ci * 31) % cdata.player().level +
+                    ((game_data.random_seed + item_index * 31) %
+                         cdata.player().level +
                      4) +
                 10;
         }
     }
     else if (category >= 50000)
     {
-        ret = inv[ci].value;
+        ret = inv[item_index].value;
     }
     else
     {
-        switch (inv[ci].identification_state)
+        switch (inv[item_index].identification_state)
         {
         case IdentifyState::unidentified: break;
         case IdentifyState::partly_identified:
-            ret = inv[ci].value * 2 / 10;
+            ret = inv[item_index].value * 2 / 10;
             break;
         case IdentifyState::almost_identified:
-            ret = inv[ci].value * 5 / 10;
+            ret = inv[item_index].value * 5 / 10;
             break;
-        case IdentifyState::completely_identified: ret = inv[ci].value; break;
+        case IdentifyState::completely_identified:
+            ret = inv[item_index].value;
+            break;
         }
     }
-    if (inv[ci].identification_state == IdentifyState::completely_identified)
+    if (inv[item_index].identification_state ==
+        IdentifyState::completely_identified)
     {
-        switch (inv[ci].curse_state)
+        switch (inv[item_index].curse_state)
         {
         case CurseState::doomed: ret = ret / 5; break;
         case CurseState::cursed: ret = ret / 2; break;
@@ -891,12 +895,12 @@ int calcitemvalue(int ci, int situation)
     }
     if (category == 57000)
     {
-        if (inv[ci].param2 > 0)
+        if (inv[item_index].param2 > 0)
         {
-            ret = ret * inv[ci].param2 * inv[ci].param2 / 10;
+            ret = ret * inv[item_index].param2 * inv[item_index].param2 / 10;
         }
     }
-    if (inv[ci].id == 333)
+    if (inv[item_index].id == 333)
     {
         if (situation == 0)
         {
@@ -907,13 +911,13 @@ int calcitemvalue(int ci, int situation)
                 800);
         }
     }
-    if (inv[ci].weight < 0)
+    if (inv[item_index].weight < 0)
     {
         if (mode == 6)
         {
             if (category == 92000)
             {
-                ret = ret * trate(inv[ci].param1) / 100;
+                ret = ret * trate(inv[item_index].param1) / 100;
                 if (situation == 1)
                 {
                     ret = ret * 65 / 100;
@@ -922,26 +926,28 @@ int calcitemvalue(int ci, int situation)
             }
         }
     }
-    if (inv[ci].has_charge())
+    if (inv[item_index].has_charge())
     {
-        dbid = inv[ci].id;
-        access_item_db(inv[ci], dbid, 2);
-        if (inv[ci].count < 0)
+        dbid = inv[item_index].id;
+        access_item_db(inv[item_index], dbid, 2);
+        if (inv[item_index].count < 0)
         {
             ret = ret / 10;
         }
         else if (category == 54000)
         {
-            ret = ret / 5 + ret * inv[ci].count / (ichargelevel * 2 + 1);
+            ret =
+                ret / 5 + ret * inv[item_index].count / (ichargelevel * 2 + 1);
         }
         else
         {
-            ret = ret / 2 + ret * inv[ci].count / (ichargelevel * 3 + 1);
+            ret =
+                ret / 2 + ret * inv[item_index].count / (ichargelevel * 3 + 1);
         }
     }
     if (category == 72000)
     {
-        if (inv[ci].param1 == 0)
+        if (inv[item_index].param1 == 0)
         {
             ret = ret / 100 + 1;
         }
@@ -974,7 +980,7 @@ int calcitemvalue(int ci, int situation)
         {
             ret /= 20;
         }
-        if (inv[ci].is_stolen())
+        if (inv[item_index].is_stolen())
         {
             if (game_data.guild.belongs_to_thieves_guild == 0)
             {
@@ -1001,7 +1007,7 @@ int calcitemvalue(int ci, int situation)
         {
             ret = 15000;
         }
-        if (inv[ci].is_stolen())
+        if (inv[item_index].is_stolen())
         {
             ret = 1;
         }

--- a/src/elona/casino.cpp
+++ b/src/elona/casino.cpp
@@ -361,15 +361,9 @@ void casino_acquire_items()
 {
     mtilefilecur = -1;
     draw_prepare_map_chips();
-    f = 0;
-    for (const auto& cnt : items(-1))
-    {
-        if (inv[cnt].number() != 0)
-        {
-            f = 1;
-        }
-    }
-    if (f == 1)
+    const auto have_any_rewards = range::any_of(
+        inv.ground(), [](const auto& item) { return item.number() != 0; });
+    if (have_any_rewards)
     {
         if (cdata.player().hp >= 0)
         {

--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -1470,9 +1470,9 @@ void chara_delete(int cc)
         chara_remove(cdata[cc]);
     }
 
-    for (const auto& cnt : items(cc))
+    for (auto&& item : inv.for_chara(cdata[cc]))
     {
-        inv[cnt].remove();
+        item.remove();
     }
     for (int cnt = 0; cnt < 10; ++cnt)
     {
@@ -1523,9 +1523,9 @@ void chara_relocate(
     const auto invhead = tmp.first;
     const auto invrange = tmp.second;
     int p = invhead;
-    for (const auto& cnt : items(slot))
+    for (auto&& item : inv.for_chara(cdata[slot]))
     {
-        if (cnt == invrange)
+        if (item.index == invrange)
         {
             break;
         }
@@ -1533,12 +1533,12 @@ void chara_relocate(
         {
             if (ci == p)
             {
-                ci = cnt;
+                ci = item.index;
             }
         }
-        Item::copy(inv[p], inv[cnt]);
+        Item::copy(inv[p], item);
         inv[p].clear();
-        inv[cnt].body_part = 0;
+        item.body_part = 0;
         ++p;
     }
 

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -380,29 +380,29 @@ TurnResult do_dig_command()
 static void _search_for_crystal()
 {
     p = 9999;
-    for (const auto& cnt : items(-1))
+    for (const auto& item : inv.ground())
     {
-        if (inv[cnt].number() == 0)
+        if (item.number() == 0)
         {
             continue;
         }
-        if (inv[cnt].own_state != 5)
+        if (item.own_state != 5)
         {
             continue;
         }
-        if (inv[cnt].id != 748)
+        if (item.id != 748)
         {
             continue;
         }
         if (p > dist(
-                    inv[cnt].position.x,
-                    inv[cnt].position.y,
+                    item.position.x,
+                    item.position.y,
                     cdata.player().position.x,
                     cdata.player().position.y))
         {
             p = dist(
-                inv[cnt].position.x,
-                inv[cnt].position.y,
+                item.position.x,
+                item.position.y,
                 cdata.player().position.x,
                 cdata.player().position.y);
         }
@@ -2738,9 +2738,9 @@ TurnResult do_open_command(bool play_sound)
         }
         else
         {
-            for (const auto& cnt : items(-1))
+            for (auto&& item : inv.ground())
             {
-                inv[cnt].remove();
+                item.remove();
             }
         }
         shoptrade = 0;

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -794,7 +794,7 @@ TurnResult do_throw_command()
                 potionthrow = 100;
                 cc = tc;
                 dbid = inv[ci].id;
-                access_item_db(15);
+                access_item_db(inv[ci], dbid, 15);
                 cc = ccthrowpotion;
                 return TurnResult::turn_end;
             }
@@ -3315,7 +3315,7 @@ TurnResult do_read_command()
     }
     efid = 0;
     dbid = inv[ci].id;
-    access_item_db(13);
+    access_item_db(inv[ci], dbid, 13);
     if (efid == 1115)
     {
         return build_new_building();
@@ -3360,14 +3360,14 @@ TurnResult do_eat_command()
 TurnResult do_drink_command()
 {
     dbid = inv[ci].id;
-    access_item_db(15);
+    access_item_db(inv[ci], dbid, 15);
     return TurnResult::turn_end;
 }
 
 TurnResult do_zap_command()
 {
     dbid = inv[ci].id;
-    access_item_db(14);
+    access_item_db(inv[ci], dbid, 14);
     int stat = do_zap();
     if (stat == 0)
     {

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -1387,8 +1387,7 @@ TurnResult do_dip_command()
                 {
                     --game_data.holy_well_count;
                     flt();
-                    int stat = itemcreate(0, 516, -1, -1, 0);
-                    if (stat != 0)
+                    if (itemcreate(0, 516, -1, -1, 0))
                     {
                         inv[ci].curse_state = CurseState::blessed;
                     }
@@ -3517,8 +3516,7 @@ TurnResult do_get_command()
             }
             flt();
             {
-                int stat = itemcreate(0, 587, -1, -1, 0);
-                if (stat != 0)
+                if (itemcreate(0, 587, -1, -1, 0))
                 {
                     inv[ci].curse_state = CurseState::none;
                     inv[ci].identification_state =

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -134,31 +134,31 @@ label_20591:
         {
             showmoney = 0;
         }
-        for (const auto& cnt : items(p))
+        for (auto& item : inv.by_index(p))
         {
-            if (inv[cnt].number() <= 0)
+            if (item.number() <= 0)
             {
-                inv[cnt].remove();
+                item.remove();
                 continue;
             }
-            if (inv[cnt].id == 488)
+            if (item.id == 488)
             {
-                inv[cnt].function = 9;
+                item.function = 9;
             }
-            if (inv[cnt].id >= maxitemid || inv[cnt].id < 0)
+            if (item.id >= maxitemid || item.id < 0)
             {
                 dialog(i18n::s.get(
-                    "core.locale.ui.inv.common.invalid", cnt, inv[cnt].id));
-                inv[cnt].remove();
-                inv[cnt].id = 0;
+                    "core.locale.ui.inv.common.invalid", item.index, item.id));
+                item.remove();
+                item.id = 0;
                 continue;
             }
             if (map_data.type == mdata_t::MapType::world_map)
             {
                 if (invctrl == 7)
                 {
-                    if (the_item_db[inv[cnt].id]->subcategory != 53100 &&
-                        inv[cnt].id != 621)
+                    if (the_item_db[item.id]->subcategory != 53100 &&
+                        item.id != 621)
                     {
                         continue;
                     }
@@ -168,26 +168,25 @@ label_20591:
             {
                 if (invctrl == 27)
                 {
-                    if (inv[cnt].position.x != tlocx ||
-                        inv[cnt].position.y != tlocy)
+                    if (item.position.x != tlocx || item.position.y != tlocy)
                     {
                         continue;
                     }
                 }
                 else if (invctrl != 11 && invctrl != 22 && invctrl != 28)
                 {
-                    if (inv[cnt].position.x != cdata[cc].position.x ||
-                        inv[cnt].position.y != cdata[cc].position.y)
+                    if (item.position.x != cdata[cc].position.x ||
+                        item.position.y != cdata[cc].position.y)
                     {
                         continue;
                     }
                 }
             }
-            item_checkknown(cnt);
-            reftype = the_item_db[inv[cnt].id]->category;
-            if (inv[cnt].own_state == 5)
+            item_checkknown(item.index);
+            reftype = the_item_db[item.id]->category;
+            if (item.own_state == 5)
             {
-                if (!inv[cnt].is_showroom_only() || invctrl != 14)
+                if (!item.is_showroom_only() || invctrl != 14)
                 {
                     if (invctrl != 1)
                     {
@@ -197,62 +196,60 @@ label_20591:
             }
             if (countequip == 0)
             {
-                if (inv[cnt].body_part != 0)
+                if (item.body_part != 0)
                 {
                     continue;
                 }
             }
-            if (inv[cnt].body_part != 0)
+            if (item.body_part != 0)
             {
                 if (reftype == 10000)
                 {
                     if (mainweapon == -1 ||
-                        inv[cnt].body_part < inv[mainweapon].body_part)
+                        item.body_part < inv[mainweapon].body_part)
                     {
-                        mainweapon = cnt;
+                        mainweapon = item.index;
                     }
                 }
             }
             if (invctrl == 5)
             {
-                if (reftype != 57000 && reftype != 91000 &&
-                    inv[cnt].material != 35)
+                if (reftype != 57000 && reftype != 91000 && item.material != 35)
                 {
                     continue;
                 }
             }
             if (invctrl == 6)
             {
-                if (iequiploc(inv[cnt]) !=
-                    cdata[cc].body_parts[body - 100] / 10000)
+                if (iequiploc(item) != cdata[cc].body_parts[body - 100] / 10000)
                 {
                     continue;
                 }
             }
             if (invctrl == 7)
             {
-                if (!the_item_db[inv[cnt].id]->is_readable)
+                if (!the_item_db[item.id]->is_readable)
                 {
                     continue;
                 }
             }
             if (invctrl == 8)
             {
-                if (!the_item_db[inv[cnt].id]->is_drinkable)
+                if (!the_item_db[item.id]->is_drinkable)
                 {
                     continue;
                 }
             }
             if (invctrl == 9)
             {
-                if (!the_item_db[inv[cnt].id]->is_zappable)
+                if (!the_item_db[item.id]->is_zappable)
                 {
                     continue;
                 }
             }
             if (invctrl == 11)
             {
-                if (inv[cnt].id == 54 || inv[cnt].id == 55)
+                if (item.id == 54 || item.id == 55)
                 {
                     continue;
                 }
@@ -261,7 +258,7 @@ label_20591:
             {
                 if (shoptrade)
                 {
-                    if (inv[cnt].weight >= 0)
+                    if (item.weight >= 0)
                     {
                         continue;
                     }
@@ -270,33 +267,33 @@ label_20591:
                         continue;
                     }
                 }
-                else if (inv[cnt].weight < 0)
+                else if (item.weight < 0)
                 {
                     if (reftype == 92000)
                     {
                         continue;
                     }
                 }
-                if (inv[cnt].value <= 1)
+                if (item.value <= 1)
                 {
                     continue;
                 }
-                if (inv[cnt].is_precious())
+                if (item.is_precious())
                 {
                     continue;
                 }
-                if (inv[cnt].param3 < 0)
+                if (item.param3 < 0)
                 {
                     continue;
                 }
-                if (inv[cnt].quality == Quality::special)
+                if (item.quality == Quality::special)
                 {
                     continue;
                 }
             }
             if (invctrl == 13)
             {
-                if (inv[cnt].identification_state ==
+                if (item.identification_state ==
                     IdentifyState::completely_identified)
                 {
                     continue;
@@ -304,16 +301,15 @@ label_20591:
             }
             if (invctrl == 14)
             {
-                if (inv[cnt].function == 0 &&
-                    !the_item_db[inv[cnt].id]->is_usable &&
-                    !inv[cnt].is_alive())
+                if (item.function == 0 && !the_item_db[item.id]->is_usable &&
+                    !item.is_alive())
                 {
                     continue;
                 }
             }
             if (invctrl == 15)
             {
-                if (reftype != 72000 && inv[cnt].id != 701)
+                if (reftype != 72000 && item.id != 701)
                 {
                     continue;
                 }
@@ -324,14 +320,14 @@ label_20591:
                 {
                     continue;
                 }
-                else if (inv[cnt].param2 != 0)
+                else if (item.param2 != 0)
                 {
                     continue;
                 }
             }
             if (invctrl == 17)
             {
-                if (reftype != 52000 && inv[cnt].id != 617)
+                if (reftype != 52000 && item.id != 617)
                 {
                     continue;
                 }
@@ -340,19 +336,19 @@ label_20591:
             {
                 if (inv[cidip].id == 617)
                 {
-                    if (inv[cnt].id != 342)
+                    if (item.id != 342)
                     {
                         continue;
                     }
                 }
-                if (cidip == cnt || inv[cnt].id == 516)
+                if (cidip == item.index || item.id == 516)
                 {
                     continue;
                 }
             }
             if (invctrl == 19)
             {
-                dbid = inv[cnt].id;
+                dbid = item.id;
                 dbspec = 12;
                 int is_offerable = access_item_db(inv[ci], dbid, 16);
                 if (is_offerable == 0)
@@ -362,19 +358,19 @@ label_20591:
             }
             if (invctrl == 20)
             {
-                if (inv[cnt].id == 54 || inv[cnt].id == 55)
+                if (item.id == 54 || item.id == 55)
                 {
                     continue;
                 }
             }
             if (invctrl == 21)
             {
-                if (calcitemvalue(cnt, 0) * inv[cnt].number() <
+                if (calcitemvalue(item.index, 0) * item.number() <
                     calcitemvalue(citrade, 0) * inv[citrade].number() / 2 * 3)
                 {
                     continue;
                 }
-                if (inv[cnt].is_stolen())
+                if (item.is_stolen())
                 {
                     continue;
                 }
@@ -407,14 +403,14 @@ label_20591:
                 }
                 if (invctrl(1) == 3)
                 {
-                    if (!inv[cnt].has_charge())
+                    if (!item.has_charge())
                     {
                         continue;
                     }
                 }
                 if (invctrl(1) == 4)
                 {
-                    if (inv[cnt].body_part != 0)
+                    if (item.body_part != 0)
                     {
                         continue;
                     }
@@ -428,15 +424,14 @@ label_20591:
                 }
                 if (invctrl(1) == 6)
                 {
-                    if (inv[cnt].weight <= 0 || inv[cnt].id == 641)
+                    if (item.weight <= 0 || item.id == 641)
                     {
                         continue;
                     }
                 }
                 if (invctrl(1) == 7)
                 {
-                    if (inv[cnt].quality >= Quality::miracle ||
-                        reftype >= 50000)
+                    if (item.quality >= Quality::miracle || reftype >= 50000)
                     {
                         continue;
                     }
@@ -448,42 +443,42 @@ label_20591:
                 {
                     if (game_data.current_map == mdata_t::MapId::lumiest)
                     {
-                        if (inv[cnt].id != 687 || inv[cnt].param2 == 0)
+                        if (item.id != 687 || item.param2 == 0)
                         {
                             continue;
                         }
                     }
-                    else if (inv[cnt].own_state != 4)
+                    else if (item.own_state != 4)
                     {
                         continue;
                     }
                 }
                 else if (invctrl(1) == 8)
                 {
-                    if (inv[cnt].id != 504)
+                    if (item.id != 504)
                     {
                         continue;
                     }
-                    else if (inv[cnt].own_state != 0)
+                    else if (item.own_state != 0)
                     {
                         continue;
                     }
-                    else if (inv[cnt].subname == 0)
+                    else if (item.subname == 0)
                     {
                         continue;
                     }
-                    else if (card(0, inv[cnt].subname))
+                    else if (card(0, item.subname))
                     {
                         continue;
                     }
                 }
-                else if (inv[cnt].own_state == 4)
+                else if (item.own_state == 4)
                 {
                     continue;
                 }
                 if (invctrl(1) == 2)
                 {
-                    if (inv[cnt].id != 615)
+                    if (item.id != 615)
                     {
                         continue;
                     }
@@ -500,7 +495,7 @@ label_20591:
                     }
                 }
             }
-            else if (inv[cnt].own_state == 4)
+            else if (item.own_state == 4)
             {
                 if (invctrl != 1 && invctrl != 2 && invctrl != 3 &&
                     invctrl != 5)
@@ -510,15 +505,14 @@ label_20591:
             }
             if (invctrl == 26)
             {
-                if (reftype != 52000 && inv[cnt].id != 578 &&
-                    inv[cnt].id != 685 && inv[cnt].id != 699 &&
-                    inv[cnt].id != 772)
+                if (reftype != 52000 && item.id != 578 && item.id != 685 &&
+                    item.id != 699 && item.id != 772)
                 {
                     continue;
                 }
-                if (inv[cnt].id == 685)
+                if (item.id == 685)
                 {
-                    if (inv[cnt].subname != 0)
+                    if (item.subname != 0)
                     {
                         continue;
                     }
@@ -528,21 +522,21 @@ label_20591:
             {
                 if (cnt2 == 0)
                 {
-                    if (inv[cnt].own_state != 1)
+                    if (item.own_state != 1)
                     {
                         continue;
                     }
                 }
             }
-            list(0, listmax) = cnt;
-            list(1, listmax) = reftype * 1000 + inv[cnt].id;
-            if (inv[cnt].id == 544)
+            list(0, listmax) = item.index;
+            list(1, listmax) = reftype * 1000 + item.id;
+            if (item.id == 544)
             {
-                list(1, listmax) += inv[cnt].param1 + 900;
+                list(1, listmax) += item.param1 + 900;
             }
             if (invctrl == 1 || invctrl == 13)
             {
-                if (inv[cnt].body_part != 0)
+                if (item.body_part != 0)
                 {
                     list(1, listmax) -= 99999000;
                 }
@@ -553,7 +547,7 @@ label_20591:
             }
             if (invctrl == 28)
             {
-                list(1, listmax) = calcmedalvalue(cnt);
+                list(1, listmax) = calcmedalvalue(item.index);
             }
             ++listmax;
         }

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -354,7 +354,7 @@ label_20591:
             {
                 dbid = inv[cnt].id;
                 dbspec = 12;
-                int is_offerable = access_item_db(16);
+                int is_offerable = access_item_db(inv[ci], dbid, 16);
                 if (is_offerable == 0)
                 {
                     continue;

--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -71,16 +71,16 @@ void dmgheal_death_by_backpack(Character& chara)
     int heaviest_weight = 0;
     std::string heaviest_item_name;
 
-    for (const auto& cnt : items(chara.index))
+    for (const auto& item : inv.for_chara(chara))
     {
-        if (inv[cnt].number() == 0)
+        if (item.number() == 0)
         {
             continue;
         }
-        if (inv[cnt].weight > heaviest_weight)
+        if (item.weight > heaviest_weight)
         {
-            heaviest_item_index = cnt;
-            heaviest_weight = inv[cnt].weight;
+            heaviest_item_index = item.index;
+            heaviest_weight = item.weight;
         }
     }
     if (heaviest_item_index == -1)

--- a/src/elona/elonacore.cpp
+++ b/src/elona/elonacore.cpp
@@ -3615,9 +3615,7 @@ void character_drops_item()
         cdata[rc].is_livestock() == 1 || 0)
     {
         flt();
-        int stat =
-            itemcreate(-1, 204, cdata[rc].position.x, cdata[rc].position.y, 0);
-        if (stat != 0)
+        if (itemcreate(-1, 204, cdata[rc].position.x, cdata[rc].position.y, 0))
         {
             remain_make(ci, rc);
             if (cdata[rc].is_livestock() == 1)
@@ -3921,13 +3919,12 @@ void lovemiracle(int chara_index)
     flt();
     if (rnd(2))
     {
-        int stat = itemcreate(
-            -1,
-            573,
-            cdata[chara_index].position.x,
-            cdata[chara_index].position.y,
-            0);
-        if (stat)
+        if (itemcreate(
+                -1,
+                573,
+                cdata[chara_index].position.x,
+                cdata[chara_index].position.y,
+                0))
         {
             inv[ci].subname = cdata[chara_index].id;
             inv[ci].weight = cdata[chara_index].weight * 10 + 250;
@@ -3939,13 +3936,12 @@ void lovemiracle(int chara_index)
     }
     else
     {
-        int stat = itemcreate(
-            -1,
-            574,
-            cdata[chara_index].position.x,
-            cdata[chara_index].position.y,
-            0);
-        if (stat)
+        if (itemcreate(
+                -1,
+                574,
+                cdata[chara_index].position.x,
+                cdata[chara_index].position.y,
+                0))
         {
             inv[ci].subname = cdata[chara_index].id;
         }
@@ -6191,9 +6187,8 @@ TurnResult do_gatcha()
                 p = 416;
             }
             flt();
-            int stat = itemcreate(
-                -1, p, cdata[cc].position.x, cdata[cc].position.y, 0);
-            if (stat != 0)
+            if (itemcreate(
+                    -1, p, cdata[cc].position.x, cdata[cc].position.y, 0))
             {
                 inv[ci].param2 = 0;
             }

--- a/src/elona/elonacore.cpp
+++ b/src/elona/elonacore.cpp
@@ -416,13 +416,13 @@ void initialize_pc_character()
     gain_race_feat();
     cdata.player().skill_bonus = 5 + trait(154);
     cdata.player().total_skill_bonus = 5 + trait(154);
-    for (const auto& cnt : items(0))
+    for (auto&& item : inv.pc())
     {
-        if (inv[cnt].number() == 0)
+        if (item.number() == 0)
         {
             continue;
         }
-        inv[cnt].identification_state = IdentifyState::completely_identified;
+        item.identification_state = IdentifyState::completely_identified;
     }
     chara_refresh(0);
 }
@@ -2958,20 +2958,20 @@ void character_drops_item()
         {
             return;
         }
-        for (const auto& cnt : items(rc))
+        for (auto&& item : inv.for_chara(cdata[rc]))
         {
-            ci = cnt;
-            if (inv[cnt].number() == 0)
+            ci = item.index;
+            if (item.number() == 0)
             {
                 continue;
             }
             if (map_data.refresh_type == 0)
             {
-                if (inv[cnt].body_part != 0)
+                if (item.body_part != 0)
                 {
                     continue;
                 }
-                if (inv[ci].is_precious())
+                if (item.is_precious())
                 {
                     continue;
                 }
@@ -2984,7 +2984,7 @@ void character_drops_item()
             {
                 continue;
             }
-            if (the_item_db[inv[ci].id]->is_cargo)
+            if (the_item_db[item.id]->is_cargo)
             {
                 if (map_data.type != mdata_t::MapType::world_map &&
                     map_data.type != mdata_t::MapType::player_owned &&
@@ -3001,27 +3001,27 @@ void character_drops_item()
                 }
             }
             f = 0;
-            if (inv[ci].body_part != 0)
+            if (item.body_part != 0)
             {
                 if (rnd(10))
                 {
                     f = 1;
                 }
-                if (inv[ci].curse_state == CurseState::blessed)
+                if (item.curse_state == CurseState::blessed)
                 {
                     if (rnd(2))
                     {
                         f = 1;
                     }
                 }
-                if (is_cursed(inv[ci].curse_state))
+                if (is_cursed(item.curse_state))
                 {
                     if (rnd(2))
                     {
                         f = 0;
                     }
                 }
-                if (inv[ci].curse_state == CurseState::doomed)
+                if (item.curse_state == CurseState::doomed)
                 {
                     if (rnd(2))
                     {
@@ -3030,7 +3030,7 @@ void character_drops_item()
                 }
             }
             else if (
-                inv[ci].identification_state ==
+                item.identification_state ==
                 IdentifyState::completely_identified)
             {
                 if (rnd(4))
@@ -3042,35 +3042,34 @@ void character_drops_item()
             {
                 continue;
             }
-            if (inv[ci].body_part != 0)
+            if (item.body_part != 0)
             {
-                cdata[rc].body_parts[inv[ci].body_part - 100] =
-                    cdata[rc].body_parts[inv[ci].body_part - 100] / 10000 *
-                    10000;
-                inv[ci].body_part = 0;
+                cdata[rc].body_parts[item.body_part - 100] =
+                    cdata[rc].body_parts[item.body_part - 100] / 10000 * 10000;
+                item.body_part = 0;
             }
             f = 0;
-            if (!inv[ci].is_precious())
+            if (!item.is_precious())
             {
                 if (rnd(4) == 0)
                 {
                     f = 1;
                 }
-                if (inv[ci].curse_state == CurseState::blessed)
+                if (item.curse_state == CurseState::blessed)
                 {
                     if (rnd(3) == 0)
                     {
                         f = 0;
                     }
                 }
-                if (is_cursed(inv[ci].curse_state))
+                if (is_cursed(item.curse_state))
                 {
                     if (rnd(3) == 0)
                     {
                         f = 1;
                     }
                 }
-                if (inv[ci].curse_state == CurseState::doomed)
+                if (item.curse_state == CurseState::doomed)
                 {
                     if (rnd(3) == 0)
                     {
@@ -3080,11 +3079,11 @@ void character_drops_item()
             }
             if (f)
             {
-                inv[ci].remove();
+                item.remove();
                 continue;
             }
-            inv[ci].position.x = cdata[rc].position.x;
-            inv[ci].position.y = cdata[rc].position.y;
+            item.position.x = cdata[rc].position.x;
+            item.position.y = cdata[rc].position.y;
             int stat = item_stack(-1, ci);
             if (stat == 0)
             {
@@ -3138,19 +3137,19 @@ void character_drops_item()
             return;
         }
     }
-    for (const auto& cnt : items(rc))
+    for (auto&& item : inv.for_chara(cdata[rc]))
     {
-        if (inv[cnt].number() == 0)
+        if (item.number() == 0)
         {
             continue;
         }
-        ci = cnt;
+        ci = item.index;
         f = 0;
         if (cdata[rc].character_role == 20)
         {
             break;
         }
-        if (inv[ci].quality > Quality::miracle || inv[ci].id == 55)
+        if (item.quality > Quality::miracle || item.id == 55)
         {
             f = 1;
         }
@@ -3179,11 +3178,11 @@ void character_drops_item()
                 f = 0;
             }
         }
-        if (inv[ci].quality == Quality::special)
+        if (item.quality == Quality::special)
         {
             f = 1;
         }
-        if (inv[ci].is_quest_target())
+        if (item.is_quest_target())
         {
             f = 1;
         }
@@ -3191,32 +3190,24 @@ void character_drops_item()
         {
             continue;
         }
-        if (catitem != 0)
+        if (catitem != 0 && !item.is_blessed_by_ehekatl() &&
+            the_item_db[item.id]->category < 50000 &&
+            item.quality >= Quality::great)
         {
-            if (!inv[ci].is_blessed_by_ehekatl())
+            if (rnd(3))
             {
-                if (the_item_db[inv[ci].id]->category < 50000)
-                {
-                    if (inv[ci].quality >= Quality::great)
-                    {
-                        if (rnd(3))
-                        {
-                            txt(i18n::s.get(
-                                    "core.locale.misc.black_cat_licks",
-                                    cdata[catitem],
-                                    inv[ci]),
-                                Message::color{ColorIndex::cyan});
-                            inv[ci].is_blessed_by_ehekatl() = true;
-                            reftype = the_item_db[inv[ci].id]->category;
-                            enchantment_add(
-                                ci,
-                                enchantment_generate(
-                                    enchantment_gen_level(rnd(4))),
-                                enchantment_gen_p());
-                            animeload(8, rc);
-                        }
-                    }
-                }
+                txt(i18n::s.get(
+                        "core.locale.misc.black_cat_licks",
+                        cdata[catitem],
+                        item),
+                    Message::color{ColorIndex::cyan});
+                item.is_blessed_by_ehekatl() = true;
+                reftype = the_item_db[item.id]->category;
+                enchantment_add(
+                    ci,
+                    enchantment_generate(enchantment_gen_level(rnd(4))),
+                    enchantment_gen_p());
+                animeload(8, rc);
             }
         }
         if (inv[ci].body_part != 0)
@@ -3856,21 +3847,20 @@ void auto_identify()
     {
         return;
     }
-    for (const auto& cnt : items(0))
+    for (const auto& item : inv.pc())
     {
-        if (inv[cnt].number() == 0 ||
-            inv[cnt].identification_state ==
-                IdentifyState::completely_identified)
+        if (item.number() == 0 ||
+            item.identification_state == IdentifyState::completely_identified)
         {
             continue;
         }
-        if (the_item_db[inv[cnt].id]->category >= 50000)
+        if (the_item_db[item.id]->category >= 50000)
         {
             continue;
         }
-        ci = cnt;
+        ci = item.index;
         p(0) = sdata(13, 0) + sdata(162, 0) * 5;
-        p(1) = 1500 + inv[ci].difficulty_of_identification * 5;
+        p(1) = 1500 + item.difficulty_of_identification * 5;
         if (p > rnd(p(1) * 5))
         {
             s = itemname(ci);
@@ -4850,9 +4840,9 @@ void atxinit()
 void begintempinv()
 {
     ctrl_file(FileOperation2::map_items_write, u8"shoptmp.s2");
-    for (const auto& cnt : items(-1))
+    for (auto&& item : inv.ground())
     {
-        inv[cnt].remove();
+        item.remove();
     }
 }
 
@@ -4945,9 +4935,9 @@ void supply_income()
     }
     else
     {
-        for (const auto& cnt : items(-1))
+        for (auto&& item : inv.ground())
         {
-            inv[cnt].remove();
+            item.remove();
         }
     }
     mode = 6;
@@ -5029,11 +5019,11 @@ void supply_income()
         {
             save_set_autosave();
             p = -1;
-            for (const auto& cnt : items(-1))
+            for (const auto& item : inv.ground())
             {
-                if (inv[cnt].number() == 0)
+                if (item.number() == 0)
                 {
-                    p = cnt;
+                    p = item.index;
                     break;
                 }
             }
@@ -6469,11 +6459,11 @@ void dump_player_info()
 
 void remove_card_and_figures()
 {
-    for (const auto& cnt : items(-1))
+    for (auto&& item : inv.ground())
     {
-        if (inv[cnt].id == 504 || inv[cnt].id == 503)
+        if (item.id == 504 || item.id == 503)
         {
-            inv[cnt].remove();
+            item.remove();
         }
     }
 }
@@ -6549,43 +6539,42 @@ void load_gene_files()
     sdata.clear(0);
     Character::copy(cdata.player(), cdata.tmp());
     cdata.player().clear();
-    for (const auto& cnt : items(-1))
+    for (auto&& item : inv.ground())
     {
-        inv[cnt].remove();
+        item.remove();
     }
-    for (const auto& cnt : items(0))
+    for (auto&& item : inv.pc())
     {
-        if (inv[cnt].number() == 0)
+        if (item.number() == 0)
         {
             continue;
         }
-        if (inv[cnt].id == 717)
+        if (item.id == 717)
         {
             lomiaseaster = 1;
         }
-        if (inv[cnt].id == 511 ||
-            the_item_db[inv[cnt].id]->subcategory == 53100)
+        if (item.id == 511 || the_item_db[item.id]->subcategory == 53100)
         {
             continue;
         }
-        if (inv[cnt].id == 578)
+        if (item.id == 578)
         {
             continue;
         }
-        if (inv[cnt].quality == Quality::special)
+        if (item.quality == Quality::special)
         {
             continue;
         }
-        if (inv[cnt].is_precious())
+        if (item.is_precious())
         {
             continue;
         }
-        if (the_item_db[inv[cnt].id]->category == 25000)
+        if (the_item_db[item.id]->category == 25000)
         {
-            inv[cnt].count = -1;
+            item.count = -1;
         }
-        inv[cnt].body_part = 0;
-        item_copy(cnt, inv_getfreeid(-1));
+        item.body_part = 0;
+        item_copy(item.index, inv_getfreeid(-1));
     }
     for (auto&& cnt : cdata.all())
     {
@@ -7333,16 +7322,16 @@ void map_global_proc_travel_events()
     if (cdata.player().nutrition <= 5000)
     {
         f = 0;
-        for (const auto& cnt : items(cc))
+        for (const auto& item : inv.for_chara(cdata[cc]))
         {
-            if (inv[cnt].number() == 0)
+            if (item.number() == 0)
             {
                 continue;
             }
-            if (the_item_db[inv[cnt].id]->category == 91000)
+            if (the_item_db[item.id]->category == 91000)
             {
                 f = 1;
-                ci = cnt;
+                ci = item.index;
                 break;
             }
         }
@@ -8967,13 +8956,13 @@ int pick_up_item(bool play_sound)
             if (map_data.play_campfire_sound == 1)
             {
                 f = 0;
-                for (const auto& cnt : items(-1))
+                for (const auto& item : inv.ground())
                 {
-                    if (inv[cnt].number() == 0)
+                    if (item.number() == 0)
                     {
                         continue;
                     }
-                    if (inv[cnt].id == 255)
+                    if (item.id == 255)
                     {
                         f = 1;
                         break;
@@ -9569,22 +9558,22 @@ void proc_autopick()
         return;
 
 
-    for (const auto& ci : items(-1))
+    for (auto&& item : inv.ground())
     {
-        if (inv[ci].number() == 0)
+        if (item.number() == 0)
             continue;
-        if (inv[ci].position != cdata.player().position)
+        if (item.position != cdata.player().position)
             continue;
-        if (inv[ci].own_state > 0)
+        if (item.own_state > 0)
             continue;
 
-        item_checkknown(ci);
+        item_checkknown(item.index);
 
         const auto x = cdata.player().position.x;
         const auto y = cdata.player().position.y;
 
         bool did_something = true;
-        const auto op = Autopick::instance().get_operation(inv[ci]);
+        const auto op = Autopick::instance().get_operation(item);
         switch (op.type)
         {
         case Autopick::Operation::Type::do_nothing:
@@ -9598,15 +9587,15 @@ void proc_autopick()
             if (op.show_prompt)
             {
                 txt(i18n::s.get(
-                    "core.locale.ui.autopick.do_you_really_pick_up", inv[ci]));
+                    "core.locale.ui.autopick.do_you_really_pick_up", item));
                 if (!yes_no())
                 {
                     did_something = false;
                     break;
                 }
             }
-            in = inv[ci].number();
-            elona::ci = ci;
+            in = item.number();
+            elona::ci = item.index;
             pick_up_item(op.sound == "");
             if (int(op.type) & int(Autopick::Operation::Type::no_drop))
             {
@@ -9627,7 +9616,7 @@ void proc_autopick()
             if (op.show_prompt)
             {
                 txt(i18n::s.get(
-                    "core.locale.ui.autopick.do_you_really_destroy", inv[ci]));
+                    "core.locale.ui.autopick.do_you_really_destroy", item));
                 if (!yes_no())
                 {
                     did_something = false;
@@ -9638,8 +9627,8 @@ void proc_autopick()
             {
                 snd("core.crush1");
             }
-            txt(i18n::s.get("core.locale.ui.autopick.destroyed", inv[ci]));
-            inv[ci].remove();
+            txt(i18n::s.get("core.locale.ui.autopick.destroyed", item));
+            item.remove();
             cell_refresh(x, y);
             cell_data.at(x, y).item_appearances_memory =
                 cell_data.at(x, y).item_appearances_actual;
@@ -9649,14 +9638,14 @@ void proc_autopick()
             if (op.show_prompt)
             {
                 txt(i18n::s.get(
-                    "core.locale.ui.autopick.do_you_really_open", inv[ci]));
+                    "core.locale.ui.autopick.do_you_really_open", item));
                 if (!yes_no())
                 {
                     did_something = false;
                     break;
                 }
             }
-            elona::ci = ci;
+            elona::ci = item.index;
             (void)do_open_command(op.sound == ""); // Result is unused.
             break;
         }

--- a/src/elona/elonacore.cpp
+++ b/src/elona/elonacore.cpp
@@ -8788,7 +8788,7 @@ int pick_up_item(bool play_sound)
                 if (inv[ci].count > 0)
                 {
                     dbid = inv[ci].id;
-                    access_item_db(14);
+                    access_item_db(inv[ci], dbid, 14);
                     txt(i18n::s.get(
                         "core.locale.action.pick_up.you_absorb_magic",
                         inv[ci]));

--- a/src/elona/enchantment.cpp
+++ b/src/elona/enchantment.cpp
@@ -626,7 +626,7 @@ void get_enchantment_description(int val0, int power, int category, bool trait)
 
 
 bool enchantment_add(
-    int ci,
+    int item_index,
     int type,
     int power,
     int flip_percentage,
@@ -634,7 +634,7 @@ bool enchantment_add(
     bool only_check,
     bool force)
 {
-    const auto category = the_item_db[inv[ci].id]->category;
+    const auto category = the_item_db[inv[item_index].id]->category;
 
     if (type == 0)
     {
@@ -750,14 +750,14 @@ bool enchantment_add(
     i_at_m48 = -1;
     for (int cnt = 0; cnt < 15; ++cnt)
     {
-        if (inv[ci].enchantments[cnt].id == enc)
+        if (inv[item_index].enchantments[cnt].id == enc)
         {
             i_at_m48 = cnt;
             continue;
         }
         if (i_at_m48 == -1)
         {
-            if (inv[ci].enchantments[cnt].id == 0)
+            if (inv[item_index].enchantments[cnt].id == 0)
             {
                 i_at_m48 = cnt;
             }
@@ -768,7 +768,7 @@ bool enchantment_add(
         return false;
     }
 
-    if (inv[ci].enchantments[i_at_m48].id == enc)
+    if (inv[item_index].enchantments[i_at_m48].id == enc)
     {
         if (category == 25000)
         {
@@ -787,12 +787,12 @@ bool enchantment_add(
         return true;
     }
 
-    if (inv[ci].enchantments[i_at_m48].id == enc)
+    if (inv[item_index].enchantments[i_at_m48].id == enc)
     {
-        encp += inv[ci].enchantments[i_at_m48].power;
+        encp += inv[item_index].enchantments[i_at_m48].power;
     }
-    inv[ci].enchantments[i_at_m48].id = enc;
-    inv[ci].enchantments[i_at_m48].power = encp;
+    inv[item_index].enchantments[i_at_m48].id = enc;
+    inv[item_index].enchantments[i_at_m48].power = encp;
 
     if (type < 10000)
     {
@@ -802,11 +802,12 @@ bool enchantment_add(
     {
         p_at_m48 = type / 10000;
     }
-    if (inv[ci].value * encref(1, p_at_m48) / 100 > 0)
+    if (inv[item_index].value * encref(1, p_at_m48) / 100 > 0)
     {
-        inv[ci].value = inv[ci].value * encref(1, p_at_m48) / 100;
+        inv[item_index].value =
+            inv[item_index].value * encref(1, p_at_m48) / 100;
     }
-    enchantment_sort(inv[ci]);
+    enchantment_sort(inv[item_index]);
 
     return true;
 }

--- a/src/elona/enchantment.hpp
+++ b/src/elona/enchantment.hpp
@@ -14,7 +14,7 @@ struct Item;
 
 
 bool enchantment_add(
-    int ci,
+    int item_index,
     int type,
     int power,
     int flip_percentage = 0,

--- a/src/elona/equipment.cpp
+++ b/src/elona/equipment.cpp
@@ -437,10 +437,10 @@ void eqrandweaponmage()
 
 void wear_most_valuable_equipment_for_all_body_parts()
 {
-    for (const auto& cnt : items(rc))
+    for (const auto& item : inv.for_chara(cdata[rc]))
     {
-        ci = cnt;
-        if (inv[cnt].number() == 0 || inv[cnt].body_part != 0)
+        ci = item.index;
+        if (item.number() == 0 || item.body_part != 0)
         {
             continue;
         }

--- a/src/elona/equipment.cpp
+++ b/src/elona/equipment.cpp
@@ -619,29 +619,31 @@ void supply_new_equipment()
         {
             break;
         }
-        int stat = itemcreate(rc, 0, -1, -1, 0);
-        if (stat == 0)
+        if (itemcreate(rc, 0, -1, -1, 0))
         {
-            break;
-        }
-        inv[ci].identification_state = IdentifyState::completely_identified;
-        if (inv[ci].quality >= Quality::miracle)
-        {
-            if (the_item_db[inv[ci].id]->category < 50000)
+            inv[ci].identification_state = IdentifyState::completely_identified;
+            if (inv[ci].quality >= Quality::miracle)
             {
-                if (cdata[rc].character_role == 13)
+                if (the_item_db[inv[ci].id]->category < 50000)
                 {
-                    addnews(1, rc, 0, itemname(ci));
+                    if (cdata[rc].character_role == 13)
+                    {
+                        addnews(1, rc, 0, itemname(ci));
+                    }
+                }
+            }
+            wear_most_valuable_equipment();
+            if (cdata[rc].character_role != 13)
+            {
+                if (rnd(3))
+                {
+                    break;
                 }
             }
         }
-        wear_most_valuable_equipment();
-        if (cdata[rc].character_role != 13)
+        else
         {
-            if (rnd(3))
-            {
-                break;
-            }
+            break;
         }
     }
 }
@@ -1461,8 +1463,7 @@ void supply_initial_equipments()
         {
             flt();
             nostack = 1;
-            int stat = itemcreate(rc, 772, -1, -1, 0);
-            if (stat != 0)
+            if (itemcreate(rc, 772, -1, -1, 0))
             {
                 inv[ci].modify_number(rnd(4));
                 if (rnd(2))

--- a/src/elona/food.cpp
+++ b/src/elona/food.cpp
@@ -278,8 +278,7 @@ void chara_vomit(Character& cc)
         if (rnd(p * p * p) == 0 || cc.index == 0)
         {
             flt();
-            int stat = itemcreate(-1, 704, cc.position.x, cc.position.y, 0);
-            if (stat != 0)
+            if (itemcreate(-1, 704, cc.position.x, cc.position.y, 0))
             {
                 if (cc.index != 0)
                 {

--- a/src/elona/food.cpp
+++ b/src/elona/food.cpp
@@ -265,11 +265,11 @@ void chara_vomit(Character& cc)
     if (map_data.type != mdata_t::MapType::world_map)
     {
         auto p = 2;
-        for (const auto& i : items(-1))
+        for (const auto& item : inv.ground())
         {
-            if (inv[i].number() > 0)
+            if (item.number() > 0)
             {
-                if (inv[i].id == 704)
+                if (item.id == 704)
                 {
                     ++p;
                 }
@@ -1507,13 +1507,13 @@ void foods_get_rotten()
             continue;
         }
 
-        for (const auto& i : items(chara))
+        for (const auto& item : inv.by_index(chara))
         {
-            if (inv[i].number() == 0)
+            if (item.number() == 0)
             {
                 continue;
             }
-            _food_gets_rotten(chara, i);
+            _food_gets_rotten(chara, item.index);
         }
     }
 }

--- a/src/elona/food.cpp
+++ b/src/elona/food.cpp
@@ -463,14 +463,14 @@ void cook()
 
 
 
-void make_dish(int ci, int type)
+void make_dish(int ingredient, int type)
 {
-    inv[ci].image = picfood(type, inv[ci].param1 / 1000);
-    inv[ci].weight = 500;
-    inv[ci].param2 = type;
-    if (inv[ci].material == 35 && inv[ci].param3 >= 0)
+    inv[ingredient].image = picfood(type, inv[ingredient].param1 / 1000);
+    inv[ingredient].weight = 500;
+    inv[ingredient].param2 = type;
+    if (inv[ingredient].material == 35 && inv[ingredient].param3 >= 0)
     {
-        inv[ci].param3 = game_data.date.hours() + 72;
+        inv[ingredient].param3 = game_data.date.hours() + 72;
     }
 }
 

--- a/src/elona/initialize_map_types.cpp
+++ b/src/elona/initialize_map_types.cpp
@@ -782,15 +782,15 @@ static void _init_map_your_home()
             // map if the home was upgraded.
             ctrl_file(
                 FileOperation2::map_items_read, u8"inv_"s + mid + u8".s2");
-            for (const auto& cnt : items(-1))
+            for (auto&& item : inv.ground())
             {
-                if (inv[cnt].number() == 0)
+                if (item.number() == 0)
                 {
                     continue;
                 }
-                inv[cnt].position.x = map_data.width / 2;
-                inv[cnt].position.y = map_data.height / 2;
-                cell_refresh(inv[cnt].position.x, inv[cnt].position.y);
+                item.position.x = map_data.width / 2;
+                item.position.y = map_data.height / 2;
+                cell_refresh(item.position.x, item.position.y);
             }
             ctrl_file(FileOperation::map_home_upgrade);
             for (auto&& cnt : cdata.others())

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -533,44 +533,44 @@ void Item::set_number(int number_)
 
 
 
-int item_separate(int ci)
+int item_separate(int src)
 {
-    if (inv[ci].number() <= 1)
-        return ci;
+    if (inv[src].number() <= 1)
+        return src;
 
-    int ti = inv_getfreeid(inv_getowner(ci));
-    if (ti == -1)
+    int dst = inv_getfreeid(inv_getowner(src));
+    if (dst == -1)
     {
-        ti = inv_getfreeid(-1);
-        if (ti == -1)
+        dst = inv_getfreeid(-1);
+        if (dst == -1)
         {
-            inv[ci].set_number(1);
+            inv[src].set_number(1);
             txt(i18n::s.get("core.locale.item.something_falls_and_disappears"));
-            return ci;
+            return src;
         }
     }
 
-    item_copy(ci, ti);
-    inv[ti].set_number(inv[ci].number() - 1);
-    inv[ci].set_number(1);
+    item_copy(src, dst);
+    inv[dst].set_number(inv[src].number() - 1);
+    inv[src].set_number(1);
 
-    if (inv_getowner(ti) == -1 && mode != 6)
+    if (inv_getowner(dst) == -1 && mode != 6)
     {
-        if (inv_getowner(ci) != -1)
+        if (inv_getowner(src) != -1)
         {
-            inv[ci].position = cdata[inv_getowner(ci)].position;
+            inv[src].position = cdata[inv_getowner(src)].position;
         }
-        inv[ti].position = inv[ci].position;
-        itemturn(ti);
-        cell_refresh(inv[ti].position.x, inv[ti].position.y);
-        if (inv_getowner(ci) != -1)
+        inv[dst].position = inv[src].position;
+        itemturn(dst);
+        cell_refresh(inv[dst].position.x, inv[dst].position.y);
+        if (inv_getowner(src) != -1)
         {
             txt(i18n::s.get("core.locale.item.something_falls_from_backpack"));
         }
         refresh_burden_state();
     }
 
-    return ti;
+    return dst;
 }
 
 

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -1573,8 +1573,8 @@ void item_dump_desc(const Item& i)
     reftype = the_item_db[i.id]->category;
 
     dbid = i.id;
-    access_item_db(2);
-    access_item_db(17);
+    access_item_db(inv[ci], dbid, 2);
+    access_item_db(inv[ci], dbid, 17);
 
     item_load_desc(ci, p(0));
 

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -158,7 +158,7 @@ public:
 
     void clear();
 
-    bool almost_equals(const Item& other, bool ignore_position);
+    bool almost_equals(const Item& other, bool ignore_position) const;
 
     // for identifying the type of a Lua reference
     static std::string lua_type()
@@ -232,6 +232,36 @@ private:
 
 
 
+struct InventorySlice
+{
+    using iterator = std::vector<Item>::iterator;
+
+    InventorySlice(const iterator& begin, const iterator& end)
+        : _begin(begin)
+        , _end(end)
+    {
+    }
+
+    iterator begin()
+    {
+        return _begin;
+    }
+
+    iterator end()
+    {
+        return _end;
+    }
+
+private:
+    const iterator _begin;
+    const iterator _end;
+};
+
+
+
+struct Character;
+
+
 struct Inventory
 {
     Inventory();
@@ -243,6 +273,31 @@ struct Inventory
     }
 
 
+    InventorySlice all()
+    {
+        return {std::begin(storage), std::end(storage)};
+    }
+
+
+    InventorySlice pc()
+    {
+        return {std::begin(storage), std::begin(storage) + 200};
+    }
+
+
+    InventorySlice ground()
+    {
+        return {std::begin(storage) + ELONA_ITEM_ON_GROUND_INDEX,
+                std::begin(storage) + ELONA_ITEM_ON_GROUND_INDEX + 400};
+    }
+
+
+    InventorySlice for_chara(const Character& chara);
+
+    InventorySlice by_index(int index);
+
+
+
 private:
     std::vector<Item> storage;
 };
@@ -251,14 +306,10 @@ private:
 extern Inventory inv;
 
 
-struct Character;
-
-
 
 IdentifyState item_identify(Item& ci, IdentifyState level);
 IdentifyState item_identify(Item& ci, int power);
 
-range::iota<int> items(int owner);
 std::vector<int> itemlist(int owner, int id);
 void itemname_additional_info();
 

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -330,5 +330,6 @@ void item_load_desc(int ci, int& p);
 
 
 int iequiploc(const Item& item);
+int access_item_db(Item& item, int legacy_id, int dbmode);
 
 } // namespace elona

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -265,7 +265,7 @@ void itemname_additional_info();
 void item_checkknown(int = 0);
 int inv_compress(int);
 void item_copy(int = 0, int = 0);
-void item_acid(const Character& owner, int ci = -1);
+void item_acid(const Character& owner, int item_index = -1);
 void item_delete(int);
 void item_exchange(int = 0, int = 0);
 void item_modify_num(Item&, int);
@@ -289,9 +289,9 @@ int item_separate(int);
 int item_stack(int = 0, int = 0, int = 0);
 void item_dump_desc(const Item&);
 
-bool item_fire(int owner, int ci = -1);
+bool item_fire(int owner, int item_index = -1);
 void mapitem_fire(int x, int y);
-bool item_cold(int owner, int ci = -1);
+bool item_cold(int owner, int item_index = -1);
 void mapitem_cold(int x, int y);
 
 // TODO unsure how these are separate from item
@@ -326,7 +326,7 @@ enum class ItemDescriptionType : int
     small_font_italic = -2,
 };
 
-void item_load_desc(int ci, int& p);
+void item_load_desc(int item_index, int& p);
 
 
 int iequiploc(const Item& item);

--- a/src/elona/item_load_desc.cpp
+++ b/src/elona/item_load_desc.cpp
@@ -112,98 +112,102 @@ static void _load_item_main_description_text(
     }
 }
 
-static void _load_item_stat_text(int ci, int& p)
+static void _load_item_stat_text(int item_index, int& p)
 {
-    if (inv[ci].material != 0)
+    if (inv[item_index].material != 0)
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::text);
         listn(0, p) = i18n::s.get(
             "core.locale.item.desc.it_is_made_of",
             i18n::s.get_m(
                 "locale.item_material",
-                the_item_material_db.get_id_from_legacy(inv[ci].material)
+                the_item_material_db
+                    .get_id_from_legacy(inv[item_index].material)
                     ->get(),
                 "name"));
         ++p;
     }
-    if (inv[ci].material == 8)
+    if (inv[item_index].material == 8)
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::text);
         listn(0, p) =
             i18n::s.get("core.locale.item.desc.speeds_up_ether_disease");
         ++p;
     }
-    if (inv[ci].is_acidproof())
+    if (inv[item_index].is_acidproof())
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::text);
         listn(0, p) = i18n::s.get("core.locale.item.desc.bit.acidproof");
         ++p;
     }
-    if (inv[ci].is_fireproof())
+    if (inv[item_index].is_fireproof())
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::text);
         listn(0, p) = i18n::s.get("core.locale.item.desc.bit.fireproof");
         ++p;
     }
-    if (inv[ci].is_precious())
+    if (inv[item_index].is_precious())
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::text);
         listn(0, p) = i18n::s.get("core.locale.item.desc.bit.precious");
         ++p;
     }
-    if (inv[ci].is_blessed_by_ehekatl())
+    if (inv[item_index].is_blessed_by_ehekatl())
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::text);
         listn(0, p) =
             i18n::s.get("core.locale.item.desc.bit.blessed_by_ehekatl");
         ++p;
     }
-    if (inv[ci].is_stolen())
+    if (inv[item_index].is_stolen())
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::text);
         listn(0, p) = i18n::s.get("core.locale.item.desc.bit.stolen");
         ++p;
     }
-    if (inv[ci].is_alive())
+    if (inv[item_index].is_alive())
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::text);
         listn(0, p) = i18n::s.get("core.locale.item.desc.bit.alive") +
-            u8" [Lv:"s + inv[ci].param1 + u8" Exp:"s +
-            clamp(inv[ci].param2 * 100 / calcexpalive(inv[ci].param1), 0, 100) +
+            u8" [Lv:"s + inv[item_index].param1 + u8" Exp:"s +
+            clamp(inv[item_index].param2 * 100 /
+                      calcexpalive(inv[item_index].param1),
+                  0,
+                  100) +
             u8"%]"s;
         ++p;
     }
-    if (inv[ci].is_showroom_only())
+    if (inv[item_index].is_showroom_only())
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::text);
         listn(0, p) = i18n::s.get("core.locale.item.desc.bit.show_room_only");
         ++p;
     }
-    if (inv[ci].is_handmade())
+    if (inv[item_index].is_handmade())
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::text);
         listn(0, p) = i18n::s.get("core.locale.item.desc.bit.handmade");
         ++p;
     }
-    if (inv[ci].dice_x != 0)
+    if (inv[item_index].dice_x != 0)
     {
-        const auto pierce = calc_rate_to_pierce(inv[ci].id);
+        const auto pierce = calc_rate_to_pierce(inv[item_index].id);
         list(0, p) = static_cast<int>(ItemDescriptionType::weapon_info);
         listn(0, p) =
             i18n::s.get("core.locale.item.desc.weapon.it_can_be_wielded") +
-            u8" ("s + inv[ci].dice_x + u8"d"s + inv[ci].dice_y +
+            u8" ("s + inv[item_index].dice_x + u8"d"s + inv[item_index].dice_y +
             i18n::s.get("core.locale.item.desc.weapon.pierce") + pierce +
             u8"%)"s;
         ++p;
         if (reftype == 10000)
         {
-            if (inv[ci].weight <= 1500)
+            if (inv[item_index].weight <= 1500)
             {
                 list(0, p) = static_cast<int>(ItemDescriptionType::weapon_info);
                 listn(0, p) = i18n::s.get("core.locale.item.desc.weapon.light");
                 ++p;
             }
-            if (inv[ci].weight >= 4000)
+            if (inv[item_index].weight >= 4000)
             {
                 list(0, p) = static_cast<int>(ItemDescriptionType::weapon_info);
                 listn(0, p) = i18n::s.get("core.locale.item.desc.weapon.heavy");
@@ -211,23 +215,25 @@ static void _load_item_stat_text(int ci, int& p)
             }
         }
     }
-    if (inv[ci].hit_bonus != 0 || inv[ci].damage_bonus != 0)
+    if (inv[item_index].hit_bonus != 0 || inv[item_index].damage_bonus != 0)
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::weapon_info);
         listn(0, p) = i18n::s.get(
             "core.locale.item.desc.bonus",
-            inv[ci].hit_bonus,
-            inv[ci].damage_bonus);
+            inv[item_index].hit_bonus,
+            inv[item_index].damage_bonus);
         ++p;
     }
-    if (inv[ci].pv != 0 || inv[ci].dv != 0)
+    if (inv[item_index].pv != 0 || inv[item_index].dv != 0)
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::armor_info);
-        listn(0, p) =
-            i18n::s.get("core.locale.item.desc.dv_pv", inv[ci].dv, inv[ci].pv);
+        listn(0, p) = i18n::s.get(
+            "core.locale.item.desc.dv_pv",
+            inv[item_index].dv,
+            inv[item_index].pv);
         ++p;
     }
-    if (inv[ci].id == 701)
+    if (inv[item_index].id == 701)
     {
         int card_count{};
         for (int i = 0; i < 1000; ++i)
@@ -249,21 +255,21 @@ static void _load_item_stat_text(int ci, int& p)
     }
 }
 
-static void _load_item_enchantment_desc(int ci, int& p)
+static void _load_item_enchantment_desc(int item_index, int& p)
 {
     int inhmax = 0;
     elona_vector1<int> inhlist;
-    getinheritance(ci, inhlist, inhmax);
+    getinheritance(item_index, inhlist, inhmax);
 
     for (int cnt = 0; cnt < 15; ++cnt)
     {
-        if (inv[ci].enchantments[cnt].id == 0)
+        if (inv[item_index].enchantments[cnt].id == 0)
         {
             break;
         }
         get_enchantment_description(
-            inv[ci].enchantments[cnt].id,
-            inv[ci].enchantments[cnt].power,
+            inv[item_index].enchantments[cnt].id,
+            inv[item_index].enchantments[cnt].power,
             reftype);
         listn(0, p) = i18n::s.get("core.locale.enchantment.it") + s;
         list(0, p) = rtval;
@@ -282,7 +288,7 @@ static void _load_item_enchantment_desc(int ci, int& p)
         }
         ++p;
     }
-    if (inv[ci].is_eternal_force())
+    if (inv[item_index].is_eternal_force())
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::enchantment);
         listn(0, p) = i18n::s.get("core.locale.item.desc.bit.eternal_force");
@@ -291,28 +297,32 @@ static void _load_item_enchantment_desc(int ci, int& p)
 }
 
 
-void item_load_desc(int ci, int& p)
+void item_load_desc(int item_index, int& p)
 {
     const I18NKey& locale_key_prefix =
-        the_item_db[inv[ci].id]->locale_key_prefix;
+        the_item_db[inv[item_index].id]->locale_key_prefix;
 
-    if (inv[ci].identification_state == IdentifyState::completely_identified)
+    if (inv[item_index].identification_state ==
+        IdentifyState::completely_identified)
     {
         _load_item_main_description_text(locale_key_prefix, p);
     }
-    if (inv[ci].identification_state >= IdentifyState::almost_identified)
+    if (inv[item_index].identification_state >=
+        IdentifyState::almost_identified)
     {
-        _load_item_stat_text(ci, p);
+        _load_item_stat_text(item_index, p);
     }
-    if (inv[ci].identification_state <= IdentifyState::partly_identified)
+    if (inv[item_index].identification_state <=
+        IdentifyState::partly_identified)
     {
         list(0, p) = static_cast<int>(ItemDescriptionType::normal);
         listn(0, p) = i18n::s.get("core.locale.item.desc.have_to_identify");
         ++p;
     }
-    if (inv[ci].identification_state == IdentifyState::completely_identified)
+    if (inv[item_index].identification_state ==
+        IdentifyState::completely_identified)
     {
-        _load_item_enchantment_desc(ci, p);
+        _load_item_enchantment_desc(item_index, p);
         _load_item_description_text(locale_key_prefix, p);
     }
     if (p == 0)

--- a/src/elona/itemgen.cpp
+++ b/src/elona/itemgen.cpp
@@ -42,7 +42,7 @@ int calculate_original_value(const Item& ci)
 namespace elona
 {
 
-int itemcreate(int slot, int id, int x, int y, int number)
+optional<int> itemcreate(int slot, int id, int x, int y, int number)
 {
     if (flttypeminor != 0)
     {
@@ -94,7 +94,9 @@ void get_random_item_id()
     dbid = sampler.get().value_or(25);
 }
 
-int do_create_item(int slot, int x, int y)
+
+
+optional<int> do_create_item(int slot, int x, int y)
 {
     if ((slot == 0 || slot == -1) && fixlv < Quality::godly)
     {
@@ -106,7 +108,7 @@ int do_create_item(int slot, int x, int y)
 
     ci = inv_getfreeid(slot);
     if (ci == -1)
-        return 0;
+        return none;
 
     item_delete(ci);
     inv[ci].index = ci;
@@ -168,7 +170,7 @@ int do_create_item(int slot, int x, int y)
             }
         }
         if (!ok)
-            return 0;
+            return none;
     }
 
     if (dbid == -1)
@@ -304,7 +306,7 @@ int do_create_item(int slot, int x, int y)
         {
             earn_gold(cdata[slot], inv[ci].number());
             inv[ci].remove();
-            return 1;
+            return ci;
         }
     }
 
@@ -485,7 +487,7 @@ int do_create_item(int slot, int x, int y)
         if (stat == 1)
         {
             ci = ti;
-            return 1;
+            return ci;
         }
     }
 
@@ -493,8 +495,10 @@ int do_create_item(int slot, int x, int y)
     {
         cell_refresh(inv[ci].position.x, inv[ci].position.y);
     }
-    return 1;
+    return ci;
 }
+
+
 
 void init_item_quality_curse_state_material_and_equipments(Item& item)
 {

--- a/src/elona/itemgen.cpp
+++ b/src/elona/itemgen.cpp
@@ -210,8 +210,8 @@ int do_create_item(int slot, int x, int y)
         dbid = 501;
     }
 
-    access_item_db(3);
-    access_item_db(2);
+    access_item_db(inv[ci], dbid, 3);
+    access_item_db(inv[ci], dbid, 2);
 
     inv[ci].color = generate_color(the_item_db[inv[ci].id]->color, inv[ci].id);
 
@@ -684,7 +684,7 @@ void change_item_material(Item& item, int material_id)
     const auto original_value = calculate_original_value(item);
 
     dbid = item.id;
-    access_item_db(10);
+    access_item_db(inv[ci], dbid, 10);
     item.value = original_value;
     if (material_id != 0)
     {

--- a/src/elona/itemgen.hpp
+++ b/src/elona/itemgen.hpp
@@ -1,13 +1,19 @@
 #pragma once
 
+#include "optional.hpp"
+
+
+
 namespace elona
 {
 
 struct Item;
 
-int itemcreate(int = 0, int = 0, int = 0, int = 0, int = 0);
+
+
+optional<int> itemcreate(int = 0, int = 0, int = 0, int = 0, int = 0);
 void get_random_item_id();
-int do_create_item(int, int, int);
+optional<int> do_create_item(int, int, int);
 void init_item_quality_curse_state_material_and_equipments(Item&);
 void calc_furniture_value(Item&);
 void initialize_item_material(Item&);

--- a/src/elona/lua_env/lua_api/lua_api_debug.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_debug.cpp
@@ -71,16 +71,15 @@ void LuaApiDebug::dump_characters()
 void LuaApiDebug::dump_items()
 {
     ELONA_LOG("lua.debug") << "===== Items  =====";
-    for (const auto& cnt : items(-1))
+    for (const auto& item : inv.ground())
     {
-        if (elona::inv[cnt].number() != 0)
+        if (item.number() != 0)
             ELONA_LOG("lua.debug")
-                << elona::inv[cnt].index << ") Name: " << elona::itemname(cnt)
-                << ", Pos: " << elona::inv[cnt].position
-                << ", Curse: " << static_cast<int>(elona::inv[cnt].curse_state)
-                << ", Ident: "
-                << static_cast<int>(elona::inv[cnt].identification_state)
-                << ", Count: " << elona::inv[cnt].count;
+                << item.index << ") Name: " << elona::itemname(item.index)
+                << ", Pos: " << item.position
+                << ", Curse: " << static_cast<int>(item.curse_state)
+                << ", Ident: " << static_cast<int>(item.identification_state)
+                << ", Count: " << item.count;
     }
 }
 

--- a/src/elona/lua_env/lua_api/lua_api_internal.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_internal.cpp
@@ -219,8 +219,7 @@ void LuaApiInternal::strange_scientist_pick_reward()
         if (f)
         {
             flt(cdata.player().level * 3 / 2, calcfixlv(Quality::good));
-            int stat = itemcreate(-1, cnt, -1, -1, 0);
-            if (stat == 1)
+            if (itemcreate(-1, cnt, -1, -1, 0))
             {
                 if (inv[ci].quality < Quality::miracle)
                 {

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -2628,7 +2628,7 @@ bool _magic_630_1129()
         if (result.succeeded)
         {
             dbid = inv[ci].id;
-            access_item_db(2);
+            access_item_db(inv[ci], dbid, 2);
             if (ichargelevel < 1 || inv[ci].id == 290 || inv[ci].id == 480 ||
                 inv[ci].id == 289 || inv[ci].id == 732 ||
                 (inv[ci].id == 687 && inv[ci].param2 != 0))
@@ -2720,7 +2720,7 @@ bool _magic_629()
         if (result.succeeded)
         {
             dbid = inv[ci].id;
-            access_item_db(2);
+            access_item_db(inv[ci], dbid, 2);
             for (int cnt = 0; cnt < 1; ++cnt)
             {
                 if (ichargelevel == 1)

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -2914,19 +2914,21 @@ bool _magic_1132(int& fltbk, int& valuebk)
             {
                 flttypemajor = fltbk;
             }
-            int stat = itemcreate(0, 0, -1, -1, 0);
-            if (stat == 0)
+            if (itemcreate(0, 0, -1, -1, 0))
             {
-                continue;
-            }
-            if (inv[ci].value > valuebk * 3 / 2 + 1000)
-            {
-                inv[ci].remove();
-                continue;
+                if (inv[ci].value > valuebk * 3 / 2 + 1000)
+                {
+                    inv[ci].remove();
+                    continue;
+                }
+                else
+                {
+                    break;
+                }
             }
             else
             {
-                break;
+                continue;
             }
         }
         txt(i18n::s.get("core.locale.magic.alchemy", inv[ci]));

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -533,15 +533,15 @@ bool _magic_183()
     if (cc != 0)
     {
         f = 0;
-        for (const auto& cnt : items(cc))
+        for (const auto& item : inv.for_chara(cdata[cc]))
         {
-            if (inv[cnt].number() == 0)
+            if (item.number() == 0)
             {
                 continue;
             }
-            if (inv[cnt].skill == 183)
+            if (item.skill == 183)
             {
-                ci = cnt;
+                ci = item.index;
                 f = 1;
                 break;
             }
@@ -1128,23 +1128,23 @@ bool _magic_412()
     }
     p(1) = 0;
     p(2) = 0;
-    for (const auto& cnt : items(tc))
+    for (auto&& item : inv.for_chara(cdata[tc]))
     {
-        if (inv[cnt].number() == 0)
+        if (item.number() == 0)
         {
             continue;
         }
-        if (!is_cursed(inv[cnt].curse_state))
+        if (!is_cursed(item.curse_state))
         {
             continue;
         }
-        ci = cnt;
+        ci = item.index;
         p = 0;
-        if (inv[ci].curse_state == CurseState::cursed)
+        if (item.curse_state == CurseState::cursed)
         {
             p = rnd(200) + 1;
         }
-        if (inv[ci].curse_state == CurseState::doomed)
+        if (item.curse_state == CurseState::doomed)
         {
             p = rnd(1000) + 1;
         }
@@ -1152,7 +1152,7 @@ bool _magic_412()
         {
             p = p / 2 + 1;
         }
-        else if (inv[ci].body_part == 0)
+        else if (item.body_part == 0)
         {
             continue;
         }
@@ -1161,7 +1161,7 @@ bool _magic_412()
             if (efp >= p)
             {
                 ++p(1);
-                inv[ci].curse_state = CurseState::none;
+                item.curse_state = CurseState::none;
                 item_stack(tc, ci, 1);
             }
             else
@@ -3391,35 +3391,35 @@ bool _magic_651()
             "core.locale.magic.scavenge.apply", cdata[cc], cdata[tc]));
     }
     p = -1;
-    for (const auto& cnt : items(tc))
+    for (const auto& item : inv.for_chara(cdata[tc]))
     {
-        if (inv[cnt].number() == 0)
+        if (item.number() == 0)
         {
             continue;
         }
-        if (inv[cnt].id == 618)
+        if (item.id == 618)
         {
-            p = cnt;
+            p = item.index;
             break;
         }
     }
     if (p == -1)
     {
-        for (const auto& cnt : items(tc))
+        for (const auto& item : inv.for_chara(cdata[tc]))
         {
-            if (inv[cnt].number() == 0)
+            if (item.number() == 0)
             {
                 continue;
             }
-            if (inv[cnt].is_precious())
+            if (item.is_precious())
             {
                 continue;
             }
-            if (the_item_db[inv[cnt].id]->category != 57000)
+            if (the_item_db[item.id]->category != 57000)
             {
                 continue;
             }
-            p = cnt;
+            p = item.index;
             break;
         }
     }
@@ -3518,9 +3518,9 @@ bool _magic_463()
     }
     else
     {
-        for (const auto& cnt : items(-1))
+        for (auto&& item : inv.ground())
         {
-            inv[cnt].remove();
+            item.remove();
         }
     }
     shoptrade = 0;

--- a/src/elona/map.cpp
+++ b/src/elona/map.cpp
@@ -347,16 +347,16 @@ void map_reload(const std::string& map_filename)
 
     mef_clear_all();
 
-    for (const auto& i : items(-1))
+    for (auto&& item : inv.ground())
     {
-        if (inv[i].number() > 0)
+        if (item.number() > 0)
         {
-            if (inv[i].own_state == 1)
+            if (item.own_state == 1)
             {
-                if (the_item_db[inv[i].id]->category == 57000)
+                if (the_item_db[item.id]->category == 57000)
                 {
-                    inv[i].remove();
-                    cell_refresh(inv[i].position.x, inv[i].position.y);
+                    item.remove();
+                    cell_refresh(item.position.x, item.position.y);
                 }
             }
         }
@@ -697,35 +697,35 @@ static void _clear_material_spots()
 
 static void _modify_items_on_regenerate()
 {
-    for (const auto& cnt : items(-1))
+    for (auto&& item : inv.ground())
     {
-        if (inv[cnt].number() == 0)
+        if (item.number() == 0)
         {
             continue;
         }
 
         // Update tree of fruits.
-        if (inv[cnt].id == 526)
+        if (item.id == 526)
         {
-            if (inv[cnt].param1 < 10)
+            if (item.param1 < 10)
             {
-                inv[cnt].param1 += 1;
-                inv[cnt].image = 591;
-                cell_refresh(inv[cnt].position.x, inv[cnt].position.y);
+                item.param1 += 1;
+                item.image = 591;
+                cell_refresh(item.position.x, item.position.y);
             }
         }
 
         // Clear player-owned items on the ground.
         if (map_is_town_or_guild())
         {
-            if (inv[cnt].own_state < 0)
+            if (item.own_state < 0)
             {
-                ++inv[cnt].own_state;
+                ++item.own_state;
             }
-            if (inv[cnt].own_state == 0)
+            if (item.own_state == 0)
             {
-                inv[cnt].remove();
-                cell_refresh(inv[cnt].position.x, inv[cnt].position.y);
+                item.remove();
+                cell_refresh(item.position.x, item.position.y);
             }
         }
     }
@@ -944,15 +944,15 @@ void map_proc_regen_and_update()
 
 void map_reload_noyel()
 {
-    for (const auto& cnt : items(-1))
+    for (auto&& item : inv.ground())
     {
-        if (inv[cnt].id == 555 || inv[cnt].id == 600)
+        if (item.id == 555 || item.id == 600)
         {
             continue;
         }
-        inv[cnt].remove();
+        item.remove();
 
-        cell_refresh(inv[cnt].position.x, inv[cnt].position.y);
+        cell_refresh(item.position.x, item.position.y);
     }
 
     if (area_data[game_data.current_map].christmas_festival)

--- a/src/elona/map.cpp
+++ b/src/elona/map.cpp
@@ -373,8 +373,7 @@ void map_reload(const std::string& map_filename)
             if (cell_data.at(x, y).item_appearances_actual == 0)
             {
                 flt();
-                int stat = itemcreate(-1, cmapdata(0, i), x, y, 0);
-                if (stat != 0)
+                if (itemcreate(-1, cmapdata(0, i), x, y, 0))
                 {
                     inv[ci].own_state = cmapdata(3, i);
                 }
@@ -838,8 +837,7 @@ static void _proc_generate_bard_items(Character& chara)
 static void _generate_bad_quality_item()
 {
     flt(calcobjlv(cdata[rc].level), calcfixlv(Quality::bad));
-    int stat = itemcreate(rc, 0, -1, -1, 0);
-    if (stat != 0)
+    if (itemcreate(rc, 0, -1, -1, 0))
     {
         if (inv[ci].weight <= 0 || inv[ci].weight >= 4000)
         {
@@ -960,35 +958,25 @@ void map_reload_noyel()
     if (area_data[game_data.current_map].christmas_festival)
     {
         flt();
-        int stat = itemcreate(-1, 763, 29, 16, 0);
-        if (stat != 0)
+        if (itemcreate(-1, 763, 29, 16, 0))
         {
             inv[ci].own_state = 1;
         }
+        flt();
+        if (itemcreate(-1, 686, 29, 16, 0))
         {
-            flt();
-            int stat = itemcreate(-1, 686, 29, 16, 0);
-            if (stat != 0)
-            {
-                inv[ci].own_state = 1;
-            }
+            inv[ci].own_state = 1;
         }
+        flt();
+        if (itemcreate(-1, 171, 29, 17, 0))
         {
-            flt();
-            int stat = itemcreate(-1, 171, 29, 17, 0);
-            if (stat != 0)
-            {
-                inv[ci].param1 = 6;
-                inv[ci].own_state = 1;
-            }
+            inv[ci].param1 = 6;
+            inv[ci].own_state = 1;
         }
+        flt();
+        if (itemcreate(-1, 756, 29, 17, 0))
         {
-            flt();
-            int stat = itemcreate(-1, 756, 29, 17, 0);
-            if (stat != 0)
-            {
-                inv[ci].own_state = 5;
-            }
+            inv[ci].own_state = 5;
         }
         {
             flt();

--- a/src/elona/map_cell.cpp
+++ b/src/elona/map_cell.cpp
@@ -181,13 +181,13 @@ void cell_movechara(int cc, int x, int y)
 int cell_itemlist(int x, int y)
 {
     listmax = 0;
-    for (const auto& cnt : items(-1))
+    for (const auto& item : inv.ground())
     {
-        if (inv[cnt].number() > 0)
+        if (item.number() > 0)
         {
-            if (inv[cnt].position.x == x && inv[cnt].position.y == y)
+            if (item.position.x == x && item.position.y == y)
             {
-                list(0, listmax) = cnt;
+                list(0, listmax) = item.index;
                 ++listmax;
             }
         }
@@ -201,18 +201,18 @@ int cell_itemlist(int x, int y)
 std::pair<int, int> cell_itemoncell(const Position& pos)
 {
     int number{};
-    int item{};
+    int item_{};
 
-    for (const auto& ci : items(-1))
+    for (const auto& item : inv.ground())
     {
-        if (inv[ci].number() > 0 && inv[ci].position == pos)
+        if (item.number() > 0 && item.position == pos)
         {
             ++number;
-            item = ci;
+            item_ = item.index;
         }
     }
 
-    return std::make_pair(number, item);
+    return std::make_pair(number, item_);
 }
 
 

--- a/src/elona/mapgen.cpp
+++ b/src/elona/mapgen.cpp
@@ -3737,9 +3737,12 @@ void map_initcustom(const std::string& map_filename)
         if (cmapdata(4, cnt) == 0)
         {
             flt();
-            int stat = itemcreate(
-                -1, cmapdata(0, cnt), cmapdata(1, cnt), cmapdata(2, cnt), 0);
-            if (stat != 0)
+            if (itemcreate(
+                    -1,
+                    cmapdata(0, cnt),
+                    cmapdata(1, cnt),
+                    cmapdata(2, cnt),
+                    0))
             {
                 inv[ci].own_state = cmapdata(3, cnt);
             }

--- a/src/elona/mapgen.cpp
+++ b/src/elona/mapgen.cpp
@@ -2908,11 +2908,11 @@ int initialize_quest_map_party()
         cdata[rc].relationship = -1;
         cdata[rc].original_relationship = -1;
     }
-    for (const auto& cnt : items(-1))
+    for (auto&& item : inv.ground())
     {
-        if (inv[cnt].number() > 0)
+        if (item.number() > 0)
         {
-            inv[cnt].own_state = 1;
+            item.own_state = 1;
         }
     }
     return 1;
@@ -2954,20 +2954,20 @@ void initialize_quest_map_town()
             cdata[rc].original_relationship = -3;
         }
     }
-    for (const auto& cnt : items(-1))
+    for (auto&& item : inv.ground())
     {
-        if (inv[cnt].number() == 0)
+        if (item.number() == 0)
         {
             continue;
         }
         f = 0;
-        if (inv[cnt].id == 109 || inv[cnt].id == 173)
+        if (item.id == 109 || item.id == 173)
         {
-            inv[cnt].param1 = -10;
+            item.param1 = -10;
         }
-        if (inv[cnt].id == 241)
+        if (item.id == 241)
         {
-            inv[cnt].param1 = 0;
+            item.param1 = 0;
         }
     }
     for (int cnt = 0, cnt_end = (map_data.height); cnt < cnt_end; ++cnt)

--- a/src/elona/mef.cpp
+++ b/src/elona/mef.cpp
@@ -279,7 +279,7 @@ void mef_proc(int tc)
             potionspill = 1;
             efstatus = static_cast<CurseState>(mef(8, ef)); // TODO
             dbid = mef(7, ef);
-            access_item_db(15);
+            access_item_db(inv[ci], dbid, 15);
             if (cdata[tc].state() == Character::State::empty)
             {
                 check_kill(mef(6, ef), tc);

--- a/src/elona/proc_event.cpp
+++ b/src/elona/proc_event.cpp
@@ -534,20 +534,19 @@ void proc_event()
             }
             p(0) = 0;
             p(1) = 6;
-            for (const auto& ci : items(-1))
+            for (const auto& item : inv.ground())
             {
-                if (inv[ci].number() == 0)
+                if (item.number() == 0)
                     continue;
-                if (inv[ci].function != 44)
+                if (item.function != 44)
                     continue;
                 if (c == tc)
                 {
-                    if (inv[ci].param1 == 2)
+                    if (item.param1 == 2)
                     {
-                        cell_swap(
-                            c, -1, inv[ci].position.x, inv[ci].position.y);
-                        i = ci;
-                        p = ci;
+                        cell_swap(c, -1, item.position.x, item.position.y);
+                        i = item.index;
+                        p = item.index;
                         break;
                     }
                     else
@@ -559,28 +558,28 @@ void proc_event()
                 {
                     break;
                 }
-                else if (ci == i)
+                else if (item.index == i)
                 {
                     continue;
                 }
                 p(2) = dist(
-                    inv[ci].position.x,
-                    inv[ci].position.y,
+                    item.position.x,
+                    item.position.y,
                     inv[i].position.x,
                     inv[i].position.y);
                 if (p(2) < p(1))
                 {
-                    if (cell_data.at(inv[ci].position.x, inv[ci].position.y)
+                    if (cell_data.at(item.position.x, item.position.y)
                                 .chara_index_plus_one == 0 ||
                         c == 0 || c == tc)
                     {
-                        p(0) = ci;
+                        p(0) = item.index;
                         p(1) = p(2);
                     }
                 }
-                if (c == 0 && inv[ci].param1 == 1)
+                if (c == 0 && item.param1 == 1)
                 {
-                    p = ci;
+                    p = item.index;
                     break;
                 }
             }

--- a/src/elona/quest.cpp
+++ b/src/elona/quest.cpp
@@ -656,8 +656,7 @@ int quest_generate()
             }
             flt(40, Quality::good);
             flttypemajor = choice(fsetcollect);
-            int stat = itemcreate(n, 0, -1, -1, 0);
-            if (stat != 0)
+            if (itemcreate(n, 0, -1, -1, 0))
             {
                 inv[ci].count = rq;
                 i(0) = n;

--- a/src/elona/quest.cpp
+++ b/src/elona/quest.cpp
@@ -1120,11 +1120,11 @@ void quest_exit_map()
 {
     if (game_data.executing_immediate_quest_type == 1006)
     {
-        for (const auto& cnt : items(0))
+        for (auto&& item : inv.pc())
         {
-            if (inv[cnt].own_state == 4)
+            if (item.own_state == 4)
             {
-                inv[cnt].remove();
+                item.remove();
             }
         }
         refresh_burden_state();

--- a/src/elona/shop.cpp
+++ b/src/elona/shop.cpp
@@ -72,9 +72,9 @@ void shop_load_shoptmp()
 
 void shop_refresh()
 {
-    for (const auto& cnt : items(-1))
+    for (auto&& item : inv.ground())
     {
-        inv[cnt].remove();
+        item.remove();
     }
 
     lua::call(

--- a/src/elona/talk_house_visitor.cpp
+++ b/src/elona/talk_house_visitor.cpp
@@ -50,9 +50,8 @@ TalkResult _talk_hv_visitor()
 void _adventurer_give_new_year_gift()
 {
     flt();
-    int stat = itemcreate(
-        -1, 752, cdata.player().position.x, cdata.player().position.y, 0);
-    if (stat != 0)
+    if (itemcreate(
+            -1, 752, cdata.player().position.x, cdata.player().position.y, 0))
     {
         inv[ci].param3 = cdata[tc].impression + rnd(50);
     }

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -93,14 +93,13 @@ TalkResult talk_wizard_identify(int chatval_)
         return TalkResult::talk_npc;
     }
     p = 0;
-    for (const auto& cnt : items(0))
+    for (const auto& item : inv.pc())
     {
-        if (inv[cnt].number() == 0)
+        if (item.number() == 0)
         {
             continue;
         }
-        if (inv[cnt].identification_state !=
-            IdentifyState::completely_identified)
+        if (item.identification_state != IdentifyState::completely_identified)
         {
             ++p;
         }
@@ -118,17 +117,17 @@ TalkResult talk_wizard_identify(int chatval_)
         p(1) = 0;
         p(0) = 0;
         p(1) = 0;
-        for (const auto& cnt : items(0))
+        for (auto&& item : inv.pc())
         {
-            if (inv[cnt].number() == 0)
+            if (item.number() == 0)
             {
                 continue;
             }
-            if (inv[cnt].identification_state !=
+            if (item.identification_state !=
                 IdentifyState::completely_identified)
             {
-                const auto result = item_identify(inv[cnt], 250);
-                item_stack(0, cnt, 1);
+                const auto result = item_identify(item, 250);
+                item_stack(0, item.index, 1);
                 ++p(1);
                 if (result >= IdentifyState::completely_identified)
                 {
@@ -218,12 +217,11 @@ TalkResult talk_healer_restore_attributes()
 TalkResult talk_trade()
 {
     invsubroutine = 1;
-    for (const auto& cnt : items(tc))
+    for (auto&& item : inv.for_chara(cdata[tc]))
     {
-        if (inv[cnt].number() != 0)
+        if (item.number() != 0)
         {
-            inv[cnt].identification_state =
-                IdentifyState::completely_identified;
+            item.identification_state = IdentifyState::completely_identified;
         }
     }
     invctrl(0) = 20;
@@ -2173,15 +2171,15 @@ TalkResult talk_npc()
                 {
                     p = quest_data[cnt].target_item_id;
                     deliver = cnt;
-                    for (const auto& cnt : items(0))
+                    for (const auto& item : inv.pc())
                     {
-                        if (inv[cnt].number() == 0)
+                        if (item.number() == 0)
                         {
                             continue;
                         }
-                        if (inv[cnt].id == p)
+                        if (item.id == p)
                         {
-                            deliver(1) = cnt;
+                            deliver(1) = item.index;
                             break;
                         }
                     }
@@ -2198,36 +2196,31 @@ TalkResult talk_npc()
             quest_data[rq].progress == 1)
         {
             supply = -1;
-            for (const auto& cnt : items(0))
+            for (const auto& item : inv.pc())
             {
-                if (inv[cnt].number() == 0)
+                if (item.number() == 0)
                 {
                     continue;
                 }
-                if (inv[cnt].is_marked_as_no_drop())
+                if (item.is_marked_as_no_drop())
                 {
                     continue;
                 }
                 if (quest_data[rq].id == 1003)
                 {
-                    if (the_item_db[inv[cnt].id]->category == 57000)
+                    if (the_item_db[item.id]->category == 57000 &&
+                        item.param1 / 1000 == quest_data[rq].extra_info_1 &&
+                        item.param2 == quest_data[rq].extra_info_2)
                     {
-                        if (inv[cnt].param1 / 1000 ==
-                            quest_data[rq].extra_info_1)
-                        {
-                            if (inv[cnt].param2 == quest_data[rq].extra_info_2)
-                            {
-                                supply = cnt;
-                                break;
-                            }
-                        }
+                        supply = item.index;
+                        break;
                     }
                 }
                 if (quest_data[rq].id == 1004 || quest_data[rq].id == 1011)
                 {
-                    if (inv[cnt].id == quest_data[rq].target_item_id)
+                    if (item.id == quest_data[rq].target_item_id)
                     {
-                        supply = cnt;
+                        supply = item.index;
                         break;
                     }
                 }
@@ -2412,6 +2405,6 @@ TalkResult talk_npc()
     }
 
     return TalkResult::talk_end;
-} // namespace elona
+}
 
 } // namespace elona

--- a/src/elona/turn_sequence.cpp
+++ b/src/elona/turn_sequence.cpp
@@ -1498,7 +1498,7 @@ TurnResult pc_turn(bool advance_time)
                 the_item_db[inv[ci].id]->category == 52000)
             {
                 dbid = inv[ci].id;
-                access_item_db(15);
+                access_item_db(inv[ci], dbid, 15);
             }
         }
         if (trait(214) != 0 && rnd(250) == 0 &&

--- a/src/elona/turn_sequence_pc_actions.cpp
+++ b/src/elona/turn_sequence_pc_actions.cpp
@@ -209,48 +209,48 @@ optional<TurnResult> handle_pc_action(std::string& action)
             action = "search";
         }
         p = 0;
-        for (const auto& ci : items(-1))
+        for (const auto& item : inv.ground())
         {
-            if (inv[ci].number() == 0)
+            if (item.number() == 0)
                 continue;
-            if (inv[ci].position != cdata[cc].position)
+            if (item.position != cdata[cc].position)
                 continue;
-            if (the_item_db[inv[ci].id]->category == 72000)
+            if (the_item_db[item.id]->category == 72000)
             {
                 p = 1;
             }
-            if (the_item_db[inv[ci].id]->subcategory == 60001)
+            if (the_item_db[item.id]->subcategory == 60001)
             {
                 p = 2;
             }
-            if (the_item_db[inv[ci].id]->category == 60002)
+            if (the_item_db[item.id]->category == 60002)
             {
                 p(0) = 3;
-                p(1) = ci;
+                p(1) = item.index;
             }
-            if (inv[ci].function != 0 || the_item_db[inv[ci].id]->is_usable)
+            if (item.function != 0 || the_item_db[item.id]->is_usable)
             {
                 p = 4;
             }
-            if (the_item_db[inv[ci].id]->is_readable)
+            if (the_item_db[item.id]->is_readable)
             {
                 p = 5;
             }
-            if (inv[ci].id == 631)
+            if (item.id == 631)
             {
                 action = "go_down";
             }
-            if (inv[ci].id == 750 &&
+            if (item.id == 750 &&
                 game_data.current_map == mdata_t::MapId::your_home)
             {
                 action = "go_up";
             }
-            if (inv[ci].id == 751 &&
+            if (item.id == 751 &&
                 game_data.current_map == mdata_t::MapId::your_home)
             {
                 action = "go_down";
             }
-            if (inv[ci].id == 753)
+            if (item.id == 753)
             {
                 action = "go_down";
             }

--- a/src/elona/variables.hpp
+++ b/src/elona/variables.hpp
@@ -722,7 +722,6 @@ int cargocheck();
 void getinheritance(int, elona_vector1<int>&, int&);
 
 // Item manipulation
-int access_item_db(int);
 int convertartifact(int = 0, int = 0);
 int discsetmc();
 void set_item_info();

--- a/src/tests/i18n.cpp
+++ b/src/tests/i18n.cpp
@@ -54,7 +54,7 @@ TEST_CASE("test format chara", "[I18N: Formatting]")
 TEST_CASE("test format item", "[I18N: Formatting]")
 {
     testing::start_in_debug_map();
-    REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, 3));
+    REQUIRE_SOME(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, 3));
     Item& i = elona::inv[elona::ci];
 
     REQUIRE(

--- a/src/tests/item.cpp
+++ b/src/tests/item.cpp
@@ -11,7 +11,7 @@ TEST_CASE("Test that index of copied item is set", "[C++: Item]")
     testing::start_in_debug_map();
     int amount = 1;
 
-    REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, amount));
+    REQUIRE_SOME(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, amount));
     Item& i = elona::inv[elona::ci];
 
     int ti = elona::inv_getfreeid(-1);

--- a/src/tests/lua_callbacks.cpp
+++ b/src/tests/lua_callbacks.cpp
@@ -270,7 +270,7 @@ Store.global.items = {}
 Event.register("core.item_created", my_item_created_handler)
 )"));
 
-    REQUIRE(elona::itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, 3));
+    REQUIRE_SOME(elona::itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, 3));
     int idx = elona::ci;
     REQUIRE(idx != -1);
     elona::lua::lua->get_mod_manager()

--- a/src/tests/lua_handles.cpp
+++ b/src/tests/lua_handles.cpp
@@ -36,7 +36,7 @@ TEST_CASE("Test that handle properties can be read", "[Lua: Handles]")
     }
     SECTION("Items")
     {
-        REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, 3));
+        REQUIRE_SOME(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, 3));
         int idx = elona::ci;
         Item& item = elona::inv[idx];
         auto handle = handle_mgr.get_handle(item);
@@ -77,7 +77,7 @@ TEST_CASE("Test that handle properties can be written", "[Lua: Handles]")
     }
     SECTION("Items")
     {
-        REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 0, 0, 1));
+        REQUIRE_SOME(itemcreate(-1, PUTITORO_PROTO_ID, 0, 0, 1));
         Item& item = elona::inv[elona::ci];
         auto handle = handle_mgr.get_handle(item);
         elona::lua::lua->get_state()->set("item", handle);
@@ -149,7 +149,7 @@ TEST_CASE("Test that handles go invalid", "[Lua: Handles]")
     }
     SECTION("Items")
     {
-        REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, 3));
+        REQUIRE_SOME(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, 3));
         Item& item = elona::inv[elona::ci];
         auto handle = handle_mgr.get_handle(item);
         elona::lua::lua->get_state()->set("item", handle);
@@ -195,7 +195,7 @@ TEST_CASE("Test invalid references to handles in store table", "[Lua: Handles]")
     }
     SECTION("Items")
     {
-        REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, 3));
+        REQUIRE_SOME(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, 3));
         Item& item = elona::inv[elona::ci];
         auto handle = handle_mgr.get_handle(item);
 
@@ -286,7 +286,7 @@ print(Chara.is_ally(Store.global.charas[0]))
     }
     SECTION("Items")
     {
-        REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, 3));
+        REQUIRE_SOME(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, 3));
         Item& item = elona::inv[elona::ci];
         auto handle = handle_mgr.get_handle(item);
 
@@ -360,7 +360,7 @@ TEST_CASE(
     start_in_debug_map();
     auto& handle_mgr = elona::lua::lua->get_handle_manager();
 
-    REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, 1));
+    REQUIRE_SOME(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, 1));
     elona::cc = 0;
     elona::in = inv[elona::ci].number();
 
@@ -526,7 +526,7 @@ TEST_CASE(
     auto& handle_mgr = elona::lua::lua->get_handle_manager();
     int amount = 2;
 
-    REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, amount));
+    REQUIRE_SOME(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, amount));
     Item& i = elona::inv[elona::ci];
     auto handle = handle_mgr.get_handle(i);
     auto old_uuid = handle["__uuid"].get<std::string>();
@@ -559,7 +559,7 @@ TEST_CASE("Test separation of item handles", "[Lua: Handles]")
     auto& handle_mgr = elona::lua::lua->get_handle_manager();
     int amount = 3;
 
-    REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, amount));
+    REQUIRE_SOME(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, amount));
     Item& i = elona::inv[elona::ci];
     sol::table handle = handle_mgr.get_handle(i);
 
@@ -582,7 +582,7 @@ TEST_CASE("Test copying of item handles", "[Lua: Handles]")
     auto& handle_mgr = elona::lua::lua->get_handle_manager();
     int amount = 1;
 
-    REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, amount));
+    REQUIRE_SOME(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, amount));
     Item& i = elona::inv[elona::ci];
     sol::table handle = handle_mgr.get_handle(i);
 
@@ -614,10 +614,10 @@ TEST_CASE("Test copying of item handles after removal", "[Lua: Handles]")
     auto& handle_mgr = elona::lua::lua->get_handle_manager();
     int amount = 1;
 
-    REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, amount));
+    REQUIRE_SOME(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, amount));
     Item& a = elona::inv[elona::ci];
 
-    REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 9, amount));
+    REQUIRE_SOME(itemcreate(-1, PUTITORO_PROTO_ID, 4, 9, amount));
     Item& b = elona::inv[elona::ci];
 
     // Mark the handle in b's slot as invalid.
@@ -633,11 +633,11 @@ TEST_CASE("Test swapping of item handles", "[Lua: Handles]")
     start_in_debug_map();
     auto& handle_mgr = elona::lua::lua->get_handle_manager();
 
-    REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, 1));
+    REQUIRE_SOME(itemcreate(-1, PUTITORO_PROTO_ID, 4, 8, 1));
     Item& item_a = elona::inv[elona::ci];
     sol::table handle_a = handle_mgr.get_handle(item_a);
 
-    REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 4, 9, 1));
+    REQUIRE_SOME(itemcreate(-1, PUTITORO_PROTO_ID, 4, 9, 1));
     Item& item_b = elona::inv[elona::ci];
     sol::table handle_b = handle_mgr.get_handle(item_b);
 

--- a/src/tests/serialization.cpp
+++ b/src/tests/serialization.cpp
@@ -37,7 +37,7 @@ TEST_CASE("Test item saving and reloading", "[C++: Serialization]")
     int x = 4;
     int y = 8;
     int number = 3;
-    REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, x, y, number));
+    REQUIRE_SOME(itemcreate(-1, PUTITORO_PROTO_ID, x, y, number));
     int index = elona::ci;
     elona::inv[index].is_aphrodisiac() = true;
     elona::inv[index].curse_state = CurseState::blessed;
@@ -79,7 +79,7 @@ TEST_CASE("Test other character index preservation", "[C++: Serialization]")
 TEST_CASE("Test item index preservation", "[C++: Serialization]")
 {
     start_in_debug_map();
-    REQUIRE(itemcreate(-1, PUTITORO_PROTO_ID, 0, 0, 0));
+    REQUIRE_SOME(itemcreate(-1, PUTITORO_PROTO_ID, 0, 0, 0));
     int index = elona::ci;
 
     save_and_reload();

--- a/src/tests/util.cpp
+++ b/src/tests/util.cpp
@@ -54,7 +54,7 @@ void normalize_item(Item& i)
 
 std::string test_itemname(int id, int number, bool prefix)
 {
-    REQUIRE(itemcreate(-1, id, 0, 0, number) == 1);
+    REQUIRE_SOME(itemcreate(-1, id, 0, 0, number));
     int index = elona::ci;
     normalize_item(elona::inv[index]);
     std::string name = itemname(index, number, prefix ? 0 : 1);
@@ -71,7 +71,7 @@ Character& create_chara(int id, int x, int y)
 
 Item& create_item(int id, int number)
 {
-    REQUIRE(itemcreate(-1, id, 0, 0, number) == 1);
+    REQUIRE_SOME(itemcreate(-1, id, 0, 0, number));
     normalize_item(elona::inv[elona::ci]);
     return elona::inv[elona::ci];
 }
@@ -87,7 +87,7 @@ void invalidate_item(Item& item)
     item_delete(old_index);
     do
     {
-        REQUIRE(itemcreate(-1, old_id, old_x, old_y, 3) == 1);
+        REQUIRE_SOME(itemcreate(-1, old_id, old_x, old_y, 3));
     } while (elona::ci != old_index);
 }
 


### PR DESCRIPTION
# Summary

Try to reduce `Inventory::operator[]()` for future extension such as #1081.


- Make `itemcreate()` return `optional<int>`, new item's index or none. It can reduce usage of `ci`.
- Rename local var 'ci' and 'ti'  …
  - There are global variables 'ci' and 'ti' which are very frequently referred to. I have a plan to delete these variables and instead use Item& or Item*. The local variation of them prevent that.
- Remove `Inventory::operator[]` from access_item_db.cpp
- Iterate items by `struct Item`, not index

# TODO

- [x] Test more...