### PR TITLE
Fix wrong forward declaration [ci skip]

### DIFF
--- a/src/elona/ui/ui_menu_mod_info.hpp
+++ b/src/elona/ui/ui_menu_mod_info.hpp
@@ -3,13 +3,14 @@
 #include "ui_menu.hpp"
 #include "ui_menu_mods.hpp"
 
+namespace elona
+{
+
 namespace snail
 {
 class Image;
 }
 
-namespace elona
-{
 namespace ui
 {
 class UIMenuModInfo : public UIMenu<DummyResult>


### PR DESCRIPTION
# Summary

Namespace `snail` is under `elona`, not in the top level.