### PR TITLE
Check if moyer is alive before writing his dialog

### DIFF
--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -2682,7 +2682,7 @@ TurnResult do_open_command(bool play_sound)
                         Character::State::alive)
                     {
                         tc = chara_find(203);
-                        if (tc != 0)
+                        if (tc != 0 && cdata[tc].state() == Character::State::alive)
                         {
                             txt(i18n::s.get(
                                     "core.locale.action.open.shackle.dialog"),

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -2682,7 +2682,8 @@ TurnResult do_open_command(bool play_sound)
                         Character::State::alive)
                     {
                         tc = chara_find(203);
-                        if (tc != 0 && cdata[tc].state() == Character::State::alive)
+                        if (tc != 0 &&
+                            cdata[tc].state() == Character::State::alive)
                         {
                             txt(i18n::s.get(
                                     "core.locale.action.open.shackle.dialog"),


### PR DESCRIPTION
# Related Issues

Close #1366.

# Summary

Check if moyer is alive.