### PR TITLE
Fix that Tuwen does not drop anything

### DIFF
--- a/runtime/mod/core/data/chara_drop.lua
+++ b/runtime/mod/core/data/chara_drop.lua
@@ -88,7 +88,7 @@ data:add_multi(
       {
          id = "tuwen",
          on_generate = function()
-            if Map.id() == 257 then
+            if Map.id() == "core.pyramid" then
                return make_drops({ "core.statue_of_opatos",
                                    "core.platinum_coin",
                                    "core.platinum_coin",


### PR DESCRIPTION
# Summary

Fix the bug that Tuwen does not drop anything.

```diff
         on_generate = function()
-            if Map.id() == 257 then
+            if Map.id() == "core.pyramid" then
               return make_drops({ "core.statue_of_opatos",
                                   "core.platinum_coin",
```

`257` is the ID of Tuwen, not pyramid map's. Also, `Map.id()` returns string ID, not legacy integer ID.