### PR TITLE
Fix and improve change appearance menu

### DIFF
--- a/src/elona/blending.cpp
+++ b/src/elona/blending.cpp
@@ -1860,7 +1860,7 @@ void blending_proc_on_success_events()
     item_stack(0, ci);
     if (inv[ci].body_part != 0)
     {
-        create_pcpic(0);
+        create_pcpic(cdata.player());
     }
     if (inv_getowner(ci) == -1)
     {

--- a/src/elona/character_making.cpp
+++ b/src/elona/character_making.cpp
@@ -235,23 +235,23 @@ MainMenuResult character_making_customize_appearance()
             "core.locale.chara_making.customize_appearance.caption");
 
         cdata.player().has_own_sprite() = true;
-        int stat = change_appearance();
-        if (stat == 0)
+        switch (menu_change_appearance(cdata.player()))
         {
+        case ChangeAppearanceResult::proceed:
+            clear_background_in_character_making();
+            return MainMenuResult::character_making_final_phase;
+        case ChangeAppearanceResult::canceled:
             clear_background_in_character_making();
             return MainMenuResult::character_making_select_alias_looped;
-        }
-        if (stat != -1)
-        {
+        case ChangeAppearanceResult::show_help:
+            show_game_help();
+            clear_background_in_character_making();
             break;
         }
-        show_game_help();
-        clear_background_in_character_making();
     }
-    clear_background_in_character_making();
-
-    return MainMenuResult::character_making_final_phase;
 }
+
+
 
 static void _reroll_character()
 {
@@ -272,8 +272,10 @@ static void _reroll_character()
     initialize_character();
     initialize_pc_character();
     cdata[rc].portrait = portrait_save;
-    create_pcpic(0);
+    create_pcpic(cdata.player());
 }
+
+
 
 static int _prompt_satisfied()
 {

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -285,10 +285,7 @@ TurnResult do_interact_command()
     if (p == 8)
     {
         gsel(0);
-        ccbk = cc;
-        cc = tc;
-        change_appearance();
-        cc = ccbk;
+        menu_change_appearance(cdata[tc]);
         update_screen();
         return TurnResult::pc_turn_user_error;
     }
@@ -1469,7 +1466,7 @@ TurnResult do_dip_command()
         }
         if (inv[ci].body_part != 0)
         {
-            create_pcpic(cc);
+            create_pcpic(cdata[cc]);
         }
         return TurnResult::turn_end;
     }
@@ -1865,10 +1862,7 @@ TurnResult do_use_command()
             tc = chara;
             screenupdate = -1;
             update_screen();
