### PR TITLE
Add uri to target_link_libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -481,7 +481,7 @@ else()
 
   # My libraries: elona
   add_subdirectory(src/elona)
-  target_link_libraries(${PROJECT_NAME} elona ${SNAIL_LIBRARY} ${SPIDER_LIBRARY} util)
+  target_link_libraries(${PROJECT_NAME} elona ${SNAIL_LIBRARY} ${SPIDER_LIBRARY} util ${NETWORK_URI_LIBRARY})
 
   if((ELONA_BUILD_TARGET STREQUAL "GAME") OR (ELONA_BUILD_TARGET STREQUAL "LAUNCHER"))
     add_subdirectory(src/thirdparty/nfd)


### PR DESCRIPTION
# Summary

When I'm trying to build the latest develop branch I get these errors:

[100%] Linking CXX executable Elona_foobar
/home/vorlent/Projects/ElonaFoobar/src/spider/http/backends/boost_asio/request.cpp:82: error: undefined reference to 'network::uri::has_scheme() const'
/home/vorlent/Projects/ElonaFoobar/src/spider/http/backends/boost_asio/request.cpp:82: error: undefined reference to 'network::uri::scheme() const'
/home/vorlent/Projects/ElonaFoobar/src/spider/http/backends/boost_asio/request.cpp:85: error: undefined reference to 'network::uri::has_host() const'
/home/vorlent/Projects/ElonaFoobar/src/spider/http/backends/boost_asio/request.cpp:87: error: undefined reference to 'network::uri::host() const'
/home/vorlent/Projects/ElonaFoobar/src/spider/http/backends/boost_asio/request.cpp:95: error: undefined reference to 'network::uri::has_port() const'
/home/vorlent/Projects/ElonaFoobar/src/spider/http/backends/boost_asio/request.cpp:97: error: undefined reference to 'network::uri::port() const'
/home/vorlent/Projects/ElonaFoobar/src/spider/http/backends/boost_asio/request.cpp:105: error: undefined reference to 'network::uri::has_path() const'
/home/vorlent/Projects/ElonaFoobar/src/spider/http/backends/boost_asio/request.cpp:107: error: undefined reference to 'network::uri::path() const'
/home/vorlent/Projects/ElonaFoobar/src/spider/http/backends/boost_asio/request.cpp:113: error: undefined reference to 'network::uri::has_query() const'
/home/vorlent/Projects/ElonaFoobar/src/spider/http/backends/boost_asio/request.cpp:115: error: undefined reference to 'network::uri::query() const'
/home/vorlent/Projects/ElonaFoobar/src/spider/http/backends/boost_asio/request.cpp:117: error: undefined reference to 'network::uri::has_fragment() const'
/home/vorlent/Projects/ElonaFoobar/src/spider/http/backends/boost_asio/request.cpp:119: error: undefined reference to 'network::uri::fragment() const'
/home/vorlent/Projects/ElonaFoobar/src/spider/http/backends/boost_asio/request.cpp:75: error: undefined reference to 'network::uri::~uri()'
/home/vorlent/Projects/ElonaFoobar/src/spider/http/backends/boost_asio/request.cpp:75: error: undefined reference to 'network::uri::~uri()'
/home/vorlent/Projects/ElonaFoobar/src/spider/http/backends/boost_asio/request.cpp:448: error: undefined reference to 'network::uri::has_scheme() const'
/home/vorlent/Projects/ElonaFoobar/src/spider/http/backends/boost_asio/request.cpp:450: error: undefined reference to 'network::uri::scheme() const'
/home/vorlent/Projects/ElonaFoobar/src/spider/http/backends/boost_asio/request.cpp:452: error: undefined reference to 'network::uri::has_authority() const'
/home/vorlent/Projects/ElonaFoobar/src/spider/http/backends/boost_asio/request.cpp:454: error: undefined reference to 'network::uri::authority() const'
/home/vorlent/Projects/ElonaFoobar/src/spider/http/backends/boost_asio/request.cpp:444: error: undefined reference to 'network::uri::~uri()'
/home/vorlent/Projects/ElonaFoobar/src/spider/http/backends/boost_asio/request.cpp:444: error: undefined reference to 'network::uri::~uri()'
/home/vorlent/Projects/ElonaFoobar/src/spider/../thirdparty/uri/include/network/uri/uri.hpp:199: error: undefined reference to 'network::uri::initialize(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/home/vorlent/Projects/ElonaFoobar/src/spider/../thirdparty/uri/include/network/uri/uri.hpp:200: error: undefined reference to 'network::make_error_code(network::uri_error)'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/Elona_foobar.dir/build.make:125: Elona_foobar] Error 1
make[1]: *** [CMakeFiles/Makefile2:78: CMakeFiles/Elona_foobar.dir/all] Error 2
make: *** [Makefile:130: all] Error 2

When you compile with gcc the order of the static libraries matters. The generated Makefile puts libnetwork-uri.a before libspider_boost_asio.a which is incorrect.

I think the android build needs to be fixed too but I didn't test it.