### PR TITLE
Change how to export modules

### DIFF
--- a/runtime/data/script/kernel/private/scan_exports.lua
+++ b/runtime/data/script/kernel/private/scan_exports.lua
@@ -24,9 +24,8 @@ end
 local function scan_exports(all_apis)
    local all_exports = {}
    for mod_name, api_table in pairs(all_apis) do
-      local exports = api_table["Exports"]
-      if exports ~= nil and type(exports) == "table" then
-         for key, value in pairs(scan_recursive(exports, mod_name)) do
+      if type(api_table) == "table" then
+         for key, value in pairs(scan_recursive(api_table, mod_name)) do
             all_exports[key] = value
          end
       end

--- a/runtime/mod/core/init.lua
+++ b/runtime/mod/core/init.lua
@@ -1,11 +1,9 @@
-local Exports = {}
+local exports = {}
 
-Exports.eating_effect = require("exports/eating_effect")
+exports.eating_effect = require("exports/eating_effect")
 
-Exports.impl = require("exports/impl")
+exports.impl = require("exports/impl")
 
 require("i18n/init")
 
-return {
-   Exports = Exports
-}
+return exports

--- a/src/tests/data/mods/test_export_keys/init.lua
+++ b/src/tests/data/mods/test_export_keys/init.lua
@@ -1,7 +1,5 @@
-local Exports = {}
+local exports = {}
 
-Exports[0] = function() end
+exports[0] = function() end
 
-return {
-    Exports = Exports
-}
+return exports

--- a/src/tests/lua/exports/eating_effect.lua
+++ b/src/tests/lua/exports/eating_effect.lua
@@ -1,10 +1,10 @@
 require "tests/lua/support/minctest"
 
 local Chara = Elona.require("Chara")
-local Exports = Elona.require("core", "Exports")
+local eating_effect = Elona.require("core", "eating_effect")
 
 Testing.start_in_debug_map()
-for name, func in pairs(Exports.eating_effect) do
+for name, func in pairs(eating_effect) do
    lrun("test " .. name, function()
       lok(pcall(function() func(Chara.player()) end), "")
    end)

--- a/src/tests/lua_data.cpp
+++ b/src/tests/lua_data.cpp
@@ -68,12 +68,9 @@ TEST_CASE(
     "[Lua: Data]")
 {
     elona::lua::LuaEnv lua;
-    REQUIRE_NOTHROW(lua.get_mod_manager().load_mods(
+    REQUIRE_THROWS(lua.get_mod_manager().load_mods(
         filesystem::dirs::mod(),
         {testing::get_test_data_path() / "mods" / "test_export_keys"}));
-
-    REQUIRE_NONE(
-        lua.get_export_manager().get_exported_function("test_export_keys.0"));
 }
 
 TEST_CASE("test order of script execution", "[Lua: Data]")

--- a/src/tests/lua_exports.cpp
+++ b/src/tests/lua_exports.cpp
@@ -15,23 +15,21 @@ TEST_CASE("test registering Lua functions", "[Lua: Exports]")
     lua.get_mod_manager().load_mods(filesystem::dirs::mod());
 
     REQUIRE_NOTHROW(lua.get_mod_manager().load_mod_from_script("test", R"(
-local Exports = {}
-Exports.nesting = {}
+local exports = {}
+exports.nesting = {}
 
-function Exports.my_callback()
+function exports.my_callback()
    mod.store.global.called_times_a = mod.store.global.called_times_a + 1
 end
 
-function Exports.nesting.my_callback()
+function exports.nesting.my_callback()
    mod.store.global.called_times_b = mod.store.global.called_times_b + 1
 end
 
 mod.store.global.called_times_a = 0
 mod.store.global.called_times_b = 0
 
-return {
-    Exports = Exports
-}
+return exports
 )"));
 
     lua.get_export_manager().register_all_exports();
@@ -81,17 +79,15 @@ TEST_CASE(
 {
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
         "test_registry_chara_callback", R"(
-local Exports = {}
+local exports = {}
 
-function Exports.my_callback(chara)
+function exports.my_callback(chara)
    mod.store.global.found_index = chara.index
 end
 
 mod.store.global.found_index = -1
 
-return {
-    Exports = Exports
-}
+return exports
 )"));
 
     elona::testing::start_in_debug_map();

--- a/src/tests/util.cpp
+++ b/src/tests/util.cpp
@@ -117,15 +117,13 @@ void register_lua_function(
     REQUIRE_NOTHROW(lua.get_mod_manager().load_mod_from_script(
         mod_id,
         "\
-local Exports = {}\
+local exports = {}\
 \
-function Exports." +
+function exports." +
             callback_signature + "\n" + callback_body + R"(
 end
 
-return {
-    Exports = Exports
-}
+return exports
 )"));
     lua.get_export_manager().register_all_exports();
 }


### PR DESCRIPTION
```lua
-- BEFORE:
-- init.lua
local Exports = {}

function Exports.say_hello()
   print("hello")
end

-- Returns a table which contains "Exports" field.
return {
    Exports = Exports
}
```
```lua
-- AFTER:
-- init.lua
local exports = {}

function exports.say_hello()
   print("hello")
end

-- Returns the module table directly.
return exports
```