### PR TITLE
Check reserved path when creating new file or directory

### DIFF
--- a/src/elona/lua_env/mod_manager.cpp
+++ b/src/elona/lua_env/mod_manager.cpp
@@ -659,6 +659,7 @@ std::vector<fs::path> template_mod_dirs(const fs::path& base_dir)
 bool is_valid_mod_id(const std::string& id)
 {
     return !id.empty() && _is_alnum_only(id) &&
+        filepathutil::is_portable_path(filepathutil::u8path(id)) &&
         !lua->get_mod_manager().mod_id_is_reserved(id);
 }
 

--- a/src/elona/profile/profile.cpp
+++ b/src/elona/profile/profile.cpp
@@ -10,7 +10,8 @@ namespace profile
 bool is_valid_id(const ProfileId& profile_id)
 {
     const std::regex pattern{u8"[0-9A-Za-z_]+"};
-    return std::regex_match(profile_id, pattern);
+    return std::regex_match(profile_id, pattern) &&
+        filepathutil::is_portable_path(filepathutil::u8path(profile_id));
 }
 
 

--- a/src/tests/filesystem.cpp
+++ b/src/tests/filesystem.cpp
@@ -4,6 +4,8 @@
 
 using namespace elona;
 
+
+
 TEST_CASE("Test resolve_path_for_mod", "[C++: Filesystem]")
 {
     using namespace filesystem;
@@ -24,4 +26,30 @@ TEST_CASE("Test resolve_path_for_mod", "[C++: Filesystem]")
     REQUIRE_THROWS(resolve_path_for_mod("file.txt"));
     REQUIRE_THROWS(resolve_path_for_mod("<>"));
     REQUIRE_THROWS(resolve_path_for_mod("<$>/file.txt"));
+}
+
+
+
+TEST_CASE("Test is_portable_path", "[C++: Filesystem]")
+{
+    const auto is_portable_path = [](const char* path) {
+        return filepathutil::is_portable_path(filepathutil::u8path(path));
+    };
+
+    CHECK(is_portable_path("."));
+    CHECK(is_portable_path(".."));
+    CHECK(is_portable_path("no-extension"));
+    CHECK(is_portable_path("README.md"));
+
+    CHECK_FALSE(is_portable_path(""));
+    CHECK_FALSE(is_portable_path("con"));
+    CHECK_FALSE(is_portable_path("nul.txt"));
+    CHECK_FALSE(is_portable_path("<>"));
+    CHECK_FALSE(is_portable_path(";"));
+    CHECK_FALSE(is_portable_path("foo "));
+    CHECK_FALSE(is_portable_path("foo."));
+    CHECK_FALSE(is_portable_path(".vimrc"));
+    CHECK_FALSE(is_portable_path("abc/xyz"));
+    CHECK_FALSE(is_portable_path("/usr"));
+    CHECK_FALSE(is_portable_path("C:\\Program Files"));
 }

--- a/src/util/filepathutil.hpp
+++ b/src/util/filepathutil.hpp
@@ -17,4 +17,14 @@ std::string to_utf8_path(const boost::filesystem::path& path);
 std::string to_forward_slashes(const boost::filesystem::path& path);
 boost::optional<boost::filesystem::path::string_type> get_executable_path();
 
+/**
+ * Check if @a filename is portable on many platforms. It returns the same
+ * result for the same @a filename regardless of the platform where you compile
+ * this file and the program runs.
+ *
+ * @param filename The filename to check
+ * @returns True if @a filename is portable; otherwise, false.
+ */
+bool is_portable_path(const boost::filesystem::path& filename);
+
 } // namespace filepathutil


### PR DESCRIPTION
# Related Issues

Close #1402.


# Summary

Check whether a filename is reserved by any system when creating new files or directories.


## Test cases

```cpp
    CHECK(is_portable_path("."));
    CHECK(is_portable_path(".."));
    CHECK(is_portable_path("no-extension"));
    CHECK(is_portable_path("README.md"));

    CHECK_FALSE(is_portable_path(""));
    CHECK_FALSE(is_portable_path("con"));
    CHECK_FALSE(is_portable_path("nul.txt"));
    CHECK_FALSE(is_portable_path("<>"));
    CHECK_FALSE(is_portable_path(";"));
    CHECK_FALSE(is_portable_path("foo "));
    CHECK_FALSE(is_portable_path("foo."));
    CHECK_FALSE(is_portable_path(".vimrc"));
    CHECK_FALSE(is_portable_path("abc/xyz"));
    CHECK_FALSE(is_portable_path("/usr"));
    CHECK_FALSE(is_portable_path("C:\\Program Files"));
```