### PR TITLE
Fix Travis CI build on macOS: brew upgrade wget

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ cache:
 before_install:
   - if [[ "$BUILD_TYPE" == "osx" ]]; then
       brew update &&
-      brew upgrade cmake boost &&
+      brew upgrade cmake boost wget &&
       brew install sdl2 sdl2_ttf sdl2_image sdl2_mixer lua openssl;
     fi
   - if [[ "$BUILD_TYPE" == "linux" ]]; then


### PR DESCRIPTION
# Related Issues

PRs currently requested are blocked due to this problem about Travis CI failure. We need merge this fix first.


# Summary

Due to recent Travis' update on macOS environment, `wget` failed to load `libssl`. Added `brew upgrade wget` to fix the problem.
