### PR TITLE
Add MenuCursorHistory to restore the previous cursor position

### DIFF
--- a/src/elona/main_menu.cpp
+++ b/src/elona/main_menu.cpp
@@ -1,5 +1,4 @@
 #include "main_menu.hpp"
-
 #include "../util/fileutil.hpp"
 #include "../util/strutil.hpp"
 #include "../version.hpp"
@@ -18,6 +17,7 @@
 #include "menu.hpp"
 #include "random.hpp"
 #include "ui.hpp"
+#include "ui/menu_cursor_history.hpp"
 #include "ui/simple_prompt.hpp"
 #include "ui/ui_menu_mods.hpp"
 #include "variables.hpp"
@@ -180,6 +180,12 @@ MainMenuResult main_title_menu()
     cs = 0;
     cs_bk = -1;
     pagesize = 0;
+
+    if (const auto cursor =
+            ui::MenuCursorHistory::instance().restore("core.main_title_menu"))
+    {
+        cs = cursor->position();
+    }
 
     load_background_variants(2);
 
@@ -361,13 +367,20 @@ MainMenuResult main_title_menu()
         int index{};
         cursor_check_ex(index);
 
+        if (index != -1)
+        {
+            ui::MenuCursorHistory::instance().save(
+                "core.main_title_menu", ui::MenuCursor{cs});
+        }
+
         switch (index)
         {
+        case -1: break;
+        case 0: snd("core.ok1"); return MainMenuResult::main_menu_continue;
         case 1:
             snd("core.ok1");
             geneuse = "";
             return MainMenuResult::main_menu_new_game;
-        case 0: snd("core.ok1"); return MainMenuResult::main_menu_continue;
         case 2: snd("core.ok1"); return MainMenuResult::main_menu_incarnate;
         case 3: snd("core.ok1"); return MainMenuResult::main_menu_about;
         case 4:
@@ -376,6 +389,7 @@ MainMenuResult main_title_menu()
             return MainMenuResult::main_title_menu;
         case 5: snd("core.ok1"); return MainMenuResult::main_menu_mods;
         case 6: snd("core.ok1"); return MainMenuResult::finish_elona;
+        default: throw "unreachable";
         }
 
         ++frame;

--- a/src/elona/ui/menu_cursor_history.hpp
+++ b/src/elona/ui/menu_cursor_history.hpp
@@ -1,0 +1,176 @@
+#pragma once
+
+#include <stack>
+#include <unordered_map>
+#include "../optional.hpp"
+
+
+
+namespace elona
+{
+namespace ui
+{
+
+/**
+ * Holds a page and a position in the current page. It must point to somewhere,
+ * and does not allow invalid position.
+ */
+struct MenuCursor
+{
+    using Page = int;
+    using Position = int;
+
+
+
+    MenuCursor(Page page, Position position)
+        : _page(page)
+        , _pos(position)
+    {
+    }
+
+
+
+    explicit MenuCursor(Position position)
+        : _page(0)
+        , _pos(position)
+    {
+    }
+
+
+
+    MenuCursor()
+        : _page(0)
+        , _pos(0)
+    {
+    }
+
+
+
+    MenuCursor(const MenuCursor&) = default;
+    MenuCursor(MenuCursor&&) = default;
+    MenuCursor& operator=(const MenuCursor&) = default;
+    MenuCursor& operator=(MenuCursor&&) = default;
+
+
+
+    // 0-indexed, but displayed as 1-indexed to players.
+    Page page() const noexcept
+    {
+        return _page;
+    }
+
+
+
+    // 0-indexed, but displayed as 1-indexed to players.
+    Position position() const noexcept
+    {
+        return _pos;
+    }
+
+
+
+private:
+    Page _page;
+    Position _pos;
+};
+
+
+
+/*
+ * Menu lifecycle and cursor history.
+ *
+ * init();
+ * cursor = MenuCursorHistory::instance().restore("key");
+ * while (true)
+ * {
+ *     cursor = player's input
+ *
+ *     MenuCursorHistory::instance().push(cursor);
+ *     open_submenu();
+ *     cursor = MenuCursorHistory::instance().pop();
+ * }
+ *
+ * MenuCursorHistory::instance().save("key", cursor);
+ * close();
+ */
+class MenuCursorHistory
+{
+public:
+    using Key = std::string;
+
+
+
+    static MenuCursorHistory& instance()
+    {
+        static MenuCursorHistory instance;
+        return instance;
+    }
+
+
+
+    /// Push the current menu cursor. Call it before opening a submenu.
+    void push(const MenuCursor& cursor)
+    {
+        _stack.push(cursor);
+    }
+
+
+
+    /// Pop the top of the stack and return it. Call it after a submenu is
+    /// closed.
+    /// If the current window is in the top level and has no parent window, this
+    /// function returns none.
+    optional<MenuCursor> pop()
+    {
+        if (_stack.empty())
+        {
+            return none;
+        }
+        else
+        {
+            const auto ret = _stack.top();
+            _stack.pop();
+            return ret;
+        }
+    }
+
+
+
+    /// Save the current menu cursor with unique key prefixed mod name (when you
+    /// call it from native code, prefix "core" to the key). Call it before the
+    /// current menu is about to be closed.
+    void save(const Key& key, const MenuCursor& cursor)
+    {
+        _history[key] = cursor;
+    }
+
+
+
+    /// Restore the previous menu cursor by the key. Call it after
+    /// initialization.
+    /// If the current menu is opened for the first time, this function returns
+    /// none.
+    optional<MenuCursor> restore(const Key& key)
+    {
+        const auto itr = _history.find(key);
+        if (itr == std::end(_history))
+        {
+            return none;
+        }
+        else
+        {
+            return itr->second;
+        }
+    }
+
+
+
+private:
+    MenuCursorHistory() = default;
+
+    std::unordered_map<Key, MenuCursor> _history;
+    std::stack<MenuCursor> _stack;
+};
+
+} // namespace ui
+} // namespace elona


### PR DESCRIPTION
# Summary


`MenuCursorHistory` is similar to `ConfigMenuHistory`, but more general solution for any list menu window to save the current cursor position and restore it in the next time.
