### PR TITLE
Fix that stacked wells dry out at the same time

### DIFF
--- a/src/elona/elonacore.cpp
+++ b/src/elona/elonacore.cpp
@@ -7973,6 +7973,7 @@ int drink_well()
         txt(i18n::s.get("core.locale.action.drink.well.is_dry", valn));
         return 1;
     }
+    item_separate(ci);
     snd_at("core.drink1", cdata[cc].position);
     const auto valn = itemname(ci);
     txt(i18n::s.get("core.locale.action.drink.well.draw", cdata[cc], valn));


### PR DESCRIPTION
# Related Issues

Close #1321.

# Summary

Call `item_separate()` before you drink.