### PR TITLE
Add string id based chara_find and replace hardcoded legacy ids

### DIFF
--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -1081,7 +1081,11 @@ int relationbetween(int c1, int c2)
     return 0;
 }
 
-
+int chara_find(const std::string& chara_id)
+{
+    // Note: if `chara_id` not found, `ensure()` throws an exception.
+    return chara_find(the_character_db.ensure(chara_id).legacy_id);
+}
 
 int chara_find(int id)
 {

--- a/src/elona/character.hpp
+++ b/src/elona/character.hpp
@@ -714,6 +714,7 @@ enum class CharaFindLocation
     others
 };
 
+int chara_find(const std::string& chara_id);
 int chara_find(int id);
 int chara_find_ally(int id);
 int chara_get_free_slot();

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -2681,7 +2681,7 @@ TurnResult do_open_command(bool play_sound)
                     if (cdata[game_data.fire_giant].state() ==
                         Character::State::alive)
                     {
-                        tc = chara_find(203);
+                        tc = chara_find("core.moyer_the_crooked");
                         if (tc != 0 &&
                             cdata[tc].state() == Character::State::alive)
                         {

--- a/src/elona/elonacore.cpp
+++ b/src/elona/elonacore.cpp
@@ -12149,13 +12149,13 @@ void conquer_lesimas()
         Message::instance().clear();
         txt(u8"あなたは、台座の上に置かれている絢爛な装飾の本を、いぶかしげに眺めた。"s);
         msg_halt();
-        tc = chara_find(23);
+        tc = chara_find("core.orphe");
         talk_to_npc();
         Message::instance().clear();
         txt(u8"青年は悪戯っぽくニヤリと笑い、壁に寄りかかった。"s);
         msg_halt();
         Message::instance().clear();
-        chara_vanquish(chara_find(23));
+        chara_vanquish(chara_find("core.orphe"));
         screenupdate = -1;
         update_screen();
         txt(u8"…どれくらい時間がたっただろう。氷の瞳の男は、いつの間にか姿を消していた。あなたは不安を振り払い、ゆっくりと本に手を伸ばした…"s);

--- a/src/elona/initialize_map.cpp
+++ b/src/elona/initialize_map.cpp
@@ -818,7 +818,7 @@ static void _update_quest_flags_lesimas()
 
 static void _update_paels_mom()
 {
-    tc = chara_find(222);
+    tc = chara_find("core.lily");
     if (tc != 0)
     {
         if (game_data.quest_flags.pael_and_her_mom >= 10)
@@ -990,21 +990,21 @@ static void _notify_distance_traveled()
 
 static void _remove_lomias_and_larnneire()
 {
-    if (chara_find(33) != 0)
+    if (chara_find("core.larnneire") != 0)
     {
-        chara_vanquish(chara_find(33));
+        chara_vanquish(chara_find("core.larnneire"));
     }
-    if (chara_find(34) != 0)
+    if (chara_find("core.lomias") != 0)
     {
-        chara_vanquish(chara_find(34));
+        chara_vanquish(chara_find("core.lomias"));
     }
 }
 
 static void _remove_xabi()
 {
-    if (chara_find(80) != 0)
+    if (chara_find("core.xabi") != 0)
     {
-        chara_vanquish(chara_find(80));
+        chara_vanquish(chara_find("core.xabi"));
     }
 }
 

--- a/src/elona/proc_event.cpp
+++ b/src/elona/proc_event.cpp
@@ -128,7 +128,7 @@ void proc_event()
             evdata2(evnum - (evnum != 0) * 1));
         break;
     case 2:
-        tc = chara_find(34);
+        tc = chara_find("core.lomias");
         talk_to_npc();
         break;
     case 24:
@@ -136,15 +136,15 @@ void proc_event()
         initialize_economy();
         break;
     case 3:
-        tc = chara_find(2);
+        tc = chara_find("core.zeome");
         talk_to_npc();
         break;
     case 11:
-        tc = chara_find(1);
+        tc = chara_find("core.shopkeeper");
         talk_to_npc();
         break;
     case 23:
-        tc = chara_find(302);
+        tc = chara_find("core.rogue_boss");
         talk_to_npc();
         game_data.rogue_boss_encountered = 23;
         break;
@@ -374,7 +374,7 @@ void proc_event()
             cdata[evdata1(evnum - (evnum != 0) * 1)].position.y,
             4);
         game_data.quest_flags.pael_and_her_mom = 1001;
-        tc = chara_find(221);
+        tc = chara_find("core.pael");
         if (tc != 0)
         {
             if (cdata[tc].state() == Character::State::alive)

--- a/src/elona/talk.cpp
+++ b/src/elona/talk.cpp
@@ -302,8 +302,8 @@ TalkResult talk_game_begin()
         listmax = 0;
         buff = i18n::s.get_enum(
             "core.locale.talk.unique.lomias.begin.easter_egg", 0);
-        tc =
-            tc * (chara_find(33) == 0) + (chara_find(33) != 0) * chara_find(33);
+        tc = tc * (chara_find("core.larnneire") == 0) +
+            (chara_find("core.larnneire") != 0) * chara_find("core.larnneire");
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.locale.ui.more");
         ++listmax;
@@ -319,8 +319,8 @@ TalkResult talk_game_begin()
         listmax = 0;
         buff = i18n::s.get_enum(
             "core.locale.talk.unique.lomias.begin.easter_egg", 1);
-        tc =
-            tc * (chara_find(34) == 0) + (chara_find(34) != 0) * chara_find(34);
+        tc = tc * (chara_find("core.lomias") == 0) +
+            (chara_find("core.lomias") != 0) * chara_find("core.lomias");
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.locale.ui.more");
         ++listmax;
@@ -350,8 +350,8 @@ TalkResult talk_game_begin()
         listmax = 0;
         buff = i18n::s.get_enum(
             "core.locale.talk.unique.lomias.begin.easter_egg", 2);
-        tc =
-            tc * (chara_find(33) == 0) + (chara_find(33) != 0) * chara_find(33);
+        tc = tc * (chara_find("core.larnneire") == 0) +
+            (chara_find("core.larnneire") != 0) * chara_find("core.larnneire");
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.locale.ui.more");
         ++listmax;
@@ -367,8 +367,8 @@ TalkResult talk_game_begin()
         listmax = 0;
         buff = i18n::s.get_enum(
             "core.locale.talk.unique.lomias.begin.easter_egg", 3);
-        tc =
-            tc * (chara_find(34) == 0) + (chara_find(34) != 0) * chara_find(34);
+        tc = tc * (chara_find("core.lomias") == 0) +
+            (chara_find("core.lomias") != 0) * chara_find("core.lomias");
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.locale.ui.more");
         ++listmax;
@@ -384,8 +384,8 @@ TalkResult talk_game_begin()
         listmax = 0;
         buff = i18n::s.get_enum(
             "core.locale.talk.unique.lomias.begin.easter_egg", 4);
-        tc =
-            tc * (chara_find(33) == 0) + (chara_find(33) != 0) * chara_find(33);
+        tc = tc * (chara_find("core.larnneire") == 0) +
+            (chara_find("core.larnneire") != 0) * chara_find("core.larnneire");
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.locale.ui.more");
         ++listmax;
@@ -401,8 +401,8 @@ TalkResult talk_game_begin()
         listmax = 0;
         buff = i18n::s.get_enum(
             "core.locale.talk.unique.lomias.begin.easter_egg", 5);
-        tc =
-            tc * (chara_find(34) == 0) + (chara_find(34) != 0) * chara_find(34);
+        tc = tc * (chara_find("core.lomias") == 0) +
+            (chara_find("core.lomias") != 0) * chara_find("core.lomias");
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.locale.ui.more");
         ++listmax;
@@ -418,8 +418,8 @@ TalkResult talk_game_begin()
         listmax = 0;
         buff = i18n::s.get_enum(
             "core.locale.talk.unique.lomias.begin.easter_egg", 6);
-        tc =
-            tc * (chara_find(33) == 0) + (chara_find(33) != 0) * chara_find(33);
+        tc = tc * (chara_find("core.larnneire") == 0) +
+            (chara_find("core.larnneire") != 0) * chara_find("core.larnneire");
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.locale.ui.more");
         ++listmax;
@@ -448,7 +448,8 @@ TalkResult talk_game_begin()
         "core.locale.talk.unique.lomias.begin.regain_consciousness"));
     listmax = 0;
     buff = i18n::s.get_enum("core.locale.talk.unique.lomias.begin", 0);
-    tc = tc * (chara_find(34) == 0) + (chara_find(34) != 0) * chara_find(34);
+    tc = tc * (chara_find("core.lomias") == 0) +
+        (chara_find("core.lomias") != 0) * chara_find("core.lomias");
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.locale.ui.more");
     ++listmax;
@@ -493,7 +494,8 @@ TalkResult talk_game_begin()
     }
     listmax = 0;
     buff = i18n::s.get_enum("core.locale.talk.unique.lomias.begin", 3);
