### PR TITLE
Show [F]eat menu keyhint based on keybinding settings

### DIFF
--- a/src/elona/ui/ui_menu_feats.cpp
+++ b/src/elona/ui/ui_menu_feats.cpp
@@ -161,7 +161,7 @@ void UIMenuFeats::_draw_window_background(bool is_chara_making)
     ui_display_window(
         i18n::s.get("core.locale.trait.window.title"),
         i18n::s.get("core.locale.trait.window.enter") + "  " + strhint2 +
-            strhint3 + u8"z,x [" +
+            strhint3 + key_mode + u8"," + key_identify + u8" [" +
             i18n::s.get("core.locale.trait.window.ally") + u8"]",
         (windoww - 730) / 2 + inf_screenx,
         winposy(430, y_adjust) + y_adjust * 15,


### PR DESCRIPTION
<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues
This PR is a fix for #1227

# Summary

keybind_manager.cpp sets the global variables key_mode (default key: 'z') and key_identify (default key: 'x'). Therefore I replaced the hard-coded strings with them.