### PR TITLE
Fix i18n error: undefined building

### DIFF
--- a/src/elona/text.cpp
+++ b/src/elona/text.cpp
@@ -428,6 +428,10 @@ std::string mapname(int id, bool description)
 std::string txtbuilding(int x, int y)
 {
     const auto type = bddata(0, x, y);
+    if (type == 0)
+    {
+        return "";
+    }
     return i18n::s.get(
         "core.locale.map.you_see",
         i18n::s.get_enum("core.locale.map.misc_location", type));


### PR DESCRIPTION
# Summary

[vanilla bug]

In vanilla these buildings are built on startup (unimplemented feature),
but the data, variable `bddata`, is not saved. Thus, they will vanish
after you save and load the save once. However, the building information
still remain in map data, variable `cell_data`. As a result, when you
stand at the ruins, you see wield system message, "You see \<i18n error\>" or "\<i18n error\>がある".
In vanilla, the message was "You see." or "がある".

- Mine
- Crop
- Art Atelier
- Smuggler's Hideout
- Light House
