### PR TITLE
Fix crash in charamaking race menu

### DIFF
--- a/src/elona/ui/ui_menu_charamake_race.cpp
+++ b/src/elona/ui/ui_menu_charamake_race.cpp
@@ -67,6 +67,10 @@ void UIMenuCharamakeRace::update()
     {
         page = 0;
     }
+    if (listmax <= page * pagesize + cs)
+    {
+        cs = listmax % pagesize - 1;
+    }
 }
 
 
@@ -124,6 +128,8 @@ void UIMenuCharamakeRace::_draw_choice(int cnt, const std::string& text)
     cs_list(cs == cnt, text, wx + 64, wy + 66 + cnt * 19 - 1);
 }
 
+
+
 void UIMenuCharamakeRace::_draw_choices()
 {
     font(14 - en * 2);
@@ -168,6 +174,8 @@ void UIMenuCharamakeRace::draw()
 
     _draw_race_info(selected_race);
 }
+
+
 
 optional<UIMenuCharamakeRace::ResultType> UIMenuCharamakeRace::on_key(
     const std::string& action)


### PR DESCRIPTION
# Related Issues

Bug:
    1. create a new adventurer.
    2. in race menu, set cursor catgod, machinegod, or undeadgod.
    3. press right arrow key.
    4. crash!


# Summary

Fix `cs`, the current cursor position, when it points out of range.