### PR TITLE
Fix lomias' easter egg event in the initial cave

### DIFF
--- a/runtime/mod/core/data/dialog/unique/lomias.lua
+++ b/runtime/mod/core/data/dialog/unique/lomias.lua
@@ -198,7 +198,7 @@ return {
       },
       get_out = function(t)
          local larnneire = Chara.find("core.larnneire", "Others")
-         if larnneire == nil then
+         if not Chara.is_alive(larnneire) then
             local lomias = Chara.find("core.lomias", "Others")
             Chara.player():act_hostile_against(lomias)
             t:say("after.get_out.larnneire_died", "__BYE__")


### PR DESCRIPTION
# Related Issues

https://github.com/ElonaFoobar/ElonaFoobar/issues/1342

# Summary

Check if larnneire is dead instead of checking if larnneire exists.