### PR TITLE
Add missing #pragma once directive [ci skip]

### DIFF
--- a/src/elona/data/types/type_buff.hpp
+++ b/src/elona/data/types/type_buff.hpp
@@ -1,6 +1,10 @@
+#pragma once
+
 #include "../../enums.hpp"
 #include "../../lua_env/wrapped_function.hpp"
 #include "../lua_lazy_cache.hpp"
+
+
 
 namespace elona
 {


### PR DESCRIPTION

# Summary

`src/elona/types/type_buff.cpp` lacks `#pragma once`.