### PR TITLE
Fix main menu crash when an unavailable option was selected via keyboard

### DIFF
--- a/src/elona/main_menu.cpp
+++ b/src/elona/main_menu.cpp
@@ -389,7 +389,7 @@ MainMenuResult main_title_menu()
             return MainMenuResult::main_title_menu;
         case 5: snd("core.ok1"); return MainMenuResult::main_menu_mods;
         case 6: snd("core.ok1"); return MainMenuResult::finish_elona;
-        default: throw "unreachable";
+        default: break;
         }
 
         ++frame;


### PR DESCRIPTION
# Related Issues

Close #1367.


# Summary
If the user presses any 'Select_X' button above 6, code throws an exception. We can just ignore those invalid actions to avoid crashing Elona.