-            ccbk = cc;
-            cc = tc;
-            change_appearance_equipment();
-            cc = ccbk;
+            change_appearance_equipment(cdata[tc]);
         }
         else
         {

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -223,7 +223,8 @@ label_20591:
             }
             if (invctrl == 6)
             {
-                if (iequiploc(cnt) != cdata[cc].body_parts[body - 100] / 10000)
+                if (iequiploc(inv[cnt]) !=
+                    cdata[cc].body_parts[body - 100] / 10000)
                 {
                     continue;
                 }
@@ -1634,7 +1635,7 @@ label_2061_internal:
                 wear_most_valuable_equipment_for_all_body_parts();
                 if (tc < 16)
                 {
-                    create_pcpic(tc);
+                    create_pcpic(cdata[tc]);
                 }
                 chara_refresh(tc);
                 refresh_burden_state();
@@ -1949,7 +1950,7 @@ label_2061_internal:
             wear_most_valuable_equipment_for_all_body_parts();
             if (tc < 16)
             {
-                create_pcpic(tc);
+                create_pcpic(cdata[tc]);
             }
             chara_refresh(tc);
             refresh_burden_state();

--- a/src/elona/draw.hpp
+++ b/src/elona/draw.hpp
@@ -73,14 +73,12 @@ void clear_damage_popups();
 void show_damage_popups();
 
 void draw_emo(int = 0, int = 0, int = 0);
-void load_pcc_part(int cc, int body_part, const char* body_part_str);
-void set_pcc_depending_on_equipments(int cc, int ci);
 
 struct Character;
 optional_ref<const Extent> chara_preparepic(const Character& cc);
 optional_ref<const Extent> chara_preparepic(int image_id);
 
-void create_pcpic(int cc, bool with_equipments = true);
+void create_pcpic(Character& chara, bool with_equipments = true);
 void initialize_map_chips(const MapChipDB&);
 void initialize_chara_chips(const CharaChipDB&);
 void initialize_item_chips(const ItemChipDB&);

--- a/src/elona/elonacore.cpp
+++ b/src/elona/elonacore.cpp
@@ -506,28 +506,6 @@ void gain_race_feat()
 
 
 
-int iequiploc(int ci)
-{
-    switch (the_item_db[inv[ci].id]->category)
-    {
-    case 12000: return 1;
-    case 34000: return 2;
-    case 20000: return 3;
-    case 16000: return 4;
-    case 10000: return 5;
-    case 14000: return 5;
-    case 32000: return 6;
-    case 22000: return 7;
-    case 18000: return 9;
-    case 24000: return 10;
-    case 25000: return 11;
-    case 19000: return 8;
-    default: return 0;
-    }
-}
-
-
-
 int roundmargin(int x, int y)
 {
     if (x > y)
@@ -1271,7 +1249,7 @@ void ride_begin(int mount)
     cell_data.at(cdata[mount].position.x, cdata[mount].position.y)
         .chara_index_plus_one = 0;
     game_data.mount = mount;
-    create_pcpic(0);
+    create_pcpic(cdata.player());
     cdata[game_data.mount].continuous_action.finish();
     refresh_speed(cdata[game_data.mount]);
     txt(""s + cdata[mount].current_speed + u8") "s);
@@ -1293,7 +1271,7 @@ void ride_end()
     cdata[mount].is_ridden() = false;
     cdata[mount].continuous_action.finish();
     game_data.mount = 0;
-    create_pcpic(0);
+    create_pcpic(cdata.player());
     refresh_speed(cdata[mount]);
 }
 
@@ -3121,7 +3099,7 @@ void character_drops_item()
             inv[ci].remove();
         }
         cell_refresh(cdata[rc].position.x, cdata[rc].position.y);
-        create_pcpic(0);
+        create_pcpic(cdata.player());
         return;
     }
     else
@@ -3130,7 +3108,7 @@ void character_drops_item()
         {
             if (cdata[rc].has_own_sprite() == 1)
             {
-                create_pcpic(rc);
+                create_pcpic(cdata[rc]);
             }
         }
         if (cdata[rc].relationship == 10)

--- a/src/elona/equipment.cpp
+++ b/src/elona/equipment.cpp
@@ -454,7 +454,7 @@ void wear_most_valuable_equipment()
 {
     int eqdup = 0;
     elona_vector1<int> bodylist;
-    i = iequiploc(ci);
+    i = iequiploc(inv[ci]);
     if (i != 0)
     {
         eqdup = 0;

--- a/src/elona/init.cpp
+++ b/src/elona/init.cpp
@@ -615,7 +615,7 @@ void initialize_debug_globals()
         mat(cnt) = 200;
     }
     create_all_adventurers();
-    create_pcpic(0);
+    create_pcpic(cdata.player());
     cdatan(1, 0) = random_title(RandomTitleType::character);
     cdatan(0, 0) = random_name();
 }

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -2318,4 +2318,24 @@ void item_build_shelter(Item& shelter)
 
 
 
