### PR TITLE
Add [[nodiscard]] attribute to i18n functions

### DIFF
--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -1357,7 +1357,8 @@ TurnResult do_dip_command()
                     "core.locale.action.dip.result.well_refilled", inv[ci]));
                 if (inv[cidip].id == 587)
                 {
-                    i18n::s.get("core.locale.action.dip.result.snow_melts.dip");
+                    txt(i18n::s.get(
+                        "core.locale.action.dip.result.snow_melts.dip"));
                 }
                 else
                 {

--- a/src/elona/elonacore.cpp
+++ b/src/elona/elonacore.cpp
@@ -5717,7 +5717,7 @@ TurnResult try_interact_with_npc()
 {
     if (cdata[tc].continuous_action.turn != 0)
     {
-        i18n::s.get("core.locale.action.npc.is_busy_now", cdata[tc]);
+        txt(i18n::s.get("core.locale.action.npc.is_busy_now", cdata[tc]));
         update_screen();
         return TurnResult::pc_turn_user_error;
     }
@@ -11789,7 +11789,8 @@ void weather_changes()
                     if (rnd(2) == 0)
                     {
                         game_data.weather = 2;
-                        i18n::s.get("core.locale.action.weather.snow.starts");
+                        txt(i18n::s.get(
+                            "core.locale.action.weather.snow.starts"));
                         break;
                     }
                 }
@@ -11798,20 +11799,22 @@ void weather_changes()
                     if (rnd(10) == 0)
                     {
                         game_data.weather = 3;
-                        i18n::s.get("core.locale.action.weather.rain.starts");
+                        txt(i18n::s.get(
+                            "core.locale.action.weather.rain.starts"));
                         break;
                     }
                     if (rnd(40) == 0)
                     {
                         game_data.weather = 4;
-                        i18n::s.get(
-                            "core.locale.action.weather.rain.starts_heavy");
+                        txt(i18n::s.get(
+                            "core.locale.action.weather.rain.starts_heavy"));
                         break;
                     }
                     if (rnd(60) == 0)
                     {
                         game_data.weather = 2;
-                        i18n::s.get("core.locale.action.weather.snow.starts");
+                        txt(i18n::s.get(
+                            "core.locale.action.weather.snow.starts"));
                         break;
                     }
                 }
