### PR TITLE
Fix PC's birth year

### DIFF
--- a/src/elona/init.cpp
+++ b/src/elona/init.cpp
@@ -741,6 +741,13 @@ void init()
 
     Config::instance().save();
 
+    // It is necessary to calculate PC's birth year correctly.
+    game_data.date.year = 517;
+    game_data.date.month = 8;
+    game_data.date.day = 12;
+    game_data.date.hour = 16;
+    game_data.date.minute = 10;
+
     quickpage = 1;
 
     // TODO: Show each time mods are reloaded.


### PR DESCRIPTION
# Related Issues

#1287

Due to the above change, the age of your newly created PC became wield. In Elona, character's age is stored as birth year, and calculated in this formula: `age = this_year - birth_year`