+int iequiploc(const Item& item)
+{
+    switch (the_item_db[item.id]->category)
+    {
+    case 12000: return 1;
+    case 34000: return 2;
+    case 20000: return 3;
+    case 16000: return 4;
+    case 10000: return 5;
+    case 14000: return 5;
+    case 32000: return 6;
+    case 22000: return 7;
+    case 18000: return 9;
+    case 24000: return 10;
+    case 25000: return 11;
+    case 19000: return 8;
+    default: return 0;
+    }
+}
+
 } // namespace elona

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -328,4 +328,7 @@ enum class ItemDescriptionType : int
 
 void item_load_desc(int ci, int& p);
 
+
+int iequiploc(const Item& item);
+
 } // namespace elona

--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -687,9 +687,10 @@ ChangeAppearanceResult menu_change_appearance(Character& chara)
     windowshadow = 1;
 
     bool init = true;
-
+    int tick = 0;
     while (true)
     {
+        ++tick;
         if (init)
         {
             init = false;
@@ -769,15 +770,6 @@ ChangeAppearanceResult menu_change_appearance(Character& chara)
             wx + 34,
             wy + 36);
         draw("deco_mirror_a", wx + ww - 40, wy);
-        ++i;
-        if (i % 100 < 45)
-        {
-            f = i % 16;
-        }
-        else
-        {
-            ++f;
-        }
         window2(wx + 234, wy + 71, 88, 120, 1, 1);
         if (cs == 1 && page == 0)
         {
@@ -801,19 +793,22 @@ ChangeAppearanceResult menu_change_appearance(Character& chara)
             gmode(2);
             const auto is_fullscale =
                 Config::instance().pcc_graphic_scale == "fullscale";
-            const auto width = is_fullscale ? (32 * 2) : (24 * 2);
-            const auto height = is_fullscale ? (48 * 2) : (40 * 2);
-            gcopy_c(
-                chara.index + 10 + PicLoader::max_buffers +
-                    TintedBuffers::max_buffers,
-                f / 4 % 4 * 32,
-                f / 16 % 4 * 48,
-                32,
-                48,
-                wx + 280,
-                wy + 130,
-                width,
-                height);
+            const auto width = is_fullscale ? 32 : 24;
+            const auto height = is_fullscale ? 48 : 40;
+            for (int i = 0; i < 4; ++i)
+            {
+                gcopy_c(
+                    chara.index + 10 + PicLoader::max_buffers +
+                        TintedBuffers::max_buffers,
+                    tick / 5 % 4 * 32,
+                    i % 4 * 48,
+                    32,
+                    48,
+                    wx + 238 + i % 2 * (32 + 8) + (32 + 8) / 2,
+                    wy + 75 + i / 2 * (48 + 8) + (48 + 8) / 2,
+                    width,
+                    height);
+            }
         }
         else
         {
@@ -1021,8 +1016,10 @@ void change_appearance_equipment(Character& chara)
         ++keyrange;
     }
 
+    int tick = 0;
     while (true)
     {
+        ++tick;
         pagesize = 0;
         ui_display_window(
             i18n::s.get("core.locale.ui.appearance.equipment.title"),
@@ -1034,28 +1031,26 @@ void change_appearance_equipment(Character& chara)
         s = i18n::s.get("core.locale.ui.appearance.equipment.part");
         pagesize = listmax;
         display_topic(s, wx + 34, wy + 36);
-        ++i;
-        if (i % 100 < 45)
-        {
-            f = i % 16;
-        }
-        else
-        {
-            ++f;
-        }
         window2(wx + 234, wy + 60, 88, 120, 1, 1);
         gmode(2);
-        gcopy_c(
-            chara.index + 10 + PicLoader::max_buffers +
-                TintedBuffers::max_buffers,
-            f / 4 % 4 * 32,
-            f / 16 % 4 * 48,
-            32,
-            48,
-            wx + 280,
-            wy + 120,
-            48,
-            80);
+        const auto is_fullscale =
+            Config::instance().pcc_graphic_scale == "fullscale";
+        const auto width = is_fullscale ? 32 : 24;
+        const auto height = is_fullscale ? 48 : 40;
+        for (int i = 0; i < 4; ++i)
+        {
+            gcopy_c(
+                chara.index + 10 + PicLoader::max_buffers +
+                    TintedBuffers::max_buffers,
+                tick / 5 % 4 * 32,
+                i % 4 * 48,
+                32,
+                48,
+                wx + 238 + i % 2 * (32 + 8) + (32 + 8) / 2,
+                wy + 64 + i / 2 * (48 + 8) + (48 + 8) / 2,
+                width,
+                height);
+        }
         gmode(2);
         font(14 - en * 2);
         cs_listbk();

--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -960,8 +960,18 @@ int change_appearance()
         create_pcpic(cc, false);
         if (action == "cancel")
         {
-            create_pcpic(cc);
-            return 0;
+            if (page == 0)
+            {
+                create_pcpic(cc);
+                return 0;
+            }
+            else
+            {
+                page = 0;
+                cs = 8;
+                init = true;
+                continue;
+            }
         }
         if (mode == 1)
         {

--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -1103,7 +1103,7 @@ void change_appearance_equipment(Character& chara)
                 snd("core.cursor1");
             }
         }
-        if ((cs == 0 && action == "entry") || action == "cancel")
+        if ((cs == 0 && action == "enter") || action == "cancel")
         {
             snd("core.ok1");
             create_pcpic(chara);

--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -855,7 +855,7 @@ ChangeAppearanceResult menu_change_appearance(Character& chara)
         redraw();
         auto action = cursor_check_ex();
         _set_pcc_info(chara, cs);
-        p = 0;
+        bool changed = false;
         if (rtval == -2)
         {
             if (action == "enter")
@@ -912,13 +912,13 @@ ChangeAppearanceResult menu_change_appearance(Character& chara)
                          (pcc(rtval, chara.index) % 1000 + 1) + u8".bmp")))
                 {
                     ++pcc(rtval, chara.index);
-                    p = 1;
+                    changed = true;
                 }
             }
             else if (pcc(rtval, chara.index) / 1000 < 21)
             {
                 pcc(rtval, chara.index) += 1000;
-                p = 1;
+                changed = true;
             }
         }
         if (action == "previous_page")
