### PR TITLE
Refactor LuaEnv and submodules

### DIFF
--- a/src/elona/ctrl_file.cpp
+++ b/src/elona/ctrl_file.cpp
@@ -788,7 +788,7 @@ void fmode_7_8(bool read, const fs::path& dir)
         }
     }
 
-    lua::ModSerializer mod_serializer(lua::lua.get());
+    lua::ModSerializer mod_serializer(*lua::lua);
     int index_start, index_end;
     if (read)
     {
@@ -1177,7 +1177,7 @@ void fmode_1_2(bool read)
     arrayfile(read, u8"cdatan2", dir / (u8"cdatan_"s + mid + u8".s2"));
     arrayfile(read, u8"mdatan", dir / (u8"mdatan_"s + mid + u8".s2"));
 
-    lua::ModSerializer mod_serializer(lua::lua.get());
+    lua::ModSerializer mod_serializer(*lua::lua);
     int index_start, index_end;
     if (read)
     {
@@ -1355,7 +1355,7 @@ void fmode_3_4(bool read, const fs::path& filename)
     // Mod handle data of map-local items
     const auto mod_filename = "mod_"s + filepathutil::to_utf8_path(filename);
     const auto mod_filepath = filesystem::dirs::tmp() / mod_filename;
-    lua::ModSerializer mod_serializer(lua::lua.get());
+    lua::ModSerializer mod_serializer(*lua::lua);
     int index_start, index_end;
     if (read)
     {

--- a/src/elona/lua_env/api_manager.hpp
+++ b/src/elona/lua_env/api_manager.hpp
@@ -1,17 +1,17 @@
 #pragma once
 
-#include "../character.hpp"
-#include "../filesystem.hpp"
-#include "../item.hpp"
-#include "lua_env.hpp"
+#include "lua_submodule.hpp"
+
+
 
 namespace elona
 {
 namespace lua
 {
 
-class LuaEnv;
 struct ModInfo;
+
+
 
 /***
  * Keeps track of built-in and mod-provided API bindings. APIs are
@@ -20,7 +20,7 @@ struct ModInfo;
  * bound to each mod so that "Elona.require" can be called to retrieve
  * a reference to an API table loaded in this manager.
  */
-class APIManager
+class APIManager : public LuaSubmodule
 {
 public:
     /***
@@ -38,7 +38,7 @@ public:
     static void set_on(LuaEnv&);
 
 public:
-    explicit APIManager(LuaEnv*);
+    explicit APIManager(LuaEnv&);
 
     /***
      * Loads Lua library files in data/lua for API implementations
@@ -88,20 +88,14 @@ public:
      */
     sol::table get_core_api_table();
 
+
+
 private:
     /***
      * Returns true if the Elona table has already been loaded into
      * the API manager's Lua environment.
      */
     bool is_loaded();
-
-    /***
-     * An isolated Lua environment where all C++ function bindings are
-     * kept.
-     */
-    sol::environment api_env;
-
-    LuaEnv* lua;
 };
 
 } // namespace lua

--- a/src/elona/lua_env/console.hpp
+++ b/src/elona/lua_env/console.hpp
@@ -6,6 +6,7 @@
 #include <boost/circular_buffer.hpp>
 #include "../../thirdparty/sol2/sol.hpp"
 #include "../optional.hpp"
+#include "lua_submodule.hpp"
 
 
 
@@ -14,7 +15,6 @@ namespace elona
 namespace lua
 {
 
-class LuaEnv;
 struct ModInfo;
 
 
@@ -32,12 +32,12 @@ struct ModInfo;
  * "COMMANDS" table. You can access any commands like this
  * "COMMANDS[namespace][command_name]" in Lua mode.
  */
-class Console
+class Console : public LuaSubmodule
 {
 public:
     typedef boost::circular_buffer<std::string> buffer;
 
-    explicit Console(LuaEnv*);
+    explicit Console(LuaEnv&);
 
     void init_constants();
     void init_environment();
@@ -77,7 +77,6 @@ private:
     void add_line(std::string);
     const char* prompt() const;
 
-    sol::environment _env();
     sol::table _command_table();
 
     void _init_builtin_lua_functions();
@@ -104,10 +103,6 @@ private:
     bool _cursor_visible = false;
 
     bool _in_lua_mode = false;
-
-    ModInfo* _console_mod;
-
-    LuaEnv* _lua;
 };
 
 } // namespace lua

--- a/src/elona/lua_env/data_manager.cpp
+++ b/src/elona/lua_env/data_manager.cpp
@@ -1,5 +1,4 @@
 #include "data_manager.hpp"
-
 #include "../../util/natural_order_comparator.hpp"
 #include "../log.hpp"
 #include "api_manager.hpp"
@@ -12,19 +11,23 @@ namespace elona
 namespace lua
 {
 
-DataManager::DataManager(LuaEnv* lua)
+DataManager::DataManager(LuaEnv& lua)
+    : LuaSubmodule(lua)
 {
-    _lua = lua;
-    _data = DataTable(_lua->get_state()->create_table());
+    _data = DataTable(lua_state()->create_table());
     clear();
 }
 
+
+
 void DataManager::clear()
 {
-    sol::table data = _lua->get_state()->script_file(filepathutil::to_utf8_path(
-        filesystem::dirs::data() / "script" / "kernel" / "data.lua"));
+    sol::table data = safe_script_file_in_global_env(
+        filesystem::dirs::data() / "script" / "kernel" / "data.lua");
     _data.storage() = data;
 }
+
+
 
 void DataManager::_init_from_mod(ModInfo& mod)
 {
@@ -43,7 +46,7 @@ void DataManager::_init_from_mod(ModInfo& mod)
     // outside of a mod environment. To determine which mod is adding new
     // types/data in the data chunk, it has to be set on the global Lua
     // state temporarily during the data loading process.
-    _lua->get_state()->set("_MOD_ID", mod.manifest.id);
+    lua_state()->set("_MOD_ID", mod.manifest.id);
 
     // for (const auto filename : {"data.lua",
     //                             "extensions.lua",
@@ -54,10 +57,8 @@ void DataManager::_init_from_mod(ModInfo& mod)
         const auto script_filepath = *mod.manifest.path / filename;
         if (fs::exists(script_filepath))
         {
-            auto result = _lua->get_state()->safe_script_file(
-                filepathutil::to_utf8_path(script_filepath),
-                mod.env,
-                sol::script_pass_on_error);
+            auto result = safe_script_file(
+                script_filepath, mod.env, sol::script_pass_on_error);
 
             if (!result.valid())
             {
@@ -68,15 +69,17 @@ void DataManager::_init_from_mod(ModInfo& mod)
     }
 }
 
+
+
 void DataManager::init_from_mods()
 {
-    for (const auto& mod_id : _lua->get_mod_manager().calculate_loading_order())
+    for (const auto& mod_id : lua().get_mod_manager().calculate_loading_order())
     {
-        const auto& mod = _lua->get_mod_manager().get_enabled_mod(mod_id);
+        const auto& mod = lua().get_mod_manager().get_enabled_mod(mod_id);
         _init_from_mod(*mod);
     }
 
-    _lua->get_state()->set("_MOD_ID", sol::lua_nil);
+    lua_state()->set("_MOD_ID", sol::lua_nil);
 
     // Prevent modifications to the 'data' table.
     sol::table metatable = _data.storage().create_with(

--- a/src/elona/lua_env/data_manager.hpp
+++ b/src/elona/lua_env/data_manager.hpp
@@ -1,9 +1,12 @@
 #pragma once
+
 #include <string>
 #include <vector>
 #include "../filesystem.hpp"
 #include "data_table.hpp"
-#include "lua_env.hpp"
+#include "lua_submodule.hpp"
+
+
 
 namespace elona
 {
@@ -11,6 +14,8 @@ namespace lua
 {
 
 struct ModInfo;
+
+
 
 /***
  * Stores arbitrary data as Lua tables in a naive object database
@@ -22,10 +27,10 @@ struct ModInfo;
  * issue then data could be serialized in a Lua-readable format, or
  * stored in an actual database like SQLite.
  */
-class DataManager
+class DataManager : public LuaSubmodule
 {
 public:
-    explicit DataManager(LuaEnv* lua);
+    explicit DataManager(LuaEnv& lua);
 
     void clear();
 
@@ -36,11 +41,12 @@ public:
         return _data;
     }
 
+
+
 private:
     void _init_from_mod(ModInfo& mod);
 
     DataTable _data;
-    LuaEnv* _lua;
 };
 
 } // namespace lua

--- a/src/elona/lua_env/event_manager.cpp
+++ b/src/elona/lua_env/event_manager.cpp
@@ -13,21 +13,25 @@ namespace elona
 namespace lua
 {
 
-EventManager::EventManager(LuaEnv* lua)
+EventManager::EventManager(LuaEnv& lua)
+    : LuaSubmodule(lua)
 {
-    this->lua = lua;
     clear();
 }
 
+
+
 void EventManager::remove_unknown_events()
 {
-    env["remove_unknown_events"](
-        *lua->get_data_manager().get().get_table("core.event"));
+    env()["remove_unknown_events"](
+        *lua().get_data_manager().get().get_table("core.event"));
 }
+
+
 
 EventResult EventManager::trigger(const BaseEvent& event)
 {
-    sol::protected_function trigger = env["Event"]["trigger"];
+    sol::protected_function trigger = env()["Event"]["trigger"];
     auto result =
         trigger(event.id, event.make_event_table(), event.make_event_options());
 
@@ -40,31 +44,30 @@ EventResult EventManager::trigger(const BaseEvent& event)
         std::cerr << message << std::endl;
         ELONA_ERROR("lua.event") << message;
 
-        return EventResult{lua->get_state()->create_table()};
+        return EventResult{lua_state()->create_table()};
     }
 
     sol::object value = result;
 
     if (!value.is<sol::table>())
     {
-        return EventResult{lua->get_state()->create_table_with(1, value)};
+        return EventResult{lua_state()->create_table_with(1, value)};
     }
 
     return EventResult{value.as<sol::table>()};
 }
 
+
+
 void EventManager::clear()
 {
-    env = sol::environment(
-        *(lua->get_state()), sol::create, lua->get_state()->globals());
+    env() = sol::environment(*lua_state(), sol::create, lua_state()->globals());
 
-    lua->get_state()->safe_script_file(
-        filepathutil::to_utf8_path(
-            filesystem::dirs::data() / "script" / "kernel" / "event.lua"),
-        env);
+    safe_script_file(
+        filesystem::dirs::data() / "script" / "kernel" / "event.lua");
 
-    sol::table core = lua->get_api_manager().get_core_api_table();
-    core["Event"] = env["Event"];
+    sol::table core = lua().get_api_manager().get_core_api_table();
+    core["Event"] = env()["Event"];
 }
 
 } // namespace lua

--- a/src/elona/lua_env/event_manager.hpp
+++ b/src/elona/lua_env/event_manager.hpp
@@ -2,22 +2,27 @@
 
 #include <map>
 #include "config_table.hpp"
-#include "lua_env.hpp"
+#include "lua_submodule.hpp"
+
+
 
 namespace elona
 {
 namespace lua
 {
 
-class LuaEnv;
 struct BaseEvent;
 
-struct EventResult : ConfigTable
+
+
+struct EventResult : public ConfigTable
 {
     EventResult(sol::table table)
         : ConfigTable(table)
     {
     }
+
+
 
     bool blocked()
     {
@@ -25,19 +30,23 @@ struct EventResult : ConfigTable
     }
 };
 
+
+
 /***
  * Manages a list of callbacks for each event type. Allows triggering
  * callbacks from C++ with any arguments needed.
  */
-class EventManager
+class EventManager : public LuaSubmodule
 {
-
 public:
-    explicit EventManager(LuaEnv* lua);
+    explicit EventManager(LuaEnv& lua);
+
+
     /***
      * Runs all callbacks for this event in the order they were registered.
      */
     EventResult trigger(const BaseEvent& event);
+
 
     /**
      * Removes events not registered in the data table.
@@ -46,11 +55,9 @@ public:
 
     void clear();
 
+
 private:
     void init_events();
-
-    sol::environment env;
-    LuaEnv* lua;
 };
 
 } // namespace lua

--- a/src/elona/lua_env/export_manager.cpp
+++ b/src/elona/lua_env/export_manager.cpp
@@ -8,35 +8,29 @@ namespace elona
 namespace lua
 {
 
-ExportManager::ExportManager(LuaEnv* lua)
+ExportManager::ExportManager(LuaEnv& lua)
+    : LuaSubmodule(lua)
 {
-    lua_ = lua;
-    export_env = sol::environment(
-        *(lua_->get_state()), sol::create, lua_->get_state()->globals());
+    env().set("Exports", lua_state()->create_table());
 
-    export_env.set("Exports", lua_->get_state()->create_table());
-
-    lua_->get_state()->safe_script(
+    safe_script(
         R"(
 scan_exports = require "private/scan_exports"
-)",
-        export_env);
+)");
 }
 
 
 void ExportManager::register_all_exports()
 {
-    export_env.set(
-        "_API_TABLE", lua_->get_api_manager().get_master_api_table());
+    env().set("_API_TABLE", lua().get_api_manager().get_master_api_table());
 
-    auto result = lua_->get_state()->safe_script(
+    auto result = safe_script(
         R"(
 Exports = scan_exports(_API_TABLE)
 )",
-        export_env,
         &sol::script_pass_on_error);
 
-    export_env.set("_API_TABLE", sol::lua_nil);
+    env().set("_API_TABLE", sol::lua_nil);
 
     if (!result.valid())
     {
@@ -49,7 +43,7 @@ Exports = scan_exports(_API_TABLE)
 optional<WrappedFunction> ExportManager::get_exported_function(
     const std::string& name) const
 {
-    sol::optional<sol::protected_function> func = export_env["Exports"][name];
+    sol::optional<sol::protected_function> func = env()["Exports"][name];
     if (func && *func != sol::lua_nil)
     {
         return WrappedFunction{name, *func};

--- a/src/elona/lua_env/export_manager.hpp
+++ b/src/elona/lua_env/export_manager.hpp
@@ -1,18 +1,19 @@
 #pragma once
+
 #include <string>
 #include "../enums.hpp"
 #include "../filesystem.hpp"
 #include "../message.hpp"
 #include "../variables.hpp"
-#include "lua_env.hpp"
+#include "lua_submodule.hpp"
 #include "wrapped_function.hpp"
+
+
 
 namespace elona
 {
 namespace lua
 {
-
-class LuaEnv;
 
 /***
  * Stores references to Lua functions that can be provided by mods by
@@ -22,10 +23,10 @@ class LuaEnv;
  * corpse is eaten, a trap is activated, and so forth, without having
  * to hardcode anything in C++.
  */
-class ExportManager
+class ExportManager : public LuaSubmodule
 {
 public:
-    explicit ExportManager(LuaEnv*);
+    explicit ExportManager(LuaEnv&);
 
     /***
      * Registers function exports that are inside the "Exports" table
@@ -103,14 +104,6 @@ public:
             return default_value;
         }
     }
-
-private:
-    /***
-     * The isolated Lua environment where data is stored.
-     */
-    sol::environment export_env;
-
-    LuaEnv* lua_;
 };
 
 } // namespace lua

--- a/src/elona/lua_env/i18n_function_manager.cpp
+++ b/src/elona/lua_env/i18n_function_manager.cpp
@@ -2,50 +2,54 @@
 #include "../config/config.hpp"
 #include "lua_env.hpp"
 
+
+
 namespace elona
 {
 namespace lua
 {
 
-I18NFunctionManager::I18NFunctionManager(LuaEnv* lua)
+I18NFunctionManager::I18NFunctionManager(LuaEnv& lua)
+    : LuaSubmodule(lua)
 {
-    this->lua_ = lua;
-    i18n_function_env = sol::environment(
-        *(lua_->get_state()), sol::create, lua_->get_state()->globals());
-
     clear();
 }
 
+
+
 void I18NFunctionManager::clear()
 {
-    i18n_function_env.set("Functions", lua_->get_state()->create_table());
+    env().set("Functions", lua_state()->create_table());
 }
+
+
 
 void I18NFunctionManager::register_function(
     const std::string& language,
     const std::string& name,
     sol::protected_function function)
 {
-    if (i18n_function_env[language] == sol::lua_nil)
+    if (env()[language] == sol::lua_nil)
     {
-        i18n_function_env[language] = lua_->get_state()->create_table();
+        env()[language] = lua_state()->create_table();
     }
 
-    i18n_function_env[language][name] = function;
+    env()[language][name] = function;
 }
+
+
 
 optional<sol::protected_function> I18NFunctionManager::find_function(
     const std::string& name)
 {
     const std::string& language = Config::instance().language;
 
-    if (i18n_function_env[language] == sol::lua_nil)
+    if (env()[language] == sol::lua_nil)
     {
         return none;
     }
 
-    sol::optional<sol::protected_function> function =
-        i18n_function_env[language][name];
+    sol::optional<sol::protected_function> function = env()[language][name];
 
     if (!function || *function == sol::lua_nil)
     {

--- a/src/elona/lua_env/i18n_function_manager.hpp
+++ b/src/elona/lua_env/i18n_function_manager.hpp
@@ -1,21 +1,19 @@
 #pragma once
-#include <string>
-#include "../../thirdparty/sol2/sol.hpp"
-#include "../enums.hpp"
-#include "../filesystem.hpp"
-#include "../variables.hpp"
+
+#include "../optional.hpp"
+#include "lua_submodule.hpp"
+
+
 
 namespace elona
 {
 namespace lua
 {
 
-class LuaEnv;
-
-class I18NFunctionManager
+class I18NFunctionManager : public LuaSubmodule
 {
 public:
-    explicit I18NFunctionManager(LuaEnv*);
+    explicit I18NFunctionManager(LuaEnv&);
 
     void clear();
 
@@ -25,14 +23,6 @@ public:
         sol::protected_function function);
 
     optional<sol::protected_function> find_function(const std::string& name);
-
-private:
-    /***
-     * The isolated Lua environment where data is stored.
-     */
-    sol::environment i18n_function_env;
-
-    LuaEnv* lua_;
 };
 
 } // namespace lua

--- a/src/elona/lua_env/lua_env.cpp
+++ b/src/elona/lua_env/lua_env.cpp
@@ -1,6 +1,8 @@
 #include "lua_env.hpp"
 
+#include "../character.hpp"
 #include "../config/config.hpp"
+#include "../item.hpp"
 #include "api_manager.hpp"
 #include "console.hpp"
 #include "data_manager.hpp"
@@ -9,6 +11,8 @@
 #include "handle_manager.hpp"
 #include "i18n_function_manager.hpp"
 #include "mod_manager.hpp"
+
+
 
 namespace elona
 {
@@ -40,14 +44,14 @@ LuaEnv::LuaEnv()
     // Make sure the API environment is initialized first so any
     // dependent managers can add new internal C++ methods to it (like
     // the event manager registering Elona.Event)
-    api_mgr = std::make_unique<APIManager>(this);
-    event_mgr = std::make_unique<EventManager>(this);
-    mod_mgr = std::make_unique<ModManager>(this);
-    handle_mgr = std::make_unique<HandleManager>(this);
-    data_mgr = std::make_unique<DataManager>(this);
-    export_mgr = std::make_unique<ExportManager>(this);
-    i18n_function_mgr = std::make_unique<I18NFunctionManager>(this);
-    console = std::make_unique<Console>(this);
+    api_mgr = std::make_unique<APIManager>(*this);
+    event_mgr = std::make_unique<EventManager>(*this);
+    mod_mgr = std::make_unique<ModManager>(*this);
+    handle_mgr = std::make_unique<HandleManager>(*this);
+    data_mgr = std::make_unique<DataManager>(*this);
+    export_mgr = std::make_unique<ExportManager>(*this);
+    i18n_function_mgr = std::make_unique<I18NFunctionManager>(*this);
+    console = std::make_unique<Console>(*this);
 }
 
 

--- a/src/elona/lua_env/lua_submodule.hpp
+++ b/src/elona/lua_env/lua_submodule.hpp
@@ -1,0 +1,135 @@
+#pragma once
+
+#include "../../util/noncopyable.hpp"
+#include "../filesystem.hpp"
+#include "lua_env.hpp"
+
+
+
+namespace elona
+{
+namespace lua
+{
+
+class LuaSubmodule : public lib::noncopyable
+{
+protected:
+    explicit LuaSubmodule(LuaEnv& lua)
+        : _lua(lua)
+        , _env(*_lua.get_state(), sol::create, _lua.get_state()->globals())
+    {
+    }
+
+
+    LuaEnv& lua()
+    {
+        return _lua;
+    }
+
+
+    std::shared_ptr<sol::state> lua_state()
+    {
+        return _lua.get_state();
+    }
+
+
+    sol::environment& env()
+    {
+        return _env;
+    }
+
+
+    const sol::environment& env() const
+    {
+        return _env;
+    }
+
+
+    auto safe_script_in_global_env(const std::string& source)
+    {
+        return lua_state()->safe_script(source);
+    }
+
+
+    auto safe_script_file_in_global_env(const fs::path& filepath)
+    {
+        return lua_state()->safe_script_file(
+            filepathutil::to_utf8_path(filepath));
+    }
+
+
+    auto safe_script(const std::string& source, sol::environment& env)
+    {
+        return lua_state()->safe_script(source, env);
+    }
+
+
+    auto safe_script_file(const fs::path& filepath, sol::environment& env)
+    {
+        return lua_state()->safe_script_file(
+            filepathutil::to_utf8_path(filepath), env);
+    }
+
+
+    auto safe_script(const std::string& source)
+    {
+        return safe_script(source, env());
+    }
+
+
+    auto safe_script_file(const fs::path& filepath)
+    {
+        return safe_script_file(filepath, env());
+    }
+
+
+    template <typename ErrorHandler>
+    auto safe_script(
+        const std::string& source,
+        sol::environment& env,
+        ErrorHandler&& error_handler)
+    {
+        return lua_state()->safe_script(
+            source, env, std::forward<ErrorHandler>(error_handler));
+    }
+
+
+    template <typename ErrorHandler>
+    auto safe_script_file(
+        const fs::path& filepath,
+        sol::environment& env,
+        ErrorHandler&& error_handler)
+    {
+        return lua_state()->safe_script_file(
+            filepathutil::to_utf8_path(filepath),
+            env,
+            std::forward<ErrorHandler>(error_handler));
+    }
+
+
+    template <typename ErrorHandler>
+    auto safe_script(const std::string& source, ErrorHandler&& error_handler)
+    {
+        return safe_script(
+            source, env(), std::forward<ErrorHandler>(error_handler));
+    }
+
+
+    template <typename ErrorHandler>
+    auto safe_script_file(
+        const fs::path& filepath,
+        ErrorHandler&& error_handler)
+    {
+        return safe_script_file(
+            filepath, env(), std::forward<ErrorHandler>(error_handler));
+    }
+
+
+
+private:
+    LuaEnv& _lua;
+    sol::environment _env;
+};
+
+} // namespace lua
+} // namespace elona

--- a/src/elona/lua_env/mod_manager.hpp
+++ b/src/elona/lua_env/mod_manager.hpp
@@ -2,13 +2,11 @@
 
 #include <map>
 #include <vector>
-
 #include <boost/range/adaptor/filtered.hpp>
-
 #include "../filesystem.hpp"
 #include "../optional.hpp"
 #include "loaded_chunk_cache.hpp"
-#include "lua_env.hpp"
+#include "lua_submodule.hpp"
 #include "mod_manifest.hpp"
 
 
@@ -117,7 +115,7 @@ enum class ModLoadingStage : unsigned
  * interface for more specialized API handling mechanisms and for
  * keeping track of mods.
  */
-class ModManager
+class ModManager : public LuaSubmodule
 {
     using ModStorageType =
         std::unordered_map<std::string, std::unique_ptr<ModInfo>>;
@@ -127,7 +125,7 @@ public:
     using iterator = ModStorageType::iterator;
     using const_iterator = ModStorageType::const_iterator;
 
-    explicit ModManager(LuaEnv*);
+    explicit ModManager(LuaEnv&);
 
     static bool mod_id_is_reserved(const std::string& id);
 
@@ -543,8 +541,6 @@ private:
      * functions are run in the correct order.
      */
     ModLoadingStage stage_ = ModLoadingStage::not_started;
-
-    LuaEnv* lua_;
 };
 
 

--- a/src/elona/lua_env/mod_serializer.hpp
+++ b/src/elona/lua_env/mod_serializer.hpp
@@ -1,10 +1,13 @@
 #pragma once
+
 #include "../../thirdparty/sol2/sol.hpp"
 #include "../filesystem.hpp"
 #include "../log.hpp"
 #include "handle_manager.hpp"
-#include "lua_env.hpp"
+#include "lua_submodule.hpp"
 #include "mod_manager.hpp"
+
+
 
 namespace elona
 {
@@ -17,20 +20,16 @@ std::pair<int, int> get_start_end_indices(
 
 std::string get_store_name(ModInfo::StoreType store_type);
 
-class LuaEnv;
 
-class ModSerializer
+
+class ModSerializer : public LuaSubmodule
 {
 public:
-    explicit ModSerializer(LuaEnv* lua)
-        : _lua(lua)
+    explicit ModSerializer(LuaEnv& lua)
+        : LuaSubmodule(lua)
     {
-        _serial_env = sol::environment(
-            *(_lua->get_state()), sol::create, _lua->get_state()->globals());
-
         // Load the Lua chunk for saving/loading data.
-        _lua->get_state()->safe_script(
-            R"(Serial = require "serial")", _serial_env);
+        safe_script(R"(Serial = require "serial")");
     }
 
     template <typename T, typename Archive>
@@ -40,7 +39,7 @@ public:
         std::tie(index_start, index_end) =
             get_start_end_indices(T::lua_type(), store_type);
 
-        auto handles = _lua->get_handle_manager().get_handle_range(
+        auto handles = lua().get_handle_manager().get_handle_range(
             T::lua_type(), index_start, index_end);
         save(handles, putit_archive);
 
@@ -62,7 +61,7 @@ public:
 
         sol::object handles = load(putit_archive);
 
-        auto& handle_mgr = _lua->get_handle_manager();
+        auto& handle_mgr = lua().get_handle_manager();
         handle_mgr.clear_handle_range(T::lua_type(), index_start, index_end);
         handle_mgr.merge_handles(T::lua_type(), handles);
 
@@ -78,7 +77,7 @@ public:
         Archive& putit_archive,
         ModInfo::StoreType store_type)
     {
-        const auto& mod_mgr = _lua->get_mod_manager();
+        const auto& mod_mgr = lua().get_mod_manager();
 
         unsigned mod_count = static_cast<unsigned>(mod_mgr.enabled_mod_count());
         putit_archive(mod_count);
@@ -105,7 +104,7 @@ public:
         Archive& putit_archive,
         ModInfo::StoreType store_type)
     {
-        auto& mod_mgr = _lua->get_mod_manager();
+        auto& mod_mgr = lua().get_mod_manager();
 
         unsigned mod_count;
         putit_archive(mod_count);
@@ -146,10 +145,9 @@ private:
     template <typename Archive>
     void save(sol::object data, Archive& ar)
     {
-        _serial_env["_TO_SERIALIZE"] = data;
-        auto result = _lua->get_state()->safe_script(
-            R"(return Serial.save(_TO_SERIALIZE))", _serial_env);
-        _serial_env["_TO_SERIALIZE"] = sol::lua_nil;
+        env()["_TO_SERIALIZE"] = data;
+        auto result = safe_script(R"(return Serial.save(_TO_SERIALIZE))");
+        env()["_TO_SERIALIZE"] = sol::lua_nil;
 
         if (result.valid())
         {
@@ -169,10 +167,9 @@ private:
         std::string dump;
         ar(dump);
 
-        _serial_env["_TO_DESERIALIZE"] = dump;
-        auto result = _lua->get_state()->safe_script(
-            R"(return Serial.load(_TO_DESERIALIZE))", _serial_env);
-        _serial_env["_TO_DESERIALIZE"] = sol::lua_nil;
+        env()["_TO_DESERIALIZE"] = dump;
+        auto result = safe_script(R"(return Serial.load(_TO_DESERIALIZE))");
+        env()["_TO_DESERIALIZE"] = sol::lua_nil;
 
         if (result.valid())
         {
@@ -184,14 +181,6 @@ private:
             throw err;
         }
     }
-
-    /***
-     * The isolated Lua environment that loads the Lua serialization
-     * code.
-     */
-    sol::environment _serial_env;
-
-    LuaEnv* _lua;
 };
 
 } // namespace lua

--- a/src/elona/save_update.cpp
+++ b/src/elona/save_update.cpp
@@ -2035,7 +2035,7 @@ void _update_save_data_8(const fs::path& save_dir)
 /// Create new mod save data for saves without it.
 void _update_save_data_9(const fs::path& save_dir)
 {
-    lua::ModSerializer mod_serializer(lua::lua.get());
+    lua::ModSerializer mod_serializer(*lua::lua);
 
     // Global mod data
     {
@@ -2177,7 +2177,7 @@ void _update_save_data_9(const fs::path& save_dir)
 /// files.
 void _update_save_data_10(const fs::path& save_dir)
 {
-    lua::ModSerializer mod_serializer(lua::lua.get());
+    lua::ModSerializer mod_serializer(*lua::lua);
 
     // _update_save_data_8
     // shop*.s2 files


### PR DESCRIPTION
# Summary

Add `class LuaSubmodule` to organize common code. It has reference to `LuaEnv` and own `sol::environment`. `XyzManager` now inherits `LuaSubmodule` and uses its protected methods.

Also, because `Console` class is rewritten by using `LuaSubmodule`, `CONSOLE` pseudo-mod to capsule side-effects while executing console commands gets unnecessary. Now that the pseudo-mod is removed.