### PR TITLE
Refactor: avoid direct index access to inv, instead use Item&

### DIFF
--- a/src/elona/adventurer.cpp
+++ b/src/elona/adventurer.cpp
@@ -320,25 +320,25 @@ void adventurer_update()
 int adventurer_discover_equipment()
 {
     f = 0;
-    for (int cnt = 0; cnt < 10; ++cnt)
+    for (int _i = 0; _i < 10; ++_i)
     {
-        ci = get_random_inv(rc);
-        if (inv[ci].number() == 0)
+        auto&& item = get_random_inv(rc);
+        if (item.number() == 0)
         {
             f = 1;
             break;
         }
-        if (inv[ci].body_part != 0)
+        if (item.body_part != 0)
         {
             continue;
         }
-        if (inv[ci].number() != 0)
+        if (item.number() != 0)
         {
-            if (cdata[rc].item_which_will_be_used == ci)
+            if (cdata[rc].item_which_will_be_used == item.index)
             {
                 cdata[rc].item_which_will_be_used = 0;
             }
-            inv[ci].remove();
+            item.remove();
             f = 1;
             break;
         }

--- a/src/elona/blending.cpp
+++ b/src/elona/blending.cpp
@@ -44,7 +44,6 @@ int rpid = 0;
 int rpmode = 0;
 elona_vector1<int> rppage;
 int rpresult = 0;
-elona_vector1<int> inhlist_at_m184;
 
 
 
@@ -407,16 +406,14 @@ void window_recipe2(int val0)
 
 
 
-void window_recipe_(int item_index, int x, int y, int width, int height)
+void window_recipe(optional_ref<Item> item, int x, int y, int width, int height)
 {
-    elona_vector1<std::string> s_at_m184;
-    int xfix2_at_m184 = 0;
-    int dx_at_m184 = 0;
-    int dy_at_m184 = 0;
-    int i_at_m184 = 0;
-    int p_at_m184 = 0;
-    int cnt2_at_m184 = 0;
-    SDIM1(s_at_m184);
+    elona_vector1<std::string> s_;
+    int xfix2_ = 0;
+    int dx_ = 0;
+    int dy_ = 0;
+    int i_ = 0;
+
     if (windowshadow == 1)
     {
         window(x + 4, y + 4, width, height - height % 8, true);
@@ -438,122 +435,106 @@ void window_recipe_(int item_index, int x, int y, int width, int height)
         x + width - 40,
         y + height - 49 - height % 8,
         {234, 220, 188});
-    s_at_m184(0) = u8"Page."s + (rppage + 1) + u8"/"s + (rppage(1) + 1);
-    s_at_m184(1) = ""s + key_prev + u8","s + key_next + ""s +
+    s_(0) = u8"Page."s + (rppage + 1) + u8"/"s + (rppage(1) + 1);
+    s_(1) = ""s + key_prev + u8","s + key_next + ""s +
         i18n::s.get("core.blending.recipe.hint");
     if (step == -1)
     {
-        s_at_m184(1) += strhint3;
+        s_(1) += strhint3;
     }
     else
     {
-        s_at_m184(1) += strhint3b;
+        s_(1) += strhint3b;
     }
     font(12 + sizefix - en * 2);
-    mes(x + 25 + 0, y + height - 43 - height % 8, s_at_m184(1));
+    mes(x + 25 + 0, y + height - 43 - height % 8, s_(1));
     font(12 + sizefix - en * 2, snail::Font::Style::bold);
-    mes(x + width - strlen_u(s_at_m184) * 7 - 40 - xfix2_at_m184,
+    mes(x + width - strlen_u(s_) * 7 - 40 - xfix2_,
         y + height - 65 - height % 8,
-        s_at_m184);
-    dx_at_m184 = x + 35;
-    dy_at_m184 = y + 48;
+        s_);
+    dx_ = x + 35;
+    dy_ = y + 48;
     font(12 - en * 2, snail::Font::Style::bold);
-    mes(dx_at_m184 - 10,
-        dy_at_m184,
-        i18n::s.get("core.blending.window.procedure"));
-    dy_at_m184 = dy_at_m184 + 18;
+    mes(dx_ - 10, dy_, i18n::s.get("core.blending.window.procedure"));
+    dy_ = dy_ + 18;
     font(13 - en * 2);
-    i_at_m184 = 1;
-    if (step == i_at_m184 - 2)
+    i_ = 1;
+    if (step == i_ - 2)
     {
-        boxf(dx_at_m184 - 10, dy_at_m184 - 2, width - 60, 17, {60, 20, 10, 32});
+        boxf(dx_ - 10, dy_ - 2, width - 60, 17, {60, 20, 10, 32});
     }
-    else if (step > i_at_m184 - 2)
+    else if (step > i_ - 2)
     {
-        boxf(dx_at_m184 - 10, dy_at_m184 - 2, width - 60, 17, {20, 20, 20, 32});
+        boxf(dx_ - 10, dy_ - 2, width - 60, 17, {20, 20, 20, 32});
     }
     if (step == -1)
     {
-        mes(dx_at_m184,
-            dy_at_m184,
-            ""s + i_at_m184 + u8"."s +
+        mes(dx_,
+            dy_,
+            ""s + i_ + u8"."s +
                 i18n::s.get("core.blending.window.choose_a_recipe"));
     }
     else
     {
-        mes(dx_at_m184,
-            dy_at_m184,
-            ""s + i_at_m184 + u8"."s +
+        mes(dx_,
+            dy_,
+            ""s + i_ + u8"."s +
                 i18n::s.get(
                     "core.blending.window.chose_the_recipe_of", rpname(rpid)));
     }
-    dy_at_m184 += 17;
-    ++i_at_m184;
+    dy_ += 17;
+    ++i_;
     for (int cnt = 0; cnt < 10; ++cnt)
     {
         if (rpdata(20 + cnt, rpid) == 0)
         {
             break;
         }
-        if (step == i_at_m184 - 2)
+        if (step == i_ - 2)
         {
-            boxf(
-                dx_at_m184 - 10,
-                dy_at_m184 - 2,
-                width - 60,
-                17,
-                {60, 20, 10, 32});
+            boxf(dx_ - 10, dy_ - 2, width - 60, 17, {60, 20, 10, 32});
         }
-        else if (step > i_at_m184 - 2)
+        else if (step > i_ - 2)
         {
-            boxf(
-                dx_at_m184 - 10,
-                dy_at_m184 - 2,
-                width - 60,
-                17,
-                {20, 20, 20, 32});
+            boxf(dx_ - 10, dy_ - 2, width - 60, 17, {20, 20, 20, 32});
         }
         if (step <= cnt)
         {
             int stat = blendmatnum(rpdata(20 + cnt, rpid), cnt);
-            p_at_m184 = stat;
-            s_at_m184 = i18n::s.get(
-                "core.blending.window.add", rpmatname(cnt), p_at_m184);
+            s_ = i18n::s.get("core.blending.window.add", rpmatname(cnt), stat);
         }
         else
         {
-            s_at_m184 = i18n::s.get(
+            s_ = i18n::s.get(
                 "core.blending.window.selected", inv[rpref(10 + cnt * 2)]);
-            s_at_m184 = strmid(s_at_m184, 0, 44);
+            s_ = strmid(s_, 0, 44);
         }
-        mes(dx_at_m184, dy_at_m184, ""s + i_at_m184 + u8"."s + s_at_m184);
-        dy_at_m184 += 17;
-        ++i_at_m184;
+        mes(dx_, dy_, ""s + i_ + u8"."s + s_);
+        dy_ += 17;
+        ++i_;
     }
     draw("deco_blend_b", wx + ww + 243, wy - 4);
-    if (step == i_at_m184 - 2)
+    if (step == i_ - 2)
     {
-        boxf(dx_at_m184 - 10, dy_at_m184 - 2, width - 60, 17, {60, 20, 10, 32});
+        boxf(dx_ - 10, dy_ - 2, width - 60, 17, {60, 20, 10, 32});
     }
-    else if (step > i_at_m184 - 2)
+    else if (step > i_ - 2)
     {
-        boxf(dx_at_m184 - 10, dy_at_m184 - 2, width - 60, 17, {20, 20, 20, 32});
+        boxf(dx_ - 10, dy_ - 2, width - 60, 17, {20, 20, 20, 32});
     }
-    mes(dx_at_m184,
-        dy_at_m184,
-        ""s + i_at_m184 + u8"."s + i18n::s.get("core.blending.window.start"));
-    dy_at_m184 += 30;
+    mes(dx_,
+        dy_,
+        ""s + i_ + u8"."s + i18n::s.get("core.blending.window.start"));
+    dy_ += 30;
     if (rppage == 0)
     {
         font(12 - en * 2, snail::Font::Style::bold);
-        mes(dx_at_m184 - 10,
-            dy_at_m184,
+        mes(dx_ - 10,
+            dy_,
             i18n::s.get("core.blending.window.the_recipe_of", rpname(rpid)));
-        dy_at_m184 += 20;
-        mes(dx_at_m184 - 10,
-            dy_at_m184,
-            i18n::s.get("core.blending.window.required_skills"));
-        dy_at_m184 = dy_at_m184 + 18;
+        dy_ += 20;
+        mes(dx_ - 10, dy_, i18n::s.get("core.blending.window.required_skills"));
+        dy_ = dy_ + 18;
         font(13 - en * 2);
         for (int cnt = 0; cnt < 5; ++cnt)
         {
@@ -565,8 +546,8 @@ void window_recipe_(int item_index, int x, int y, int width, int height)
                                      sdata(rpdata(10 + cnt * 2, rpid), 0))
                 ? snail::Color{150, 0, 0}
                 : snail::Color{0, 120, 0};
-            mes(dx_at_m184 + cnt % 2 * 140,
-                dy_at_m184 + cnt / 2 * 17,
+            mes(dx_ + cnt % 2 * 140,
+                dy_ + cnt / 2 * 17,
                 i18n::s.get_m(
                     "ability",
                     the_ability_db
@@ -577,58 +558,50 @@ void window_recipe_(int item_index, int x, int y, int width, int height)
                     sdata(rpdata((10 + cnt * 2), rpid), 0) + u8")"s,
                 text_color);
         }
-        dy_at_m184 += 50;
+        dy_ += 50;
         font(12 - en * 2, snail::Font::Style::bold);
-        mes(dx_at_m184 - 10,
-            dy_at_m184,
+        mes(dx_ - 10,
+            dy_,
             i18n::s.get("core.blending.window.required_equipment"));
         return;
     }
-    if (item_index == -1)
-    {
+
+    if (!item)
         return;
-    }
+
     font(12 - en * 2, snail::Font::Style::bold);
-    mes(dx_at_m184 - 10, dy_at_m184, itemname(item_index));
-    dy_at_m184 += 20;
+    mes(dx_ - 10, dy_, itemname(item->index));
+    dy_ += 20;
     font(13 - en * 2);
-    if (inv[item_index].identify_state <= IdentifyState::partly)
+    if (item->identify_state <= IdentifyState::partly)
     {
-        mes(dx_at_m184,
-            dy_at_m184,
-            i18n::s.get("core.blending.window.havent_identified"));
-        dy_at_m184 += 16;
+        mes(dx_, dy_, i18n::s.get("core.blending.window.havent_identified"));
+        dy_ += 16;
         return;
     }
-    getinheritance(item_index, inhlist_at_m184, p_at_m184);
-    if (p_at_m184 > 0)
+
+    const auto inheritance = item_get_inheritance(*item);
+    if (inheritance.empty())
     {
-        for (int cnt = 0, cnt_end = (p_at_m184); cnt < cnt_end; ++cnt)
-        {
-            cnt2_at_m184 = inhlist_at_m184(cnt);
-            if (inv[item_index].enchantments[cnt2_at_m184].id == 0)
-            {
-                break;
-            }
-            get_enchantment_description(
-                inv[item_index].enchantments[cnt2_at_m184].id,
-                inv[item_index].enchantments[cnt2_at_m184].power,
-                the_item_db[itemid2int(inv[item_index].id)]->category);
-            const auto text_color =
-                inv[item_index].enchantments[cnt2_at_m184].power < 0
-                ? snail::Color{180, 0, 0}
-                : snail::Color{0, 0, 100};
-            mes(dx_at_m184, dy_at_m184, cnven(s), text_color);
-            dy_at_m184 += 16;
-        }
+        mes(dx_, dy_, i18n::s.get("core.blending.window.no_inherited_effects"));
     }
     else
     {
-        mes(dx_at_m184,
-            dy_at_m184,
-            i18n::s.get("core.blending.window.no_inherited_effects"));
-        dy_at_m184 += 16;
-        ++p_at_m184;
+        for (const auto& inh : inheritance)
+        {
+            if (item->enchantments[inh].id == 0)
+                break;
+
+            get_enchantment_description(
+                item->enchantments[inh].id,
+                item->enchantments[inh].power,
+                the_item_db[itemid2int(item->id)]->category);
+            const auto text_color = item->enchantments[inh].power < 0
+                ? snail::Color{180, 0, 0}
+                : snail::Color{0, 0, 100};
+            mes(dx_, dy_, cnven(s), text_color);
+            dy_ += 16;
+        }
     }
 }
 
@@ -649,7 +622,7 @@ label_1923:
         if (rpdata(20 + step, rpid) == 0)
         {
             rppage = 0;
-            window_recipe(list2, -1, wx + ww, wy, 400, wh);
+            window_recipe(none, wx + ww, wy, 400, wh);
             Message::instance().linebreak();
             txt(i18n::s.get("core.blending.prompt.how_many"));
             p = 10;
@@ -818,7 +791,7 @@ label_1925_internal:
     {
         rpid = list(0, pagesize * page + cs);
         windowshadow = windowshadow(1);
-        window_recipe(list2, -1, wx + ww, wy, 400, wh);
+        window_recipe(none, wx + ww, wy, 400, wh);
     }
     if (keyrange != 0)
     {
@@ -950,7 +923,8 @@ label_1928_internal:
     if (cs_bk != cs)
     {
         windowshadow = windowshadow(1);
-        window_recipe(list2, p, wx + ww, wy, 400, wh);
+        window_recipe(
+            p == -1 ? none : optional_ref<Item>(inv[p]), wx + ww, wy, 400, wh);
     }
     if (keyrange != 0)
     {
@@ -1629,7 +1603,7 @@ void blending_start_attempt()
                         break;
                     }
                     enchantment_add(
-                        ci,
+                        inv[ci],
                         rpdata(50 + cnt * 2, rpid),
                         rpdata(51 + cnt * 2, rpid),
                         0,

--- a/src/elona/blending.hpp
+++ b/src/elona/blending.hpp
@@ -6,8 +6,6 @@
 namespace elona
 {
 
-#define window_recipe(a, b, c, d, e, f) window_recipe_(b, c, d, e, f)
-
 TurnResult blending_menu();
 void initialize_recipememory();
 void initialize_recipe();

--- a/src/elona/building.cpp
+++ b/src/elona/building.cpp
@@ -230,7 +230,7 @@ static optional<const MapDefData&> _find_map_from_deed(int item_id)
     if (!map_id)
     {
         txt("Cannot find map which is created by item '"s +
-                itemid2int(inv[ci].id) + "'."s,
+                std::to_string(item_id) + "'."s,
             Message::color(ColorIndex::red));
         return none;
     }

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -1649,7 +1649,7 @@ TurnResult do_use_command()
             {
                 randomize(inv[ci].subname + inv[ci].param1 * 10 + cnt);
                 if (enchantment_add(
-                        ci,
+                        inv[ci],
                         enchantment_generate(enchantment_gen_level(4)),
                         enchantment_gen_p(),
                         0,
@@ -1691,7 +1691,8 @@ TurnResult do_use_command()
                 }
                 else
                 {
-                    enchantment_add(ci, list(0, rtval), list(1, rtval), 0, 1);
+                    enchantment_add(
+                        inv[ci], list(0, rtval), list(1, rtval), 0, 1);
                 }
                 txt(i18n::s.get("core.action.use.living.pleased", inv[ci]),
                     Message::color{ColorIndex::green});
@@ -1700,7 +1701,7 @@ TurnResult do_use_command()
                 {
                     txt(i18n::s.get(
                         "core.action.use.living.becoming_a_threat"));
-                    if (!enchantment_add(ci, 45, 50))
+                    if (!enchantment_add(inv[ci], 45, 50))
                     {
                         inv[ci].enchantments[14].id = 0;
                         txt(i18n::s.get(

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -1045,7 +1045,7 @@ label_2061_internal:
         }
         if (invctrl == 1)
         {
-            item_show_description();
+            item_show_description(inv[ci]);
             goto label_20591;
         }
         if (invctrl == 2)
@@ -1969,7 +1969,7 @@ label_2061_internal:
         if (listmax != 0)
         {
             ci = list(0, pagesize * page + cs);
-            item_show_description();
+            item_show_description(inv[ci]);
             goto label_20591;
         }
     }

--- a/src/elona/elonacore.cpp
+++ b/src/elona/elonacore.cpp
@@ -718,45 +718,6 @@ void csvsort(
 
 
 
-void getinheritance(int item_index, elona_vector1<int>& inhlist_, int& inhmax_)
-{
-    int p_at_m42 = 0;
-    int f_at_m42 = 0;
-    randomize(inv[item_index].turn + 1);
-    DIM2(inhlist_, 15);
-    inhmax_ = 0;
-    for (int cnt = 0; cnt < 10; ++cnt)
-    {
-        p_at_m42 = rnd(15);
-        if (inv[item_index].enchantments[p_at_m42].id == 0)
-        {
-            continue;
-        }
-        f_at_m42 = 0;
-        for (int cnt = 0, cnt_end = (inhmax_ + 1); cnt < cnt_end; ++cnt)
-        {
-            if (p_at_m42 == inhlist_(cnt))
-            {
-                f_at_m42 = 1;
-                break;
-            }
-        }
-        if (f_at_m42 == 1)
-        {
-            continue;
-        }
-        if (rnd(4) > inhmax_ ||
-            inv[item_index].enchantments[p_at_m42].power < 0)
-        {
-            inhlist_(inhmax_) = p_at_m42;
-            ++inhmax_;
-        }
-    }
-    randomize();
-}
-
-
-
 void flt(int level, Quality quality)
 {
     filtermax = 0;
@@ -3152,7 +3113,7 @@ void character_drops_item()
                 item.is_blessed_by_ehekatl() = true;
                 reftype = the_item_db[itemid2int(item.id)]->category;
                 enchantment_add(
-                    ci,
+                    item,
                     enchantment_generate(enchantment_gen_level(rnd(4))),
                     enchantment_gen_p());
                 animeload(8, rc);
@@ -3166,7 +3127,7 @@ void character_drops_item()
         }
         inv[ci].position.x = cdata[rc].position.x;
         inv[ci].position.y = cdata[rc].position.y;
-        itemturn(ci);
+        itemturn(inv[ci]);
         int stat = item_stack(-1, ci);
         if (stat == 0)
         {
@@ -7300,7 +7261,7 @@ int read_normal_book()
     }
     tc = cc;
     item_identify(inv[ci], IdentifyState::partly);
-    show_book_window();
+    show_book_window(inv[ci]);
     return 1;
 }
 

--- a/src/elona/enchantment.cpp
+++ b/src/elona/enchantment.cpp
@@ -22,7 +22,6 @@ elona_vector1<int> p_at_m47;
 elona_vector2<int> enclist;
 elona_vector2<int> egoenc;
 elona_vector2<int> egoref;
-elona_vector1<int> egolist;
 int maxegominorn = 0;
 int p_at_m48 = 0;
 
@@ -86,36 +85,52 @@ void enchantment_sort(Item& item)
 
 
 
-void add_enchantment_by_fixed_ego()
+void add_one_enchantment_by_fixed_ego(Item& item, int ego_type)
 {
-    p = 0;
-    for (int cnt = 0; cnt < 11; ++cnt)
+    for (int i = 0; i < 10; ++i)
     {
-        if (egoref(0, cnt) != egolv)
+        if (egoenc(i * 2, ego_type) == 0)
         {
-            continue;
+            break;
         }
-        if (egoref(1, cnt) != 0)
+        enchantment_add(
+            item,
+            egoenc(i * 2, ego_type),
+            enchantment_gen_p(egoenc(i * 2 + 1, ego_type)));
+    }
+}
+
+
+
+void add_enchantment_by_fixed_ego(Item& item, int egolv)
+{
+    std::vector<int> ego_list;
+    for (int i = 0; i < 11; ++i)
+    {
+        if (egoref(0, i) != egolv)
+            continue;
+
+        if (egoref(1, i) != 0)
         {
-            if (!enchantment_filter(reftype, egoref(1, cnt)))
+            if (!enchantment_filter(reftype, egoref(1, i)))
             {
                 continue;
             }
         }
-        egolist(p) = cnt;
-        ++p;
+
+        ego_list.push_back(i);
     }
-    if (p == 0)
-    {
+
+    if (ego_list.empty())
         return;
-    }
-    p = egolist(rnd(p(0)));
-    inv[ci].subname = 10000 + p;
-    ego_add(ci, p);
+
+    const auto ego_id = choice(ego_list);
+    item.subname = 10000 + ego_id;
+    add_one_enchantment_by_fixed_ego(item, ego_id);
     if (rnd(2) == 0)
     {
         enchantment_add(
-            ci,
+            item,
             enchantment_generate(enchantment_gen_level(egolv)),
             enchantment_gen_p(),
             20);
@@ -123,7 +138,7 @@ void add_enchantment_by_fixed_ego()
     if (rnd(4) == 0)
     {
         enchantment_add(
-            ci,
+            item,
             enchantment_generate(enchantment_gen_level(egolv)),
             enchantment_gen_p(),
             25);
@@ -132,17 +147,18 @@ void add_enchantment_by_fixed_ego()
 
 
 
-void add_enchantments_depending_on_ego()
+void add_enchantments_depending_on_ego(Item& item, int egolv)
 {
-    for (int cnt = 0, cnt_end = (rnd(rnd(5) + 1) + 1); cnt < cnt_end; ++cnt)
+    const auto num_of_enc = rnd(rnd(5) + 1) + 1;
+    for (int _i = 0; _i < num_of_enc; ++_i)
     {
         enchantment_add(
-            ci,
+            item,
             enchantment_generate(enchantment_gen_level(egolv)),
             enchantment_gen_p(),
             8);
     }
-    inv[ci].subname = 20000 + rnd(maxegominorn);
+    item.subname = 20000 + rnd(maxegominorn);
 }
 
 } // namespace
@@ -624,7 +640,7 @@ void get_enchantment_description(int val0, int power, int category, bool trait)
 
 
 bool enchantment_add(
-    int item_index,
+    Item& item,
     int type,
     int power,
     int flip_percentage,
@@ -632,7 +648,7 @@ bool enchantment_add(
     bool only_check,
     bool force)
 {
-    const auto category = the_item_db[itemid2int(inv[item_index].id)]->category;
+    const auto category = the_item_db[itemid2int(item.id)]->category;
 
     if (type == 0)
     {
@@ -748,14 +764,14 @@ bool enchantment_add(
     i_at_m48 = -1;
     for (int cnt = 0; cnt < 15; ++cnt)
     {
-        if (inv[item_index].enchantments[cnt].id == enc)
+        if (item.enchantments[cnt].id == enc)
         {
             i_at_m48 = cnt;
             continue;
         }
         if (i_at_m48 == -1)
         {
-            if (inv[item_index].enchantments[cnt].id == 0)
+            if (item.enchantments[cnt].id == 0)
             {
                 i_at_m48 = cnt;
             }
@@ -766,7 +782,7 @@ bool enchantment_add(
         return false;
     }
 
-    if (inv[item_index].enchantments[i_at_m48].id == enc)
+    if (item.enchantments[i_at_m48].id == enc)
     {
         if (category == 25000)
         {
@@ -785,12 +801,12 @@ bool enchantment_add(
         return true;
     }
 
-    if (inv[item_index].enchantments[i_at_m48].id == enc)
+    if (item.enchantments[i_at_m48].id == enc)
     {
-        encp += inv[item_index].enchantments[i_at_m48].power;
+        encp += item.enchantments[i_at_m48].power;
     }
-    inv[item_index].enchantments[i_at_m48].id = enc;
-    inv[item_index].enchantments[i_at_m48].power = encp;
+    item.enchantments[i_at_m48].id = enc;
+    item.enchantments[i_at_m48].power = encp;
 
     if (type < 10000)
     {
@@ -800,12 +816,11 @@ bool enchantment_add(
     {
         p_at_m48 = type / 10000;
     }
-    if (inv[item_index].value * encref(1, p_at_m48) / 100 > 0)
+    if (item.value * encref(1, p_at_m48) / 100 > 0)
     {
-        inv[item_index].value =
-            inv[item_index].value * encref(1, p_at_m48) / 100;
+        item.value = item.value * encref(1, p_at_m48) / 100;
     }
-    enchantment_sort(inv[item_index]);
+    enchantment_sort(item);
 
     return true;
 }
@@ -944,11 +959,11 @@ int enchantment_gen_p(int multiplier)
 
 
 
-void add_enchantments()
+void add_enchantments(Item& item)
 {
     if (reftype == 25000)
     {
-        inv[ci].count = -1;
+        item.count = -1;
     }
     if (fixlv <= Quality::good)
     {
@@ -961,8 +976,8 @@ void add_enchantments()
     else
     {
         egolv = rnd(clamp(rnd(objlv / 10 + 3), 0, 4) + 1);
-        inv[ci].value = inv[ci].value * 3;
-        inv[ci].difficulty_of_identification = 50 +
+        item.value = item.value * 3;
+        item.difficulty_of_identification = 50 +
             rnd(std::abs(
                     static_cast<int>(fixlv) - static_cast<int>(Quality::good)) *
                     100 +
@@ -974,25 +989,25 @@ void add_enchantments()
         {
             if (rnd(10) == 0)
             {
-                enchantment_add(ci, 34, enchantment_gen_p());
+                enchantment_add(item, 34, enchantment_gen_p());
             }
             if (rnd(10) == 0)
             {
-                enchantment_add(ci, 10016, enchantment_gen_p());
+                enchantment_add(item, 10016, enchantment_gen_p());
             }
             if (rnd(10) == 0)
             {
-                enchantment_add(ci, 30172, enchantment_gen_p());
+                enchantment_add(item, 30172, enchantment_gen_p());
                 break;
             }
             if (rnd(10) == 0)
             {
-                enchantment_add(ci, 10003, enchantment_gen_p());
+                enchantment_add(item, 10003, enchantment_gen_p());
                 break;
             }
             if (rnd(10) == 0)
             {
-                enchantment_add(ci, 30164, enchantment_gen_p());
+                enchantment_add(item, 30164, enchantment_gen_p());
                 break;
             }
         }
@@ -1001,27 +1016,28 @@ void add_enchantments()
     {
         if (rnd(2))
         {
-            add_enchantments_depending_on_ego();
+            add_enchantments_depending_on_ego(item, egolv);
         }
         else
         {
-            add_enchantment_by_fixed_ego();
+            add_enchantment_by_fixed_ego(item, egolv);
         }
     }
     if (fixlv == Quality::miracle || fixlv == Quality::godly)
     {
-        inv[ci].subname = 40000 + rnd(30000);
+        item.subname = 40000 + rnd(30000);
         if (fixlv == Quality::godly ||
             (fixlv == Quality::miracle && rnd(10) == 0))
         {
-            enchantment_add(ci, enchantment_generate(99), enchantment_gen_p());
+            enchantment_add(
+                item, enchantment_generate(99), enchantment_gen_p());
         }
         if (rnd(100) == 0 || 0)
         {
             if (reftype == 24000 || reftype == 10000)
             {
-                inv[ci].is_alive() = true;
-                inv[ci].param1 = 1;
+                item.is_alive() = true;
+                item.param1 = 1;
                 return;
             }
         }
@@ -1039,22 +1055,22 @@ void add_enchantments()
             {
                 if (rnd(10) == 0)
                 {
-                    inv[ci].is_eternal_force() = true;
+                    item.is_eternal_force() = true;
                     enchantment_add(
-                        ci, enchantment_generate(99), enchantment_gen_p());
-                    inv[ci].curse_state = CurseState::blessed;
+                        item, enchantment_generate(99), enchantment_gen_p());
+                    item.curse_state = CurseState::blessed;
                 }
             }
         }
         for (int cnt = 0, cnt_end = (p); cnt < cnt_end; ++cnt)
         {
             enchantment_add(
-                ci,
+                item,
                 enchantment_generate(enchantment_gen_level(egolv)),
                 enchantment_gen_p() + (fixlv == Quality::godly) * 100 +
-                    (inv[ci].is_eternal_force()) * 100,
+                    (item.is_eternal_force()) * 100,
                 20 - (fixlv == Quality::godly) * 10 -
-                    (inv[ci].is_eternal_force()) * 20);
+                    (item.is_eternal_force()) * 20);
         }
     }
     if (fixlv == Quality::special)
@@ -1062,36 +1078,37 @@ void add_enchantments()
         for (int cnt = 0, cnt_end = (rnd(3)); cnt < cnt_end; ++cnt)
         {
             enchantment_add(
-                ci,
+                item,
                 enchantment_generate(enchantment_gen_level(egolv)),
                 enchantment_gen_p(),
                 10);
         }
     }
-    if (is_cursed(inv[ci].curse_state))
+    if (is_cursed(item.curse_state))
     {
         enchantment_add(
-            ci,
+            item,
             enchantment_generate(enchantment_gen_level(egolv)),
             clamp(enchantment_gen_p(), 250, 10000) *
-                (125 + (inv[ci].curse_state == CurseState::doomed) * 25) / 100);
+                (125 + (item.curse_state == CurseState::doomed) * 25) / 100);
         for (int cnt = 0,
                  cnt_end = cnt +
-                 (1 + (inv[ci].curse_state == CurseState::doomed) + rnd(2));
+                 (1 + (item.curse_state == CurseState::doomed) + rnd(2));
              cnt < cnt_end;
              ++cnt)
         {
             if (rnd(3) == 0)
             {
-                enchantment_add(ci, 2, enchantment_gen_p() * 3 / 2, 100);
+                enchantment_add(item, 2, enchantment_gen_p() * 3 / 2, 100);
                 continue;
             }
             if (rnd(3) == 0)
             {
-                enchantment_add(ci, 1, enchantment_gen_p() * 5 / 2, 100);
+                enchantment_add(item, 1, enchantment_gen_p() * 5 / 2, 100);
                 continue;
             }
-            enchantment_add(ci, enchantment_generate(-1), enchantment_gen_p());
+            enchantment_add(
+                item, enchantment_generate(-1), enchantment_gen_p());
         }
     }
 }
@@ -1103,7 +1120,6 @@ void initialize_ego_data()
     SDIM1(egoname);
     DIM3(egoenc, 20, 11);
     DIM3(egoref, 2, 11);
-    DIM2(egolist, 11);
 
     for (int cnt = 0; cnt < 11; cnt++)
     {
@@ -1185,23 +1201,6 @@ void initialize_ego_data()
     }
 
     maxegominorn = egominorn.size();
-}
-
-
-
-void ego_add(int item_index, int ego_type)
-{
-    for (int cnt = 0; cnt < 10; ++cnt)
-    {
-        if (egoenc(cnt * 2, ego_type) == 0)
-        {
-            break;
-        }
-        enchantment_add(
-            item_index,
-            egoenc(cnt * 2, ego_type),
-            enchantment_gen_p(egoenc(cnt * 2 + 1, ego_type)));
-    }
 }
 
 

--- a/src/elona/enchantment.hpp
+++ b/src/elona/enchantment.hpp
@@ -14,7 +14,7 @@ struct Item;
 
 
 bool enchantment_add(
-    int item_index,
+    Item& item,
     int type,
     int power,
     int flip_percentage = 0,
@@ -70,10 +70,9 @@ int enchantment_gen_p(int multiplier = 100);
 
 std::string enchantment_print_level(int level);
 void get_enchantment_description(int, int, int, bool = false);
-void add_enchantments();
+void add_enchantments(Item& item);
 
 void initialize_ego_data();
-void ego_add(int = 0, int = 0);
 
 
 

--- a/src/elona/equipment.cpp
+++ b/src/elona/equipment.cpp
@@ -323,32 +323,32 @@ void supply_new_equipment()
     for (int cnt = 0; cnt < 100; ++cnt)
     {
         f = 0;
-        for (int cnt = 0; cnt < 4; ++cnt)
+        for (int _j = 0; _j < 4; ++_j)
         {
-            ci = get_random_inv(rc);
-            if (inv[ci].number() == 0)
+            auto&& item = get_random_inv(rc);
+            if (item.number() == 0)
             {
                 f = 1;
                 break;
             }
-            if (inv[ci].body_part != 0)
+            if (item.body_part != 0)
             {
                 continue;
             }
-            if (inv[ci].is_quest_target())
+            if (item.is_quest_target())
             {
                 continue;
             }
-            if (inv[ci].number() != 0)
+            if (item.number() != 0)
             {
-                inv[ci].remove();
+                item.remove();
                 f = 1;
                 break;
             }
         }
         if (f == 0)
         {
-            ci = invhead + invrange - 1;
+            break;
         }
         if (cdata[rc].character_role == 13)
         {

--- a/src/elona/food.hpp
+++ b/src/elona/food.hpp
@@ -1,14 +1,17 @@
 #pragma once
+
 #include <string>
+
 
 
 namespace elona
 {
 
-
-
 enum class CurseState;
 struct Character;
+struct Item;
+
+
 
 void chara_anorexia(Character& cc);
 void cure_anorexia(Character& cc);
@@ -24,16 +27,14 @@ void get_hungry(Character& cc);
 void show_eating_message();
 void eat_rotten_food();
 
-void cook();
+void cook(Item& cook_tool, Item& food);
 
-void make_dish(int, int);
+void make_dish(Item& food, int dish_rank);
 
 void apply_general_eating_effect(int);
 
 std::string foodname(int, const std::string&, int = 0, int = 0);
 
 void foods_get_rotten();
-
-
 
 } // namespace elona

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -435,15 +435,16 @@ void cell_refresh(int x, int y)
 
 
 
-void itemturn(int ci)
+void itemturn(Item& item)
 {
+    ++game_data.item_turns;
     if (game_data.item_turns < 0)
     {
-        game_data.item_turns = 0;
+        game_data.item_turns = 1;
     }
-    ++game_data.item_turns;
-    inv[ci].turn = game_data.item_turns;
+    item.turn = game_data.item_turns;
 }
+
 
 
 void item_copy(int a, int b)
@@ -491,13 +492,14 @@ void Item::remove()
     number_ = 0;
 }
 
-void item_delete(int ci)
-{
-    inv[ci].remove();
 
-    inv[ci].clear();
-    // Restore "index".
-    inv[ci].index = ci;
+
+void item_delete(Item& item)
+{
+    const auto index = item.index;
+    item.remove();
+    item.clear();
+    item.index = index; // Restore "index".
 }
 
 
@@ -581,7 +583,7 @@ int item_separate(int src)
             inv[src].position = cdata[inv_getowner(src)].position;
         }
         inv[dst].position = inv[src].position;
-        itemturn(dst);
+        itemturn(inv[dst]);
         cell_refresh(inv[dst].position.x, inv[dst].position.y);
         if (inv_getowner(src) != -1)
         {
@@ -1676,7 +1678,7 @@ void item_dump_desc(const Item& i)
     item_db_get_charge_level(inv[ci], dbid);
     item_db_get_description(inv[ci], dbid);
 
-    item_load_desc(ci, p(0));
+    p = item_load_desc(inv[ci]);
 
     listmax = p;
     pagemax = (listmax - 1) / pagesize;
@@ -1818,7 +1820,7 @@ bool item_fire(int owner, int ci)
                         Message::color{ColorIndex::gold});
                 }
             }
-            make_dish(ci_, rnd(5) + 1);
+            make_dish(inv[ci_], rnd(5) + 1);
             burned = true;
             continue;
         }
@@ -2124,11 +2126,14 @@ void mapitem_cold(int x, int y)
 
 
 
-int get_random_inv(int owner)
+Item& get_random_inv(int owner)
 {
     const auto tmp = inv_getheader(owner);
-    return tmp.first + rnd(tmp.second);
+    const auto index = tmp.first + rnd(tmp.second);
+    return inv[index];
 }
+
+
 
 std::pair<int, int> inv_getheader(int owner)
 {
@@ -2251,16 +2256,15 @@ int inv_compress(int owner)
     if (slot == -1)
     {
         // Destroy 1 existing item forcely.
-        slot = get_random_inv(owner);
-        inv[slot].remove();
+        auto&& item = get_random_inv(owner);
+        slot = item.index;
+        item.remove();
         if (mode != 6)
         {
-            if (inv[slot].position.x >= 0 &&
-                inv[slot].position.x < map_data.width &&
-                inv[slot].position.y >= 0 &&
-                inv[slot].position.y < map_data.height)
+            if (item.position.x >= 0 && item.position.x < map_data.width &&
+                item.position.y >= 0 && item.position.y < map_data.height)
             {
-                cell_refresh(inv[slot].position.x, inv[slot].position.y);
+                cell_refresh(item.position.x, item.position.y);
             }
         }
     }
@@ -2347,7 +2351,7 @@ void item_drop(Item& item_in_inventory, int num, bool building_shelter)
     item_copy(item_in_inventory.index, ti);
     inv[ti].position = cdata[cc].position;
     inv[ti].set_number(num);
-    itemturn(ti);
+    itemturn(inv[ti]);
 
     if (building_shelter)
     {
@@ -2436,6 +2440,36 @@ int iequiploc(const Item& item)
     case 19000: return 8;
     default: return 0;
     }
+}
+
+
+
+std::vector<int> item_get_inheritance(const Item& item)
+{
+    std::vector<int> result;
+
+    randomize(item.turn + 1);
+    for (int _i = 0; _i < 10; ++_i)
+    {
+        const auto enc_index = rnd(15);
+        if (enc_index == 0)
+            continue;
+        if (item.enchantments[enc_index].id == 0)
+            continue;
+
+        const auto exists = range::find(result, enc_index) != std::end(result);
+        if (exists)
+            continue;
+
+        if (item.enchantments[enc_index].power < 0 ||
+            static_cast<int>(result.size()) < rnd(4))
+        {
+            result.push_back(enc_index);
+        }
+    }
+    randomize();
+
+    return result;
 }
 
 } // namespace elona

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -318,11 +318,11 @@ void item_checkknown(int = 0);
 int inv_compress(int);
 void item_copy(int = 0, int = 0);
 void item_acid(const Character& owner, int item_index = -1);
-void item_delete(int);
+void item_delete(Item& item);
 void item_exchange(int = 0, int = 0);
 void item_modify_num(Item&, int);
 void item_set_num(Item&, int);
-void itemturn(int = 0);
+void itemturn(Item& item);
 int itemfind(int = 0, int = 0, int = 0);
 int itemusingfind(int, bool = false);
 
@@ -348,7 +348,7 @@ void mapitem_cold(int x, int y);
 
 // TODO unsure how these are separate from item
 int inv_find(int = 0, int = 0);
-int get_random_inv(int owner);
+Item& get_random_inv(int owner);
 int inv_getfreeid(int = 0);
 int inv_getowner(int = 0);
 int inv_sum(int = 0);
@@ -378,7 +378,7 @@ enum class ItemDescriptionType : int
     small_font_italic = -2,
 };
 
-void item_load_desc(int item_index, int& p);
+size_t item_load_desc(const Item& item);
 
 
 int iequiploc(const Item& item);
@@ -391,5 +391,8 @@ void item_db_set_full_stats(Item& item, int legacy_id);
 void item_db_on_read(Item& item, int legacy_id);
 void item_db_on_zap(Item& item, int legacy_id);
 void item_db_on_drink(Item& item, int legacy_id);
+
+
+std::vector<int> item_get_inheritance(const Item& item);
 
 } // namespace elona

--- a/src/elona/item_load_desc.cpp
+++ b/src/elona/item_load_desc.cpp
@@ -8,21 +8,17 @@
 
 
 
+namespace elona
+{
+
 namespace
 {
 
 elona_vector1<int> inhlist;
 
-}
 
 
-
-namespace elona
-{
-
-static void _load_single_item_description_text(
-    const I18NKey& desc_key_prefix,
-    int& p)
+void _load_single_item_description_text(const I18NKey& desc_key_prefix, int& p)
 {
     auto desc_opt = i18n::s.get_optional(desc_key_prefix + ".text");
     if (!desc_opt)
@@ -88,220 +84,231 @@ static void _load_single_item_description_text(
 }
 
 
-static void _load_item_description_text(
+
+void _load_item_description_text(
     const I18NKey& locale_key_prefix,
-    int& p)
+    int& num_of_desc)
 {
-    for (int cnt = 0; cnt < 3; ++cnt)
+    for (int i = 0; i < 3; ++i)
     {
         _load_single_item_description_text(
-            locale_key_prefix + ".description._" + std::to_string(cnt), p);
+            locale_key_prefix + ".description._" + std::to_string(i),
+            num_of_desc);
     }
 }
 
-static void _load_item_main_description_text(
+
+
+void _load_item_main_description_text(
     const I18NKey& locale_key_prefix,
-    int& p)
+    int& num_of_desc)
 {
     if (auto text =
             i18n::s.get_optional(locale_key_prefix + ".description.main.text"))
     {
-        list(0, p) = static_cast<int>(ItemDescriptionType::text);
-        listn(0, p) = *text;
-        ++p;
+        list(0, num_of_desc) = static_cast<int>(ItemDescriptionType::text);
+        listn(0, num_of_desc) = *text;
+        ++num_of_desc;
     }
 }
 
-static void _load_item_stat_text(int item_index, int& p)
+
+
+void _load_item_stat_text(const Item& item, int& num_of_desc)
 {
-    if (inv[item_index].material != 0)
+    if (item.material != 0)
     {
-        list(0, p) = static_cast<int>(ItemDescriptionType::text);
-        listn(0, p) = i18n::s.get(
+        list(0, num_of_desc) = static_cast<int>(ItemDescriptionType::text);
+        listn(0, num_of_desc) = i18n::s.get(
             "core.item.desc.it_is_made_of",
             i18n::s.get_m(
                 "item_material",
-                the_item_material_db
-                    .get_id_from_legacy(inv[item_index].material)
-                    ->get(),
+                the_item_material_db.get_id_from_legacy(item.material)->get(),
                 "name"));
-        ++p;
+        ++num_of_desc;
     }
-    if (inv[item_index].material == 8)
+    if (item.material == 8)
     {
-        list(0, p) = static_cast<int>(ItemDescriptionType::text);
-        listn(0, p) = i18n::s.get("core.item.desc.speeds_up_ether_disease");
-        ++p;
+        list(0, num_of_desc) = static_cast<int>(ItemDescriptionType::text);
+        listn(0, num_of_desc) =
+            i18n::s.get("core.item.desc.speeds_up_ether_disease");
+        ++num_of_desc;
     }
-    if (inv[item_index].is_acidproof())
+    if (item.is_acidproof())
     {
-        list(0, p) = static_cast<int>(ItemDescriptionType::text);
-        listn(0, p) = i18n::s.get("core.item.desc.bit.acidproof");
-        ++p;
+        list(0, num_of_desc) = static_cast<int>(ItemDescriptionType::text);
+        listn(0, num_of_desc) = i18n::s.get("core.item.desc.bit.acidproof");
+        ++num_of_desc;
     }
-    if (inv[item_index].is_fireproof())
+    if (item.is_fireproof())
     {
-        list(0, p) = static_cast<int>(ItemDescriptionType::text);
-        listn(0, p) = i18n::s.get("core.item.desc.bit.fireproof");
-        ++p;
+        list(0, num_of_desc) = static_cast<int>(ItemDescriptionType::text);
+        listn(0, num_of_desc) = i18n::s.get("core.item.desc.bit.fireproof");
+        ++num_of_desc;
     }
-    if (inv[item_index].is_precious())
+    if (item.is_precious())
     {
-        list(0, p) = static_cast<int>(ItemDescriptionType::text);
-        listn(0, p) = i18n::s.get("core.item.desc.bit.precious");
-        ++p;
+        list(0, num_of_desc) = static_cast<int>(ItemDescriptionType::text);
+        listn(0, num_of_desc) = i18n::s.get("core.item.desc.bit.precious");
+        ++num_of_desc;
     }
-    if (inv[item_index].is_blessed_by_ehekatl())
+    if (item.is_blessed_by_ehekatl())
     {
-        list(0, p) = static_cast<int>(ItemDescriptionType::text);
-        listn(0, p) = i18n::s.get("core.item.desc.bit.blessed_by_ehekatl");
-        ++p;
+        list(0, num_of_desc) = static_cast<int>(ItemDescriptionType::text);
+        listn(0, num_of_desc) =
+            i18n::s.get("core.item.desc.bit.blessed_by_ehekatl");
+        ++num_of_desc;
     }
-    if (inv[item_index].is_stolen())
+    if (item.is_stolen())
     {
-        list(0, p) = static_cast<int>(ItemDescriptionType::text);
-        listn(0, p) = i18n::s.get("core.item.desc.bit.stolen");
-        ++p;
+        list(0, num_of_desc) = static_cast<int>(ItemDescriptionType::text);
+        listn(0, num_of_desc) = i18n::s.get("core.item.desc.bit.stolen");
+        ++num_of_desc;
     }
-    if (inv[item_index].is_alive())
+    if (item.is_alive())
     {
-        list(0, p) = static_cast<int>(ItemDescriptionType::text);
-        listn(0, p) = i18n::s.get("core.item.desc.bit.alive") + u8" [Lv:"s +
-            inv[item_index].param1 + u8" Exp:"s +
-            clamp(inv[item_index].param2 * 100 /
-                      calcexpalive(inv[item_index].param1),
-                  0,
-                  100) +
+        list(0, num_of_desc) = static_cast<int>(ItemDescriptionType::text);
+        listn(0, num_of_desc) = i18n::s.get("core.item.desc.bit.alive") +
+            u8" [Lv:"s + item.param1 + u8" Exp:"s +
+            clamp(item.param2 * 100 / calcexpalive(item.param1), 0, 100) +
             u8"%]"s;
-        ++p;
+        ++num_of_desc;
     }
-    if (inv[item_index].is_showroom_only())
+    if (item.is_showroom_only())
     {
-        list(0, p) = static_cast<int>(ItemDescriptionType::text);
-        listn(0, p) = i18n::s.get("core.item.desc.bit.show_room_only");
-        ++p;
+        list(0, num_of_desc) = static_cast<int>(ItemDescriptionType::text);
+        listn(0, num_of_desc) =
+            i18n::s.get("core.item.desc.bit.show_room_only");
+        ++num_of_desc;
     }
-    if (inv[item_index].is_handmade())
+    if (item.is_handmade())
     {
-        list(0, p) = static_cast<int>(ItemDescriptionType::text);
-        listn(0, p) = i18n::s.get("core.item.desc.bit.handmade");
-        ++p;
+        list(0, num_of_desc) = static_cast<int>(ItemDescriptionType::text);
+        listn(0, num_of_desc) = i18n::s.get("core.item.desc.bit.handmade");
+        ++num_of_desc;
     }
-    if (inv[item_index].dice_x != 0)
+    if (item.dice_x != 0)
     {
-        const auto pierce = calc_rate_to_pierce(itemid2int(inv[item_index].id));
-        list(0, p) = static_cast<int>(ItemDescriptionType::weapon_info);
-        listn(0, p) = i18n::s.get("core.item.desc.weapon.it_can_be_wielded") +
-            u8" ("s + inv[item_index].dice_x + u8"d"s + inv[item_index].dice_y +
+        const auto pierce = calc_rate_to_pierce(itemid2int(item.id));
+        list(0, num_of_desc) =
+            static_cast<int>(ItemDescriptionType::weapon_info);
+        listn(0, num_of_desc) =
+            i18n::s.get("core.item.desc.weapon.it_can_be_wielded") + u8" ("s +
+            item.dice_x + u8"d"s + item.dice_y +
             i18n::s.get("core.item.desc.weapon.pierce") + pierce + u8"%)"s;
-        ++p;
+        ++num_of_desc;
         if (reftype == 10000)
         {
-            if (inv[item_index].weight <= 1500)
+            if (item.weight <= 1500)
             {
-                list(0, p) = static_cast<int>(ItemDescriptionType::weapon_info);
-                listn(0, p) = i18n::s.get("core.item.desc.weapon.light");
-                ++p;
+                list(0, num_of_desc) =
+                    static_cast<int>(ItemDescriptionType::weapon_info);
+                listn(0, num_of_desc) =
+                    i18n::s.get("core.item.desc.weapon.light");
+                ++num_of_desc;
             }
-            if (inv[item_index].weight >= 4000)
+            if (item.weight >= 4000)
             {
-                list(0, p) = static_cast<int>(ItemDescriptionType::weapon_info);
-                listn(0, p) = i18n::s.get("core.item.desc.weapon.heavy");
-                ++p;
+                list(0, num_of_desc) =
+                    static_cast<int>(ItemDescriptionType::weapon_info);
+                listn(0, num_of_desc) =
+                    i18n::s.get("core.item.desc.weapon.heavy");
+                ++num_of_desc;
             }
         }
     }
-    if (inv[item_index].hit_bonus != 0 || inv[item_index].damage_bonus != 0)
+    if (item.hit_bonus != 0 || item.damage_bonus != 0)
     {
-        list(0, p) = static_cast<int>(ItemDescriptionType::weapon_info);
-        listn(0, p) = i18n::s.get(
-            "core.item.desc.bonus",
-            inv[item_index].hit_bonus,
-            inv[item_index].damage_bonus);
-        ++p;
+        list(0, num_of_desc) =
+            static_cast<int>(ItemDescriptionType::weapon_info);
+        listn(0, num_of_desc) = i18n::s.get(
+            "core.item.desc.bonus", item.hit_bonus, item.damage_bonus);
+        ++num_of_desc;
     }
-    if (inv[item_index].pv != 0 || inv[item_index].dv != 0)
+    if (item.pv != 0 || item.dv != 0)
     {
-        list(0, p) = static_cast<int>(ItemDescriptionType::armor_info);
-        listn(0, p) = i18n::s.get(
-            "core.item.desc.dv_pv", inv[item_index].dv, inv[item_index].pv);
-        ++p;
+        list(0, num_of_desc) =
+            static_cast<int>(ItemDescriptionType::armor_info);
+        listn(0, num_of_desc) =
+            i18n::s.get("core.item.desc.dv_pv", item.dv, item.pv);
+        ++num_of_desc;
     }
 }
 
-static void _load_item_enchantment_desc(int item_index, int& p)
-{
-    int inhmax = 0;
-    elona_vector1<int> inhlist;
-    getinheritance(item_index, inhlist, inhmax);
 
-    for (int cnt = 0; cnt < 15; ++cnt)
+
+void _load_item_enchantment_desc(const Item& item, int& num_of_desc)
+{
+    const auto inheritance = item_get_inheritance(item);
+
+    size_t enc_index{};
+    for (const auto& enc : item.enchantments)
     {
-        if (inv[item_index].enchantments[cnt].id == 0)
-        {
+        if (enc.id == 0)
             break;
-        }
-        get_enchantment_description(
-            inv[item_index].enchantments[cnt].id,
-            inv[item_index].enchantments[cnt].power,
-            reftype);
-        listn(0, p) = i18n::s.get("core.enchantment.it") + s;
-        list(0, p) = rtval;
-        list(1, p) = rtval(1);
-        if (inhmax > 0)
+
+        get_enchantment_description(enc.id, enc.power, reftype);
+        listn(0, num_of_desc) = i18n::s.get("core.enchantment.it") + s;
+        list(0, num_of_desc) = rtval;
+        list(1, num_of_desc) = rtval(1);
+
+        const auto is_inherited =
+            range::find(inheritance, enc_index) != std::end(inheritance);
+        if (is_inherited)
         {
-            int cnt2 = cnt;
-            for (int cnt = 0, cnt_end = (inhmax); cnt < cnt_end; ++cnt)
-            {
-                if (cnt2 == inhlist(cnt))
-                {
-                    list(0, p) += 10000;
-                    break;
-                }
-            }
+            list(0, num_of_desc) += 10000;
         }
-        ++p;
+        ++num_of_desc;
+        ++enc_index;
     }
-    if (inv[item_index].is_eternal_force())
+
+    if (item.is_eternal_force())
     {
-        list(0, p) = static_cast<int>(ItemDescriptionType::enchantment);
-        listn(0, p) = i18n::s.get("core.item.desc.bit.eternal_force");
-        ++p;
+        list(0, num_of_desc) =
+            static_cast<int>(ItemDescriptionType::enchantment);
+        listn(0, num_of_desc) = i18n::s.get("core.item.desc.bit.eternal_force");
+        ++num_of_desc;
     }
 }
 
+} // namespace
 
 
-void item_load_desc(int item_index, int& p)
+
+size_t item_load_desc(const Item& item)
 {
-    const I18NKey& locale_key_prefix =
-        the_item_db[itemid2int(inv[item_index].id)]->locale_key_prefix;
+    int num_of_desc{};
 
-    if (inv[item_index].identify_state == IdentifyState::completely)
+    const I18NKey& locale_key_prefix =
+        the_item_db[itemid2int(item.id)]->locale_key_prefix;
+
+    if (item.identify_state == IdentifyState::completely)
     {
-        _load_item_main_description_text(locale_key_prefix, p);
+        _load_item_main_description_text(locale_key_prefix, num_of_desc);
     }
-    if (inv[item_index].identify_state >= IdentifyState::almost)
+    if (item.identify_state >= IdentifyState::almost)
     {
-        _load_item_stat_text(item_index, p);
+        _load_item_stat_text(item, num_of_desc);
     }
-    if (inv[item_index].identify_state <= IdentifyState::partly)
+    if (item.identify_state <= IdentifyState::partly)
     {
-        list(0, p) = static_cast<int>(ItemDescriptionType::normal);
-        listn(0, p) = i18n::s.get("core.item.desc.have_to_identify");
-        ++p;
+        list(0, num_of_desc) = static_cast<int>(ItemDescriptionType::normal);
+        listn(0, num_of_desc) = i18n::s.get("core.item.desc.have_to_identify");
+        ++num_of_desc;
     }
-    if (inv[item_index].identify_state == IdentifyState::completely)
+    if (item.identify_state == IdentifyState::completely)
     {
-        _load_item_enchantment_desc(item_index, p);
-        _load_item_description_text(locale_key_prefix, p);
+        _load_item_enchantment_desc(item, num_of_desc);
+        _load_item_description_text(locale_key_prefix, num_of_desc);
     }
-    if (p == 0)
+    if (num_of_desc == 0)
     {
-        list(0, p) = static_cast<int>(ItemDescriptionType::normal);
-        listn(0, p) = i18n::s.get("core.item.desc.no_information");
-        ++p;
+        list(0, num_of_desc) = static_cast<int>(ItemDescriptionType::normal);
+        listn(0, num_of_desc) = i18n::s.get("core.item.desc.no_information");
+        ++num_of_desc;
     }
+
+    return static_cast<size_t>(num_of_desc);
 }
 
 } // namespace elona

--- a/src/elona/itemgen.cpp
+++ b/src/elona/itemgen.cpp
@@ -110,7 +110,7 @@ optional<int> do_create_item(int slot, int x, int y)
     if (ci == -1)
         return none;
 
-    item_delete(ci);
+    item_delete(inv[ci]);
     inv[ci].index = ci;
 
     if (slot == -1 && mode != 6 && mode != 9)
@@ -474,7 +474,7 @@ optional<int> do_create_item(int slot, int x, int y)
 
     calc_furniture_value(inv[ci]);
 
-    itemturn(ci);
+    itemturn(inv[ci]);
 
     if (initnum != 0)
     {
@@ -548,7 +548,7 @@ void init_item_quality_curse_state_material_and_equipments(Item& item)
                 break;
             }
             enchantment_add(
-                ci,
+                item,
                 fixeditemenc(cnt * 2),
                 fixeditemenc(cnt * 2 + 1),
                 0,
@@ -559,7 +559,7 @@ void init_item_quality_curse_state_material_and_equipments(Item& item)
     }
     if (reftype < 52000)
     {
-        add_enchantments();
+        add_enchantments(item);
     }
     else if (item.quality != Quality::special)
     {
@@ -780,7 +780,7 @@ void set_material_specific_attributes(Item& item)
     p = item.material;
     for (auto e : the_item_material_db[p]->enchantments)
     {
-        enchantment_add(ci, e.first, e.second, 0, 1);
+        enchantment_add(item, e.first, e.second, 0, 1);
     }
     for (int cnt = 0; cnt < 10; ++cnt)
     {

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -587,7 +587,7 @@ bool _magic_184()
         txt(i18n::s.get("core.magic.cook.do_not_know"));
         return false;
     }
-    cooktool = ci;
+    auto&& cook_tool = inv[ci];
     invsubroutine = 1;
     invctrl = 16;
     snd("core.inv");
@@ -614,7 +614,7 @@ bool _magic_184()
             rnd(the_ability_db[efid]->cost / 2 + 1) +
                 the_ability_db[efid]->cost / 2 + 1);
     }
-    cook();
+    cook(cook_tool, inv[ci]);
     return true;
 }
 
@@ -2067,12 +2067,13 @@ bool _magic_645_1114()
     {
         for (int cnt = 0; cnt < 200; ++cnt)
         {
-            p = get_random_inv(tc);
-            if (inv[p].number() == 0)
+            const auto& item = get_random_inv(tc);
+            p = item.index;
+            if (item.number() == 0)
             {
                 continue;
             }
-            if (inv[p].curse_state == CurseState::blessed)
+            if (item.curse_state == CurseState::blessed)
             {
                 if (rnd(10))
                 {
@@ -2399,7 +2400,7 @@ bool _magic_49(int efcibk)
     {
         randomize(inv[efcibk].param1);
         enchantment_add(
-            ci,
+            inv[ci],
             enchantment_generate(enchantment_gen_level(egolv)),
             enchantment_gen_p() + (fixlv == Quality::godly) * 100 +
                 (inv[ci].is_eternal_force()) * 100,

--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -1463,21 +1463,16 @@ int change_npc_tone()
 
 
 
-void show_book_window()
+void show_book_window(const Item& book)
 {
-    ui::UIMenuBook(inv[ci].param1).show();
+    ui::UIMenuBook(book.param1).show();
 }
 
 
-void item_show_description()
-{
-    if (ci < 0)
-    {
-        dialog(i18n::s.get("core.item.desc.window.error"));
-        return;
-    }
 
-    ui::UIMenuItemDesc(inv[ci]).show();
+void item_show_description(const Item& item)
+{
+    ui::UIMenuItemDesc(item).show();
 
     returnfromidentify = 1;
 }

--- a/src/elona/menu.hpp
+++ b/src/elona/menu.hpp
@@ -8,6 +8,7 @@ namespace elona
 
 enum class TurnResult;
 struct Character;
+struct Item;
 
 
 
@@ -95,9 +96,9 @@ void show_city_chart();
 void begin_to_believe_god(int);
 void screen_analyze_self();
 int ctrl_ally(ControlAllyOperation);
-void show_book_window();
+void show_book_window(const Item& book);
 int change_npc_tone();
-void item_show_description();
+void item_show_description(const Item& item);
 
 MenuResult ctrl_inventory();
 

--- a/src/elona/turn_sequence.cpp
+++ b/src/elona/turn_sequence.cpp
@@ -1489,12 +1489,13 @@ TurnResult pc_turn(bool advance_time)
         }
         if (trait(210) != 0 && rnd(5) == 0)
         {
-            ci = get_random_inv(0);
-            if (inv[ci].number() > 0 &&
-                the_item_db[itemid2int(inv[ci].id)]->category == 52000)
+            auto&& item = get_random_inv(0);
+            if (item.number() > 0 &&
+                the_item_db[itemid2int(item.id)]->category == 52000)
             {
-                dbid = itemid2int(inv[ci].id);
-                item_db_on_drink(inv[ci], dbid);
+                ci = item.index;
+                dbid = itemid2int(item.id);
+                item_db_on_drink(item, dbid);
             }
         }
         if (trait(214) != 0 && rnd(250) == 0 &&

--- a/src/elona/ui/ui_menu_equipment.cpp
+++ b/src/elona/ui/ui_menu_equipment.cpp
@@ -326,7 +326,7 @@ static bool _on_list_entry_select(int index)
 static void _show_item_desc(int body_)
 {
     ci = cdata[cc].body_parts[body_ - 100] % 10000 - 1;
-    item_show_description();
+    item_show_description(inv[ci]);
     nowindowanime = 1;
     returnfromidentify = 0;
     screenupdate = -1;

--- a/src/elona/variables.hpp
+++ b/src/elona/variables.hpp
@@ -331,7 +331,6 @@ ELONA_EXTERN(int cm);
 ELONA_EXTERN(int cmbg);
 ELONA_EXTERN(int cmsex);
 ELONA_EXTERN(int cmshade);
-ELONA_EXTERN(int cooktool);
 ELONA_EXTERN(int creaturepack);
 ELONA_EXTERN(int critical);
 ELONA_EXTERN(int crop);
@@ -585,7 +584,6 @@ void gain_race_feat();
 
 // Item status querying
 int cargocheck();
-void getinheritance(int, elona_vector1<int>&, int&);
 
 // Item manipulation
 int convertartifact(int = 0, int = 0);

--- a/src/tests/util.cpp
+++ b/src/tests/util.cpp
@@ -58,7 +58,7 @@ std::string test_itemname(int id, int number, bool prefix)
     int index = elona::ci;
     normalize_item(elona::inv[index]);
     std::string name = itemname(index, number, prefix ? 0 : 1);
-    item_delete(index);
+    item_delete(inv[index]);
     return name;
 }
 
@@ -84,7 +84,7 @@ void invalidate_item(Item& item)
     int old_y = item.position.y;
 
     // Delete the item and create new ones until the index is taken again.
-    item_delete(old_index);
+    item_delete(inv[old_index]);
     do
     {
         REQUIRE_SOME(itemcreate(-1, old_id, old_x, old_y, 3));


### PR DESCRIPTION
# Summary

Avoid direct index access to `inv` (e.g., `inv[ci]`), instead use `Item&` as arguments. This refactoring also reduces usage of global variable `ci`.