### PR TITLE
Refactor: Move legacy ID support out of LuaLazyCache

### DIFF
--- a/src/elona/data/types/type_ability.hpp
+++ b/src/elona/data/types/type_ability.hpp
@@ -20,7 +20,7 @@ struct AbilityData
 
 
 
-ELONA_DEFINE_LUA_DB(AbilityDB, AbilityData, true, "core.ability")
+ELONA_DEFINE_LUA_DB(AbilityDB, AbilityData, "core.ability")
 
 
 

--- a/src/elona/data/types/type_asset.hpp
+++ b/src/elona/data/types/type_asset.hpp
@@ -39,7 +39,7 @@ struct AssetData
 
 
 
-ELONA_DEFINE_LUA_DB(AssetDB, AssetData, false, "core.asset")
+ELONA_DEFINE_LUA_DB(AssetDB, AssetData, "core.asset")
 
 
 

--- a/src/elona/data/types/type_buff.hpp
+++ b/src/elona/data/types/type_buff.hpp
@@ -19,7 +19,7 @@ struct BuffData
 
 
 
-ELONA_DEFINE_LUA_DB(BuffDB, BuffData, true, "core.buff")
+ELONA_DEFINE_LUA_DB(BuffDB, BuffData, "core.buff")
 
 
 

--- a/src/elona/data/types/type_chara_chip.hpp
+++ b/src/elona/data/types/type_chara_chip.hpp
@@ -18,6 +18,6 @@ struct CharaChipData
 
 
 // Used only as an intermediary between registry and initialize_chara_chips().
-ELONA_DEFINE_LUA_DB(CharaChipDB, CharaChipData, true, "core.chara_chip")
+ELONA_DEFINE_LUA_DB(CharaChipDB, CharaChipData, "core.chara_chip")
 
 } // namespace elona

--- a/src/elona/data/types/type_character.hpp
+++ b/src/elona/data/types/type_character.hpp
@@ -140,7 +140,7 @@ struct CharacterData
 
 
 
-ELONA_DEFINE_LUA_DB(CharacterDB, CharacterData, true, "core.chara")
+ELONA_DEFINE_LUA_DB(CharacterDB, CharacterData, "core.chara")
 
 
 

--- a/src/elona/data/types/type_class.hpp
+++ b/src/elona/data/types/type_class.hpp
@@ -18,7 +18,7 @@ struct ClassData
 
 
 
-ELONA_DEFINE_LUA_DB(ClassDB, ClassData, true, "core.class")
+ELONA_DEFINE_LUA_DB(ClassDB, ClassData, "core.class")
 
 
 

--- a/src/elona/data/types/type_fish.hpp
+++ b/src/elona/data/types/type_fish.hpp
@@ -21,7 +21,7 @@ struct FishData
 
 
 
-ELONA_DEFINE_LUA_DB(FishDB, FishData, true, "core.fish")
+ELONA_DEFINE_LUA_DB(FishDB, FishData, "core.fish")
 
 
 

--- a/src/elona/data/types/type_god.hpp
+++ b/src/elona/data/types/type_god.hpp
@@ -14,7 +14,7 @@ struct GodData
 
 
 
-ELONA_DEFINE_LUA_DB(GodDB, GodData, true, "core.god")
+ELONA_DEFINE_LUA_DB(GodDB, GodData, "core.god")
 
 
 

--- a/src/elona/data/types/type_item.hpp
+++ b/src/elona/data/types/type_item.hpp
@@ -55,7 +55,7 @@ struct ItemData
 
 
 
-ELONA_DEFINE_LUA_DB(ItemDB, ItemData, true, "core.item")
+ELONA_DEFINE_LUA_DB(ItemDB, ItemData, "core.item")
 
 
 

--- a/src/elona/data/types/type_item_chip.hpp
+++ b/src/elona/data/types/type_item_chip.hpp
@@ -18,6 +18,6 @@ struct ItemChipData
 
 
 