@@ -944,16 +944,19 @@ ChangeAppearanceResult menu_change_appearance(Character& chara)
                          (pcc(rtval, chara.index) % 1000 - 1) + u8".bmp"s)))
                 {
                     --pcc(rtval, chara.index);
-                    p = 1;
+                    changed = true;
                 }
             }
             else if (pcc(rtval, chara.index) / 1000 > 0)
             {
                 pcc(rtval, chara.index) -= 1000;
-                p = 1;
+                changed = true;
             }
         }
-        create_pcpic(chara, false);
+        if (changed)
+        {
+            create_pcpic(chara, false);
+        }
         if (action == "cancel")
         {
             if (page == 0)

--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -57,7 +57,7 @@
 namespace
 {
 
-void _set_pcc_info(int val0)
+void _set_pcc_info(Character& chara, int val0)
 {
     rtval = -2;
     if (page == 0)
@@ -71,47 +71,47 @@ void _set_pcc_info(int val0)
             rtval(0) = 100;
             rtval(1) = 0;
             rtval(2) = -2;
-            rtvaln = cdata[cc].portrait;
+            rtvaln = chara.portrait;
         }
         if (val0 == 2)
         {
             rtval(0) = 1;
             rtval(1) = 0;
-            rtval(2) = pcc(1, cc) % 1000;
+            rtval(2) = pcc(1, chara.index) % 1000;
             rtvaln = u8"hair"s;
         }
         if (val0 == 3)
         {
             rtval(0) = 10;
             rtval(1) = 0;
-            rtval(2) = pcc(10, cc) % 1000;
+            rtval(2) = pcc(10, chara.index) % 1000;
             rtvaln = u8"subhair"s;
         }
         if (val0 == 4)
         {
             rtval(0) = 1;
             rtval(1) = 1;
-            rtval(2) = pcc(1, cc) / 1000;
+            rtval(2) = pcc(1, chara.index) / 1000;
         }
         if (val0 == 5)
         {
             rtval(0) = 15;
             rtval(1) = 0;
-            rtval(2) = pcc(15, cc) % 1000;
+            rtval(2) = pcc(15, chara.index) % 1000;
             rtvaln = u8"body"s;
         }
         if (val0 == 6)
         {
             rtval(0) = 9;
             rtval(1) = 0;
-            rtval(2) = pcc(9, cc) % 1000;
+            rtval(2) = pcc(9, chara.index) % 1000;
             rtvaln = u8"cloth"s;
         }
         if (val0 == 7)
         {
             rtval(0) = 7;
             rtval(1) = 0;
-            rtval(2) = pcc(7, cc) % 1000;
+            rtval(2) = pcc(7, chara.index) % 1000;
             rtvaln = u8"pants"s;
         }
         if (val0 == 8)
@@ -121,17 +121,17 @@ void _set_pcc_info(int val0)
         }
         if (val0 == 9)
         {
-            if (cc != 0)
+            if (chara.index != 0)
             {
                 rtval(0) = 101;
                 rtval(1) = 0;
-                rtval(2) = cdata[cc].has_own_sprite();
+                rtval(2) = chara.has_own_sprite();
             }
             else
             {
                 rtval(0) = 16;
                 rtval(1) = 0;
-                rtval(2) = pcc(16, cc) % 1000;
+                rtval(2) = pcc(16, chara.index) % 1000;
                 rtvaln = u8"ride"s;
             }
         }
@@ -142,46 +142,46 @@ void _set_pcc_info(int val0)
         {
             rtval(0) = 15;
             rtval(1) = 1;
-            rtval(2) = pcc(15, cc) / 1000;
+            rtval(2) = pcc(15, chara.index) / 1000;
         }
         if (val0 == 1)
         {
             rtval(0) = 9;
             rtval(1) = 1;
-            rtval(2) = pcc(9, cc) / 1000;
+            rtval(2) = pcc(9, chara.index) / 1000;
         }
         if (val0 == 2)
         {
             rtval(0) = 7;
             rtval(1) = 1;
-            rtval(2) = pcc(7, cc) / 1000;
+            rtval(2) = pcc(7, chara.index) / 1000;
         }
         if (val0 == 3)
         {
             rtval(0) = 11;
             rtval(1) = 0;
-            rtval(2) = pcc(11, cc) % 1000;
+            rtval(2) = pcc(11, chara.index) % 1000;
             rtvaln = u8"etc"s;
         }
         if (val0 == 4)
         {
             rtval(0) = 12;
             rtval(1) = 0;
-            rtval(2) = pcc(12, cc) % 1000;
+            rtval(2) = pcc(12, chara.index) % 1000;
             rtvaln = u8"etc"s;
         }
         if (val0 == 5)
         {
             rtval(0) = 13;
             rtval(1) = 0;
-            rtval(2) = pcc(13, cc) % 1000;
+            rtval(2) = pcc(13, chara.index) % 1000;
             rtvaln = u8"etc"s;
         }
         if (val0 == 6)
         {
             rtval(0) = 14;
             rtval(1) = 0;
-            rtval(2) = pcc(14, cc) % 1000;
+            rtval(2) = pcc(14, chara.index) % 1000;
             rtvaln = u8"eye"s;
         }
         if (val0 == 7)
@@ -669,9 +669,9 @@ MenuResult menu_feats_character_making()
 
 
 
-int change_appearance()
+ChangeAppearanceResult menu_change_appearance(Character& chara)
 {
-    create_pcpic(cc, false);
+    create_pcpic(chara, false);
     page = 0;
     pagesize = 19;
     cs = 0;
@@ -707,7 +707,7 @@ int change_appearance()
                 s(7) = i18n::s.get("core.locale.ui.appearance.basic.pants");
                 s(8) =
                     i18n::s.get("core.locale.ui.appearance.basic.set_detail");
-                if (cc != 0)
+                if (chara.index != 0)
                 {
                     s(9) =
                         i18n::s.get("core.locale.ui.appearance.basic.custom");
@@ -717,7 +717,8 @@ int change_appearance()
                     s(9) =
                         i18n::s.get("core.locale.ui.appearance.basic.riding");
                 }
-                p = 9 + (cc != 0) + (cc == 0) * (game_data.mount != 0);
+                p = 9 + (chara.index != 0) +
+                    (chara.index == 0) * (game_data.mount != 0);
             }
             else
             {
@@ -780,10 +781,9 @@ int change_appearance()
         window2(wx + 234, wy + 71, 88, 120, 1, 1);
         if (cs == 1 && page == 0)
         {
-            if (cdata[cc].portrait != "")
+            if (chara.portrait != "")
             {
-                if (const auto rect =
-                        draw_get_rect_portrait(cdata[cc].portrait))
+                if (const auto rect = draw_get_rect_portrait(chara.portrait))
                 {
                     gcopy(
                         rect->buffer,
@@ -796,7 +796,7 @@ int change_appearance()
                 }
             }
         }
-        else if (cdata[cc].has_own_sprite())
+        else if (chara.has_own_sprite())
         {
             gmode(2);
             const auto is_fullscale =
@@ -804,7 +804,8 @@ int change_appearance()
             const auto width = is_fullscale ? (32 * 2) : (24 * 2);
             const auto height = is_fullscale ? (48 * 2) : (40 * 2);
             gcopy_c(
-                cc + 10 + PicLoader::max_buffers + TintedBuffers::max_buffers,
+                chara.index + 10 + PicLoader::max_buffers +
+                    TintedBuffers::max_buffers,
                 f / 4 % 4 * 32,
                 f / 16 % 4 * 48,
                 32,
@@ -816,7 +817,7 @@ int change_appearance()
         }
         else
         {
-            draw_chara(cdata[cc], wx + 280, wy + 130);
+            draw_chara(chara, wx + 280, wy + 130);
         }
         gmode(2);
         font(14 - en * 2);
@@ -828,7 +829,7 @@ int change_appearance()
             {
                 break;
             }
-            _set_pcc_info(cnt);
+            _set_pcc_info(chara, cnt);
             s = listn(0, p);
             if (rtval >= 0)
             {
@@ -858,14 +859,14 @@ int change_appearance()
         }
         redraw();
         auto action = cursor_check_ex();
-        _set_pcc_info(cs);
+        _set_pcc_info(chara, cs);
         p = 0;
         if (rtval == -2)
         {
             if (action == "enter")
             {
-                create_pcpic(cc);
-                return 1;
+                create_pcpic(chara);
+                return ChangeAppearanceResult::proceed;
             }
             if (action == "next_page" || action == "previous_page")
             {
@@ -899,13 +900,13 @@ int change_appearance()
             snd("core.cursor1");
             if (rtval == 100)
             {
-                cdata[cc].portrait =
-                    the_portrait_db.get_next_portrait(cdata[cc].portrait);
+                chara.portrait =
+                    the_portrait_db.get_next_portrait(chara.portrait);
                 continue;
             }
             if (rtval == 101)
             {
-                cdata[cc].has_own_sprite() = true;
+                chara.has_own_sprite() = true;
                 continue;
             }
             if (rtval(1) == 0)
@@ -913,15 +914,15 @@ int change_appearance()
                 if (fs::exists(
                         filesystem::dir::graphic() /
                         (u8"pcc_"s + rtvaln + u8"_" +
-                         (pcc(rtval, cc) % 1000 + 1) + u8".bmp")))
+                         (pcc(rtval, chara.index) % 1000 + 1) + u8".bmp")))
                 {
-                    ++pcc(rtval, cc);
+                    ++pcc(rtval, chara.index);
                     p = 1;
                 }
             }
-            else if (pcc(rtval, cc) / 1000 < 21)
+            else if (pcc(rtval, chara.index) / 1000 < 21)
             {
-                pcc(rtval, cc) += 1000;
+                pcc(rtval, chara.index) += 1000;
                 p = 1;
             }
         }
@@ -930,40 +931,40 @@ int change_appearance()
             snd("core.cursor1");
             if (rtval == 100)
             {
-                cdata[cc].portrait =
-                    the_portrait_db.get_previous_portrait(cdata[cc].portrait);
+                chara.portrait =
+                    the_portrait_db.get_previous_portrait(chara.portrait);
                 continue;
             }
             if (rtval == 101)
             {
-                cdata[cc].has_own_sprite() = false;
+                chara.has_own_sprite() = false;
                 continue;
             }
             if (rtval(1) == 0)
             {
-                if ((pcc(rtval, cc) % 1000 == 1 && rtval != 15) ||
+                if ((pcc(rtval, chara.index) % 1000 == 1 && rtval != 15) ||
                     fs::exists(
                         filesystem::dir::graphic() /
                         (u8"pcc_"s + rtvaln + u8"_"s +
-                         (pcc(rtval, cc) % 1000 - 1) + u8".bmp"s)))
+                         (pcc(rtval, chara.index) % 1000 - 1) + u8".bmp"s)))
                 {
-                    --pcc(rtval, cc);
+                    --pcc(rtval, chara.index);
                     p = 1;
                 }
             }
