### PR TITLE
Fix non-exhaustive switch cases / 3xx redirect handling

### DIFF
--- a/src/spider/http/backends/boost_asio/request.cpp
+++ b/src/spider/http/backends/boost_asio/request.cpp
@@ -166,7 +166,8 @@ public:
         _timeout = request.timeout();
 
         // 120; old IE's maximum redirect count.
-        _redirects = std::min(120, std::max(0, request.max_redirects()));
+        _redirects_max = std::min(120, std::max(0, request.max_redirects()));
+        _redirects = _redirects_max;
 
         const auto parsed_url = parse_url(request.url());
         if (!parsed_url)
@@ -211,6 +212,7 @@ private:
     RawRequest _request;
     RawResponse _response;
     int _timeout; // in milliseconds
+    int _redirects_max;
     int _redirects;
     FullfilledHandler _done;
     RejectedHandler _failed;
@@ -445,9 +447,14 @@ private:
             if (0 < _redirects)
             {
                 do_redirect(_response[field::location].to_string());
-                return;
             }
-            break;
+            else
+            {
+                fail(
+                    "Too many redirects, over " +
+                    std::to_string(_redirects_max) + " times");
+            }
+            return;
         default: break;
         }
 

--- a/src/spider/http/backends/boost_asio/request.cpp
+++ b/src/spider/http/backends/boost_asio/request.cpp
@@ -447,6 +447,8 @@ private:
                 do_redirect(_response[field::location].to_string());
                 return;
             }
+            break;
+        default: break;
         }
 
         _done(_construct_response());

--- a/src/spider/http/error.hpp
+++ b/src/spider/http/error.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdexcept>
 #include <string>
 
 
@@ -11,23 +12,12 @@ namespace spider
 namespace http
 {
 
-struct Error
+struct Error : public std::runtime_error
 {
-    Error(const std::string& what)
-        : _what(what)
+    Error(const std::string& error_message)
+        : std::runtime_error(error_message)
     {
     }
-
-
-    const std::string& what() const
-    {
-        return _what;
-    }
-
-
-
-private:
-    std::string _what;
 };
 
 } // namespace http


### PR DESCRIPTION
# Summary

- Add `default` clause to a non-exhaustive switch statement in `spider` library to suppress compiler warning.
- Raise an error on redirecting (status code: 3xx) to many times. Before, you might receive a 3xx response as a success result on redirecting over `Request::max_redirects()` times. Now, the error handler you pass to `Request::send()` is called to handle too many redirects error.