### PR TITLE
Hide config sections marked as hidden in Options menu

### DIFF
--- a/runtime/data/script/kernel/config_dsl.lua
+++ b/runtime/data/script/kernel/config_dsl.lua
@@ -41,6 +41,7 @@ local function process_section_internal(schema, options)
       children_keys[#children_keys+1] = name
    end
 
+   is_hidden = is_hidden or options.is_hidden
    return schema, is_hidden, children_keys
 end
 


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

fix up #1443's change


# Summary

"debug" section is marked as "hidden", but is shown in Options menu.