### PR TITLE
Change RNG from mt19937 to xorshift's variant

### DIFF
--- a/src/elona/gdata.cpp
+++ b/src/elona/gdata.cpp
@@ -6,9 +6,10 @@
 namespace elona
 {
 
-
 GameData game_data;
 FoobarData foobar_data;
+
+
 
 #define GDATA_PACK(x, ident) gdata(x) = ident;
 #define GDATA_UNPACK(x, ident) ident = gdata(x);
@@ -27,6 +28,7 @@ FoobarData foobar_data;
     SERIALIZE(6, pc_y_in_world_map); \
     SERIALIZE(7, play_days); \
     SERIALIZE(8, random_seed); \
+    SERIALIZE(9, random_seed_offset); \
     SERIALIZE(10, date.year); \
     SERIALIZE(11, date.month); \
     SERIALIZE(12, date.day); \
@@ -207,7 +209,5 @@ void modify_crowd_density(int cc, int delta)
             game_data.crowd_density = 0;
     }
 }
-
-
 
 } // namespace elona

--- a/src/elona/gdata.hpp
+++ b/src/elona/gdata.hpp
@@ -1,12 +1,17 @@
 #pragma once
+
 #include <array>
 #include "../version.hpp"
+
+
 
 namespace elona
 {
 
 template <typename T>
 struct elona_vector1;
+
+
 
 struct DateTime
 {
@@ -22,6 +27,8 @@ struct DateTime
         return hour + (day * 24) + (month * 24 * 30) + (year * 24 * 30 * 12);
     }
 };
+
+
 
 struct QuestFlags
 {
@@ -58,6 +65,8 @@ struct QuestFlags
     int gift_count_of_little_sister;
 };
 
+
+
 struct GuildData
 {
     int belongs_to_mages_guild;
@@ -78,6 +87,8 @@ struct GuildData
     int thieves_guild_quota_recurring;
 };
 
+
+
 /**
  * Global game data that is serialized. Replaces gdata.
  */
@@ -95,6 +106,7 @@ struct GameData
     int pc_y_in_world_map;
     int play_days;
     int random_seed;
+    int random_seed_offset;
     DateTime date;
     int next_inventory_serial_id;
     int weather;
@@ -241,6 +253,5 @@ extern FoobarData foobar_data;
 
 // TODO: Make gdata class and make this function method.
 void modify_crowd_density(int cc, int delta);
-
 
 } // namespace elona

--- a/src/elona/init.cpp
+++ b/src/elona/init.cpp
@@ -417,7 +417,7 @@ void initialize_elona()
     initialize_cell_object_data();
     load_random_title_table();
     load_random_name_table();
-    game_data.random_seed = rnd(800) + 2;
+    game_data.random_seed = 1 + rnd(2000000000);
     game_data.random_seed_offset = 0;
     set_item_info();
     clear_trait_data();
@@ -564,7 +564,7 @@ void initialize_debug_globals()
     game_data.pc_x_in_world_map = 22;
     game_data.pc_y_in_world_map = 21;
     game_data.previous_map = -1;
-    game_data.random_seed = rnd(800) + 2;
+    game_data.random_seed = 1 + rnd(2000000000);
     game_data.random_seed_offset = 0;
     game_data.current_map = static_cast<int>(mdata_t::MapId::north_tyris);
     game_data.current_dungeon_level = 0;

--- a/src/elona/init.cpp
+++ b/src/elona/init.cpp
@@ -418,6 +418,7 @@ void initialize_elona()
     load_random_title_table();
     load_random_name_table();
     game_data.random_seed = rnd(800) + 2;
+    game_data.random_seed_offset = 0;
     set_item_info();
     clear_trait_data();
     initialize_rankn();
@@ -564,6 +565,7 @@ void initialize_debug_globals()
     game_data.pc_y_in_world_map = 21;
     game_data.previous_map = -1;
     game_data.random_seed = rnd(800) + 2;
+    game_data.random_seed_offset = 0;
     game_data.current_map = static_cast<int>(mdata_t::MapId::north_tyris);
     game_data.current_dungeon_level = 0;
     game_data.entrance_type = 7;

--- a/src/elona/random.cpp
+++ b/src/elona/random.cpp
@@ -1,11 +1,22 @@
 #include "random.hpp"
+#include "gdata.hpp"
 
 
 
 namespace elona
 {
+
 namespace detail
 {
 std::mt19937 engine{std::random_device{}()};
 } // namespace detail
+
+
+
+void randomize()
+{
+    ++game_data.random_seed_offset;
+    randomize(game_data.random_seed + game_data.random_seed_offset);
+}
+
 } // namespace elona

--- a/src/elona/random.cpp
+++ b/src/elona/random.cpp
@@ -8,7 +8,7 @@ namespace elona
 
 namespace detail
 {
-std::mt19937 engine{std::random_device{}()};
+xoshiro256::xoshiro256_engine engine{std::random_device{}()};
 } // namespace detail
 
 

--- a/src/elona/random.hpp
+++ b/src/elona/random.hpp
@@ -25,11 +25,12 @@ extern std::mt19937 engine;
 
 
 
-// TODO: pass more proper seed
-// This function is called very frequently in a certain circumstances.
-// In general, std::random_device is slower than other generators.
-inline void randomize(
-    std::random_device::result_type seed = std::random_device{}())
+// Reset random seed to the global seed.
+void randomize();
+
+
+
+inline void randomize(int seed)
 {
     detail::engine.seed(seed);
 }