-            else if (pcc(rtval, cc) / 1000 > 0)
+            else if (pcc(rtval, chara.index) / 1000 > 0)
             {
-                pcc(rtval, cc) -= 1000;
+                pcc(rtval, chara.index) -= 1000;
                 p = 1;
             }
         }
-        create_pcpic(cc, false);
+        create_pcpic(chara, false);
         if (action == "cancel")
         {
             if (page == 0)
             {
-                create_pcpic(cc);
-                return 0;
+                create_pcpic(chara);
+                return ChangeAppearanceResult::canceled;
             }
             else
             {
@@ -977,15 +978,17 @@ int change_appearance()
         {
             if (getkey(snail::Key::f1))
             {
-                return -1;
+                return ChangeAppearanceResult::show_help;
             }
         }
     }
 }
 
-int change_appearance_equipment()
+
+
+void change_appearance_equipment(Character& chara)
 {
-    create_pcpic(cc);
+    create_pcpic(chara);
     snd("core.pop2");
     page = 0;
     pagesize = 18;
@@ -1018,7 +1021,7 @@ int change_appearance_equipment()
         ++keyrange;
     }
 
-    while (1)
+    while (true)
     {
         pagesize = 0;
         ui_display_window(
@@ -1043,7 +1046,8 @@ int change_appearance_equipment()
         window2(wx + 234, wy + 60, 88, 120, 1, 1);
         gmode(2);
         gcopy_c(
-            cc + 10 + PicLoader::max_buffers + TintedBuffers::max_buffers,
+            chara.index + 10 + PicLoader::max_buffers +
+                TintedBuffers::max_buffers,
             f / 4 % 4 * 32,
             f / 16 % 4 * 48,
             32,
@@ -1065,7 +1069,7 @@ int change_appearance_equipment()
             s = listn(0, p);
             if (cnt != 0)
             {
-                if (pcc(20 + cnt - 1, cc) == 0)
+                if (pcc(20 + cnt - 1, chara.index) == 0)
                 {
                     s += u8"On"s;
                 }
@@ -1092,26 +1096,28 @@ int change_appearance_equipment()
             }
             if (action == "next_page" || action == "previous_page")
             {
-                if (pcc(20 + cs - 1, cc) == 0)
+                if (pcc(20 + cs - 1, chara.index) == 0)
                 {
-                    pcc(20 + cs - 1, cc) = 1;
+                    pcc(20 + cs - 1, chara.index) = 1;
                 }
                 else
                 {
-                    pcc(20 + cs - 1, cc) = 0;
+                    pcc(20 + cs - 1, chara.index) = 0;
                 }
-                create_pcpic(cc);
+                create_pcpic(chara);
                 snd("core.cursor1");
             }
         }
         if ((cs == 0 && action == "entry") || action == "cancel")
         {
             snd("core.ok1");
-            create_pcpic(cc);
-            return 1;
+            create_pcpic(chara);
+            return;
         }
     }
 }
