### PR TITLE
Check whether user/talk direcotry exists or not to avoid crash

### DIFF
--- a/src/elona/ui/ui_menu_npc_tone.cpp
+++ b/src/elona/ui/ui_menu_npc_tone.cpp
@@ -19,15 +19,18 @@ static int _load_talk_entries()
 
     ++_listmax;
     const auto base_dir = filesystem::dir::user() / u8"talk";
-    for (const auto& entry : filesystem::dir_entries(
-             base_dir,
-             filesystem::DirEntryRange::Type::file,
-             std::regex{u8R"(.*\.txt)"}))
+    if (fs::exists(base_dir))
     {
-        list(0, _listmax) = _listmax;
-        listn(0, _listmax) =
-            filepathutil::to_utf8_path(fs::relative(entry.path(), base_dir));
-        ++_listmax;
+        for (const auto& entry : filesystem::dir_entries(
+                 base_dir,
+                 filesystem::DirEntryRange::Type::file,
+                 std::regex{u8R"(.*\.txt)"}))
+        {
+            list(0, _listmax) = _listmax;
+            listn(0, _listmax) = filepathutil::to_utf8_path(
+                fs::relative(entry.path(), base_dir));
+            ++_listmax;
+        }
     }
 
     return _listmax;


### PR DESCRIPTION
# Summary

Check whether `profile/<current profile>/user/talk` exists or not before trying to iterate over the folder.