### PR TITLE
Remove Boost.Locale from foobar dependencies

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -6,4 +6,4 @@ export BOOST_ROOT="$TRAVIS_BUILD_DIR/../boost"
 export CMAKE_MODULE_PATH="$CMAKE_MODULE_PATH;$BOOST_ROOT"
 if [ ! -f "$DOWNLOAD_ROOT/boost_1_69_0.tar.gz" ]; then wget --no-verbose --output-document="$DOWNLOAD_ROOT/boost_1_69_0.tar.gz" "$BOOST_DOWNLOAD_URL"; fi
 if [ ! -d "$BOOST_ROOT" ]; then mkdir -p "$BOOST_ROOT" && tar xzf "$DOWNLOAD_ROOT/boost_1_69_0.tar.gz" --strip-components=1 -C "$BOOST_ROOT"; fi
-if [ ! -f "$BOOST_ROOT/b2" ]; then cd "$BOOST_ROOT"; ./bootstrap.sh --with-toolset="$BOOST_TOOLSET" --with-libraries=system,filesystem,locale; fi
+if [ ! -f "$BOOST_ROOT/b2" ]; then cd "$BOOST_ROOT"; ./bootstrap.sh --with-toolset="$BOOST_TOOLSET" --with-libraries=system,filesystem; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,7 +261,7 @@ else()
   endif()
 
   # Thirdparty libraries
-  find_package(Boost REQUIRED COMPONENTS system filesystem locale)
+  find_package(Boost REQUIRED COMPONENTS system filesystem)
   include_directories(${Boost_INCLUDE_DIRS})
   target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES})
 

