### PR TITLE
Fix SSL error

### DIFF
--- a/src/elona/lua_env/console.cpp
+++ b/src/elona/lua_env/console.cpp
@@ -667,9 +667,8 @@ void Console::_init_builtin_lua_functions()
         print("I am perfectly normal, thank you very much.");
     };
 
-    funcs["ex"] = [this]() {
-        spider::http::Request req{spider::http::Verb::GET,
-                                  "http://elonafoobar.com"};
+    funcs["httpget"] = [this](const std::string& url) {
+        spider::http::Request req{spider::http::Verb::GET, url};
         req.send(
             [this](const auto& res) { print(res.body); },
             [this](const auto& err) { print(err.what()); });

--- a/src/elona/lua_env/console.cpp
+++ b/src/elona/lua_env/console.cpp
@@ -34,24 +34,6 @@ namespace lua
 namespace
 {
 
-struct CommandLineParseError : std::runtime_error
-{
-    CommandLineParseError(const std::string& msg)
-        : std::runtime_error(msg)
-    {
-    }
-};
-
-
-
-struct ParsedCommandLine
-{
-    std::vector<std::pair<std::string, std::vector<std::string>>>
-        piped_commands;
-};
-
-
-
 constexpr const char* prompt_normal = "> ";
 constexpr const char* prompt_lua_primary = "lua> ";
 constexpr const char* prompt_lua_secondary = "lua>> ";

--- a/src/elona/net.cpp
+++ b/src/elona/net.cpp
@@ -120,7 +120,8 @@ std::vector<ChatData> net_receive_chats(bool skip_old_chat)
     {
         return {};
     }
-    if (Clock::now() - last_chat_received_at < chat_receive_interval)
+    if (skip_old_chat &&
+        Clock::now() - last_chat_received_at < chat_receive_interval)
     {
         return {};
     }

--- a/src/elona/ui/ui_menu_voting_box.cpp
+++ b/src/elona/ui/ui_menu_voting_box.cpp
@@ -118,10 +118,10 @@ void UIMenuVotingBox::draw()
         cmbg / 4 / 4 % 2 * 300,
         180,
         300,
-        ww / 5 * 3,
-        wh - 80,
         wx + ww / 3 * 2,
-        wy + wh / 2);
+        wy + wh / 2,
+        ww / 5 * 3,
+        wh - 80);
     gmode(2);
 
     display_topic(

--- a/src/spider/http/backends/boost_asio/request.cpp
+++ b/src/spider/http/backends/boost_asio/request.cpp
@@ -426,8 +426,9 @@ private:
                 do_redirect(_response[field::location].to_string());
                 return;
             }
-        default: _done(_construct_response()); break;
         }
+
+        _done(_construct_response());
     }
 
 

--- a/src/spider/http/backends/boost_asio/request.cpp
+++ b/src/spider/http/backends/boost_asio/request.cpp
@@ -364,6 +364,10 @@ private:
 
         if (_is_https)
         {
+            // Cancel all pending operations.
+            error_code ec_;
+            _secure_socket.lowest_layer().cancel(ec_);
+            // Shut down the TLS socket.
             auto self = shared_from_this();
             _secure_socket.async_shutdown(
                 [this, self](const auto& ec) { on_shutdown(ec); });
@@ -390,19 +394,36 @@ private:
     {
         if (ec)
         {
-            if (ec == asio::error::eof ||
-                (ec.category() == asio::error::get_ssl_category() &&
-                 ERR_GET_REASON(ec.value()) ==
-                     asio::ssl::error::stream_errors::stream_truncated))
+            if (ec == asio::error::eof)
             {
-                // This error can be ignored.
+                // Shutdown operation actually succeeded.
+                // See this page for rationale:
                 // http://stackoverflow.com/questions/25587403/boost-asio-ssl-async-shutdown-always-finishes-with-an-error
+                // This behaviour was fixed in Boost 1.70, then Boost suppresses
+                // this kind of EOF error.
             }
             else
             {
-                fail("Failed to shutdown the connection: " + _url);
-                return;
+                // FIXME: work around
+                // This shutdown operation always fails with
+                // asio::ssl::error::stream_errors::stream_truncated.
+                // According to this page,
+                // https://github.com/cpp-netlib/cpp-netlib/issues/670
+                // to ignore the error is incorrect, but I cannot find
+                // an proper handling.
+
+                // fail("Failed to shutdown the connection: " + _url);
+                // return;
             }
+        }
+
+        // Close the lower layer's connection under TLS socket.
+        error_code ec_;
+        _secure_socket.lowest_layer().close(ec_);
+        if (ec_)
+        {
+            fail("Failed to shutdown the connection: " + _url);
+            return;
         }
 
         on_successfully_recieved();


### PR DESCRIPTION
# Summary

- Refactor: delete unused `struct`s.
- Add console command for testing: `httpget`.
  - Usage: `httpget URL`
- Fix background image of voting box menu.
- Fix chat list of chat history menu.
   - Not all chats were listed before.
- Refactor: fix ambiguous fall-through.
- Fix SSL shutdown error.
  - FIXME: it is just a work around, not a correct solution. We just ignore error regardless of whether it is false-positive or not.