### PR TITLE
Rename repository name to elonafoobar

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,21 +1,21 @@
 [submodule "android/external/lua"]
 	path = android/external/lua
-	url = https://github.com/ElonaFoobar/lua53-android.git
+	url = https://github.com/elonafoobar/lua53-android.git
 [submodule "android/external/SDL2"]
 	path = android/external/SDL2
-	url = https://github.com/ElonaFoobar/SDL2.git
+	url = https://github.com/elonafoobar/SDL2.git
 [submodule "android/external/SDL2_mixer"]
 	path = android/external/SDL2_mixer
-	url = https://github.com/ElonaFoobar/SDL2_mixer.git
+	url = https://github.com/elonafoobar/SDL2_mixer.git
 [submodule "android/external/SDL2_image"]
 	path = android/external/SDL2_image
-	url = https://github.com/ElonaFoobar/SDL2_image.git
+	url = https://github.com/elonafoobar/SDL2_image.git
 [submodule "android/external/SDL2_ttf"]
 	path = android/external/SDL2_ttf
-	url = https://github.com/ElonaFoobar/SDL2_ttf.git
+	url = https://github.com/elonafoobar/SDL2_ttf.git
 [submodule "android/external/boost"]
 	path = android/external/boost
-	url = https://github.com/ElonaFoobar/libboost-1.69-android.git
+	url = https://github.com/elonafoobar/libboost-1.69-android.git
 [submodule "deps/windows"]
 	path = deps/windows
-	url = https://github.com/ElonaFoobar/windows_deps.git
+	url = https://github.com/elonafoobar/windows_deps.git

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".ElonaFoobarActivity"
+        <activity android:name=".ElonafoobarActivity"
                   android:label="@string/appName"
                   android:launchMode="singleInstance"
                   android:keepScreenOn="true"

--- a/android/app/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android/app/src/main/java/org/libsdl/app/SDLActivity.java
@@ -322,7 +322,7 @@ public class SDLActivity extends Activity {
         // Reset everything in case the user re opens the app
         SDLActivity.initialize();
 
-        // HACK (ElonaFoobar): Forcibly exit the application to avoid
+        // HACK (Elonafoobar): Forcibly exit the application to avoid
         // it lingering in the cache. If the app is reopened again
         // without exiting, it will crash due to static variables
         // already being initialized. To fix this, all static

--- a/android/app/src/main/java/xyz/ki/elonafoobar/ElonafoobarActivity.java
+++ b/android/app/src/main/java/xyz/ki/elonafoobar/ElonafoobarActivity.java
@@ -11,7 +11,7 @@ import android.view.View;
 import android.widget.Toast;
 import org.libsdl.app.SDLActivity;
 
-public class ElonaFoobarActivity extends SDLActivity
+public class ElonafoobarActivity extends SDLActivity
 {
     private static final String TAG = "Elona foobar";
 

--- a/android/app/src/main/java/xyz/ki/elonafoobar/SplashScreen.java
+++ b/android/app/src/main/java/xyz/ki/elonafoobar/SplashScreen.java
@@ -222,7 +222,7 @@ public class SplashScreen extends Activity {
     private final class StartGameRunnable implements Runnable {
         @Override
         public void run() {
-            Intent intent = new Intent(SplashScreen.this, ElonaFoobarActivity.class);
+            Intent intent = new Intent(SplashScreen.this, ElonafoobarActivity.class);
             intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
             startActivity(intent);
             finish();

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-clone_folder: C:\projects\ElonaFoobar
+clone_folder: C:\projects\elonafoobar
 
 os:
   - Visual Studio 2017
@@ -36,18 +36,18 @@ branches:
 
 cache:
   - C:\SDK -> appveyor.yml
-  - C:\projects\ElonaFoobar\bin -> appveyor.yml
+  - C:\projects\elonafoobar\bin -> appveyor.yml
 
 before_build:
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
-  - cd C:\projects\ElonaFoobar
+  - cd C:\projects\elonafoobar
   - ps: "$(git ls-files) -split \"`r`n\" | where { $_ -match '\\.(c|h|cpp|hpp|cxx|hxx|cc|hh)$' } | foreach { Set-ItemProperty $_ -Name LastWriteTime -Value $([DateTime]::Parse($(git log --format=%cI -n1 $_))) }"
   - if exist %PREFIX% set NEEDDEPENDS=rem
   - |-
     %NEEDDEPENDS% mkdir %PREFIX%
-    %NEEDDEPENDS% cp C:\projects\ElonaFoobar\deps\install.bat %PREFIX%
+    %NEEDDEPENDS% cp C:\projects\elonafoobar\deps\install.bat %PREFIX%
     %NEEDDEPENDS% cd %PREFIX%
-    %NEEDDEPENDS% git clone --depth=1 https://github.com/ElonaFoobar/windows_deps windows
+    %NEEDDEPENDS% git clone --depth=1 https://github.com/elonafoobar/windows_deps windows
     %NEEDDEPENDS% call .\install.bat
 
 build_script:

--- a/runtime/README (en).txt
+++ b/runtime/README (en).txt
@@ -61,5 +61,5 @@ See CREDITS.txt.
 
 - Twitter: https://twitter.com/ElonaFoobar
 - Discord: https://discord.gg/4htdyc2
-- GitHub: https://github.com/ElonaFoobar/ElonaFoobar/issues/new/choose
+- GitHub: https://github.com/elonafoobar/elonafoobar/issues/new/choose
 - Gmail: elonafoobar@gmail.com

--- a/runtime/README (ja).txt
+++ b/runtime/README (ja).txt
@@ -61,5 +61,5 @@ CREDITS.txtをご覧ください。
 
 - Twitter: https://twitter.com/ElonaFoobar
 - Discord: https://discord.gg/4htdyc2
-- GitHub: https://github.com/ElonaFoobar/ElonaFoobar/issues/new/choose
+- GitHub: https://github.com/elonafoobar/elonafoobar/issues/new/choose
 - Gmail: elonafoobar@gmail.com

--- a/src/elona/testing.cpp
+++ b/src/elona/testing.cpp
@@ -177,7 +177,7 @@ void pre_init()
     initialize_config_defs();
     initialize_config_preload();
 
-    title(u8"Elona Foobar version "s + latest_version.short_string());
+    title(u8"Elona foobar version "s + latest_version.short_string());
 
     init_assets();
     filesystem::dirs::set_base_save_directory(fs::path("save"));

--- a/tools/i18n_checker/src/i18n_checker/main.lua
+++ b/tools/i18n_checker/src/i18n_checker/main.lua
@@ -24,7 +24,7 @@ local function get_parser()
       :help_max_width(120)
 
    parser:argument "root_path"
-      :description("Root directory of ElonaFoobar repo")
+      :description("Root directory of elonafoobar repo")
       :args(1)
       :argname "<root_path>"
 


### PR DESCRIPTION
# Summary

Rename repository and organization name from ElonaFoobar to elonafoobar. You developers and players do not need to do anything because GitHub ignores repository and organization name's case.