### PR TITLE
Support data-update.lua

### DIFF
--- a/src/tests/data/registry/load_order/data-update.lua
+++ b/src/tests/data/registry/load_order/data-update.lua
@@ -1,0 +1,10 @@
+-- local Data = Elona.require 'Data'
+--
+-- local spell = Data.get('core.ability', 'load_order.expecto_patronum')
+-- spell.cost = 100
+
+-- work-around: Data API internally refers to global LuaEnv, elona::lua::lua,
+-- but test code creates isolated LuaEnv. As two LuaEnv are different, the
+-- above code which calls Data.get() does not work properly.
+local spell = data.raw['core.ability']['load_order.expecto_patronum']
+spell.cost = 100

--- a/src/tests/data/registry/load_order/data.lua
+++ b/src/tests/data/registry/load_order/data.lua
@@ -1,0 +1,14 @@
+data:add(
+   {
+      {
+         type = 'core.ability',
+         id = 'expecto_patronum',
+         legacy_id = 9999,
+         related_basic_attribute = 17,
+         ability_type = 0,
+         cost = 20,
+         range = 0,
+         difficulty = 100,
+      },
+   }
+)

--- a/src/tests/data/registry/load_order/init.lua
+++ b/src/tests/data/registry/load_order/init.lua
@@ -1,0 +1,19 @@
+local Data = Elona.require 'Data'
+
+print('----- init -----')
+
+do
+   local spell = Data.get('core.ability', 'core.healing')
+   print(spell)
+   local spells = Data.get_table('core.ability')
+   print(spells)
+end
+
+print('----------')
+
+-- do
+--    local spell = data.raw['core.ability']['core.healing']
+--    print(spell)
+--    local spells = data.raw['core.ability']
+--    print(spells)
+-- end

--- a/src/tests/data/registry/load_order/mod.hcl
+++ b/src/tests/data/registry/load_order/mod.hcl
@@ -1,0 +1,9 @@
+mod {
+    id = "load_order"
+    name = "load_order"
+    author = "KI"
+    version = "0.1.0"
+    license = "MIT"
+    description = "Test mod."
+    dependencies = { core = "*" }
+}

--- a/src/tests/lua_data.cpp
+++ b/src/tests/lua_data.cpp
@@ -75,3 +75,21 @@ TEST_CASE(
     REQUIRE_NONE(lua.get_export_manager().get_exported_function(
         "exports:test_export_keys.0"));
 }
+
+TEST_CASE("test order of script execution", "[Lua: Data]")
+{
+    const auto base_path = testing::get_test_data_path() / "registry";
+
+    elona::lua::LuaEnv lua;
+    lua.get_mod_manager().load_mods(
+        filesystem::dirs::mod(), {base_path / "load_order"});
+
+    REQUIRE_NOTHROW(lua.get_data_manager().init_from_mods());
+
+    auto& table = lua.get_data_manager().get();
+
+    auto spell = table.raw("core.ability", "load_order.expecto_patronum");
+    REQUIRE_SOME(spell);
+    REQUIRE((*spell)["related_basic_attribute"].get<int>() == 17);
+    REQUIRE((*spell)["cost"].get<int>() == 100);
+}


### PR DESCRIPTION
# Summary

Support data editing. `data-update.lua` is always loaded after `data.lua` is loaded. You can modify existing data, add new ones, and remove them in the file.