--- a/src/elona/random.hpp
+++ b/src/elona/random.hpp
@@ -5,6 +5,7 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
+#include "../thirdparty/xoshiro256//xoshiro256.hpp"
 #include "optional.hpp"
 
 // DO NOT use `std::uniform_int_distribution` because its algorithm is
@@ -20,7 +21,7 @@ namespace elona
 
 namespace detail
 {
-extern std::mt19937 engine;
+extern xoshiro256::xoshiro256_engine engine;
 } // namespace detail
 
 

--- a/src/thirdparty/xoshiro256/splitmix64.hpp
+++ b/src/thirdparty/xoshiro256/splitmix64.hpp
@@ -1,0 +1,48 @@
+/*  Written in 2015 by Sebastiano Vigna (vigna@acm.org)
+
+To the extent possible under law, the author has dedicated all copyright
+and related and neighboring rights to this software to the public domain
+worldwide. This software is distributed without any warranty.
+
+See <http://creativecommons.org/publicdomain/zero/1.0/>. */
+#pragma once
+
+#include <cstdint>
+
+
+/* This is a fixed-increment version of Java 8's SplittableRandom generator
+   See http://dx.doi.org/10.1145/2714064.2660195 and
+   http://docs.oracle.com/javase/8/docs/api/java/util/SplittableRandom.html
+
+   It is a very fast generator passing BigCrush, and it can be useful if
+   for some reason you absolutely want 64 bits of state; otherwise, we
+   rather suggest to use a xoroshiro128+ (for moderately parallel
+   computations) or xorshift1024* (for massively parallel computations)
+   generator. */
+
+namespace xoshiro256
+{
+
+struct splitmix64_engine
+{
+    splitmix64_engine(uint64_t x)
+        : x(x)
+    {
+    }
+
+
+
+    uint64_t next()
+    {
+        uint64_t z = (x += 0x9e3779b97f4a7c15);
+        z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9;
+        z = (z ^ (z >> 27)) * 0x94d049bb133111eb;
+        return z ^ (z >> 31);
+    }
+
+
+private:
+    uint64_t x;
+};
+
+} // namespace xoshiro256

--- a/src/thirdparty/xoshiro256/xoshiro256.hpp
+++ b/src/thirdparty/xoshiro256/xoshiro256.hpp
@@ -1,0 +1,96 @@
+/*  Written in 2018 by David Blackman and Sebastiano Vigna (vigna@acm.org)
+
+To the extent possible under law, the author has dedicated all copyright
+and related and neighboring rights to this software to the public domain
+worldwide. This software is distributed without any warranty.
+
+See <http://creativecommons.org/publicdomain/zero/1.0/>. */
+#pragma once
+
+#include "splitmix64.hpp"
+
+
+/* This is xoshiro256** 1.0, our all-purpose, rock-solid generator. It has
+   excellent (sub-ns) speed, a state (256 bits) that is large enough for
+   any parallel application, and it passes all tests we are aware of.
+
+   For generating just floating-point numbers, xoshiro256+ is even faster.
+
+   The state must be seeded so that it is not everywhere zero. If you have
+   a 64-bit seed, we suggest to seed a splitmix64 generator and use its
+   output to fill s. */
+
+namespace xoshiro256
+{
+
+class xoshiro256_engine
+{
+public:
+    using result_type = uint64_t;
+    using seed_type = uint64_t;
+
+
+
+    xoshiro256_engine(seed_type initial_seed)
+    {
+        seed(initial_seed);
+    }
+
+
+
+    void seed(seed_type new_seed)
+    {
+        splitmix64_engine seed_gen(new_seed);
+        s[0] = seed_gen.next();
+        s[1] = seed_gen.next();
+        s[2] = seed_gen.next();
+        s[3] = seed_gen.next();
+    }
+
+
+
+    result_type operator()()
+    {
+        const result_type result_starstar = rotl(s[1] * 5, 7) * 9;
+
+        const result_type t = s[1] << 17;
+
+        s[2] ^= s[0];
+        s[3] ^= s[1];
+        s[1] ^= s[2];
+        s[0] ^= s[3];
+
+        s[2] ^= t;
+
+        s[3] = rotl(s[3], 45);
+
+        return result_starstar;
+    }
+
+
+
+    static constexpr result_type min()
+    {
+        return 0;
+    }
+
+
+
+    static constexpr result_type max()
+    {
+        return static_cast<result_type>(-1);
+    }
+
+
+
+private:
+    static result_type rotl(const result_type x, int k)
+    {
+        return (x << k) | (x >> (64 - k));
+    }
+
+
+    result_type s[4];
+};
+
+} // namespace xoshiro256


### PR DESCRIPTION
# Summary

- Reset random seed to he global seed + offset. Previously, `randomie()` function  calls `std::random_device`, but the RNG may be slow on some platforms. Also, the function's result is non-deterministic. Now, we use `game_data.random_seed + game_data.random_seed_offset` instead. The offset is incremented every time `randomize()` is called. It improves performance and make RNG deterministic.
- Widen range of global random seed: 2-801 to 1-2000000000.
- Change global RNG from mt19937 to xoshiro256, variant of xorshift. Elona frequently resets the random seed, which slows down the performance of mt19937 engine. Xorshift is much more lightweight algorithm and the performance is not affected by a lot of calls of `randomize()`.
