### PR TITLE
Fix get_executable_path() on Windows

### DIFF
--- a/src/util/filepathutil.cpp
+++ b/src/util/filepathutil.cpp
@@ -57,17 +57,15 @@ std::string to_forward_slashes(const fs::path& path)
 }
 
 
-boost::optional<std::string> get_executable_path()
+boost::optional<boost::filesystem::path::string_type> get_executable_path()
 {
 #if BOOST_OS_WINDOWS
-    TCHAR buf_wide[1024 + 1];
-    size_t buf_size = sizeof(buf_wide);
-    if (GetModuleFileName(nullptr, buf_wide, buf_size) == 0)
+    wchar_t buf[1024 + 1];
+    size_t buf_size = sizeof(buf);
+    if (GetModuleFileName(nullptr, buf, buf_size) == 0)
     {
         return boost::none;
     }
-    char buf[2048 + 1];
-    wcstombs(buf, buf_wide, wcslen(buf_wide) + 1);
 #elif BOOST_OS_MACOS
     char buf[PATH_MAX + 1];
     uint32_t buf_size = sizeof(buf);
@@ -93,7 +91,7 @@ boost::optional<std::string> get_executable_path()
 #error Unsupported OS
 #endif
 
-    return std::string(buf);
+    return fs::path::string_type(buf);
 }
 
 } // namespace filepathutil

--- a/src/util/filepathutil.hpp
+++ b/src/util/filepathutil.hpp
@@ -15,6 +15,6 @@ boost::filesystem::path u8path(const std::string&);
 std::string make_preferred_path_in_utf8(const boost::filesystem::path& path);
 std::string to_utf8_path(const boost::filesystem::path& path);
 std::string to_forward_slashes(const boost::filesystem::path& path);
-boost::optional<std::string> get_executable_path();
+boost::optional<boost::filesystem::path::string_type> get_executable_path();
 
 } // namespace filepathutil


### PR DESCRIPTION
# Related Issues

Close #1325.


# Summary

wcstombs() takes a multibyte character buffer (output), a wide character
buffer, and the length of the output buffer. However, actually, the
length of *wide character buffer* was passed to. Due to that,
get_executable_path() returns a shorter path than the actual one on
Windows. Now, the function does not convert wchar_t* to char* and
returns internal representation on each OS. On Windows, it is UTF-16,
wchar_t*. (Strictly speaking, C++ specification does not say wchar_t* is
encoded in UTF-16 but Windows does so.)
