### PR TITLE
Fixed a bug that the game does not start.

### DIFF
--- a/src/elona/init.cpp
+++ b/src/elona/init.cpp
@@ -648,19 +648,17 @@ void init()
 
     lua::lua->get_api_manager().lock();
 
-    /*
     if (g_config.font_filename().empty())
     {
         // If no font is specified in `config.json`, use a pre-defined font
         // depending on each language.
-        g_config.font_filename() = i18n::s.get("core.meta.default_font");
+        g_config.set_font_filename(i18n::s.get("core.meta.default_font"));
         if (jp)
         {
             // TODO: work around
-            g_config.set()("core.font.vertical_offset", -3);
+            elona::vfix = -3;
         }
     }
-     */
 
     initialize_keybindings();
 


### PR DESCRIPTION
# Summary
Startup fails due to empty default font.

## Log
```
0.004 INFO  [system] Elona foobar version 0.5.0 (f81287a5), compiled on Windows-6.1.7601 at 2019-11-20T05:55:52Z
0.131 INFO  [profile] Initialize with 'default'.
0.131 INFO  [profile] Load 'default'.
2.286 INFO  [lua.mod] Found mod core
2.293 INFO  [lua.mod] Loaded mod core
6.147 FATAL [system] Couldn't open C:/ElonaFoobar\font
```

# 環境 Environment
* OS version: Windows 7 SP1 64bit Visual Studio 2019
* Elona foobar verision: f81287a54270ec3eea8727b7f5f13ef24cbc2f24

# 再現方法 How to reproduce
* Start with a new profile.
* Even if you take over from 0.4.x, a problem occurs.