### PR TITLE
Fix strange behavior when you present gift

### DIFF
--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -1470,8 +1470,13 @@ label_2061_internal:
                     "core.locale.ui.inv.give.present.dialog", cdata[tc]));
                 chara_modify_impression(cdata[tc], giftvalue(inv[ci].param4));
                 cdata[tc].emotion_icon = 317;
+                refresh_burden_state();
+                if (invally == 1)
+                {
+                    goto label_20591;
+                }
                 update_screen();
-                result.turn_result = TurnResult::pc_turn_user_error;
+                result.turn_result = TurnResult::turn_end;
                 return result;
             }
             f = 0;


### PR DESCRIPTION
# Related Issues

[vanilla bug]

When you present gift to someone,

- [to npc/to ally] Your burden state won't be refreshed.
- [to ally] You cannot give other items continuously.
- [to npc] The game turn does not pass.
- [to ally] When you press `x`, opening inventory, the ally's [G]ive menu is shown.

See this page for details: [ElonaFoobar/bugfixes](https://elonafoobar.github.io/bugfixes/#%E3%83%9A%E3%83%83%E3%83%88%E3%81%AB%E3%81%8A%E3%81%BF%E3%82%84%E3%81%92%E3%82%92%E6%B8%A1%E3%81%97%E3%81%9F%E3%81%A8%E3%81%8D%E3%81%AE%E6%8C%99%E5%8B%95%E3%81%8C%E3%81%8A%E3%81%8B%E3%81%97%E3%81%84%E5%95%8F%E9%A1%8C)

# Summary

- Add missing call of refresh_burden_state().
- When you present gift to your ally, you can give other items
  continuously.
- When you present gift to other NPCs, the game turn passes.