+
+
 
 void append_accuracy_info(int val0)
 {

--- a/src/elona/menu.hpp
+++ b/src/elona/menu.hpp
@@ -7,6 +7,9 @@ namespace elona
 {
 
 enum class TurnResult;
+struct Character;
+
+
 
 struct MenuResult
 {
@@ -55,7 +58,19 @@ TurnResult play_scene();
 TurnResult show_spell_list();
 TurnResult show_skill_list();
 std::string make_spell_description(int skill_id);
-int change_appearance();
+
+
+enum class ChangeAppearanceResult
+{
+    proceed,
+    canceled,
+    show_help,
+};
+
+ChangeAppearanceResult menu_change_appearance(Character& chara);
+void change_appearance_equipment(Character& chara);
+
+
 MenuResult menu_feats();
 MenuResult menu_materials();
 

--- a/src/elona/save.cpp
+++ b/src/elona/save.cpp
@@ -74,7 +74,7 @@ void load_save_data()
     {
         if (cdata[cnt].has_own_sprite() == 1 || cnt == 0)
         {
-            create_pcpic(cnt);
+            create_pcpic(cdata[cnt]);
         }
     }
     if (game_data.wizard == 1)

--- a/src/elona/ui/ui_menu_character_sheet.cpp
+++ b/src/elona/ui/ui_menu_character_sheet.cpp
@@ -1080,7 +1080,7 @@ optional<UIMenuCharacterSheet::ResultType> UIMenuCharacterSheet::on_key(
         {
             if (cc < 16)
             {
-                change_appearance();
+                menu_change_appearance(cdata[cc]);
                 if (_operation != CharacterSheetOperation::character_making)
                 {
                     nowindowanime = 1;

--- a/src/elona/ui/ui_menu_equipment.cpp
+++ b/src/elona/ui/ui_menu_equipment.cpp
@@ -397,7 +397,7 @@ optional<UIMenuEquipment::ResultType> UIMenuEquipment::on_key(
     else if (action == "cancel")
     {
         menucycle = 0;
-        create_pcpic(cc);
+        create_pcpic(cdata[cc]);
         update_screen();
         // result.turn_result = TurnResult::pc_turn_user_error
         return UIMenuEquipment::Result::cancel();

--- a/src/elona/variables.hpp
+++ b/src/elona/variables.hpp
@@ -720,7 +720,6 @@ void gain_race_feat();
 // Item status querying
 int cargocheck();
 void getinheritance(int, elona_vector1<int>&, int&);
-int iequiploc(int = 0);
 
 // Item manipulation
 int access_item_db(int);
@@ -887,11 +886,6 @@ int blending_find_required_mat();
 int blending_spend_materials();
 void blending_start_attempt();
 void blending_proc_on_success_events();
-
-
-//// Menus
-int change_appearance_equipment();
-
 
 //// Map
 int map_barrel(int = 0, int = 0);


### PR DESCRIPTION
# Summary

- [vanilla] Don't go back when you press ESC in change appearance>detail submenu. Instead, go back basic change appearance menu.
- Refactor `menu_change_appearance()`, `menu_change_appearance_equipment()`, `createpcpic()`.
- Improve change appearance menu: show 4 direction at once. It is highly inspired by oor.

![image](https://user-images.githubusercontent.com/36858341/58757287-d50a4080-8544-11e9-8104-7296ea917d6f.png)

- Fix that you cannot close change appearance equipment menu by Enter key due to typo in source code.
- Improve performance of change appearance menu. Load PCC graphics only if you change something.