@@ -11892,7 +11895,7 @@ void weather_changes()
         {
             if (mode == 0)
             {
-                i18n::s.get("core.locale.action.move.global.nap");
+                txt(i18n::s.get("core.locale.action.move.global.nap"));
                 game_data.continuous_active_hours -= 3;
                 if (game_data.continuous_active_hours < 0)
                 {

--- a/src/elona/i18n.hpp
+++ b/src/elona/i18n.hpp
@@ -540,7 +540,7 @@ public:
     }
 
     template <typename Head, typename... Tail>
-    optional<std::string>
+    ELONA_NODISCARD_ATTR optional<std::string>
     get_optional(const I18NKey& key, Head const& head, Tail&&... tail)
     {
         const auto& found = find_translation(key);
@@ -553,7 +553,9 @@ public:
     }
 
     template <typename... Tail>
-    optional<std::string> get_optional(const I18NKey& key, Tail&&... tail)
+    ELONA_NODISCARD_ATTR optional<std::string> get_optional(
+        const I18NKey& key,
+        Tail&&... tail)
     {
         const auto& found = find_translation(key);
         if (!found)
@@ -565,7 +567,8 @@ public:
     }
 
     template <typename Head, typename... Tail>
-    std::string get(const I18NKey& key, Head const& head, Tail&&... tail)
+    ELONA_NODISCARD_ATTR std::string
+    get(const I18NKey& key, Head const& head, Tail&&... tail)
     {
         if (auto text = get_optional(key, head, std::forward<Tail>(tail)...))
         {
@@ -583,7 +586,7 @@ public:
     }
 
     template <typename... Tail>
-    std::string get(const I18NKey& key, Tail&&... tail)
+    ELONA_NODISCARD_ATTR std::string get(const I18NKey& key, Tail&&... tail)
     {
         if (auto text = get_optional(key, std::forward<Tail>(tail)...))
         {
@@ -604,7 +607,7 @@ public:
     // Convenience methods for cases like "core.element._<enum index>.name"
 
     template <typename Head, typename... Tail>
-    std::string
+    ELONA_NODISCARD_ATTR std::string
     get_enum(const I18NKey& key, int index, Head const& head, Tail&&... tail)
     {
         return get(
@@ -614,14 +617,15 @@ public:
     }
 
     template <typename... Tail>
-    std::string get_enum(const I18NKey& key, int index, Tail&&... tail)
+    ELONA_NODISCARD_ATTR std::string
+    get_enum(const I18NKey& key, int index, Tail&&... tail)
     {
         return get(
             key + "._" + std::to_string(index), std::forward<Tail>(tail)...);
     }
 
     template <typename Head, typename... Tail>
-    optional<std::string> get_enum_optional(
+    ELONA_NODISCARD_ATTR optional<std::string> get_enum_optional(
         const I18NKey& key,
         int index,
         Head const& head,
@@ -634,7 +638,7 @@ public:
     }
 
     template <typename... Tail>
-    optional<std::string>
+    ELONA_NODISCARD_ATTR optional<std::string>
     get_enum_optional(const I18NKey& key, int index, Tail&&... tail)
     {
         return get_optional(
@@ -642,7 +646,7 @@ public:
     }
 
     template <typename Head, typename... Tail>
-    std::string get_enum_property(
+    ELONA_NODISCARD_ATTR std::string get_enum_property(
         const std::string& key_head,
         int index,
         const std::string& key_tail,
@@ -656,7 +660,7 @@ public:
     }
 
     template <typename... Tail>
-    std::string get_enum_property(
+    ELONA_NODISCARD_ATTR std::string get_enum_property(
         const std::string& key_head,
         const std::string& key_tail,
         int index,
@@ -668,7 +672,7 @@ public:
     }
 
     template <typename Head, typename... Tail>
-    optional<std::string> get_enum_property_opt(
+    ELONA_NODISCARD_ATTR optional<std::string> get_enum_property_opt(
         const std::string& key_head,
         const std::string& key_tail,
         int index,
@@ -682,7 +686,7 @@ public:
     }
 
     template <typename... Tail>
-    optional<std::string> get_enum_property_opt(
+    ELONA_NODISCARD_ATTR optional<std::string> get_enum_property_opt(
         const std::string& key_head,
         const std::string& key_tail,
         int index,
@@ -697,7 +701,9 @@ public:
     // returns 1-size list which contains the value. If `key` does not exist,
     // returns empty list.
     template <typename... Args>
-    std::vector<std::string> get_list(const I18NKey& key, Args&&... args)
+    ELONA_NODISCARD_ATTR std::vector<std::string> get_list(
+        const I18NKey& key,
+        Args&&... args)
     {
         std::vector<std::string> ret;
 
@@ -731,6 +737,7 @@ public:
     // i18n::s.get_m("locale.class", "modname.classname", "name")
     // // The above call is equivalent to:
     // i18n::s.get("modname.locale.class.classname.name")
+    ELONA_NODISCARD_ATTR
     std::string get_m(
         const I18NKey& data_type_key,
         const I18NKey& data_key,
@@ -748,6 +755,7 @@ public:
     // i18n::s.get_m_optional("locale.class", "modname.classname", "name")
     // // The above call is equivalent to:
     // i18n::s.get_optional("modname.locale.class.classname.name")
+    ELONA_NODISCARD_ATTR
     optional<std::string> get_m_optional(
         const I18NKey& data_type_key,
         const I18NKey& data_key,

--- a/src/elona/macro.hpp
+++ b/src/elona/macro.hpp
@@ -25,3 +25,13 @@
     } while (0)
 
 #define UNUSED(x) (void)x
+
+
+
+#if defined(__clang__) || defined(__GNUC__)
+#define ELONA_NODISCARD_ATTR __attribute__((warn_unused_result))
+#elif defined(MSVC)
+#define ELONA_NODISCARD_ATTR _Check_return_
+#else
+#define ELONA_NODISCARD_ATTR
+#endif


### PR DESCRIPTION
# Related Issues

Close #1375


# Summary

- Add non-standard attribute compatible with `[[nodiscard]]` in C++17 each compiler provides to i18n-related functions.
- Fix some text not being shown to players.