-    tc = tc * (chara_find(33) == 0) + (chara_find(33) != 0) * chara_find(33);
+    tc = tc * (chara_find("core.larnneire") == 0) +
+        (chara_find("core.larnneire") != 0) * chara_find("core.larnneire");
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.locale.ui.more");
     ++listmax;
@@ -509,7 +511,8 @@ TalkResult talk_game_begin()
     listmax = 0;
     buff = i18n::s.get_enum(
         "core.locale.talk.unique.lomias.begin", 4, cdatan(0, 0));
-    tc = tc * (chara_find(34) == 0) + (chara_find(34) != 0) * chara_find(34);
+    tc = tc * (chara_find("core.lomias") == 0) +
+        (chara_find("core.lomias") != 0) * chara_find("core.lomias");
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.locale.ui.more");
     ++listmax;

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -1078,7 +1078,7 @@ TalkResult talk_moyer_sell_paels_mom()
         snd("core.getgold1");
         earn_gold(cdata.player(), 50000);
         game_data.quest_flags.pael_and_her_mom = 1002;
-        rc = chara_find(222);
+        rc = chara_find("core.lily");
         cdata[rc].ai_calm = 3;
         cdata[rc].relationship = 0;
         cdata[rc].initial_position.x = 48;
@@ -2278,7 +2278,7 @@ TalkResult talk_npc()
     {
         if (game_data.quest_flags.pael_and_her_mom == 1000)
         {
-            rc = chara_find(222);
+            rc = chara_find("core.lily");
             if (rc != 0)
             {
                 if (cdata[rc].state() == Character::State::alive)


### PR DESCRIPTION
# Related Issues

#45

# Summary

I replaced the numeric legacy ids with the new string based IDs. chara_find can find all characters with the new string id and it therefore calling ensure on the character db will not throw an exception. 