--- a/runtime/mod/core/locale/jp/config.hcl
+++ b/runtime/mod/core/locale/jp/config.hcl
@@ -1,4 +1,4 @@
-﻿locale {
+locale {
     config {
         common {
             menu = "項目"

--- a/src/util/unicode.hpp
+++ b/src/util/unicode.hpp
@@ -1,0 +1,346 @@
+// sol2
+
+// The MIT License (MIT)
+
+// Copyright (c) 2013-2017 Rapptz, ThePhD and contributors
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to
+// do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <array>
+
+namespace lib
+{
+// Everything here was lifted pretty much straight out of
+// ogonek, because fuck figuring it out=
+namespace unicode
+{
+enum error_code
+{
+    ok = 0,
+    invalid_code_point,
+    invalid_code_unit,
+    invalid_leading_surrogate,
+    invalid_trailing_surrogate,
+    sequence_too_short,
+    overlong_sequence,
+};
+
+template <typename It>
+struct decoded_result
+{
+    error_code error;
+    char32_t codepoint;
+    It next;
+};
+
+template <typename C>
+struct encoded_result
+{
+    error_code error;
+    std::size_t code_units_size;
+    std::array<C, 4> code_units;
+};
+
+struct unicode_detail
+{
+    // codepoint related
+    static constexpr char32_t last_code_point = 0x10FFFF;
+
+    static constexpr char32_t first_lead_surrogate = 0xD800;
+    static constexpr char32_t last_lead_surrogate = 0xDBFF;
+
+    static constexpr char32_t first_trail_surrogate = 0xDC00;
+    static constexpr char32_t last_trail_surrogate = 0xDFFF;
+
+    static constexpr char32_t first_surrogate = first_lead_surrogate;
+    static constexpr char32_t last_surrogate = last_trail_surrogate;
+
+    static constexpr bool is_lead_surrogate(char32_t u)
+    {
+        return u >= first_lead_surrogate && u <= last_lead_surrogate;
+    }
+    static constexpr bool is_trail_surrogate(char32_t u)
+    {
+        return u >= first_trail_surrogate && u <= last_trail_surrogate;
+    }
+    static constexpr bool is_surrogate(char32_t u)
+    {
+        return u >= first_surrogate && u <= last_surrogate;
+    }
+
+    // utf8 related
+    static constexpr auto last_1byte_value = 0x7Fu;
+    static constexpr auto last_2byte_value = 0x7FFu;
+    static constexpr auto last_3byte_value = 0xFFFFu;
+
+    static constexpr auto start_2byte_mask = 0x80u;
+    static constexpr auto start_3byte_mask = 0xE0u;
+    static constexpr auto start_4byte_mask = 0xF0u;
+
+    static constexpr auto continuation_mask = 0xC0u;
+    static constexpr auto continuation_signature = 0x80u;
+
+    static constexpr int sequence_length(unsigned char b)
+    {
+        return (b & start_2byte_mask) == 0
+            ? 1
+            : (b & start_3byte_mask) != start_3byte_mask
+                ? 2
+                : (b & start_4byte_mask) != start_4byte_mask ? 3 : 4;
+    }
+
+    static constexpr char32_t decode(unsigned char b0, unsigned char b1)
+    {
+        return ((b0 & 0x1F) << 6) | (b1 & 0x3F);
+    }
+    static constexpr char32_t
+    decode(unsigned char b0, unsigned char b1, unsigned char b2)
+    {
+        return ((b0 & 0x0F) << 12) | ((b1 & 0x3F) << 6) | (b2 & 0x3F);
+    }
+    static constexpr char32_t decode(
+        unsigned char b0,
+        unsigned char b1,
+        unsigned char b2,
+        unsigned char b3)
+    {
+        return ((b0 & 0x07) << 18) | ((b1 & 0x3F) << 12) | ((b2 & 0x3F) << 6) |
+            (b3 & 0x3F);
+    }
+
+    // utf16 related
+    static constexpr char32_t last_bmp_value = 0xFFFF;
+    static constexpr char32_t normalizing_value = 0x10000;
+    static constexpr int lead_surrogate_bitmask = 0xFFC00;
+    static constexpr int trail_surrogate_bitmask = 0x3FF;
+    static constexpr int lead_shifted_bits = 10;
+
+    static char32_t combine_surrogates(wchar_t lead, wchar_t trail)
+    {
+        auto hi = lead - first_lead_surrogate;
+        auto lo = trail - first_trail_surrogate;
+        return normalizing_value + ((hi << lead_shifted_bits) | lo);
+    }
+};
+
+inline encoded_result<char> code_point_to_utf8(char32_t codepoint)
+{
+    encoded_result<char> er;
+    er.error = error_code::ok;
+    if (codepoint <= unicode_detail::last_1byte_value)
+    {
+        er.code_units_size = 1;
+        er.code_units = std::array<char, 4>{static_cast<char>(codepoint)};
+    }
+    else if (codepoint <= unicode_detail::last_2byte_value)
+    {
+        er.code_units_size = 2;
+        er.code_units = std::array<char, 4>{
+            static_cast<char>(0xC0 | ((codepoint & 0x7C0) >> 6)),
+            static_cast<char>(0x80 | (codepoint & 0x3F)),
+        };
+    }
+    else if (codepoint <= unicode_detail::last_3byte_value)
+    {
+        er.code_units_size = 3;
+        er.code_units = std::array<char, 4>{
+            static_cast<char>(0xE0 | ((codepoint & 0xF000) >> 12)),
+            static_cast<char>(0x80 | ((codepoint & 0xFC0) >> 6)),
+            static_cast<char>(0x80 | (codepoint & 0x3F)),
+        };
+    }
+    else
+    {
+        er.code_units_size = 4;
+        er.code_units = std::array<char, 4>{
+            static_cast<char>(0xF0 | ((codepoint & 0x1C0000) >> 18)),
+            static_cast<char>(0x80 | ((codepoint & 0x3F000) >> 12)),
+            static_cast<char>(0x80 | ((codepoint & 0xFC0) >> 6)),
+            static_cast<char>(0x80 | (codepoint & 0x3F)),
+        };
+    }
+    return er;
+}
+
+inline encoded_result<wchar_t> code_point_to_utf16(char32_t codepoint)
+{
+    encoded_result<wchar_t> er;
+
+    if (codepoint <= unicode_detail::last_bmp_value)
+    {
+        er.code_units_size = 1;
+        er.code_units = std::array<wchar_t, 4>{static_cast<wchar_t>(codepoint)};
+        er.error = error_code::ok;
+    }
+    else
+    {
+        auto normal = codepoint - unicode_detail::normalizing_value;
+        auto lead = unicode_detail::first_lead_surrogate +
+            ((normal & unicode_detail::lead_surrogate_bitmask) >>
+             unicode_detail::lead_shifted_bits);
+        auto trail = unicode_detail::first_trail_surrogate +
+            (normal & unicode_detail::trail_surrogate_bitmask);
+        er.code_units = std::array<wchar_t, 4>{static_cast<wchar_t>(lead),
+                                               static_cast<wchar_t>(trail)};
+        er.code_units_size = 2;
+        er.error = error_code::ok;
+    }
+    return er;
+}
+
+inline encoded_result<char32_t> code_point_to_utf32(char32_t codepoint)
+{
+    encoded_result<char32_t> er;
+    er.code_units_size = 1;
+    er.code_units[0] = codepoint;
+    er.error = error_code::ok;
+    return er;
+}
+
+template <typename It>
+inline decoded_result<It> utf8_to_code_point(It it, It)
+{
+    decoded_result<It> dr;
+
+    unsigned char b0 = *it;
+    std::size_t length = unicode_detail::sequence_length(b0);
+
+    if (length == 1)
+    {
+        dr.codepoint = static_cast<char32_t>(b0);
+        dr.error = error_code::ok;
+        ++it;
+        dr.next = it;
+        return dr;
+    }
+
+    auto is_invalid = [](unsigned char b) {
+        return b == 0xC0 || b == 0xC1 || b > 0xF4;
+    };
+    auto is_continuation = [](unsigned char b) {
+        return (b & unicode_detail::continuation_mask) ==
+            unicode_detail::continuation_signature;
+    };
+
+    if (is_invalid(b0) || is_continuation(b0))
+    {
+        dr.error = error_code::invalid_code_unit;
+        dr.next = it;
+        return dr;
+    }
+
+    ++it;
+    std::array<unsigned char, 4> b;
+    b[0] = b0;
+    for (size_t i = 1; i < length; ++i)
+    {
+        b[i] = *it;
+        if (!is_continuation(b[i]))
+        {
+            dr.error = error_code::invalid_code_unit;
+            dr.next = it;
+            return dr;
+        }
+        ++it;
+    }
+
+    char32_t decoded;
+    switch (length)
+    {
+    case 2: decoded = unicode_detail::decode(b[0], b[1]); break;
+    case 3: decoded = unicode_detail::decode(b[0], b[1], b[2]); break;
+    default: decoded = unicode_detail::decode(b[0], b[1], b[2], b[3]); break;
+    }
+
+    auto is_overlong = [](char32_t u, std::size_t bytes) {
+        return u <= unicode_detail::last_1byte_value ||
+            (u <= unicode_detail::last_2byte_value && bytes > 2) ||
+            (u <= unicode_detail::last_3byte_value && bytes > 3);
+    };
+    if (is_overlong(decoded, length))
+    {
+        dr.error = error_code::overlong_sequence;
+        return dr;
+    }
+    if (unicode_detail::is_surrogate(decoded) ||
+        decoded > unicode_detail::last_code_point)
+    {
+        dr.error = error_code::invalid_code_point;
+        return dr;
+    }
+
+    // then everything is fine
+    dr.codepoint = decoded;
+    dr.error = error_code::ok;
+    dr.next = it;
+    return dr;
+}
+
+template <typename It>
+inline decoded_result<It> utf16_to_code_point(It it, It)
+{
+    decoded_result<It> dr;
+
+    wchar_t lead = static_cast<wchar_t>(*it);
+
+    if (!unicode_detail::is_surrogate(lead))
+    {
+        ++it;
+        dr.codepoint = static_cast<char32_t>(lead);
+        dr.next = it;
+        dr.error = error_code::ok;
+        return dr;
+    }
+    if (!unicode_detail::is_lead_surrogate(lead))
+    {
+        dr.error = error_code::invalid_leading_surrogate;
+        dr.next = it;
+        return dr;
+    }
+
+    ++it;
+    auto trail = *it;
+    if (!unicode_detail::is_trail_surrogate(trail))
+    {
+        dr.error = error_code::invalid_trailing_surrogate;
+        dr.next = it;
+        return dr;
+    }
+
+    dr.codepoint = unicode_detail::combine_surrogates(lead, trail);
+    dr.next = ++it;
+    dr.error = error_code::ok;
+    return dr;
+}
+
+template <typename It>
+inline decoded_result<It> utf32_to_code_point(It it, It)
+{
+    decoded_result<It> dr;
+    dr.codepoint = static_cast<char32_t>(*it);
+    dr.next = ++it;
+    dr.error = error_code::ok;
+    return dr;
+}
+} // namespace unicode
+} // namespace lib

--- a/src/util/unicode_utf16.hpp
+++ b/src/util/unicode_utf16.hpp
@@ -1,0 +1,94 @@
+#pragma once
+
+#include "unicode.hpp"
+
+
+
+namespace lib
+{
+namespace unicode
+{
+
+// The following are adapted from sol2's string conversion code. They assume
+// wchar_t is 2 bytes, as MSVC uses std::wstring instead of std::u16string.
+// (wchar_t can be 4 bytes depending on the platform.) This file should only be
+// compiled on Windows, as that is the only platform where UTF-16 conversion is
+// necessary.
+
+static_assert(sizeof(wchar_t) == 2, "wchar_t must be 2 bytes");
+
+inline std::string utf16_to_utf8(const wchar_t* strb, const wchar_t* stre)
+{
+    std::size_t needed_size = 0;
+    for (const wchar_t* strtarget = strb; strtarget < stre;)
+    {
+        auto dr = lib::unicode::utf16_to_code_point(strtarget, stre);
+        auto er = lib::unicode::code_point_to_utf8(dr.codepoint);
+        needed_size += er.code_units_size;
+        strtarget = dr.next;
+    }
+
+    std::string u8str("", 0);
+    u8str.resize(needed_size);
+    char* target = &u8str[0];
+
+    for (const wchar_t* strtarget = strb; strtarget < stre;)
+    {
+        auto dr = lib::unicode::utf16_to_code_point(strtarget, stre);
+        auto er = lib::unicode::code_point_to_utf8(dr.codepoint);
+        const char* utf8data = er.code_units.data();
+        std::memcpy(target, utf8data, er.code_units_size * sizeof(char));
+        target += er.code_units_size;
+        strtarget = dr.next;
+    }
+
+    return u8str;
+}
+
+
+
+inline std::string utf16_to_utf8(const std::wstring& u16str)
+{
+    const wchar_t* strb = &u16str[0];
+    const wchar_t* stre = strb + std::char_traits<wchar_t>::length(strb);
+
+    return utf16_to_utf8(strb, stre);
+}
+
+
+
+inline std::wstring utf8_to_utf16(const std::string& u8str)
+{
+    size_t len = std::char_traits<char>::length(u8str.c_str());
+    std::size_t needed_size = 0;
+    const char* utf8p = u8str.c_str();
+    const char* strb = utf8p;
+    const char* stre = utf8p + len;
+
+    for (const char* strtarget = strb; strtarget < stre;)
+    {
+        auto dr = lib::unicode::utf8_to_code_point(strtarget, stre);
+        auto er = lib::unicode::code_point_to_utf16(dr.codepoint);
+        needed_size += er.code_units_size;
+        strtarget = dr.next;
+    }
+
+    std::wstring r(needed_size, 0);
+    r.resize(needed_size);
+    wchar_t* target = &r[0];
+
+    for (const char* strtarget = strb; strtarget < stre;)
+    {
+        auto dr = lib::unicode::utf8_to_code_point(strtarget, stre);
+        auto er = lib::unicode::code_point_to_utf16(dr.codepoint);
+        std::memcpy(
+            target, er.code_units.data(), er.code_units_size * sizeof(wchar_t));
+        strtarget = dr.next;
+        target += er.code_units_size;
+    }
+
+    return r;
+}
+
+} // namespace unicode
+} // namespace lib


### PR DESCRIPTION
# Related Issues

Most of code is borrowed from #1294.


# Summary

Remove Boost.Locale from dependencies, and instead use utilities borrowed from sol2.