### PR TITLE
Add new options: initial_key_repeat_wait / key_repeat_wait

### DIFF
--- a/runtime/mod/core/config_def.hcl
+++ b/runtime/mod/core/config_def.hcl
@@ -193,6 +193,18 @@ config {
                 max = 10
             }
 
+            initial_key_repeat_wait = {
+                default = 5
+                min = 1
+                max = 20
+            }
+
+            key_repeat_wait = {
+                default = 1
+                min = 1
+                max = 5
+            }
+
             select_wait = {
                 default = 10
                 min = 1

--- a/runtime/mod/core/locale/en/config.hcl
+++ b/runtime/mod/core/locale/en/config.hcl
@@ -324,6 +324,16 @@ DOC
                     doc = "Number of frames to wait between presses of shortcut keys."
                     formatter = core.locale.config.common.formatter.wait
                 }
+                initial_key_repeat_wait {
+                    name = "Initial key repeat wait"
+                    doc = "Number of frames to wait between the first action and the second."
+                    formatter = core.locale.config.common.formatter.wait
+                }
+                key_repeat_wait {
+                    name = "Key repeat wait"
+                    doc = "Number of frames to wait between any actions."
+                    formatter = core.locale.config.common.formatter.wait
+                }
                 select_wait {
                     name = "Select Wait"
                     doc = "Number of frames to wait between item selection initially."

--- a/runtime/mod/core/locale/jp/config.hcl
+++ b/runtime/mod/core/locale/jp/config.hcl
@@ -296,6 +296,14 @@ DOC
                     name = "キーウェイト"
                     formatter = core.locale.config.common.formatter.wait
                 }
+                initial_key_repeat_wait {
+                    name = "キーリピートウェイト(開始)"
+                    formatter = core.locale.config.common.formatter.wait
+                }
+                key_repeat_wait {
+                    name = "キーリピートウェイト"
+                    formatter = core.locale.config.common.formatter.wait
+                }
                 select_wait {
                     name = "選択ウェイト"
                     formatter = core.locale.config.common.formatter.wait

--- a/runtime/profile/default/config.hcl
+++ b/runtime/profile/default/config.hcl
@@ -142,6 +142,14 @@ config {
             # Number of frames to wait between presses of shortcut keys.
             # Valid values are 1 - 10.
             key_wait = 5
+
+            # Number of frames to wait between the first action and the second.
+            # Valid values are 1 - 20.
+            initial_key_repeat_wait = 5
+
+            # Number of frames to wait between any actions.
+            # Valid values are 1 - 5.
+            key_repeat_wait = 1
         }
 
         # These settings affect game balance.

--- a/src/elona/config/config.cpp
+++ b/src/elona/config/config.cpp
@@ -361,6 +361,8 @@ void load_config()
     CONFIG_OPTION("input.attack_wait"s, int, Config::instance().attack_wait);
     CONFIG_OPTION("input.autodisable_numlock"s, bool, Config::instance().autodisable_numlock);
     CONFIG_OPTION("input.key_wait"s, int, Config::instance().key_wait);
+    CONFIG_OPTION("input.initial_key_repeat_wait"s, int, Config::instance().initial_key_repeat_wait);
+    CONFIG_OPTION("input.key_repeat_wait"s, int, Config::instance().key_repeat_wait);
     CONFIG_OPTION("input.walk_wait"s, int, Config::instance().walk_wait);
     CONFIG_OPTION("input.run_wait"s, int, Config::instance().run_wait);
     CONFIG_OPTION("input.start_run_wait"s, int, Config::instance().start_run_wait);

--- a/src/elona/config/config.hpp
+++ b/src/elona/config/config.hpp
@@ -68,7 +68,9 @@ public:
     bool hide_shop_updates;
     bool high_quality_shadow;
     std::string hp_bar_position;
+    int initial_key_repeat_wait;
     bool joypad;
+    int key_repeat_wait;
     int key_wait;
     std::string language;
     bool leash_icon;

--- a/src/elona/keybind/input_context.cpp
+++ b/src/elona/keybind/input_context.cpp
@@ -401,7 +401,10 @@ bool InputContext::_delay_normal_action(const Keybind& keybind)
         last_held_key_frames = 0;
     }
 
-    bool delayed = _is_keypress_delayed(last_held_key_frames, 1, 20);
+    bool delayed = _is_keypress_delayed(
+        last_held_key_frames,
+        Config::instance().key_repeat_wait,
+        Config::instance().initial_key_repeat_wait);
 
     last_held_key_frames++;
 


### PR DESCRIPTION
# Summary

Add new options: `initial_key_repeat_wait` and `key_repeat_wait`. They allow you to change key repeat wait. Also change the default value of `initial_key_repeat_wait` from 20 to 5 because I feel the previous value is too long. It should improve UX.

```hcl
# Number of frames to wait between the first action and the second.
# Valid values are 1 - 20.
initial_key_repeat_wait = 5

# Number of frames to wait between any actions.
# Valid values are 1 - 5.
key_repeat_wait = 1
```