-ELONA_DEFINE_LUA_DB(ItemChipDB, ItemChipData, true, "core.item_chip")
+ELONA_DEFINE_LUA_DB(ItemChipDB, ItemChipData, "core.item_chip")
 
 } // namespace elona

--- a/src/elona/data/types/type_item_material.hpp
+++ b/src/elona/data/types/type_item_material.hpp
@@ -25,11 +25,7 @@ struct ItemMaterialData
 
 
 
-ELONA_DEFINE_LUA_DB(
-    ItemMaterialDB,
-    ItemMaterialData,
-    true,
-    "core.item_material")
+ELONA_DEFINE_LUA_DB(ItemMaterialDB, ItemMaterialData, "core.item_material")
 
 
 

--- a/src/elona/data/types/type_map.hpp
+++ b/src/elona/data/types/type_map.hpp
@@ -48,7 +48,7 @@ struct MapDefData
 
 
 
-ELONA_DEFINE_LUA_DB(MapDefDB, MapDefData, true, "core.map")
+ELONA_DEFINE_LUA_DB(MapDefDB, MapDefData, "core.map")
 
 
 

--- a/src/elona/data/types/type_map_chip.hpp
+++ b/src/elona/data/types/type_map_chip.hpp
@@ -67,6 +67,6 @@ struct MapChip
 
 
 
-ELONA_DEFINE_LUA_DB(MapChipDB, MapChip, false, "core.map_chip")
+ELONA_DEFINE_LUA_DB(MapChipDB, MapChip, "core.map_chip")
 
 } // namespace elona

--- a/src/elona/data/types/type_music.hpp
+++ b/src/elona/data/types/type_music.hpp
@@ -12,7 +12,7 @@ struct MusicData
     fs::path file;
 };
 
-ELONA_DEFINE_LUA_DB(MusicDB, MusicData, true, "core.music")
+ELONA_DEFINE_LUA_DB(MusicDB, MusicData, "core.music")
 
 extern MusicDB the_music_db;
 

--- a/src/elona/data/types/type_portrait.hpp
+++ b/src/elona/data/types/type_portrait.hpp
@@ -19,7 +19,7 @@ struct PortraitData
 
 
 
-ELONA_DEFINE_LUA_DB(_PortraitDBBase, PortraitData, false, "core.portrait")
+ELONA_DEFINE_LUA_DB(_PortraitDBBase, PortraitData, "core.portrait")
 
 
 

--- a/src/elona/data/types/type_race.hpp
+++ b/src/elona/data/types/type_race.hpp
@@ -30,7 +30,7 @@ struct RaceData
 
 
 
-ELONA_DEFINE_LUA_DB(RaceDB, RaceData, false, "core.race")
+ELONA_DEFINE_LUA_DB(RaceDB, RaceData, "core.race")
 
 
 

--- a/src/elona/data/types/type_sound.hpp
+++ b/src/elona/data/types/type_sound.hpp
@@ -1,5 +1,8 @@
 #pragma once
+
 #include "../lua_lazy_cache.hpp"
+
+
 
 namespace elona
 {
@@ -13,7 +16,7 @@ struct SoundData
 
 
 
-ELONA_DEFINE_LUA_DB(SoundDB, SoundData, true, "core.sound")
+ELONA_DEFINE_LUA_DB(SoundDB, SoundData, "core.sound")
 
 
 extern SoundDB the_sound_db;

--- a/src/elona/data/types/type_trait.hpp
+++ b/src/elona/data/types/type_trait.hpp
@@ -17,7 +17,7 @@ struct TraitData
 
 
 
-ELONA_DEFINE_LUA_DB(TraitDB, TraitData, true, "core.trait")
+ELONA_DEFINE_LUA_DB(TraitDB, TraitData, "core.trait")
 
 
 


### PR DESCRIPTION

# Summary

Now, `LuaLazyCacheWithLegacyIdTable` which is derived from `LuaLazyCache` has fields and methods related to legacy ID. It can reduce memory usage and detect unintended call of `get_id_from_legacy()` against data type which does not have legacy ID.

