### PR TITLE
Fix text color of damage popup of atomic bomb

### DIFF
--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -306,7 +306,7 @@ int damage_hp(
 
     if (is_in_fov(victim))
     {
-        const auto color_id = element_color_id(ele);
+        const auto color_id = element_color_id(element);
         const auto r = static_cast<uint8_t>(255 - c_col(0, color_id));
         const auto g = static_cast<uint8_t>(255 - c_col(1, color_id));
         const auto b = static_cast<uint8_t>(255 - c_col(2, color_id));


### PR DESCRIPTION
# Summary

Atomic bomb's damage is no element, but text color of the damage popup was colored in purple.

![image](https://user-images.githubusercontent.com/36858341/58747488-dedd6680-84a6-11e9-93df-d9b8e94b8344.png)

⬇️ 


![image](https://user-images.githubusercontent.com/36858341/58747512-0cc2ab00-84a7-11e9-8b2f-6543d69893b1.png)
