### PR TITLE
Lua API: unify Config.get_{type} and Config.set_{type}

### DIFF
--- a/doc/api/config.luadoc
+++ b/doc/api/config.luadoc
@@ -3,35 +3,20 @@
 --  @usage local Config = require("game.Config")
 module "Config"
 
---- Sets a string-type config item's value.
---  @raise if the config item does not exist or is not a string.
---  @function set_string
-function set_string(key, value) end
+--- Sets config item's value.
+--  @tparam string key Option key
+--  @tparam any value Option value
+--  @raise if the config item does not exist or is not a boolean, an integer, or
+--  a string.
+--  @function set
+function set(key, value) end
 
---- Sets an integer-type config item's value.
---  @raise if the config item does not exist or is not an integer.
---  @function set_int
-function set_int(key, value) end
-
---- Sets a boolean-type config items' value.
---  @raise if the config item does not exist or is not an integer.
---  @function set_bool
-function set_bool(key, value) end
-
---- Gets the value of a string-type config item.
---  @raise if the config item does not exist or is not a string.
---  @function get_string
-function get_string(key) end
-
---- Gets the value of an integer-type config item.
---  @raise if the config item does not exist or is not an integer.
---  @function get_int
-function get_int(key) end
-
---- Gets the value of a boolean-type config item.
---  @raise if the config item does not exist or is not a boolean.
---  @function get_bool
-function get_bool(key) end
+--- Gets config item's value.
+--  @tparam string key Option key
+--  @raise if the config item does not exist or is not a boolean, an integer, or
+--  a string.
+--  @function get
+function get(key, s) end
 
 --- Saves the current sate of the config to the config options file. Be sure to
 --  call this when you modify the config using this API.

--- a/doc/topics/config.md
+++ b/doc/topics/config.md
@@ -65,8 +65,8 @@ config {
         options = {
             # Corresponds to "<mod_name>.section.section_option".
             #
-            # Config.get_bool("mymod.section.section_option")
-            # Config.set_bool("mymod.section.section_option", false)
+            # Config.get("mymod.section.section_option")
+            # Config.set("mymod.section.section_option", false)
             section_option = true
         }
     }
@@ -229,8 +229,8 @@ To access and change config options from mods, use the [Config](../modules/Confi
 ```lua
 local Config = require("game.Config")
 
-print(Config.get_bool("core.game.extra_help"))
-print(Config.set_int("core.balance.restock_interval", 10))
+print(Config.get("core.game.extra_help"))
+print(Config.set("core.balance.restock_interval", 10))
 Config.save()
 ```
 

--- a/src/elona/config/config.hpp
+++ b/src/elona/config/config.hpp
@@ -202,6 +202,17 @@ public:
         }
     }
 
+    template <typename T>
+    bool check_type(const std::string& key) const
+    {
+        const auto itr = storage_.find(key);
+        if (itr == storage_.end())
+        {
+            throw std::runtime_error("No such config value " + key);
+        }
+        return itr->second.is<T>();
+    }
+
     void set(const std::string& key, const hcl::Value value)
     {
         ELONA_LOG("config") << "Set: " << key << " to " << value;

--- a/src/elona/lua_env/lua_api/lua_api_config.hpp
+++ b/src/elona/lua_env/lua_api/lua_api_config.hpp
@@ -1,5 +1,8 @@
 #pragma once
+
 #include "lua_api_common.hpp"
+
+
 
 namespace elona
 {
@@ -14,22 +17,13 @@ namespace lua
  */
 namespace LuaApiConfig
 {
-void set_string(const std::string& key, const std::string& value);
 
-void set_int(const std::string& key, int value);
-
-void set_bool(const std::string& key, bool value);
-
-std::string get_string(const std::string& key);
-
-int get_int(const std::string& key);
-
-bool get_bool(const std::string& key);
-
+void set(const std::string& key, sol::object value);
+sol::object get(const std::string& key, sol::this_state s);
 void save();
 
-
 void bind(sol::table&);
+
 } // namespace LuaApiConfig
 
 } // namespace lua

--- a/src/tests/lua/config.lua
+++ b/src/tests/lua/config.lua
@@ -1,0 +1,53 @@
+require_relative("tests/lua/support/minctest")
+
+local Config = require("game.Config")
+
+local function lfail(f)
+   local ok = pcall(f)
+   lequal(ok, false)
+end
+
+
+
+lrun("test Config.get", function()
+   local extra_help = Config.get("core.game.extra_help")
+   lequal(type(extra_help), "boolean")
+   lequal(extra_help, true)
+
+   local general_wait = Config.get("core.anime.general_wait")
+   lequal(type(general_wait), "number")
+   lequal(general_wait, 30)
+
+   local font_quality = Config.get("core.font.quality")
+   lequal(type(font_quality), "string")
+   lequal(font_quality, "high")
+
+   lfail(function()
+      Config.get("core.foo") -- not exist
+   end)
+end)
+
+
+
+lrun("test Config.set", function()
+   Config.set("core.game.extra_help", false)
+   lequal(Config.get("core.game.extra_help"), false)
+
+   Config.set("core.anime.general_wait", 10)
+   lequal(Config.get("core.anime.general_wait"), 10)
+
+   Config.set("core.font.quality", "low")
+   lequal(Config.get("core.font.quality"), "low")
+
+   lfail(function()
+      Config.set("core.foo", 1) -- not exist
+   end)
+
+   lfail(function()
+      Config.set("core.font.quality", 1) -- invalid type
+   end)
+
+   -- Setting nil does nothing.
+   Config.set("core.message.transparency", nil)
+   lequal(Config.get("core.message.transparency"), 4)
+end)

--- a/src/tests/lua_api.cpp
+++ b/src/tests/lua_api.cpp
@@ -83,6 +83,11 @@ assert(Env.MOD_API_VERSION, "0.1")
 )"));
 }
 
+TEST_CASE("Core API: Config", "[Lua: API]")
+{
+    lua_testcase("config.lua");
+}
+
 TEST_CASE("Core API: FOV", "[Lua: API]")
 {
     lua_testcase("fov.lua");


### PR DESCRIPTION
# Summary

Since Lua is a dynamically-typed language, there is no rationale to separate functions for each types.

`Config.get_int()`
`Config.get_bool()`
`Config.get_string()`
=> `Config.get()`

`Config.set_int()`
`Config.set_bool()`
`Config.set_string()`
=> `Config.set()`
