### PR TITLE
Fix wrong locale key [ci skip]

### DIFF
--- a/src/elona/elonacore.cpp
+++ b/src/elona/elonacore.cpp
@@ -5530,7 +5530,8 @@ int target_position(bool target_chara)
             {
                 if (cansee == 0 || chip_data.for_cell(tlocx, tlocy).effect & 4)
                 {
-                    txt(i18n::s.get("core.action.which_direction.cannot_see"));
+                    txt(i18n::s.get(
+                        "core.action.which_direction.cannot_see_location"));
                     continue;
                 }
                 snd("core.ok1");


### PR DESCRIPTION
# Summary

Fix wrong locale key: `core.action.which_direction.cannot_see` -> `core.action.which_direction.cannot_see_location`