### PR TITLE
 Don't save volatile data in Store object

### DIFF
--- a/runtime/data/script/kernel/serial.lua
+++ b/runtime/data/script/kernel/serial.lua
@@ -19,6 +19,26 @@ local function resolve_handle(value, seen)
    end
 end
 
+-- Does not mutate `value`.
+local function remove_volatile_data(value)
+   if type(value) ~= "table" then
+      return value
+   end
+
+   -- For table, remove volatile data.
+   local result = {}
+   for k, v in pairs(value) do
+      if type(k) == "string" and k:sub(1, 1) == "_" then
+         -- It's a private field, skipping.
+      else
+         -- This rule is only applied to top-level fields because we have to
+         -- save Handle object with its private fields such as `__index`.
+         result[k] = v
+      end
+   end
+   return result
+end
+
 resolve_handles = function(data, seen)
    for key, value in pairs(data) do
       resolve_handle(value, seen)
@@ -26,6 +46,7 @@ resolve_handles = function(data, seen)
 end
 
 Serial.save = function(s)
+   s = remove_volatile_data(s)
    local dump = serpent.dump(s)
    return dump
 end


### PR DESCRIPTION

# Related Issues

Close #1397 


# Summary

Skip fields prefixed by `_` in `Store` object. If `Store` is not a table, the value is directly saved.
This rule is only applied to top level fields, i.e., this process is NOT performed recursively, because we have to save `Handle` object which has `__handle`, `__kind` and `__index`.