### PR TITLE
Fix being able to talk to neutral NPCs

### DIFF
--- a/src/elona/lua_env/lua_api/lua_api_input.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_input.cpp
@@ -388,7 +388,10 @@ void LuaApiInput::start_dialog(LuaCharacterHandle speaker)
             "Character has no dialog: "s + speaker_ref.new_id().get());
     }
 
-    talk_setup_variables(speaker_ref);
+    if (!talk_setup_variables(speaker_ref))
+    {
+        return;
+    }
     talk_start();
 
     dialog_start(speaker_ref, *data.dialog_id);
@@ -410,7 +413,10 @@ void LuaApiInput::start_dialog_with_data(
 {
     auto& speaker_ref = lua::ref<Character>(speaker);
 
-    talk_setup_variables(speaker_ref);
+    if (!talk_setup_variables(speaker_ref))
+    {
+        return;
+    }
     talk_start();
 
     dialog_start(speaker_ref, dialog);

--- a/src/elona/talk.cpp
+++ b/src/elona/talk.cpp
@@ -89,7 +89,10 @@ void talk_to_npc()
 
 void talk_to_npc(Character &chara)
 {
-    talk_setup_variables(chara);
+    if (!talk_setup_variables(chara))
+    {
+        return;
+    }
 
     talk_start();
     if (scenemode == 1)


### PR DESCRIPTION
# Related Issues

Neutral NPCs like Gwen usually won't listen to you, but in v0.4.2, you can talk to such NPCs.


# Summary

Check the return value of `talk_setup_variables()`, and if false, return immediately without showing dialog window.