### PR TITLE
Refactor: avoid index access of inv

### DIFF
--- a/src/elona/adventurer.cpp
+++ b/src/elona/adventurer.cpp
@@ -356,14 +356,14 @@ int adventurer_discover_equipment()
     {
         flttypemajor = choice(fsetitem);
     }
-    if (itemcreate(rc, 0, -1, -1, 0))
+    if (const auto item = itemcreate_chara_inv(rc, 0, 0))
     {
-        inv[ci].identify_state = IdentifyState::completely;
-        if (inv[ci].quality >= Quality::miracle)
+        item->identify_state = IdentifyState::completely;
+        if (item->quality >= Quality::miracle)
         {
-            if (the_item_db[itemid2int(inv[ci].id)]->category < 50000)
+            if (the_item_db[itemid2int(item->id)]->category < 50000)
             {
-                addnews(1, rc, 0, itemname(ci));
+                addnews(1, rc, 0, itemname(item->index));
             }
         }
         wear_most_valuable_equipment();

--- a/src/elona/blending.cpp
+++ b/src/elona/blending.cpp
@@ -1621,7 +1621,7 @@ int blending_spend_materials()
                 "core.blending.you_lose", inv[rpref(10 + cnt * 2)]));
             inv[rpref(10 + cnt * 2)].modify_number(-1);
         }
-        if (chara_unequip(rpref(10 + cnt * 2)))
+        if (chara_unequip(inv[rpref(10 + cnt * 2)]))
         {
             chara_refresh(0);
         }
@@ -1652,12 +1652,8 @@ void blending_start_attempt()
         {
             flt();
             nostack = 1;
-            if (itemcreate(
-                    -1,
-                    rpdata(0, rpid),
-                    cdata.player().position.x,
-                    cdata.player().position.y,
-                    0))
+            if (const auto item = itemcreate_extra_inv(
+                    rpdata(0, rpid), cdata.player().position, 0))
             {
                 for (int cnt = 0;; ++cnt)
                 {
@@ -1666,16 +1662,16 @@ void blending_start_attempt()
                         break;
                     }
                     enchantment_add(
-                        inv[ci],
+                        *item,
                         rpdata(50 + cnt * 2, rpid),
                         rpdata(51 + cnt * 2, rpid),
                         0,
                         1);
                 }
+                txt(i18n::s.get("core.blending.succeeded", *item),
+                    Message::color{ColorIndex::green});
+                snd("core.drink1");
             }
-            txt(i18n::s.get("core.blending.succeeded", inv[ci]),
-                Message::color{ColorIndex::green});
-            snd("core.drink1");
         }
         for (int cnt = 0; cnt < 5; ++cnt)
         {
@@ -1846,9 +1842,9 @@ void blending_proc_on_success_events()
         {
             --game_data.holy_well_count;
             flt();
-            if (itemcreate(0, 516, -1, -1, 0))
+            if (const auto item = itemcreate_player_inv(516, 0))
             {
-                inv[ci].curse_state = CurseState::blessed;
+                item->curse_state = CurseState::blessed;
             }
         }
         else
@@ -1856,19 +1852,19 @@ void blending_proc_on_success_events()
             inv[ci].param1 -= 3;
             flt(20);
             flttypemajor = 52000;
-            itemcreate(0, 0, -1, -1, 0);
+            itemcreate_player_inv(0, 0);
         }
         txt(i18n::s.get("core.action.dip.result.natural_potion"));
         txt(i18n::s.get("core.action.dip.you_get", inv[ci]),
             Message::color{ColorIndex::green});
-        item_stack(0, ci, 1);
-        item_stack(0, ci);
+        item_stack(0, inv[ci], true);
+        item_stack(0, inv[ci]);
         ci = cibk;
         snd("core.drink1");
         break;
     }
 
-    item_stack(0, ci);
+    item_stack(0, inv[ci]);
     if (inv[ci].body_part != 0)
     {
         create_pcpic(cdata.player());

--- a/src/elona/building.cpp
+++ b/src/elona/building.cpp
@@ -1077,7 +1077,7 @@ void show_shop_log()
         p = rnd(dblistmax);
         ci = dblist(0, p);
         int category = dblist(1, p);
-        int val0 = calcitemvalue(ci, 2);
+        int val0 = calcitemvalue(inv[ci], 2);
         val0 = val0 * int((10 + std::sqrt(sdata(156, worker) * 200))) / 100;
         if (val0 <= 1)
         {
@@ -1155,7 +1155,7 @@ void show_shop_log()
     if (income != 0)
     {
         flt();
-        itemcreate(-1, 54, -1, -1, income);
+        itemcreate_extra_inv(54, -1, -1, income);
     }
     for (int cnt = 0, cnt_end = (listmax); cnt < cnt_end; ++cnt)
     {
@@ -1165,17 +1165,17 @@ void show_shop_log()
             flt(list(0, cnt2), static_cast<Quality>(list(1, cnt2)));
             flttypemajor = elona::stoi(listn(0, cnt2));
             nostack = 1;
-            if (itemcreate(-1, 0, -1, -1, 0))
+            if (const auto item = itemcreate_extra_inv(0, -1, -1, 0))
             {
-                if (inv[ci].value > elona::stoi(listn(1, cnt2)) * 2)
+                if (item->value > elona::stoi(listn(1, cnt2)) * 2)
                 {
-                    item_stack(-1, ci);
+                    item_stack(-1, *item);
                     f = 1;
                     break;
                 }
                 else
                 {
-                    inv[ci].remove();
+                    item->remove();
                     if (cnt == 3)
                     {
                         f = 0;
@@ -1195,7 +1195,7 @@ void show_shop_log()
         }
         if (f == 0)
         {
-            itemcreate(-1, 54, -1, -1, elona::stoi(listn(1, cnt)));
+            itemcreate_extra_inv(54, -1, -1, elona::stoi(listn(1, cnt)));
             income += elona::stoi(listn(1, cnt));
         }
         else
@@ -1553,11 +1553,11 @@ void update_ranch()
                     (cdatan(2, chara.index) == "core.chicken" && rnd(20) == 0))
                 {
                     ++egg_or_milk_count;
-                    if (itemcreate(-1, 573, x, y, 0))
+                    if (const auto item = itemcreate_extra_inv(573, x, y, 0))
                     {
-                        inv[ci].subname = charaid2int(chara.id);
-                        inv[ci].weight = chara.weight * 10 + 250;
-                        inv[ci].value = clamp(
+                        item->subname = charaid2int(chara.id);
+                        item->weight = chara.weight * 10 + 250;
+                        item->value = clamp(
                             chara.weight * chara.weight / 10000, 200, 40000);
                     }
                 }
@@ -1568,9 +1568,9 @@ void update_ranch()
                     (cdatan(2, chara.index) == "core.sheep" && rnd(20) == 0))
                 {
                     ++egg_or_milk_count;
-                    if (itemcreate(-1, 574, x, y, 0))
+                    if (const auto item = itemcreate_extra_inv(574, x, y, 0))
                     {
-                        inv[ci].subname = charaid2int(chara.id);
+                        item->subname = charaid2int(chara.id);
                     }
                 }
                 break;
@@ -1578,11 +1578,11 @@ void update_ranch()
                 // Shit
                 if (rnd(80) == 0)
                 {
-                    if (itemcreate(-1, 575, x, y, 0))
+                    if (const auto item = itemcreate_extra_inv(575, x, y, 0))
                     {
-                        inv[ci].subname = charaid2int(chara.id);
-                        inv[ci].weight = chara.weight * 40 + 300;
-                        inv[ci].value =
+                        item->subname = charaid2int(chara.id);
+                        item->weight = chara.weight * 40 + 300;
+                        item->value =
                             clamp(chara.weight * chara.weight / 5000, 1, 20000);
                     }
                 }
@@ -1596,7 +1596,7 @@ void update_ranch()
                     {
                         dbid = 45;
                     }
-                    itemcreate(-1, dbid, x, y, 0);
+                    itemcreate_extra_inv(dbid, x, y, 0);
                 }
                 break;
             case 4:

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -815,49 +815,49 @@ int calcattackdmg(AttackDamageCalculationMode mode)
 
 
 
-int calcmedalvalue(int item_index)
+int calcmedalvalue(const Item& item)
 {
-    switch (itemid2int(inv[item_index].id))
+    switch (item.id)
     {
-    case 430: return 5;
-    case 431: return 8;
-    case 502: return 7;
-    case 480: return 20;
-    case 421: return 15;
-    case 603: return 20;
-    case 615: return 5;
-    case 559: return 10;
-    case 516: return 3;
-    case 616: return 18;
-    case 623: return 85;
-    case 624: return 25;
-    case 505: return 12;
-    case 625: return 11;
-    case 626: return 30;
-    case 627: return 55;
-    case 56: return 65;
-    case 742: return 72;
-    case 760: return 94;
+    case ItemId::diablo: return 65;
+    case ItemId::artifact_seed: return 15;
+    case ItemId::scroll_of_growth: return 5;
+    case ItemId::scroll_of_faith: return 8;
+    case ItemId::rod_of_domination: return 20;
+    case ItemId::scroll_of_superior_material: return 7;
+    case ItemId::little_sisters_diary: return 12;
+    case ItemId::bottle_of_water: return 3;
+    case ItemId::potion_of_cure_corruption: return 10;
+    case ItemId::presidents_chair: return 20;
+    case ItemId::bill: return 5;
+    case ItemId::tax_masters_tax_box: return 18;
+    case ItemId::cat_sisters_diary: return 85;
+    case ItemId::girls_diary: return 25;
+    case ItemId::shrine_gate: return 11;
+    case ItemId::bottle_of_hermes_blood: return 30;
+    case ItemId::sages_helm: return 55;
+    case ItemId::license_of_the_void_explorer: return 72;
+    case ItemId::garoks_hammer: return 94;
     default: return 1;
     }
 }
 
 
 
-int calcitemvalue(int item_index, int situation)
+int calcitemvalue(const Item& item, int calc_mode)
 {
-    int category = the_item_db[itemid2int(inv[item_index].id)]->category;
+    int category = the_item_db[itemid2int(item.id)]->category;
     int ret = 0;
-    if (inv[item_index].identify_state == IdentifyState::unidentified)
+    if (item.identify_state == IdentifyState::unidentified)
     {
-        if (situation == 2)
+        if (calc_mode == 2)
         {
-            ret = inv[item_index].value * 4 / 10;
+            ret = item.value * 4 / 10;
         }
         else
         {
             ret = cdata.player().level / 5 *
-                    ((game_data.random_seed + item_index * 31) %
+                    ((game_data.random_seed + item.index * 31) %
                          cdata.player().level +
                      4) +
                 10;
@@ -865,21 +865,21 @@ int calcitemvalue(int item_index, int situation)
     }
     else if (category >= 50000)
     {
-        ret = inv[item_index].value;
+        ret = item.value;
     }
     else
     {
-        switch (inv[item_index].identify_state)
+        switch (item.identify_state)
         {
         case IdentifyState::unidentified: break;
-        case IdentifyState::partly: ret = inv[item_index].value * 2 / 10; break;
-        case IdentifyState::almost: ret = inv[item_index].value * 5 / 10; break;
-        case IdentifyState::completely: ret = inv[item_index].value; break;
+        case IdentifyState::partly: ret = item.value * 2 / 10; break;
+        case IdentifyState::almost: ret = item.value * 5 / 10; break;
+        case IdentifyState::completely: ret = item.value; break;
         }
     }
-    if (inv[item_index].identify_state == IdentifyState::completely)
+    if (item.identify_state == IdentifyState::completely)
     {
-        switch (inv[item_index].curse_state)
+        switch (item.curse_state)
         {
         case CurseState::doomed: ret = ret / 5; break;
         case CurseState::cursed: ret = ret / 2; break;
@@ -889,14 +889,14 @@ int calcitemvalue(int item_index, int situation)
     }
     if (category == 57000)
     {
-        if (inv[item_index].param2 > 0)
+        if (item.param2 > 0)
         {
-            ret = ret * inv[item_index].param2 * inv[item_index].param2 / 10;
+            ret = ret * item.param2 * item.param2 / 10;
         }
     }
-    if (inv[item_index].id == ItemId::cargo_travelers_food)
+    if (item.id == ItemId::cargo_travelers_food)
     {
-        if (situation == 0)
+        if (calc_mode == 0)
         {
             ret += clamp(
                 cdata.player().fame / 40 +
@@ -905,14 +905,14 @@ int calcitemvalue(int item_index, int situation)
                 800);
         }
     }
-    if (inv[item_index].weight < 0)
+    if (item.weight < 0)
     {
         if (mode == 6)
         {
             if (category == 92000)
             {
-                ret = ret * trate(inv[item_index].param1) / 100;
-                if (situation == 1)
+                ret = ret * trate(item.param1) / 100;
+                if (calc_mode == 1)
                 {
                     ret = ret * 65 / 100;
                 }
@@ -920,33 +920,31 @@ int calcitemvalue(int item_index, int situation)
             }
         }
     }
-    if (inv[item_index].has_charge())
+    if (item.has_charge())
     {
-        dbid = itemid2int(inv[item_index].id);
-        item_db_get_charge_level(inv[item_index], dbid);
-        if (inv[item_index].count < 0)
+        dbid = itemid2int(item.id);
+        item_db_get_charge_level(item, dbid);
+        if (item.count < 0)
         {
             ret = ret / 10;
         }
         else if (category == 54000)
         {
-            ret =
-                ret / 5 + ret * inv[item_index].count / (ichargelevel * 2 + 1);
+            ret = ret / 5 + ret * item.count / (ichargelevel * 2 + 1);
         }
         else
         {
-            ret =
-                ret / 2 + ret * inv[item_index].count / (ichargelevel * 3 + 1);
+            ret = ret / 2 + ret * item.count / (ichargelevel * 3 + 1);
         }
     }
     if (category == 72000)
     {
-        if (inv[item_index].param1 == 0)
+        if (item.param1 == 0)
         {
             ret = ret / 100 + 1;
         }
     }
-    if (situation == 0)
+    if (calc_mode == 0)
     {
         int max = ret / 2;
         ret = ret * 100 / (100 + sdata(156, 0));
@@ -962,7 +960,7 @@ int calcitemvalue(int item_index, int situation)
             ret = max;
         }
     }
-    if (situation == 1)
+    if (calc_mode == 1)
     {
         int max = sdata(156, 0) * 250 + 5000;
         if (ret / 3 < max)
@@ -974,7 +972,7 @@ int calcitemvalue(int item_index, int situation)
         {
             ret /= 20;
         }
-        if (inv[item_index].is_stolen())
+        if (item.is_stolen())
         {
             if (game_data.guild.belongs_to_thieves_guild == 0)
             {
@@ -990,7 +988,7 @@ int calcitemvalue(int item_index, int situation)
             ret = max;
         }
     }
-    if (situation == 2)
+    if (calc_mode == 2)
     {
         ret = ret / 5;
         if (category < 50000)
@@ -1001,7 +999,7 @@ int calcitemvalue(int item_index, int situation)
         {
             ret = 15000;
         }
-        if (inv[item_index].is_stolen())
+        if (item.is_stolen())
         {
             ret = 1;
         }

--- a/src/elona/calc.hpp
+++ b/src/elona/calc.hpp
@@ -5,10 +5,14 @@
 #include "optional.hpp"
 
 
+
 namespace elona
 {
 
 struct Character;
+struct Item;
+
+
 
 struct SkillDamage
 {
@@ -40,8 +44,8 @@ enum class AttackDamageCalculationMode
 };
 int calcattackdmg(AttackDamageCalculationMode);
 
-int calcmedalvalue(int = 0);
-int calcitemvalue(int = 0, int = 0);
+int calcmedalvalue(const Item& item);
+int calcitemvalue(const Item& item, int calc_mode);
 int calcinvestvalue();
 int calcguiltvalue();
 int calchireadv(int = 0);

--- a/src/elona/casino.cpp
+++ b/src/elona/casino.cpp
@@ -705,7 +705,7 @@ bool casino_blackjack()
     {
         atxinit();
         noteadd(i18n::s.get("core.casino.blackjack.game.total_wins", winrow));
-        for (int cnt = 0; cnt < 1; ++cnt)
+        while (true)
         {
             Quality quality = Quality::good;
             if (winrow > 2)
@@ -729,27 +729,28 @@ bool casino_blackjack()
             flt(calcobjlv(rnd(stake + winrow * 2) + winrow * 3 / 2 + stake / 2),
                 quality);
             flttypemajor = choice(fsetwear);
-            itemcreate(-1, 0, -1, -1, 0);
-            if (inv[ci].number() == 0)
+            if (const auto item = itemcreate_extra_inv(0, -1, -1, 0))
             {
-                --cnt;
-                continue;
+                snd("core.get3");
+                noteadd(
+                    "@GR" +
+                    i18n::s.get("core.casino.blackjack.game.loot", *item));
+                break;
             }
         }
-        snd("core.get3");
-        noteadd(
-            "@GR" + i18n::s.get("core.casino.blackjack.game.loot", inv[ci]));
         if (winrow > 3)
         {
             // Potion of cure corruption
             if (winrow + 1 > rnd(10))
             {
                 flt();
-                itemcreate(-1, 559, -1, -1, 0);
-                snd("core.get3");
-                noteadd(
-                    "@GR" +
-                    i18n::s.get("core.casino.blackjack.game.loot", inv[ci]));
+                if (const auto item = itemcreate_extra_inv(559, -1, -1, 0))
+                {
+                    snd("core.get3");
+                    noteadd(
+                        "@GR" +
+                        i18n::s.get("core.casino.blackjack.game.loot", *item));
+                }
             }
         }
         list(0, listmax) = 0;

--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -1689,12 +1689,12 @@ void chara_relocate(
 
 
 
-void chara_set_item_which_will_be_used(Character& cc)
+void chara_set_item_which_will_be_used(Character& chara, const Item& item)
 {
-    int category = the_item_db[itemid2int(inv[ci].id)]->category;
+    const auto category = the_item_db[itemid2int(item.id)]->category;
     if (category == 57000 || category == 52000 || category == 53000)
     {
-        cc.item_which_will_be_used = ci;
+        chara.item_which_will_be_used = item.index;
     }
 }
 

--- a/src/elona/character.hpp
+++ b/src/elona/character.hpp
@@ -17,8 +17,13 @@
 #define ELONA_MAX_OTHER_CHARACTERS 188
 
 
+
 namespace elona
 {
+
+struct Item;
+
+
 
 /// @putit
 struct Buff
@@ -717,11 +722,11 @@ int chara_find(int id);
 int chara_find_ally(int id);
 int chara_get_free_slot();
 int chara_get_free_slot_ally();
-bool chara_unequip(int);
+bool chara_unequip(Item& item);
 int chara_custom_talk(int = 0, int = 0);
 int chara_impression_level(int = 0);
 void chara_modify_impression(Character& cc, int delta);
-void chara_set_item_which_will_be_used(Character& cc);
+void chara_set_item_which_will_be_used(Character& chara, const Item& item);
 int chara_armor_class(const Character& cc);
 int chara_breed_power(const Character&);
 

--- a/src/elona/crafting.cpp
+++ b/src/elona/crafting.cpp
@@ -391,15 +391,21 @@ static Quality _determine_crafted_fixlv(const CraftingRecipe& recipe)
     return ret;
 }
 
+
+
 static void _craft_item(int matid, const CraftingRecipe& recipe)
 {
     fixlv = _determine_crafted_fixlv(recipe);
     flt(calcobjlv(sdata(recipe.skill_used, 0)), calcfixlv(fixlv));
     nostack = 1;
-    itemcreate(0, matid, -1, -1, 0);
-    txt(i18n::s.get("core.crafting.you_crafted", inv[ci]));
-    item_stack(0, ci, 0);
+    if (const auto item = itemcreate_player_inv(matid, 0))
+    {
+        txt(i18n::s.get("core.crafting.you_crafted", *item));
+        item_stack(0, *item);
+    }
 }
+
+
 
 void crafting_menu()
 {

--- a/src/elona/deferred_event.cpp
+++ b/src/elona/deferred_event.cpp
@@ -192,25 +192,25 @@ void eh_conquer_nefia(const DeferredEvent&)
     snd("core.complete1");
     flt(0, calcfixlv());
     flttypemajor = 54000;
-    itemcreate(-1, 0, cdata.player().position.x, cdata.player().position.y, 0);
+    itemcreate_extra_inv(0, cdata.player().position, 0);
     flt();
-    itemcreate(
-        -1, 236, cdata.player().position.x, cdata.player().position.y, 0);
+    itemcreate_extra_inv(236, cdata.player().position, 0);
     nostack = 1;
     flt();
-    itemcreate(-1, 54, cdata.player().position.x, cdata.player().position.y);
-    inv[ci].set_number(200 + inv[ci].number() * 5);
+    if (const auto item = itemcreate_extra_inv(54, cdata.player().position, 0))
+    {
+        item->set_number(200 + item->number() * 5);
+    }
     flt();
-    itemcreate(
-        -1,
+    itemcreate_extra_inv(
         55,
-        cdata.player().position.x,
-        cdata.player().position.y,
+        cdata.player().position,
         clamp(rnd(3) + game_data.current_dungeon_level / 10, 1, 6));
     flt();
-    itemcreate(
-        -1, 239, cdata.player().position.x, cdata.player().position.y, 0);
-    inv[ci].param2 = 0;
+    if (const auto item = itemcreate_extra_inv(239, cdata.player().position, 0))
+    {
+        item->param2 = 0;
+    }
     txt(i18n::s.get("core.quest.completed"), Message::color{ColorIndex::green});
     snd("core.complete1");
     txt(i18n::s.get("core.common.something_is_put_on_the_ground"));
@@ -343,18 +343,11 @@ void eh_marriage(const DeferredEvent&)
     {
         flt(calcobjlv(cdata[marry].level + 5), calcfixlv(Quality::good));
         flttypemajor = choice(fsetchest);
-        itemcreate(
-            -1, 0, cdata.player().position.x, cdata.player().position.y, 0);
+        itemcreate_extra_inv(0, cdata.player().position, 0);
     }
-    itemcreate(
-        -1, 559, cdata.player().position.x, cdata.player().position.y, 0);
+    itemcreate_extra_inv(559, cdata.player().position, 0);
     flt();
-    itemcreate(
-        -1,
-        55,
-        cdata.player().position.x,
-        cdata.player().position.y,
-        rnd(3) + 2);
+    itemcreate_extra_inv(55, cdata.player().position, rnd(3) + 2);
     txt(i18n::s.get("core.common.something_is_put_on_the_ground"));
     save_set_autosave();
 }
@@ -576,12 +569,7 @@ void eh_lily_killed(const DeferredEvent& event)
     cdata[event.param1].character_role = 0;
     cdata[event.param1].set_state(Character::State::empty);
     flt();
-    itemcreate(
-        -1,
-        55,
-        cdata[event.param1].position.x,
-        cdata[event.param1].position.y,
-        4);
+    itemcreate_extra_inv(55, cdata[event.param1].position, 4);
     game_data.quest_flags.pael_and_her_mom = 1001;
     tc = chara_find("core.pael");
     if (tc != 0)
@@ -851,67 +839,62 @@ void eh_guest_visit(const DeferredEvent&)
         txt(i18n::s.get("core.event.guest_lost_his_way"));
         return;
     }
+
     if (rnd(3) == 0)
     {
         flt(0, Quality::good);
-        for (int i = 0; i < 1; ++i)
+        if ((game_data.last_month_when_trainer_visited !=
+                 game_data.date.month ||
+             rnd(5) == 0) &&
+            rnd(3))
         {
-            if (game_data.last_month_when_trainer_visited !=
-                    game_data.date.month ||
-                rnd(5) == 0)
-            {
-                if (rnd(3))
-                {
-                    chara_create(-1, 333, -3, 0);
-                    cdata[rc].character_role = 2005;
-                    break;
-                }
-            }
-            if (rnd(10) == 0)
-            {
-                chara_create(-1, 334, -3, 0);
-                cdata[rc].character_role = 2006;
-                break;
-            }
-            if (rnd(10) == 0)
-            {
-                chara_create(-1, 1, -3, 0);
-                cdata[rc].character_role = 2003;
-                cdata[rc].shop_rank = clamp(cdata.player().fame / 100, 20, 100);
-                break;
-            }
-            if (rnd(4) == 0)
-            {
-                chara_create(-1, 9, -3, 0);
-                cdata[rc].character_role = 2000;
-                break;
-            }
-            if (rnd(4) == 0)
-            {
-                chara_create(-1, 174, -3, 0);
-                cdata[rc].character_role = 2001;
-                break;
-            }
+            chara_create(-1, 333, -3, 0);
+            cdata[rc].character_role = 2005;
+        }
+        else if (rnd(10) == 0)
+        {
+            chara_create(-1, 334, -3, 0);
+            cdata[rc].character_role = 2006;
+        }
+        else if (rnd(10) == 0)
+        {
+            chara_create(-1, 1, -3, 0);
+            cdata[rc].character_role = 2003;
+            cdata[rc].shop_rank = clamp(cdata.player().fame / 100, 20, 100);
+        }
+        else if (rnd(4) == 0)
+        {
+            chara_create(-1, 9, -3, 0);
+            cdata[rc].character_role = 2000;
+        }
+        else if (rnd(4) == 0)
+        {
+            chara_create(-1, 174, -3, 0);
+            cdata[rc].character_role = 2001;
+        }
+        else
+        {
             chara_create(-1, 16, -3, 0);
             cdata[rc].character_role = 2002;
-            break;
         }
+        cdata[rc].relationship = 0;
+        cdata[rc].original_relationship = 0;
+        cdata[rc].is_temporary() = true;
         tc = rc;
-        cdata[tc].relationship = 0;
-        cdata[tc].original_relationship = 0;
-        cdata[tc].is_temporary() = true;
     }
     else
     {
-        p = 0;
+        int p = 0;
         tc = 0;
-        for (int j = 0; j < 100; ++j)
+        for (int _i = 0; _i < 100; ++_i)
         {
-            i = rnd(39) + 16;
-            if (cdata[i].state() == Character::State::adventurer_in_other_map &&
-                cdata[i].is_contracting() == 0 &&
-                cdata[i].current_map != game_data.current_map &&
-                cdata[i].relationship >= 0)
+            const auto adventurer_index = rnd(39) + 16;
+            const auto& adventurer = cdata[adventurer_index];
+            if (adventurer.state() ==
+                    Character::State::adventurer_in_other_map &&
+                !adventurer.is_contracting() &&
+                adventurer.current_map != game_data.current_map &&
+                adventurer.relationship >= 0)
             {
                 if (rnd(25) < p)
                 {
@@ -919,16 +902,16 @@ void eh_guest_visit(const DeferredEvent&)
                 }
                 if (tc == 0)
                 {
-                    tc = i;
+                    tc = adventurer_index;
                     ++p;
-                    if (cdata[tc].impression < 25)
+                    if (adventurer.impression < 25)
                     {
                         if (rnd(12) == 0)
                         {
                             break;
                         }
                     }
-                    if (cdata[tc].impression < 0)
+                    if (adventurer.impression < 0)
                     {
                         if (rnd(4))
                         {
@@ -937,9 +920,9 @@ void eh_guest_visit(const DeferredEvent&)
                     }
                     continue;
                 }
-                if (cdata[tc].impression < cdata[i].impression)
+                if (cdata[tc].impression < adventurer.impression)
                 {
-                    tc = i;
+                    tc = adventurer_index;
                     ++p;
                 }
             }
@@ -955,45 +938,37 @@ void eh_guest_visit(const DeferredEvent&)
         cyinit = cdata.player().position.y;
         chara_place();
     }
+
     cdata[tc].visited_just_now() = true;
-    i = 0;
-    for (int cnt = 0; cnt < 17; ++cnt) // 17?
+    optional_ref<const Item> chair_for_guest;
+    for (int cnt = 0; cnt < 17; ++cnt)
     {
-        int c{};
-        if (cnt == 0)
-        {
-            c = tc;
-        }
-        else
-        {
-            c = cnt - 1;
-        }
-        if (cdata[c].state() != Character::State::alive)
+        const auto chara_index = cnt == 0 ? tc : cnt - 1;
+        auto&& chara = cdata[chara_index];
+        if (chara.state() != Character::State::alive)
         {
             continue;
         }
-        if (game_data.mount != 0)
+        if (game_data.mount != 0 && chara.index == game_data.mount)
         {
-            if (c == game_data.mount)
-            {
-                continue;
-            }
+            continue;
         }
-        p(0) = 0;
-        p(1) = 6;
+        optional_ref<const Item> chair;
+        auto distance_to_guest_chair = 6;
         for (const auto& item : inv.ground())
         {
             if (item.number() == 0)
                 continue;
             if (item.function != 44)
                 continue;
-            if (c == tc)
+            if (chara.index == tc)
             {
                 if (item.param1 == 2)
                 {
-                    cell_swap(c, -1, item.position.x, item.position.y);
-                    i = item.index;
-                    p = item.index;
+                    cell_swap(
+                        chara.index, -1, item.position.x, item.position.y);
+                    chair_for_guest = item;
+                    chair = item;
                     break;
                 }
                 else
@@ -1001,49 +976,50 @@ void eh_guest_visit(const DeferredEvent&)
                     continue;
                 }
             }
-            if (i == 0)
+            if (!chair_for_guest)
             {
                 break;
             }
-            else if (item.index == i)
+            else if (item.index == chair_for_guest->index)
             {
                 continue;
             }
-            p(2) = dist(
+            const auto d = dist(
                 item.position.x,
                 item.position.y,
-                inv[i].position.x,
-                inv[i].position.y);
-            if (p(2) < p(1))
+                chair_for_guest->position.x,
+                chair_for_guest->position.y);
+            if (d < distance_to_guest_chair)
             {
                 if (cell_data.at(item.position.x, item.position.y)
                             .chara_index_plus_one == 0 ||
-                    c == 0 || c == tc)
+                    chara.index == 0 || chara.index == tc)
                 {
-                    p(0) = item.index;
-                    p(1) = p(2);
+                    chair = item;
+                    distance_to_guest_chair = d;
                 }
             }
-            if (c == 0 && item.param1 == 1)
+            if (chara.index == 0 && item.param1 == 1)
             {
-                p = item.index;
+                chair = item;
                 break;
             }
         }
-        if (p != 0)
+        if (chair)
         {
-            cell_swap(c, -1, inv[p].position.x, inv[p].position.y);
+            cell_swap(chara.index, -1, chair->position.x, chair->position.y);
         }
-        cdata[c].direction = direction(
-            cdata[c].position.x,
-            cdata[c].position.y,
+        chara.direction = direction(
+            chara.position.x,
+            chara.position.y,
             cdata[tc].position.x,
             cdata[tc].position.y);
-        if (c == 0)
+        if (chara.index == 0)
         {
-            game_data.player_next_move_direction = cdata[c].direction;
+            game_data.player_next_move_direction = chara.direction;
         }
     }
+
     talk_to_npc();
 }
 

--- a/src/elona/equipment.cpp
+++ b/src/elona/equipment.cpp
@@ -422,16 +422,16 @@ void supply_new_equipment()
         {
             break;
         }
-        if (itemcreate(rc, 0, -1, -1, 0))
+        if (const auto item = itemcreate_chara_inv(rc, 0, 0))
         {
-            inv[ci].identify_state = IdentifyState::completely;
-            if (inv[ci].quality >= Quality::miracle)
+            item->identify_state = IdentifyState::completely;
+            if (item->quality >= Quality::miracle)
             {
-                if (the_item_db[itemid2int(inv[ci].id)]->category < 50000)
+                if (the_item_db[itemid2int(item->id)]->category < 50000)
                 {
                     if (cdata[rc].character_role == 13)
                     {
-                        addnews(1, rc, 0, itemname(ci));
+                        addnews(1, rc, 0, itemname(item->index));
                     }
                 }
             }
@@ -851,7 +851,7 @@ void supply_initial_equipments()
                     flt();
                     dbid = eqamulet1;
                 }
-                itemcreate(rc, dbid, -1, -1, 0);
+                itemcreate_chara_inv(rc, dbid, 0);
                 body = 100 + i;
                 equip_item(rc);
                 eqamulet1 = 0;
@@ -871,7 +871,7 @@ void supply_initial_equipments()
                     flt();
                     dbid = eqamulet2;
                 }
-                itemcreate(rc, dbid, -1, -1, 0);
+                itemcreate_chara_inv(rc, dbid, 0);
                 body = 100 + i;
                 equip_item(rc);
                 eqamulet2 = 0;
@@ -894,7 +894,7 @@ void supply_initial_equipments()
                     flt();
                     dbid = eqring1;
                 }
-                itemcreate(rc, dbid, -1, -1, 0);
+                itemcreate_chara_inv(rc, dbid, 0);
                 body = 100 + i;
                 equip_item(rc);
                 eqring1 = 0;
@@ -914,7 +914,7 @@ void supply_initial_equipments()
                     flt();
                     dbid = eqring2;
                 }
-                itemcreate(rc, dbid, -1, -1, 0);
+                itemcreate_chara_inv(rc, dbid, 0);
                 body = 100 + i;
                 equip_item(rc);
                 eqring2 = 0;
@@ -937,7 +937,7 @@ void supply_initial_equipments()
                     flt();
                     dbid = eqcloack;
                 }
-                itemcreate(rc, dbid, -1, -1, 0);
+                itemcreate_chara_inv(rc, dbid, 0);
                 body = 100 + i;
                 equip_item(rc);
                 eqcloack = 0;
@@ -961,7 +961,7 @@ void supply_initial_equipments()
                     flt();
                     dbid = eqgirdle;
                 }
-                itemcreate(rc, dbid, -1, -1, 0);
+                itemcreate_chara_inv(rc, dbid, 0);
                 body = 100 + i;
                 equip_item(rc);
                 eqgirdle = 0;
@@ -985,7 +985,7 @@ void supply_initial_equipments()
                     flt();
                     dbid = eqhelm;
                 }
-                itemcreate(rc, dbid, -1, -1, 0);
+                itemcreate_chara_inv(rc, dbid, 0);
                 body = 100 + i;
                 equip_item(rc);
                 eqhelm = 0;
@@ -1009,7 +1009,7 @@ void supply_initial_equipments()
                     flt();
                     dbid = eqarmor;
                 }
-                itemcreate(rc, dbid, -1, -1, 0);
+                itemcreate_chara_inv(rc, dbid, 0);
                 body = 100 + i;
                 equip_item(rc);
                 eqarmor = 0;
@@ -1033,7 +1033,7 @@ void supply_initial_equipments()
                     flt();
                     dbid = eqglove;
                 }
-                itemcreate(rc, dbid, -1, -1, 0);
+                itemcreate_chara_inv(rc, dbid, 0);
                 body = 100 + i;
                 equip_item(rc);
                 eqglove = 0;
@@ -1057,7 +1057,7 @@ void supply_initial_equipments()
                     flt();
                     dbid = eqboots;
                 }
-                itemcreate(rc, dbid, -1, -1, 0);
+                itemcreate_chara_inv(rc, dbid, 0);
                 body = 100 + i;
                 equip_item(rc);
                 eqboots = 0;
@@ -1073,7 +1073,7 @@ void supply_initial_equipments()
                 {
                     flt(calcobjlv(cdata[rc].level),
                         calcfixlv(static_cast<Quality>(2 + fixeq)));
-                    itemcreate(rc, eqmultiweapon, -1, -1, 0);
+                    itemcreate_chara_inv(rc, eqmultiweapon, 0);
                     if (inv[ci].weight > 1500)
                     {
                         if (cnt < 14)
@@ -1100,7 +1100,7 @@ void supply_initial_equipments()
                                 static_cast<Quality>(fixeq + eqweapon1(1))));
                         flttypeminor = eqweapon1;
                         dbid = -1;
-                        itemcreate(rc, dbid, -1, -1, 0);
+                        itemcreate_chara_inv(rc, dbid, 0);
                         if (eqtwohand)
                         {
                             if (inv[ci].weight < 4000)
@@ -1130,7 +1130,7 @@ void supply_initial_equipments()
                 {
                     flt();
                     dbid = eqweapon1;
-                    itemcreate(rc, dbid, -1, -1, 0);
+                    itemcreate_chara_inv(rc, dbid, 0);
                 }
                 body = 100 + i;
                 equip_item(rc);
@@ -1148,7 +1148,7 @@ void supply_initial_equipments()
                                 static_cast<Quality>(fixeq + eqweapon2(1))));
                         flttypeminor = eqweapon2;
                         dbid = -1;
-                        itemcreate(rc, dbid, -1, -1, 0);
+                        itemcreate_chara_inv(rc, dbid, 0);
                         if (eqtwowield)
                         {
                             if (inv[ci].weight > 1500)
@@ -1167,7 +1167,7 @@ void supply_initial_equipments()
                 {
                     flt();
                     dbid = eqweapon2;
-                    itemcreate(rc, dbid, -1, -1, 0);
+                    itemcreate_chara_inv(rc, dbid, 0);
                 }
                 eqweapon2 = 0;
                 body = 100 + i;
@@ -1188,7 +1188,7 @@ void supply_initial_equipments()
                     flt();
                     dbid = eqshield;
                 }
-                itemcreate(rc, dbid, -1, -1, 0);
+                itemcreate_chara_inv(rc, dbid, 0);
                 body = 100 + i;
                 equip_item(rc);
                 eqshield = 0;
@@ -1212,7 +1212,7 @@ void supply_initial_equipments()
                     flt();
                     dbid = eqrange;
                 }
-                itemcreate(rc, dbid, -1, -1, 0);
+                itemcreate_chara_inv(rc, dbid, 0);
                 body = 100 + i;
                 equip_item(rc);
                 eqrange = 0;
@@ -1236,7 +1236,7 @@ void supply_initial_equipments()
                     flt();
                     dbid = eqammo;
                 }
-                itemcreate(rc, dbid, -1, -1, 0);
+                itemcreate_chara_inv(rc, dbid, 0);
                 body = 100 + i;
                 equip_item(rc);
                 eqammo = 0;
@@ -1250,13 +1250,13 @@ void supply_initial_equipments()
         if (rnd(150) == 0)
         {
             flt();
-            itemcreate(rc, 707, -1, -1, 0);
+            itemcreate_chara_inv(rc, 707, 0);
         }
         else
         {
             flt(calcobjlv(cdata[rc].level), calcfixlv());
             flttypeminor = 60005;
-            itemcreate(rc, 0, -1, -1, 0);
+            itemcreate_chara_inv(rc, 0, 0);
         }
     }
     if (cdata[rc].id == CharaId::the_leopard_warrior ||
@@ -1266,13 +1266,13 @@ void supply_initial_equipments()
         {
             flt();
             nostack = 1;
-            if (itemcreate(rc, 772, -1, -1, 0))
+            if (const auto item = itemcreate_chara_inv(rc, 772, 0))
             {
-                inv[ci].modify_number(rnd(4));
+                item->modify_number(rnd(4));
                 if (rnd(2))
                 {
-                    inv[ci].param3 = -1;
-                    inv[ci].image = 336;
+                    item->param3 = -1;
+                    item->image = 336;
                 }
             }
         }

--- a/src/elona/fish.cpp
+++ b/src/elona/fish.cpp
@@ -14,19 +14,21 @@ namespace elona
 void fish_get(int legacy_fish_id)
 {
     flt();
-    itemcreate(0, the_fish_db[legacy_fish_id]->item_id, -1, -1, 0);
-    inv[ci].subname = legacy_fish_id;
-    inv[ci].value = the_fish_db[legacy_fish_id]->value;
-    inv[ci].weight = the_fish_db[legacy_fish_id]->weight;
-    txt(i18n::s.get("core.activity.fishing.get", inv[ci]));
-    item_stack(0, ci, 1);
+    if (const auto item =
+            itemcreate_player_inv(the_fish_db[legacy_fish_id]->item_id, 0))
+    {
+        item->subname = legacy_fish_id;
+        item->value = the_fish_db[legacy_fish_id]->value;
+        item->weight = the_fish_db[legacy_fish_id]->weight;
+        txt(i18n::s.get("core.activity.fishing.get", *item));
+        item_stack(0, *item, true);
+    }
 }
 
 
 
-int fish_select_at_random()
+int fish_select_at_random(int bait)
 {
-    const auto bait = inv[cdata.player().activity.item].param4;
     WeightedRandomSampler<int> sampler;
     for (const auto& fish : the_fish_db.values())
     {

--- a/src/elona/fish.hpp
+++ b/src/elona/fish.hpp
@@ -8,6 +8,6 @@ namespace elona
 {
 
 void fish_get(int legacy_fish_id);
-int fish_select_at_random();
+int fish_select_at_random(int bait);
 
 } // namespace elona

--- a/src/elona/food.cpp
+++ b/src/elona/food.cpp
@@ -88,7 +88,7 @@ void _food_gets_rotten(int chara_idx, Item& food)
             food.modify_number(-food.number());
             flt(calcobjlv(cdata.player().level));
             flttypeminor = 58500;
-            itemcreate(0, 0, -1, -1, seed_num);
+            itemcreate_player_inv(0, seed_num);
         }
     }
 }
@@ -274,11 +274,11 @@ void chara_vomit(Character& cc)
         if (rnd(p * p * p) == 0 || cc.index == 0)
         {
             flt();
-            if (itemcreate(-1, 704, cc.position.x, cc.position.y, 0))
+            if (const auto item = itemcreate_extra_inv(704, cc.position, 0))
             {
                 if (cc.index != 0)
                 {
-                    inv[ci].subname = charaid2int(cc.id);
+                    item->subname = charaid2int(cc.id);
                 }
             }
         }
@@ -444,7 +444,7 @@ void cook(Item& cook_tool, Item& food)
 
     make_dish(food, dish_rank);
     txt(i18n::s.get("core.food.cook", item_name_prev, cook_tool, food));
-    item_stack(0, food.index, 1);
+    item_stack(0, food, true);
     const auto rank = food.param2;
     if (rank > 2)
     {
@@ -468,9 +468,9 @@ void make_dish(Item& food, int dish_rank)
 
 
 
-void apply_general_eating_effect(int cieat)
+void apply_general_eating_effect(Character& eater, Item& food)
 {
-    tc = cc;
+    tc = eater.index;
     DIM3(fdlist, 2, 10);
     for (int cnt = 0, cnt_end = (fdmax); cnt < cnt_end; ++cnt)
     {
@@ -478,12 +478,12 @@ void apply_general_eating_effect(int cieat)
         fdlist(1, cnt) = 0;
     }
     nutrition = 2500;
-    if (the_item_db[itemid2int(inv[ci].id)]->is_cargo)
+    if (the_item_db[itemid2int(food.id)]->is_cargo)
     {
         nutrition += 2500;
     }
     fdmax = 0;
-    i = inv[ci].param1 / 1000;
+    i = food.param1 / 1000;
     if (i == 1)
     {
         if (fdmax < 10)
@@ -654,46 +654,45 @@ void apply_general_eating_effect(int cieat)
         }
         nutrition = 3500;
     }
-    if (the_item_db[itemid2int(inv[ci].id)]->category == 57000)
+    if (the_item_db[itemid2int(food.id)]->category == 57000)
     {
-        nutrition = nutrition * (100 + inv[ci].param2 * 15) / 100;
+        nutrition = nutrition * (100 + food.param2 * 15) / 100;
     }
     for (int cnt = 0, cnt_end = (fdmax); cnt < cnt_end; ++cnt)
     {
         if (fdlist(1, cnt) > 0)
         {
-            if (inv[ci].param2 < 3)
+            if (food.param2 < 3)
             {
                 fdlist(1, cnt) = fdlist(1, cnt) / 2;
             }
             else
             {
-                fdlist(1, cnt) =
-                    fdlist(1, cnt) * (50 + inv[ci].param2 * 20) / 100;
+                fdlist(1, cnt) = fdlist(1, cnt) * (50 + food.param2 * 20) / 100;
             }
         }
-        else if (inv[ci].param2 < 3)
+        else if (food.param2 < 3)
         {
             fdlist(1, cnt) =
-                fdlist(1, cnt) * ((3 - inv[ci].param2) * 100 + 100) / 100;
+                fdlist(1, cnt) * ((3 - food.param2) * 100 + 100) / 100;
         }
         else
         {
-            fdlist(1, cnt) = fdlist(1, cnt) * 100 / (inv[ci].param2 * 50);
+            fdlist(1, cnt) = fdlist(1, cnt) * 100 / (food.param2 * 50);
         }
     }
-    if (cc == 0)
+    if (eater.index == 0)
     {
-        p = inv[ci].param1 / 1000;
+        p = food.param1 / 1000;
         for (int cnt = 0; cnt < 1; ++cnt)
         {
-            if (cc == 0)
+            if (eater.index == 0)
             {
                 if (trait(41))
                 {
-                    if (inv[ci].id == ItemId::corpse)
+                    if (food.id == ItemId::corpse)
                     {
-                        s = chara_db_get_filter(int2charaid(inv[ci].subname));
+                        s = chara_db_get_filter(int2charaid(food.subname));
                         if (strutil::contains(s(0), u8"/man/"))
                         {
                             txt(i18n::s.get(
@@ -703,15 +702,15 @@ void apply_general_eating_effect(int cieat)
                     }
                 }
             }
-            if (inv[ci].material == 35)
+            if (food.material == 35)
             {
-                if (inv[ci].param3 < 0)
+                if (food.param3 < 0)
                 {
                     txt(i18n::s.get("core.food.effect.rotten"));
                     break;
                 }
             }
-            if (inv[ci].param2 == 0)
+            if (food.param2 == 0)
             {
                 if (p == 1)
                 {
@@ -731,22 +730,22 @@ void apply_general_eating_effect(int cieat)
                 txt(i18n::s.get("core.food.effect.boring"));
                 break;
             }
-            if (inv[ci].param2 < 3)
+            if (food.param2 < 3)
             {
                 txt(i18n::s.get("core.food.effect.quality.bad"));
                 break;
             }
-            if (inv[ci].param2 < 5)
+            if (food.param2 < 5)
             {
                 txt(i18n::s.get("core.food.effect.quality.so_so"));
                 break;
             }
-            if (inv[ci].param2 < 7)
+            if (food.param2 < 7)
             {
                 txt(i18n::s.get("core.food.effect.quality.good"));
                 break;
             }
-            if (inv[ci].param2 < 9)
+            if (food.param2 < 9)
             {
                 txt(i18n::s.get("core.food.effect.quality.great"));
                 break;
@@ -754,14 +753,14 @@ void apply_general_eating_effect(int cieat)
             txt(i18n::s.get("core.food.effect.quality.delicious"));
         }
     }
-    else if (inv[ci].material == 35)
+    else if (food.material == 35)
     {
-        if (inv[ci].param3 < 0)
+        if (food.param3 < 0)
         {
-            txt(i18n::s.get("core.food.effect.raw_glum", cdata[cc]));
+            txt(i18n::s.get("core.food.effect.raw_glum", eater));
         }
     }
-    if (inv[ci].id == ItemId::curaria)
+    if (food.id == ItemId::curaria)
     {
         fdmax = 0;
         if (fdmax < 10)
@@ -813,13 +812,13 @@ void apply_general_eating_effect(int cieat)
             ++fdmax;
         }
         nutrition = 2500;
-        if (cc == 0)
+        if (eater.index == 0)
         {
             txt(i18n::s.get("core.food.effect.herb.curaria"),
                 Message::color{ColorIndex::green});
         }
     }
-    if (inv[ci].id == ItemId::morgia)
+    if (food.id == ItemId::morgia)
     {
         fdmax = 0;
         if (fdmax < 10)
@@ -871,15 +870,15 @@ void apply_general_eating_effect(int cieat)
             ++fdmax;
         }
         nutrition = 500;
-        modify_potential(cdata[cc], 10, 2);
-        modify_potential(cdata[cc], 11, 2);
-        if (cc == 0)
+        modify_potential(eater, 10, 2);
+        modify_potential(eater, 11, 2);
+        if (eater.index == 0)
         {
             txt(i18n::s.get("core.food.effect.herb.morgia"),
                 Message::color{ColorIndex::green});
         }
     }
-    if (inv[ci].id == ItemId::mareilon)
+    if (food.id == ItemId::mareilon)
     {
         fdmax = 0;
         if (fdmax < 10)
@@ -931,15 +930,15 @@ void apply_general_eating_effect(int cieat)
             ++fdmax;
         }
         nutrition = 500;
-        modify_potential(cdata[cc], 16, 2);
-        modify_potential(cdata[cc], 15, 2);
-        if (cc == 0)
+        modify_potential(eater, 16, 2);
+        modify_potential(eater, 15, 2);
+        if (eater.index == 0)
         {
             txt(i18n::s.get("core.food.effect.herb.mareilon"),
                 Message::color{ColorIndex::green});
         }
     }
-    if (inv[ci].id == ItemId::spenseweed)
+    if (food.id == ItemId::spenseweed)
     {
         fdmax = 0;
         if (fdmax < 10)
@@ -990,16 +989,16 @@ void apply_general_eating_effect(int cieat)
             fdlist(1, fdmax) = 10;
             ++fdmax;
         }
-        modify_potential(cdata[cc], 12, 2);
-        modify_potential(cdata[cc], 13, 2);
+        modify_potential(eater, 12, 2);
+        modify_potential(eater, 13, 2);
         nutrition = 500;
-        if (cc == 0)
+        if (eater.index == 0)
         {
             txt(i18n::s.get("core.food.effect.herb.spenseweed"),
                 Message::color{ColorIndex::green});
         }
     }
-    if (inv[ci].id == ItemId::alraunia)
+    if (food.id == ItemId::alraunia)
     {
         fdmax = 0;
         if (fdmax < 10)
@@ -1051,15 +1050,15 @@ void apply_general_eating_effect(int cieat)
             ++fdmax;
         }
         nutrition = 500;
-        modify_potential(cdata[cc], 17, 2);
-        modify_potential(cdata[cc], 14, 2);
-        if (cc == 0)
+        modify_potential(eater, 17, 2);
+        modify_potential(eater, 14, 2);
+        if (eater.index == 0)
         {
             txt(i18n::s.get("core.food.effect.herb.alraunia"),
                 Message::color{ColorIndex::green});
         }
     }
-    if (inv[ci].id == ItemId::stomafillia)
+    if (food.id == ItemId::stomafillia)
     {
         fdmax = 0;
         if (fdmax < 10)
@@ -1112,24 +1111,24 @@ void apply_general_eating_effect(int cieat)
         }
         nutrition = 20000;
     }
-    if (inv[ci].id == ItemId::fortune_cookie)
+    if (food.id == ItemId::fortune_cookie)
     {
         nutrition = 750;
     }
-    if (cc == 0)
+    if (eater.index == 0)
     {
-        if (inv[ci].material == 35)
+        if (food.material == 35)
         {
-            if (inv[ci].param3 < 0)
+            if (food.param3 < 0)
             {
                 eat_rotten_food();
             }
         }
     }
-    if (inv[ci].id == ItemId::corpse)
+    if (food.id == ItemId::corpse)
     {
-        s = chara_db_get_filter(int2charaid(inv[ci].subname));
-        if (cc == 0)
+        s = chara_db_get_filter(int2charaid(food.subname));
+        if (eater.index == 0)
         {
             if (strutil::contains(s(0), u8"/man/"))
             {
@@ -1140,9 +1139,8 @@ void apply_general_eating_effect(int cieat)
                 else
                 {
                     txt(i18n::s.get("core.food.effect.human.dislike"));
-                    damage_insanity(cdata[cc], 15);
-                    status_ailment_damage(
-                        cdata[cc], StatusAilment::insane, 150);
+                    damage_insanity(eater, 15);
+                    status_ailment_damage(eater, StatusAilment::insane, 150);
                     if (trait(41) == 0)
                     {
                         if (rnd(5) == 0)
@@ -1163,26 +1161,25 @@ void apply_general_eating_effect(int cieat)
             }
         }
     }
-    if (inv[ci].id == ItemId::corpse ||
-        ((inv[ci].id == ItemId::jerky || inv[ci].id == ItemId::egg) &&
-         rnd(3) == 0))
+    if (food.id == ItemId::corpse ||
+        ((food.id == ItemId::jerky || food.id == ItemId::egg) && rnd(3) == 0))
     {
-        chara_db_invoke_eating_effect(int2charaid(inv[ci].subname));
+        chara_db_invoke_eating_effect(int2charaid(food.subname));
     }
     for (int cnt = 0, cnt_end = (fdmax); cnt < cnt_end; ++cnt)
     {
         i = 100;
-        if (cdata[cc].nutrition >= 5000)
+        if (eater.nutrition >= 5000)
         {
-            p = (cdata[cc].nutrition - 5000) / 25;
+            p = (eater.nutrition - 5000) / 25;
             i = i * 100 / (100 + p);
         }
-        if (cc != 0)
+        if (eater.index != 0)
         {
             i = 1500;
-            if (inv[ci].material == 35)
+            if (food.material == 35)
             {
-                if (inv[ci].param3 < 0)
+                if (food.param3 < 0)
                 {
                     i = 500;
                 }
@@ -1191,126 +1188,127 @@ void apply_general_eating_effect(int cieat)
         if (i > 0)
         {
             chara_gain_skill_exp(
-                cdata[cc], fdlist(0, cnt), fdlist(1, cnt) * i / 100);
+                eater, fdlist(0, cnt), fdlist(1, cnt) * i / 100);
         }
     }
-    if (inv[ci].curse_state == CurseState::blessed)
+    if (food.curse_state == CurseState::blessed)
     {
         nutrition = nutrition * 150 / 100;
     }
-    if (is_cursed(inv[ci].curse_state))
+    if (is_cursed(food.curse_state))
     {
         nutrition = nutrition * 50 / 100;
     }
-    cdata[cc].nutrition += nutrition;
+    eater.nutrition += nutrition;
     if (nutrition >= 3000)
     {
-        if (rnd(10) == 0 || cdata[cc].nutrition >= 12000)
+        if (rnd(10) == 0 || eater.nutrition >= 12000)
         {
             modify_weight(
-                cdata[cc],
+                eater,
                 rnd(3) + 1,
-                cdata[cc].nutrition >= 20000 &&
-                    rnd(30000 / std::max(1, cdata[cc].nutrition) + 2) == 0);
+                eater.nutrition >= 20000 &&
+                    rnd(30000 / std::max(1, eater.nutrition) + 2) == 0);
         }
     }
-    if (cdata[cc].id == CharaId::cute_fairy)
+    if (eater.id == CharaId::cute_fairy)
     {
         if (nutrition >= 2000)
         {
-            int cibk = ci;
-            flt(calcobjlv(cdata[cc].level));
+            const auto ci_save = ci;
+            flt(calcobjlv(eater.level));
             flttypeminor = 58500;
-            itemcreate(-1, 0, cdata[cc].position.x, cdata[cc].position.y, 0);
-            txt(i18n::s.get("core.food.effect.bomb_fish", cdata[cc], inv[ci]),
-                Message::color{ColorIndex::cyan});
-            ci = cibk;
+            if (const auto item = itemcreate_extra_inv(0, eater.position, 0))
+            {
+                txt(i18n::s.get("core.food.effect.bomb_fish", eater, *item),
+                    Message::color{ColorIndex::cyan});
+            }
+            ci = ci_save;
         }
     }
-    if (inv[ci].id == ItemId::corpse)
+    if (food.id == ItemId::corpse)
     {
-        if (inv[ci].subname == 319)
+        if (food.subname == 319)
         {
-            txt(i18n::s.get("core.food.effect.little_sister", cdata[cc]),
+            txt(i18n::s.get("core.food.effect.little_sister", eater),
                 Message::color{ColorIndex::green});
-            if (rnd(sdata.get(2, cc).original_level *
-                        sdata.get(2, cc).original_level +
+            if (rnd(sdata.get(2, eater.index).original_level *
+                        sdata.get(2, eater.index).original_level +
                     1) < 2000)
             {
-                chara_gain_fixed_skill_exp(cdata[cc], 2, 1000);
+                chara_gain_fixed_skill_exp(eater, 2, 1000);
             }
-            if (rnd(sdata.get(3, cc).original_level *
-                        sdata.get(3, cc).original_level +
+            if (rnd(sdata.get(3, eater.index).original_level *
+                        sdata.get(3, eater.index).original_level +
                     1) < 2000)
             {
-                chara_gain_fixed_skill_exp(cdata[cc], 3, 1000);
+                chara_gain_fixed_skill_exp(eater, 3, 1000);
             }
             for (int cnt = 100; cnt < 400; ++cnt)
             {
                 if (!the_ability_db[cnt] ||
                     the_ability_db[cnt]->related_basic_attribute == 0 ||
-                    sdata.get(cnt, cc).original_level == 0)
+                    sdata.get(cnt, eater.index).original_level == 0)
                 {
                     continue;
                 }
-                modify_potential(cdata[cc], cnt, rnd(10) + 1);
+                modify_potential(eater, cnt, rnd(10) + 1);
             }
         }
     }
-    if (inv[ci].id == ItemId::kagami_mochi)
+    if (food.id == ItemId::kagami_mochi)
     {
         txt(i18n::s.get("core.food.effect.hero_cheese"));
-        chara_gain_fixed_skill_exp(cdata[cc], 19, 2000);
+        chara_gain_fixed_skill_exp(eater, 19, 2000);
     }
-    if (inv[ci].id == ItemId::rabbits_tail)
+    if (food.id == ItemId::rabbits_tail)
     {
-        chara_gain_fixed_skill_exp(cdata[cc], 19, 1000);
+        chara_gain_fixed_skill_exp(eater, 19, 1000);
     }
-    if (inv[ci].id == ItemId::happy_apple)
+    if (food.id == ItemId::happy_apple)
     {
-        chara_gain_fixed_skill_exp(cdata[cc], 19, 20000);
+        chara_gain_fixed_skill_exp(eater, 19, 20000);
     }
-    if (inv[ci].id == ItemId::hero_cheese)
+    if (food.id == ItemId::hero_cheese)
     {
-        chara_gain_fixed_skill_exp(cdata[cc], 2, 3000);
+        chara_gain_fixed_skill_exp(eater, 2, 3000);
     }
-    if (inv[ci].id == ItemId::magic_fruit)
+    if (food.id == ItemId::magic_fruit)
     {
-        chara_gain_fixed_skill_exp(cdata[cc], 3, 3000);
+        chara_gain_fixed_skill_exp(eater, 3, 3000);
     }
-    if (inv[ci].id == ItemId::fortune_cookie)
+    if (food.id == ItemId::fortune_cookie)
     {
-        if (cc < 16)
+        if (eater.index < 16)
         {
-            txt(i18n::s.get("core.food.effect.fortune_cookie", cdata[cc]));
+            txt(i18n::s.get("core.food.effect.fortune_cookie", eater));
             read_talk_file(u8"%COOKIE2");
-            if (inv[ci].curse_state == CurseState::blessed ||
-                (inv[ci].curse_state == CurseState::none && rnd(2)))
+            if (food.curse_state == CurseState::blessed ||
+                (food.curse_state == CurseState::none && rnd(2)))
             {
                 read_talk_file(u8"%COOKIE1");
             }
             txt(""s + buff, Message::color{ColorIndex::orange});
         }
     }
-    if (inv[ci].id == ItemId::sisters_love_fueled_lunch)
+    if (food.id == ItemId::sisters_love_fueled_lunch)
     {
-        txt(i18n::s.get(
-            "core.food.effect.sisters_love_fueled_lunch", cdata[cc]));
-        heal_insanity(cdata[cc], 30);
+        txt(i18n::s.get("core.food.effect.sisters_love_fueled_lunch", eater));
+        heal_insanity(eater, 30);
     }
-    if (inv[ci].is_poisoned())
+    if (food.is_poisoned())
     {
-        if (is_in_fov(cdata[cc]))
+        if (is_in_fov(eater))
         {
-            txt(i18n::s.get("core.food.effect.poisoned.text", cdata[cc]));
+            txt(i18n::s.get("core.food.effect.poisoned.text", eater));
             txt(i18n::s.get("core.food.effect.poisoned.dialog"));
         }
-        damage_hp(cdata[cc], rnd(250) + 250, -4);
-        if (cdata[cc].state() != Character::State::alive)
+        damage_hp(eater, rnd(250) + 250, -4);
+        if (eater.state() != Character::State::alive)
         {
-            if (cc != 0)
+            if (eater.index != 0)
             {
-                if (cdata[cc].relationship >= 0)
+                if (eater.relationship >= 0)
                 {
                     modify_karma(cdata.player(), -1);
                 }
@@ -1318,56 +1316,56 @@ void apply_general_eating_effect(int cieat)
             return;
         }
     }
-    if (inv[ci].is_aphrodisiac())
+    if (food.is_aphrodisiac())
     {
-        if (cc == 0)
+        if (eater.index == 0)
         {
             txt(i18n::s.get("core.food.effect.spiked.self"));
         }
         else
         {
-            txt(i18n::s.get("core.food.effect.spiked.other", cdata[cc]),
+            txt(i18n::s.get("core.food.effect.spiked.other", eater),
                 Message::color{ColorIndex::cyan});
-            cdata[cc].emotion_icon = 317;
-            chara_modify_impression(cdata[cc], 30);
+            eater.emotion_icon = 317;
+            chara_modify_impression(eater, 30);
             modify_karma(cdata.player(), -10);
-            lovemiracle(cc);
+            lovemiracle(eater.index);
         }
-        status_ailment_damage(cdata[cc], StatusAilment::dimmed, 500);
-        cdata[cc].emotion_icon = 317;
+        status_ailment_damage(eater, StatusAilment::dimmed, 500);
+        eater.emotion_icon = 317;
     }
     for (int cnt = 0; cnt < 15; ++cnt)
     {
-        if (inv[ci].enchantments[cnt].id == 0)
+        if (food.enchantments[cnt].id == 0)
         {
             break;
         }
-        enc = inv[ci].enchantments[cnt].id;
+        enc = food.enchantments[cnt].id;
         if (enc == 36)
         {
-            p = rnd(inv[ci].enchantments[cnt].power / 50 + 1) + 1;
-            heal_sp(cdata[cc], p);
+            p = rnd(food.enchantments[cnt].power / 50 + 1) + 1;
+            heal_sp(eater, p);
             continue;
         }
         if (enc == 38)
         {
-            p = rnd(inv[ci].enchantments[cnt].power / 25 + 1) + 1;
-            heal_mp(cdata[cc], p / 5);
+            p = rnd(food.enchantments[cnt].power / 25 + 1) + 1;
+            heal_mp(eater, p / 5);
             continue;
         }
         if (enc == 37)
         {
-            event_add(18, cc);
+            event_add(18, eater.index);
             continue;
         }
         if (enc == 40)
         {
             if (game_data.left_turns_of_timestop == 0)
             {
-                txt(i18n::s.get("core.action.time_stop.begins", cdata[cc]),
+                txt(i18n::s.get("core.action.time_stop.begins", eater),
                     Message::color{ColorIndex::cyan});
                 game_data.left_turns_of_timestop =
-                    inv[ci].enchantments[cnt].power / 100 + 1 + 1;
+                    food.enchantments[cnt].power / 100 + 1 + 1;
                 continue;
             }
         }
@@ -1377,13 +1375,13 @@ void apply_general_eating_effect(int cieat)
             enc = enc % 10000;
             if (enc2 == 1)
             {
-                if (is_in_fov(cdata[cc]))
+                if (is_in_fov(eater))
                 {
-                    if (inv[ci].enchantments[cnt].power / 50 + 1 >= 0)
+                    if (food.enchantments[cnt].power / 50 + 1 >= 0)
                     {
                         txt(i18n::s.get(
                             "core.food.effect.ability.develops",
-                            cdata[cc],
+                            eater,
                             i18n::s.get_m(
                                 "ability",
                                 the_ability_db.get_id_from_legacy(enc)->get(),
@@ -1393,7 +1391,7 @@ void apply_general_eating_effect(int cieat)
                     {
                         txt(i18n::s.get(
                             "core.food.effect.ability.deteriorates",
-                            cdata[cc],
+                            eater,
                             i18n::s.get_m(
                                 "ability",
                                 the_ability_db.get_id_from_legacy(enc)->get(),
@@ -1401,18 +1399,18 @@ void apply_general_eating_effect(int cieat)
                     }
                 }
                 chara_gain_skill_exp(
-                    cdata[cc],
+                    eater,
                     enc,
-                    (inv[ci].enchantments[cnt].power / 50 + 1) * 100 *
-                        (1 + (cc != 0) * 5));
+                    (food.enchantments[cnt].power / 50 + 1) * 100 *
+                        (1 + (eater.index != 0) * 5));
                 continue;
             }
             if (enc2 == 6)
             {
-                if (is_in_fov(cdata[cc]))
+                if (is_in_fov(eater))
                 {
                     txt(i18n::s.get_enum_property(
-                        "core.buff", enc + 10, "apply", cdata[cc]));
+                        "core.buff", enc + 10, "apply", eater));
                 }
 
                 int legacy_id = 20 + (enc - 10);
@@ -1420,17 +1418,17 @@ void apply_general_eating_effect(int cieat)
                 assert(buff_id);
 
                 buff_add(
-                    cdata[cc],
+                    eater,
                     *buff_id,
-                    (inv[ci].enchantments[cnt].power / 50 + 1) * 5 *
-                        (1 + (cc != 0) * 2),
+                    (food.enchantments[cnt].power / 50 + 1) * 5 *
+                        (1 + (eater.index != 0) * 2),
                     2000);
 
                 continue;
             }
         }
     }
-    eatstatus(inv[cieat].curse_state, cc);
+    eatstatus(food.curse_state, eater.index);
 }
 
 

--- a/src/elona/food.hpp
+++ b/src/elona/food.hpp
@@ -31,7 +31,7 @@ void cook(Item& cook_tool, Item& food);
 
 void make_dish(Item& food, int dish_rank);
 
-void apply_general_eating_effect(int);
+void apply_general_eating_effect(Character& eater, Item& food);
 
 std::string foodname(int, const std::string&, int = 0, int = 0);
 

--- a/src/elona/god.cpp
+++ b/src/elona/god.cpp
@@ -396,7 +396,7 @@ void apply_god_blessing(int cc)
 
 
 
-void god_proc_switching_penalty()
+void god_proc_switching_penalty(const GodId& new_religion)
 {
     if (rtval == 0)
     {
@@ -421,7 +421,7 @@ void god_proc_switching_penalty()
             mode = 0;
             await(g_config.animation_wait() * 20);
         }
-        cdata.player().god_id = core_god::int2godid(inv[ci].param1);
+        cdata.player().god_id = new_religion;
         switch_religion();
         msg_halt();
     }
@@ -619,46 +619,37 @@ TurnResult do_pray()
                 {
                     dbid = 559;
                 }
-                itemcreate(
-                    -1,
-                    dbid,
-                    cdata.player().position.x,
-                    cdata.player().position.y,
-                    0);
+                itemcreate_extra_inv(dbid, cdata.player().position, 0);
             }
             else
             {
                 nostack = 1;
-                itemcreate(
-                    -1,
-                    672,
-                    cdata.player().position.x,
-                    cdata.player().position.y,
-                    0);
-                if (cdata.player().god_id == core_god::itzpalt)
+                if (const auto item =
+                        itemcreate_extra_inv(672, cdata.player().position, 0))
                 {
-                    inv[ci].param1 = 165;
-                }
-                if (cdata.player().god_id == core_god::ehekatl)
-                {
-                    inv[ci].param1 = 163;
-                }
-                if (cdata.player().god_id == core_god::opatos)
-                {
-                    inv[ci].param1 = 164;
+                    if (cdata.player().god_id == core_god::itzpalt)
+                    {
+                        item->param1 = 165;
+                    }
+                    if (cdata.player().god_id == core_god::ehekatl)
+                    {
+                        item->param1 = 163;
+                    }
+                    if (cdata.player().god_id == core_god::opatos)
+                    {
+                        item->param1 = 164;
+                    }
                 }
             }
             if (cdata.player().god_id == core_god::jure)
             {
                 flt();
                 nostack = 1;
-                itemcreate(
-                    -1,
-                    672,
-                    cdata.player().position.x,
-                    cdata.player().position.y,
-                    0);
-                inv[ci].param1 = 166;
+                if (const auto item =
+                        itemcreate_extra_inv(672, cdata.player().position, 0))
+                {
+                    item->param1 = 166;
+                }
             }
             txt(i18n::s.get("core.common.something_is_put_on_the_ground"));
         }
@@ -698,12 +689,7 @@ TurnResult do_pray()
             {
                 dbid = 621;
             }
-            itemcreate(
-                -1,
-                dbid,
-                cdata.player().position.x,
-                cdata.player().position.y,
-                0);
+            itemcreate_extra_inv(dbid, cdata.player().position, 0);
             txt(i18n::s.get("core.common.something_is_put_on_the_ground"));
         }
         ++game_data.god_rank;

--- a/src/elona/god.hpp
+++ b/src/elona/god.hpp
@@ -74,7 +74,7 @@ void god_modify_piety(int amount);
 void set_npc_religion();
 void apply_god_blessing(int cc);
 std::string get_god_description(int);
-void god_proc_switching_penalty();
+void god_proc_switching_penalty(const GodId& new_religion);
 void switch_religion();
 TurnResult do_pray();
 TurnResult do_offer();

--- a/src/elona/initialize_map.cpp
+++ b/src/elona/initialize_map.cpp
@@ -121,9 +121,9 @@ void _clear_map_and_objects()
     {
         cnt.set_state(Character::State::empty);
     }
-    for (int cnt = ELONA_OTHER_INVENTORIES_INDEX; cnt < ELONA_MAX_ITEMS; ++cnt)
+    for (auto&& item : inv.map_local())
     {
-        inv[cnt].remove();
+        item.remove();
     }
 
     map_data.clear();

--- a/src/elona/initialize_map_types.cpp
+++ b/src/elona/initialize_map_types.cpp
@@ -16,6 +16,8 @@
 #include "text.hpp"
 #include "variables.hpp"
 
+
+
 namespace elona
 {
 
@@ -38,6 +40,8 @@ static void _init_map_shelter()
     map_data.bgm = 68;
 }
 
+
+
 static void _init_map_nefia()
 {
     generate_random_nefia();
@@ -48,6 +52,8 @@ static void _init_map_nefia()
     }
 }
 
+
+
 static void _init_map_museum()
 {
     map_initcustom(u8"museum_1"s);
@@ -55,9 +61,13 @@ static void _init_map_museum()
     map_placeplayer();
     map_data.user_map_flag = 0;
     flt();
-    itemcreate(-1, 24, 15, 17, 0);
-    inv[ci].param1 = 4;
+    if (const auto item = itemcreate_extra_inv(24, 15, 17, 0))
+    {
+        item->param1 = 4;
+    }
 }
+
+
 
 static void _init_map_shop()
 {
@@ -67,14 +77,20 @@ static void _init_map_shop()
     map_placeplayer();
     map_data.user_map_flag = 0;
     flt();
-    itemcreate(-1, 24, 17, 14, 0);
-    inv[ci].param1 = 8;
+    if (const auto item = itemcreate_extra_inv(24, 17, 14, 0))
+    {
+        item->param1 = 8;
+    }
     flt();
-    itemcreate(-1, 561, 19, 10, 0);
-    inv[ci].count = 5;
+    if (const auto item = itemcreate_extra_inv(561, 19, 10, 0))
+    {
+        item->count = 5;
+    }
     flt();
-    itemcreate(-1, 562, 17, 11, 0);
+    itemcreate_extra_inv(562, 17, 11, 0);
 }
+
+
 
 static void _init_map_crop()
 {
@@ -84,9 +100,13 @@ static void _init_map_crop()
     map_data.max_item_count = 80;
     map_data.user_map_flag = 0;
     flt();
-    itemcreate(-1, 24, 14, 5, 0);
-    inv[ci].param1 = 9;
+    if (const auto item = itemcreate_extra_inv(24, 14, 5, 0))
+    {
+        item->param1 = 9;
+    }
 }
+
+
 
 static void _init_map_ranch()
 {
@@ -96,11 +116,15 @@ static void _init_map_ranch()
     map_data.max_item_count = 80;
     map_data.user_map_flag = 0;
     flt();
-    itemcreate(-1, 24, 23, 8, 0);
-    inv[ci].param1 = 11;
+    if (const auto item = itemcreate_extra_inv(24, 23, 8, 0))
+    {
+        item->param1 = 11;
+    }
     flt();
-    itemcreate(-1, 562, 22, 6, 0);
+    itemcreate_extra_inv(562, 22, 6, 0);
 }
+
+
 
 static void _init_map_your_dungeon()
 {
@@ -110,9 +134,13 @@ static void _init_map_your_dungeon()
     map_data.max_item_count = 350;
     map_data.user_map_flag = 0;
     flt();
-    itemcreate(-1, 24, 39, 54, 0);
-    inv[ci].param1 = 15;
+    if (const auto item = itemcreate_extra_inv(24, 39, 54, 0))
+    {
+        item->param1 = 15;
+    }
 }
+
+
 
 static void _init_map_storage_house()
 {
@@ -122,6 +150,8 @@ static void _init_map_storage_house()
     map_data.max_item_count = 200;
     map_data.user_map_flag = 0;
 }
+
+
 
 static void _init_map_test_site()
 {
@@ -156,6 +186,8 @@ static void _init_map_test_site()
     cdata[rc].is_livestock() = true;
 }
 
+
+
 static void _init_map_lumiest_graveyard()
 {
     map_initcustom(u8"grave_1"s);
@@ -170,6 +202,8 @@ static void _init_map_lumiest_graveyard()
     }
 }
 
+
+
 static void _init_map_jail()
 {
     map_initcustom(u8"jail1"s);
@@ -178,41 +212,59 @@ static void _init_map_jail()
     map_placeplayer();
 }
 
+
+
 static void _init_map_truce_ground()
 {
     map_initcustom(u8"shrine_1"s);
     map_data.max_crowd_density = 10;
     flt();
-    itemcreate(-1, 171, 10, 8, 0);
-    inv[ci].param1 = 1;
-    inv[ci].own_state = 1;
+    if (const auto item = itemcreate_extra_inv(171, 10, 8, 0))
+    {
+        item->param1 = 1;
+        item->own_state = 1;
+    }
     flt();
-    itemcreate(-1, 171, 13, 8, 0);
-    inv[ci].param1 = 2;
-    inv[ci].own_state = 1;
+    if (const auto item = itemcreate_extra_inv(171, 13, 8, 0))
+    {
+        item->param1 = 2;
+        item->own_state = 1;
+    }
     flt();
-    itemcreate(-1, 171, 10, 13, 0);
-    inv[ci].param1 = 5;
-    inv[ci].own_state = 1;
+    if (const auto item = itemcreate_extra_inv(171, 10, 13, 0))
+    {
+        item->param1 = 5;
+        item->own_state = 1;
+    }
     flt();
-    itemcreate(-1, 171, 13, 13, 0);
-    inv[ci].param1 = 4;
-    inv[ci].own_state = 1;
+    if (const auto item = itemcreate_extra_inv(171, 13, 13, 0))
+    {
+        item->param1 = 4;
+        item->own_state = 1;
+    }
     flt();
-    itemcreate(-1, 171, 20, 8, 0);
-    inv[ci].param1 = 3;
-    inv[ci].own_state = 1;
+    if (const auto item = itemcreate_extra_inv(171, 20, 8, 0))
+    {
+        item->param1 = 3;
+        item->own_state = 1;
+    }
     flt();
-    itemcreate(-1, 171, 23, 8, 0);
-    inv[ci].param1 = 7;
-    inv[ci].own_state = 1;
+    if (const auto item = itemcreate_extra_inv(171, 23, 8, 0))
+    {
+        item->param1 = 7;
+        item->own_state = 1;
+    }
     flt();
-    itemcreate(-1, 171, 20, 13, 0);
-    inv[ci].param1 = 6;
-    inv[ci].own_state = 1;
+    if (const auto item = itemcreate_extra_inv(171, 20, 13, 0))
+    {
+        item->param1 = 6;
+        item->own_state = 1;
+    }
     flt();
-    itemcreate(-1, 171, 23, 13, 0);
-    inv[ci].own_state = 1;
+    if (const auto item = itemcreate_extra_inv(171, 23, 13, 0))
+    {
+        item->own_state = 1;
+    }
     map_data.bgm = 79;
     map_placeplayer();
     for (int cnt = 0, cnt_end = (map_data.max_crowd_density / 2); cnt < cnt_end;
@@ -222,6 +274,8 @@ static void _init_map_truce_ground()
         chara_create(-1, 0, -3, 0);
     }
 }
+
+
 
 static void _init_map_embassy()
 {
@@ -261,6 +315,8 @@ static void _init_map_embassy()
     map_data.bgm = 79;
     map_placeplayer();
 }
+
+
 
 static void _init_map_test_world_north_border()
 {
@@ -319,6 +375,8 @@ static void _init_map_test_world_north_border()
     event_add(30);
 }
 
+
+
 static void _init_map_tyris_border()
 {
     map_initcustom(u8"station-nt1"s);
@@ -374,6 +432,8 @@ static void _init_map_tyris_border()
     map_data.bgm = 79;
     map_placeplayer();
 }
+
+
 
 static void _init_map_the_smoke_and_pipe()
 {
@@ -445,6 +505,8 @@ static void _init_map_the_smoke_and_pipe()
     map_placeplayer();
 }
 
+
+
 static void _init_map_miral_and_garoks_workshop()
 {
     map_initcustom(u8"smith0"s);
@@ -466,6 +528,8 @@ static void _init_map_miral_and_garoks_workshop()
     map_placeplayer();
 }
 
+
+
 static void _init_map_mansion_of_younger_sister()
 {
     map_initcustom(u8"sister"s);
@@ -474,8 +538,10 @@ static void _init_map_mansion_of_younger_sister()
     if (mapupdate == 0)
     {
         flt();
-        itemcreate(-1, 668, 12, 8, 0);
-        inv[ci].param2 = 4;
+        if (const auto item = itemcreate_extra_inv(668, 12, 8, 0))
+        {
+            item->param2 = 4;
+        }
     }
     flt();
     chara_create(-1, 249, 12, 6);
@@ -495,14 +561,18 @@ static void _init_map_mansion_of_younger_sister()
     map_placeplayer();
 }
 
+
+
 static void _init_map_cyber_dome()
 {
     map_initcustom(u8"cyberdome"s);
     map_data.max_crowd_density = 10;
     flt();
-    itemcreate(-1, 171, 19, 5, 0);
-    inv[ci].param1 = 1;
-    inv[ci].own_state = 1;
+    if (const auto item = itemcreate_extra_inv(171, 19, 5, 0))
+    {
+        item->param1 = 1;
+        item->own_state = 1;
+    }
     flt();
     chara_create(-1, 173, 9, 16);
     cdata[rc].character_role = 1011;
@@ -532,6 +602,8 @@ static void _init_map_cyber_dome()
     map_data.bgm = 79;
     map_placeplayer();
 }
+
+
 
 static void _init_map_larna()
 {
@@ -592,6 +664,8 @@ static void _init_map_larna()
     map_placeplayer();
 }
 
+
+
 static void _init_map_arena()
 {
     map_initcustom(u8"arena_1"s);
@@ -649,6 +723,8 @@ static void _init_map_arena()
         }
     }
 }
+
+
 
 static void _init_map_pet_arena()
 {
@@ -713,6 +789,8 @@ static void _init_map_pet_arena()
     }
 }
 
+
+
 static void _init_map_fort_of_chaos_beast()
 {
     map_initcustom(u8"god"s);
@@ -722,6 +800,8 @@ static void _init_map_fort_of_chaos_beast()
     chara_create(-1, 175, 12, 14);
     map_placeplayer();
 }
+
+
 
 static void _init_map_fort_of_chaos_machine()
 {
@@ -733,6 +813,8 @@ static void _init_map_fort_of_chaos_machine()
     map_placeplayer();
 }
 
+
+
 static void _init_map_fort_of_chaos_collapsed()
 {
     map_initcustom(u8"god"s);
@@ -742,6 +824,8 @@ static void _init_map_fort_of_chaos_collapsed()
     chara_create(-1, 178, 12, 14);
     map_placeplayer();
 }
+
+
 
 static void _init_map_your_home()
 {
@@ -763,17 +847,25 @@ static void _init_map_your_home()
             chara_create(-1, 34, 16, 11);
             cdata[rc].character_role = 3;
             flt();
-            itemcreate(-1, 510, 6, 10, 0);
-            inv[ci].count = 3;
+            if (const auto item = itemcreate_extra_inv(510, 6, 10, 0))
+            {
+                item->count = 3;
+            }
             flt();
-            itemcreate(-1, 547, 15, 19, 0);
-            inv[ci].count = 4;
+            if (const auto item = itemcreate_extra_inv(547, 15, 19, 0))
+            {
+                item->count = 4;
+            }
             flt();
-            itemcreate(-1, 579, 9, 8, 0);
-            inv[ci].count = 6;
+            if (const auto item = itemcreate_extra_inv(579, 9, 8, 0))
+            {
+                item->count = 6;
+            }
             flt();
-            itemcreate(-1, 24, 18, 19, 0);
-            inv[ci].param1 = 1;
+            if (const auto item = itemcreate_extra_inv(24, 18, 19, 0))
+            {
+                item->param1 = 1;
+            }
         }
         else
         {
@@ -836,11 +928,12 @@ static void _init_map_your_home()
     else
     {
         flt();
-        itemcreate(
-            -1, 219, cdata.player().position.x, cdata.player().position.y, 0);
+        itemcreate_extra_inv(219, cdata.player().position, 0);
     }
     initialize_home_mdata();
 }
+
+
 
 static void _init_map_north_tyris()
 {
@@ -849,6 +942,8 @@ static void _init_map_north_tyris()
     map_placeplayer();
 }
 
+
+
 static void _init_map_south_tyris()
 {
     map_initcustom(u8"styris"s);
@@ -856,12 +951,16 @@ static void _init_map_south_tyris()
     map_placeplayer();
 }
 
+
+
 static void _init_map_test_world()
 {
     map_initcustom(u8"test"s);
     initialize_world_map();
     map_placeplayer();
 }
+
+
 
 static void _init_map_derphy_town()
 {
@@ -950,6 +1049,8 @@ static void _init_map_derphy_town()
     }
 }
 
+
+
 static void _init_map_derphy_thieves_guild()
 {
     map_data.tileset = 0;
@@ -993,6 +1094,8 @@ static void _init_map_derphy_thieves_guild()
     }
 }
 
+
+
 static void _init_map_derphy()
 {
     if (game_data.current_dungeon_level == 1)
@@ -1004,6 +1107,8 @@ static void _init_map_derphy()
         _init_map_derphy_thieves_guild();
     }
 }
+
+
 
 static void _init_map_palmia()
 {
@@ -1162,6 +1267,8 @@ static void _init_map_palmia()
     }
 }
 
+
+
 static void _init_map_lumiest_town()
 {
     map_data.max_crowd_density = 40;
@@ -1279,6 +1386,8 @@ static void _init_map_lumiest_town()
     }
 }
 
+
+
 static void _init_map_lumiest_mages_guild()
 {
     map_data.tileset = 0;
@@ -1319,6 +1428,8 @@ static void _init_map_lumiest_mages_guild()
     }
 }
 
+
+
 static void _init_map_lumiest_sewer()
 {
     map_data.tileset = 0;
@@ -1333,6 +1444,8 @@ static void _init_map_lumiest_sewer()
     game_data.entrance_type = 1;
     map_placeplayer();
 }
+
+
 
 static void _init_map_lumiest()
 {
@@ -1349,6 +1462,8 @@ static void _init_map_lumiest()
         _init_map_lumiest_sewer();
     }
 }
+
+
 
 static void _init_map_yowyn_town()
 {
@@ -1446,6 +1561,8 @@ static void _init_map_yowyn_town()
     }
 }
 
+
+
 static void _init_map_yowyn_cat_mansion()
 {
     map_data.tileset = 0;
@@ -1459,6 +1576,8 @@ static void _init_map_yowyn_cat_mansion()
     quest_place_target();
     map_placeplayer();
 }
+
+
 
 static void _init_map_yowyn_battle_field()
 {
@@ -1501,6 +1620,8 @@ static void _init_map_yowyn_battle_field()
     noaggrorefresh = 1;
 }
 
+
+
 static void _init_map_yowyn()
 {
     if (game_data.current_dungeon_level == 1)
@@ -1516,6 +1637,8 @@ static void _init_map_yowyn()
         _init_map_yowyn_battle_field();
     }
 }
+
+
 
 static void _init_map_noyel()
 {
@@ -1634,6 +1757,8 @@ static void _init_map_noyel()
         chara_create(-1, dbid, rnd(55), rnd(map_data.height));
     }
 }
+
+
 
 static void _init_map_port_kapul_town()
 {
@@ -1763,6 +1888,8 @@ static void _init_map_port_kapul_town()
     }
 }
 
+
+
 static void _init_map_port_kapul_fighters_guild()
 {
     map_data.tileset = 0;
@@ -1799,6 +1926,8 @@ static void _init_map_port_kapul_fighters_guild()
     }
 }
 
+
+
 static void _init_map_port_kapul_doom_ground()
 {
     map_data.tileset = 0;
@@ -1824,6 +1953,8 @@ static void _init_map_port_kapul_doom_ground()
     noaggrorefresh = 1;
 }
 
+
+
 static void _init_map_port_kapul()
 {
     if (game_data.current_dungeon_level == 1)
@@ -1839,6 +1970,8 @@ static void _init_map_port_kapul()
         _init_map_port_kapul_doom_ground();
     }
 }
+
+
 
 static void _init_map_vernis_town()
 {
@@ -1956,6 +2089,8 @@ static void _init_map_vernis_town()
     }
 }
 
+
+
 static void _init_map_vernis_the_mine()
 {
     map_data.tileset = 0;
@@ -1970,6 +2105,8 @@ static void _init_map_vernis_the_mine()
     map_placeplayer();
 }
 
+
+
 static void _init_map_vernis_robbers_hideout()
 {
     map_data.tileset = 0;
@@ -1983,6 +2120,8 @@ static void _init_map_vernis_robbers_hideout()
     quest_place_target();
     map_placeplayer();
 }
+
+
 
 static void _init_map_vernis_test_site()
 {
@@ -2000,6 +2139,8 @@ static void _init_map_vernis_test_site()
     mapstarty = 27;
     map_placeplayer();
 }
+
+
 
 static void _init_map_vernis()
 {
@@ -2021,6 +2162,8 @@ static void _init_map_vernis()
     }
 }
 
+
+
 static void _init_map_fields_forest()
 {
     mdatan(0) = i18n::s.get_enum_property("core.map.unique", "forest", 2);
@@ -2032,16 +2175,22 @@ static void _init_map_fields_forest()
     {
         flt();
         flttypemajor = 80000;
-        itemcreate(-1, 0, -1, -1, 0);
-        inv[ci].own_state = 1;
-        cell_data.at(inv[ci].position.x, inv[ci].position.y).chip_id_actual = 0;
+        if (const auto item = itemcreate_extra_inv(0, -1, -1, 0))
+        {
+            item->own_state = 1;
+            cell_data.at(item->position.x, item->position.y).chip_id_actual = 0;
+        }
     }
 }
+
+
 
 static void _init_map_fields_sea()
 {
     mdatan(0) = i18n::s.get_enum_property("core.map.unique", "sea", 2);
 }
+
+
 
 static void _init_map_fields_grassland()
 {
@@ -2058,10 +2207,14 @@ static void _init_map_fields_grassland()
     {
         flt();
         flttypemajor = 80000;
-        itemcreate(-1, 0, -1, -1, 0);
-        inv[ci].own_state = 1;
+        if (const auto item = itemcreate_extra_inv(0, -1, -1, 0))
+        {
+            item->own_state = 1;
+        }
     }
 }
+
+
 
 static void _init_map_fields_desert()
 {
@@ -2074,10 +2227,14 @@ static void _init_map_fields_desert()
     for (int cnt = 0, cnt_end = (4 + rnd(4)); cnt < cnt_end; ++cnt)
     {
         flt();
-        itemcreate(-1, 527, -1, -1, 0);
-        inv[ci].own_state = 1;
+        if (const auto item = itemcreate_extra_inv(527, -1, -1, 0))
+        {
+            item->own_state = 1;
+        }
     }
 }
+
+
 
 static void _init_map_fields_snow_field()
 {
@@ -2094,10 +2251,14 @@ static void _init_map_fields_snow_field()
         flt();
         flttypemajor = 80000;
         fltselect = 8;
-        itemcreate(-1, 0, -1, -1, 0);
-        inv[ci].own_state = 1;
+        if (const auto item = itemcreate_extra_inv(0, -1, -1, 0))
+        {
+            item->own_state = 1;
+        }
     }
 }
+
+
 
 static void _init_map_fields_plain_field()
 {
@@ -2112,10 +2273,14 @@ static void _init_map_fields_plain_field()
     {
         flt();
         flttypemajor = 80000;
-        itemcreate(-1, 0, -1, -1, 0);
-        inv[ci].own_state = 1;
+        if (const auto item = itemcreate_extra_inv(0, -1, -1, 0))
+        {
+            item->own_state = 1;
+        }
     }
 }
+
+
 
 static void _init_map_fields_maybe_generate_encounter()
 {
@@ -2230,6 +2395,8 @@ static void _init_map_fields_maybe_generate_encounter()
     encounter = 0;
 }
 
+
+
 static void _init_map_fields()
 {
     map_data.width = 34;
@@ -2268,12 +2435,14 @@ static void _init_map_fields()
         {
             flt();
             flttypeminor = 64000;
-            itemcreate(-1, 0, -1, -1, 0);
+            itemcreate_extra_inv(0, -1, -1, 0);
         }
     }
 
     _init_map_fields_maybe_generate_encounter();
 }
+
+
 
 static void _init_map_the_void()
 {
@@ -2292,6 +2461,8 @@ static void _init_map_the_void()
         area_data[game_data.current_map].has_been_conquered = 0;
     }
 }
+
+
 
 static void _init_map_lesimas()
 {
@@ -2347,6 +2518,8 @@ static void _init_map_lesimas()
     }
 }
 
+
+
 static void _init_map_tower_of_fire()
 {
     if (game_data.current_dungeon_level ==
@@ -2362,6 +2535,8 @@ static void _init_map_tower_of_fire()
         generate_random_nefia();
     }
 }
+
+
 
 static void _init_map_crypt_of_the_damned()
 {
@@ -2379,6 +2554,8 @@ static void _init_map_crypt_of_the_damned()
     }
 }
 
+
+
 static void _init_map_ancient_castle()
 {
     if (game_data.current_dungeon_level ==
@@ -2394,6 +2571,8 @@ static void _init_map_ancient_castle()
         generate_random_nefia();
     }
 }
+
+
 
 static void _init_map_dragons_nest()
 {
@@ -2427,6 +2606,8 @@ static void _init_map_minotaurs_nest()
     }
 }
 
+
+
 static void _init_map_yeeks_nest()
 {
     generate_random_nefia();
@@ -2457,6 +2638,8 @@ static void _init_map_yeeks_nest()
     }
 }
 
+
+
 static void _init_map_pyramid_first_floor()
 {
     map_initcustom(u8"sqPyramid"s);
@@ -2471,6 +2654,8 @@ static void _init_map_pyramid_first_floor()
     }
 }
 
+
+
 static void _init_map_pyramid_second_floor()
 {
     map_initcustom(u8"sqPyramid2"s);
@@ -2478,6 +2663,8 @@ static void _init_map_pyramid_second_floor()
     map_data.bgm = 61;
     map_placeplayer();
 }
+
+
 
 static void _init_map_pyramid()
 {
@@ -2490,6 +2677,8 @@ static void _init_map_pyramid()
         _init_map_pyramid_second_floor();
     }
 }
+
+
 
 void initialize_map_from_map_type()
 {

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -293,6 +293,13 @@ struct Inventory
     }
 
 
+    InventorySlice map_local()
+    {
+        return {std::begin(storage) + ELONA_OTHER_INVENTORIES_INDEX,
+                std::end(storage)};
+    }
+
+
     InventorySlice for_chara(const Character& chara);
 
     InventorySlice by_index(int index);
@@ -308,13 +315,13 @@ extern Inventory inv;
 
 
 
-IdentifyState item_identify(Item& ci, IdentifyState level);
-IdentifyState item_identify(Item& ci, int power);
+IdentifyState item_identify(Item& item, IdentifyState level);
+IdentifyState item_identify(Item& item, int power);
 
-std::vector<int> itemlist(int owner, int id);
+std::vector<std::reference_wrapper<Item>> itemlist(int owner, int id);
 void itemname_additional_info();
 
-void item_checkknown(int = 0);
+void item_checkknown(Item& item);
 int inv_compress(int);
 void item_copy(int = 0, int = 0);
 void item_acid(const Character& owner, int item_index = -1);
@@ -323,8 +330,9 @@ void item_exchange(int = 0, int = 0);
 void item_modify_num(Item&, int);
 void item_set_num(Item&, int);
 void itemturn(Item& item);
-int itemfind(int = 0, int = 0, int = 0);
-int itemusingfind(int, bool = false);
+optional_ref<Item>
+itemfind(int inventory_id, int matcher, int matcher_type = 0);
+int itemusingfind(const Item& item, bool disallow_pc = false);
 
 enum class ItemFindLocation
 {
@@ -332,18 +340,18 @@ enum class ItemFindLocation
     ground,
     player_inventory_and_ground,
 };
-int item_find(
-    int = 0,
-    int = 0,
+optional_ref<Item> item_find(
+    int matcher,
+    int matcher_type = 0,
     ItemFindLocation = ItemFindLocation::player_inventory_and_ground);
 
 int item_separate(int);
-int item_stack(int = 0, int = 0, int = 0);
+bool item_stack(int inventory_id, Item& base_item, bool show_message = false);
 void item_dump_desc(const Item&);
 
-bool item_fire(int owner, int item_index = -1);
+bool item_fire(int owner, optional_ref<Item> burned_item = none);
 void mapitem_fire(int x, int y);
-bool item_cold(int owner, int item_index = -1);
+bool item_cold(int owner, optional_ref<Item> destroyed_item = none);
 void mapitem_cold(int x, int y);
 
 // TODO unsure how these are separate from item
@@ -355,6 +363,8 @@ int inv_sum(int = 0);
 int inv_weight(int = 0);
 bool inv_getspace(int);
 int inv_getfreeid_force();
+
+void remain_make(Item& remain, const Character& chara);
 
 
 void item_drop(Item& item_in_inventory, int num, bool building_shelter = false);
@@ -386,7 +396,7 @@ int iequiploc(const Item& item);
 void item_db_set_basic_stats(Item& item, int legacy_id);
 bool item_db_is_offerable(Item& item, int legacy_id);
 void item_db_get_description(Item& item, int legacy_id);
-void item_db_get_charge_level(Item& item, int legacy_id);
+void item_db_get_charge_level(const Item& item, int legacy_id);
 void item_db_set_full_stats(Item& item, int legacy_id);
 void item_db_on_read(Item& item, int legacy_id);
 void item_db_on_zap(Item& item, int legacy_id);

--- a/src/elona/item_db.cpp
+++ b/src/elona/item_db.cpp
@@ -129,7 +129,7 @@ void item_db_get_description(Item& item, int legacy_id)
 
 
 
-void item_db_get_charge_level(Item& item, int legacy_id)
+void item_db_get_charge_level(const Item& item, int legacy_id)
 {
     (void)item;
 

--- a/src/elona/itemgen.hpp
+++ b/src/elona/itemgen.hpp
@@ -8,12 +8,27 @@ namespace elona
 {
 
 struct Item;
+struct Position;
 
 
 
-optional<int> itemcreate(int = 0, int = 0, int = 0, int = 0, int = 0);
+optional_ref<Item> itemcreate(int slot, int id, int x, int y, int number = 0);
+
+optional_ref<Item>
+itemcreate(int slot, int id, const Position& pos, int number = 0);
+
+optional_ref<Item> itemcreate_player_inv(int id, int number = 0);
+
+optional_ref<Item>
+itemcreate_chara_inv(int chara_index, int id, int number = 0);
+
+optional_ref<Item> itemcreate_extra_inv(int id, int x, int y, int number = 0);
+
+optional_ref<Item>
+itemcreate_extra_inv(int id, const Position& pos, int number = 0);
+
+
 void get_random_item_id();
-optional<int> do_create_item(int, int, int);
 void init_item_quality_curse_state_material_and_equipments(Item&);
 void calc_furniture_value(Item&);
 void initialize_item_material(Item&);

--- a/src/elona/lua_env/handle_manager.cpp
+++ b/src/elona/lua_env/handle_manager.cpp
@@ -175,9 +175,9 @@ void HandleManager::clear_map_local_handles()
     {
         remove_chara_handle(cdata[i]);
     }
-    for (int i = ELONA_OTHER_INVENTORIES_INDEX; i < ELONA_MAX_ITEMS; i++)
+    for (auto&& item : inv.map_local())
     {
-        remove_item_handle(inv[i]);
+        remove_item_handle(item);
     }
 }
 

--- a/src/elona/lua_env/lua_api/lua_api_internal.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_internal.cpp
@@ -180,9 +180,9 @@ void LuaApiInternal::strange_scientist_pick_reward()
     begintempinv();
     mode = 6;
     flt();
-    itemcreate(-1, 283, -1, -1, 0);
+    itemcreate_extra_inv(283, -1, -1, 0);
     flt();
-    itemcreate(-1, 284, -1, -1, 0);
+    itemcreate_extra_inv(284, -1, -1, 0);
     for (int cnt = 0; cnt < 800; ++cnt)
     {
         if (cnt == 672)
@@ -219,11 +219,11 @@ void LuaApiInternal::strange_scientist_pick_reward()
         if (f)
         {
             flt(cdata.player().level * 3 / 2, calcfixlv(Quality::good));
-            if (itemcreate(-1, cnt, -1, -1, 0))
+            if (const auto item = itemcreate_extra_inv(cnt, -1, -1, 0))
             {
-                if (inv[ci].quality < Quality::miracle)
+                if (item->quality < Quality::miracle)
                 {
-                    inv[ci].remove();
+                    item->remove();
                 }
             }
         }

--- a/src/elona/lua_env/lua_api/lua_api_item.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_item.cpp
@@ -192,10 +192,9 @@ LuaApiItem::create_xy(int x, int y, sol::table args)
         id = data.legacy_id;
     }
 
-    if (itemcreate(slot, id, x, y, number) != 0)
+    if (const auto item = itemcreate(slot, id, x, y, number))
     {
-        LuaItemHandle handle =
-            lua::lua->get_handle_manager().get_handle(inv[ci]);
+        LuaItemHandle handle = lua::lua->get_handle_manager().get_handle(*item);
         return handle;
     }
     else
@@ -249,7 +248,7 @@ sol::optional<LuaItemHandle> LuaApiItem::stack(
     auto& item_ref = lua::ref<Item>(handle);
 
     int tibk = ti;
-    item_stack(inventory_id, item_ref.index);
+    item_stack(inventory_id, item_ref);
     auto& item = inv[ti];
     ti = tibk;
 
@@ -297,13 +296,14 @@ sol::optional<LuaItemHandle> LuaApiItem::find(
     auto location_value =
         LuaEnums::ItemFindLocationTable.ensure_from_string(location);
 
-    auto stat = item_find(data.legacy_id, 3, location_value);
-    if (stat == -1)
+    if (const auto item = item_find(data.legacy_id, 3, location_value))
+    {
+        return lua::handle(*item);
+    }
+    else
     {
         return sol::nullopt;
     }
-
-    return lua::handle(inv[stat]);
 }
 
 

--- a/src/elona/lua_env/lua_env.cpp
+++ b/src/elona/lua_env/lua_env.cpp
@@ -70,11 +70,11 @@ LuaEnv::~LuaEnv() = default;
 
 void LuaEnv::clear()
 {
-    for (int i = 0; i < ELONA_MAX_ITEMS; i++)
+    for (auto&& item : inv.all())
     {
-        if (inv[i].number() != 0)
+        if (item.number() != 0)
         {
-            handle_mgr->remove_item_handle(inv[i]);
+            handle_mgr->remove_item_handle(item);
         }
     }
 

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -1154,7 +1154,7 @@ bool _magic_412()
             {
                 ++p(1);
                 item.curse_state = CurseState::none;
-                item_stack(tc, ci, 1);
+                item_stack(tc, item, true);
             }
             else
             {
@@ -2097,7 +2097,7 @@ bool _magic_645_1114()
         chara_refresh(tc);
         snd("core.curse3");
         animeload(14, tc);
-        item_stack(tc, i, 1);
+        item_stack(tc, inv[i], true);
     }
     else
     {
@@ -2461,7 +2461,7 @@ bool _magic_21_1127()
                 inv[ci]));
             inv[ci].modify_number(-1);
             flt();
-            itemcreate(0, itemid2int(inv[ci].id), -1, -1, 0);
+            itemcreate_player_inv(itemid2int(inv[ci].id), 0);
         }
         else
         {
@@ -2872,7 +2872,7 @@ bool _magic_1132(int& fltbk, int& valuebk)
         save_set_autosave();
         animeload(8, cc);
         fltbk = the_item_db[itemid2int(inv[ci].id)]->category;
-        valuebk = calcitemvalue(ci, 0);
+        valuebk = calcitemvalue(inv[ci], 0);
         inv[ci].remove();
         for (int cnt = 0;; ++cnt)
         {
@@ -2881,11 +2881,11 @@ bool _magic_1132(int& fltbk, int& valuebk)
             {
                 flttypemajor = fltbk;
             }
-            if (itemcreate(0, 0, -1, -1, 0))
+            if (const auto item = itemcreate_player_inv(0, 0))
             {
-                if (inv[ci].value > valuebk * 3 / 2 + 1000)
+                if (item->value > valuebk * 3 / 2 + 1000)
                 {
-                    inv[ci].remove();
+                    item->remove();
                     continue;
                 }
                 else
@@ -3396,8 +3396,7 @@ bool _magic_464()
             number = 1;
         }
         nostack = 1;
-        itemcreate(
-            -1, dbid, cdata[cc].position.x, cdata[cc].position.y, number);
+        itemcreate_extra_inv(dbid, cdata[cc].position, number);
         const auto message = i18n::s.get("core.magic.wizards_harvest", inv[ci]);
         if (fastest)
         {

--- a/src/elona/map.cpp
+++ b/src/elona/map.cpp
@@ -63,16 +63,20 @@ void _map_randsite()
             if (rnd(25) == 0)
             {
                 flt();
-                itemcreate(-1, 173, pos->x, pos->y, 0);
-                inv[ci].own_state = 1;
+                if (const auto item = itemcreate_extra_inv(173, *pos, 0))
+                {
+                    item->own_state = 1;
+                }
                 return;
             }
             if (rnd(100) == 0)
             {
                 flt();
-                itemcreate(-1, 172, pos->x, pos->y, 0);
-                inv[ci].own_state = 1;
-                inv[ci].param1 = choice(isetgod);
+                if (const auto item = itemcreate_extra_inv(172, *pos, 0))
+                {
+                    item->own_state = 1;
+                    item->param1 = choice(isetgod);
+                }
                 return;
             }
         }
@@ -109,25 +113,25 @@ void _map_randsite()
         if (rnd(3) == 0)
         {
             flt();
-            itemcreate(-1, 631, pos->x, pos->y, 0);
+            itemcreate_extra_inv(631, *pos, 0);
             return;
         }
         if (rnd(15) == 0)
         {
             flt();
-            itemcreate(-1, 55, pos->x, pos->y, 0);
+            itemcreate_extra_inv(55, *pos, 0);
             return;
         }
         if (rnd(20) == 0)
         {
             flt();
-            itemcreate(-1, 284, pos->x, pos->y, 0);
+            itemcreate_extra_inv(284, *pos, 0);
             return;
         }
         if (rnd(15) == 0)
         {
             flt();
-            itemcreate(-1, 283, pos->x, pos->y, 0);
+            itemcreate_extra_inv(283, *pos, 0);
             return;
         }
         if (rnd(18) == 0)
@@ -135,12 +139,12 @@ void _map_randsite()
             flt(calcobjlv(rnd(cdata.player().level + 10)),
                 calcfixlv(Quality::good));
             flttypemajor = choice(fsetwear);
-            itemcreate(-1, 0, pos->x, pos->y, 0);
+            itemcreate_extra_inv(0, *pos, 0);
             return;
         }
         flt(10);
         flttypeminor = 64100;
-        itemcreate(-1, 0, pos->x, pos->y, 0);
+        itemcreate_extra_inv(0, *pos, 0);
         return;
     }
 }
@@ -373,9 +377,10 @@ void map_reload(const std::string& map_filename)
             if (cell_data.at(x, y).item_appearances_actual == 0)
             {
                 flt();
-                if (itemcreate(-1, cmapdata(0, i), x, y, 0))
+                if (const auto item =
+                        itemcreate_extra_inv(cmapdata(0, i), x, y, 0))
                 {
-                    inv[ci].own_state = cmapdata(3, i);
+                    item->own_state = cmapdata(3, i);
                 }
             }
             cell_refresh(x, y);
@@ -815,20 +820,20 @@ static void _grow_plants()
 
 static void _proc_generate_bard_items(Character& chara)
 {
-    if (itemfind(chara.index, 60005, 1) == -1)
+    if (!itemfind(chara.index, 60005, 1))
     {
         if (rnd(150) == 0)
         {
             // Stradivarius
             flt();
-            itemcreate(chara.index, 707, -1, -1, 0);
+            itemcreate_chara_inv(chara.index, 707, 0);
         }
         else
         {
             // Random instrument
             flt(calcobjlv(chara.level), calcfixlv());
             flttypeminor = 60005;
-            itemcreate(chara.index, 0, -1, -1, 0);
+            itemcreate_chara_inv(chara.index, 0, 0);
         }
     }
 }
@@ -837,11 +842,11 @@ static void _proc_generate_bard_items(Character& chara)
 static void _generate_bad_quality_item()
 {
     flt(calcobjlv(cdata[rc].level), calcfixlv(Quality::bad));
-    if (itemcreate(rc, 0, -1, -1, 0))
+    if (const auto item = itemcreate_chara_inv(rc, 0, 0))
     {
-        if (inv[ci].weight <= 0 || inv[ci].weight >= 4000)
+        if (item->weight <= 0 || item->weight >= 4000)
         {
-            inv[ci].remove();
+            item->remove();
         }
     }
 }
@@ -958,25 +963,25 @@ void map_reload_noyel()
     if (area_data[game_data.current_map].christmas_festival)
     {
         flt();
-        if (itemcreate(-1, 763, 29, 16, 0))
+        if (const auto item = itemcreate_extra_inv(763, 29, 16, 0))
         {
-            inv[ci].own_state = 1;
+            item->own_state = 1;
         }
         flt();
-        if (itemcreate(-1, 686, 29, 16, 0))
+        if (const auto item = itemcreate_extra_inv(686, 29, 16, 0))
         {
-            inv[ci].own_state = 1;
+            item->own_state = 1;
         }
         flt();
-        if (itemcreate(-1, 171, 29, 17, 0))
+        if (const auto item = itemcreate_extra_inv(171, 29, 17, 0))
         {
-            inv[ci].param1 = 6;
-            inv[ci].own_state = 1;
+            item->param1 = 6;
+            item->own_state = 1;
         }
         flt();
-        if (itemcreate(-1, 756, 29, 17, 0))
+        if (const auto item = itemcreate_extra_inv(756, 29, 17, 0))
         {
-            inv[ci].own_state = 5;
+            item->own_state = 5;
         }
         {
             flt();

--- a/src/elona/mapgen.cpp
+++ b/src/elona/mapgen.cpp
@@ -1201,12 +1201,13 @@ int map_createroom(int type)
                                         p(1) = 300;
                                         p(2) = 312;
                                         p(3) = 604;
-                                        itemcreate(-1, p(rnd(4)), x, y + 1, 0);
+                                        itemcreate_extra_inv(
+                                            p(rnd(4)), x, y + 1, 0);
                                     }
                                     else if (cnt % 2 == 1)
                                     {
                                         flt();
-                                        itemcreate(-1, 584, x, y + 1, 0);
+                                        itemcreate_extra_inv(584, x, y + 1, 0);
                                     }
                                 }
                                 tile = 1;
@@ -1230,12 +1231,13 @@ int map_createroom(int type)
                                     p(1) = 300;
                                     p(2) = 312;
                                     p(3) = 604;
-                                    itemcreate(-1, p(rnd(4)), x, y + 1, 0);
+                                    itemcreate_extra_inv(
+                                        p(rnd(4)), x, y + 1, 0);
                                 }
                                 else if (cnt % 2 == 1)
                                 {
                                     flt();
-                                    itemcreate(-1, 584, x, y + 1, 0);
+                                    itemcreate_extra_inv(584, x, y + 1, 0);
                                 }
                                 tile = 1;
                             }
@@ -1951,7 +1953,7 @@ void generate_random_nefia()
                 flt(calcobjlv(game_data.current_dungeon_level),
                     calcfixlv(Quality::bad));
                 flttypemajor = fltsetdungeon();
-                itemcreate(-1, 0, rnd(rw) + rx, rnd(rh) + ry, 0);
+                itemcreate_extra_inv(0, rnd(rw) + rx, rnd(rh) + ry, 0);
             }
             map_set_chara_generation_filter();
             int stat = chara_create(-1, 0, rnd(rw) + rx, rnd(rh) + ry);
@@ -2012,7 +2014,8 @@ void generate_random_nefia()
                         {
                             flt();
                             flttypemajor = 72000;
-                            itemcreate(-1, 0, rnd(rw) + rx, rnd(rh) + ry, 0);
+                            itemcreate_extra_inv(
+                                0, rnd(rw) + rx, rnd(rh) + ry, 0);
                         }
                     }
                 }
@@ -2026,7 +2029,7 @@ void generate_random_nefia()
         flt();
         flttypemajor = choice(fsetwear);
         fixlv = Quality::miracle;
-        itemcreate(-1, 0, -1, -1, 0);
+        itemcreate_extra_inv(0, -1, -1, 0);
         mobdensity = map_data.max_crowd_density / 2;
         itemdensity = map_data.max_crowd_density / 3;
     }
@@ -2055,7 +2058,7 @@ void generate_random_nefia()
         flt(calcobjlv(game_data.current_dungeon_level),
             calcfixlv(Quality::bad));
         flttypemajor = fltsetdungeon();
-        itemcreate(-1, 0, -1, -1, 0);
+        itemcreate_extra_inv(0, -1, -1, 0);
     }
     for (int cnt = 0, cnt_end = (rnd(map_data.width * map_data.height / 80));
          cnt < cnt_end;
@@ -2149,8 +2152,10 @@ void initialize_random_nefia_rdtype6()
     {
         flt();
         flttypemajor = 80000;
-        itemcreate(-1, 0, -1, -1, 0);
-        inv[ci].own_state = 1;
+        if (const auto item = itemcreate_extra_inv(0, -1, -1, 0))
+        {
+            item->own_state = 1;
+        }
     }
 }
 
@@ -2229,11 +2234,13 @@ int initialize_quest_map_crop()
                     dbid = choice(isetcrop);
                 }
                 flt();
-                itemcreate(-1, dbid, x, y, 0);
-                inv[ci].own_state = 4;
-                p = clamp(size + rnd((rnd(4) + 1)), 0, 9);
-                inv[ci].weight = inv[ci].weight * (80 + p * p * 100) / 100;
-                inv[ci].subname = p;
+                if (const auto item = itemcreate_extra_inv(dbid, x, y, 0))
+                {
+                    item->own_state = 4;
+                    p = clamp(size + rnd(rnd(4) + 1), 0, 9);
+                    item->weight = item->weight * (80 + p * p * 100) / 100;
+                    item->subname = p;
+                }
             }
         }
     }
@@ -2242,29 +2249,31 @@ int initialize_quest_map_crop()
     mapstarty = rnd(map_data.height / 3) + map_data.height / 3;
     map_placeplayer();
     flt();
-    itemcreate(
-        -1, 560, cdata.player().position.x + 1, cdata.player().position.y, 0);
-    inv[ci].own_state = 1;
+    if (const auto item = itemcreate_extra_inv(
+            560, cdata.player().position.x + 1, cdata.player().position.y, 0))
+    {
+        item->own_state = 1;
+    }
     for (int cnt = 0, cnt_end = (70 + rnd(20)); cnt < cnt_end; ++cnt)
     {
         x = rnd(map_data.width);
         y = rnd(map_data.height);
         if (cell_data.at(x, y).chip_id_actual != 30 &&
-            cell_data.at(x, y).chip_id_actual != 31)
+            cell_data.at(x, y).chip_id_actual != 31 &&
+            cell_data.at(x, y).item_appearances_actual == 0)
         {
-            if (cell_data.at(x, y).item_appearances_actual == 0)
+            if (rnd(8))
             {
-                if (rnd(8))
+                flt();
+                flttypemajor = 80000;
+                if (const auto item = itemcreate_extra_inv(0, x, y, 0))
                 {
-                    flt();
-                    flttypemajor = 80000;
-                    itemcreate(-1, 0, x, y, 0);
-                    inv[ci].own_state = 1;
+                    item->own_state = 1;
                 }
-                else
-                {
-                    cell_featset(x, y, tile_pot, 30);
-                }
+            }
+            else
+            {
+                cell_featset(x, y, tile_pot, 30);
             }
         }
     }
@@ -2678,7 +2687,7 @@ int initialize_quest_map_party()
                         {
                             cell_data.at(x, y).chip_id_actual = 206;
                             flt();
-                            itemcreate(-1, 91, x, y, 0);
+                            itemcreate_extra_inv(91, x, y, 0);
                         }
                     }
                     if (n == 3)
@@ -2687,7 +2696,7 @@ int initialize_quest_map_party()
                         {
                             cell_data.at(x, y).chip_id_actual = 204;
                             flt();
-                            itemcreate(-1, 585, x, y, 0);
+                            itemcreate_extra_inv(585, x, y, 0);
                         }
                     }
                     if (n == 4)
@@ -2696,7 +2705,7 @@ int initialize_quest_map_party()
                         {
                             flt();
                             cell_data.at(x, y).chip_id_actual = 69;
-                            itemcreate(-1, 138, x, y, 0);
+                            itemcreate_extra_inv(138, x, y, 0);
                         }
                     }
                 }
@@ -2705,26 +2714,26 @@ int initialize_quest_map_party()
         if (p(1) == 1)
         {
             flt();
-            itemcreate(-1, 83, dx + 1, dy + 1, 0);
+            itemcreate_extra_inv(83, dx + 1, dy + 1, 0);
             if (rnd(2))
             {
                 flt();
-                itemcreate(-1, 92, dx + 1, dy, 0);
+                itemcreate_extra_inv(92, dx + 1, dy, 0);
             }
             if (rnd(2))
             {
                 flt();
-                itemcreate(-1, 92, dx + 1, dy + 2, 0);
+                itemcreate_extra_inv(92, dx + 1, dy + 2, 0);
             }
             if (rnd(2))
             {
                 flt();
-                itemcreate(-1, 92, dx, dy + 1, 0);
+                itemcreate_extra_inv(92, dx, dy + 1, 0);
             }
             if (rnd(2))
             {
                 flt();
-                itemcreate(-1, 92, dx + 2, dy + 1, 0);
+                itemcreate_extra_inv(92, dx + 2, dy + 1, 0);
             }
         }
     }
@@ -2773,7 +2782,7 @@ int initialize_quest_map_party()
             if (cell_data.at(x, y).item_appearances_actual == 0)
             {
                 flt();
-                itemcreate(-1, 88, x, y, 0);
+                itemcreate_extra_inv(88, x, y, 0);
             }
         }
         if (rnd(3) == 0)
@@ -2783,7 +2792,7 @@ int initialize_quest_map_party()
             if (cell_data.at(x, y).item_appearances_actual == 0)
             {
                 flt();
-                itemcreate(-1, 313, x, y, 0);
+                itemcreate_extra_inv(313, x, y, 0);
             }
         }
         if (rnd(2) == 0)
@@ -2793,7 +2802,7 @@ int initialize_quest_map_party()
             if (cell_data.at(x, y).item_appearances_actual == 0)
             {
                 flt();
-                itemcreate(-1, 156, x, y, 0);
+                itemcreate_extra_inv(156, x, y, 0);
             }
         }
         if (rnd(3) == 0)
@@ -2803,7 +2812,7 @@ int initialize_quest_map_party()
             if (cell_data.at(x, y).item_appearances_actual == 0)
             {
                 flt();
-                itemcreate(-1, 606, x, y, 0);
+                itemcreate_extra_inv(606, x, y, 0);
             }
         }
         for (int cnt = 0,
@@ -2845,7 +2854,7 @@ int initialize_quest_map_party()
         p(6) = 152;
         p(7) = 91;
         p(8) = 189;
-        itemcreate(-1, p(rnd(9)), x, y, 0);
+        itemcreate_extra_inv(p(rnd(9)), x, y, 0);
     }
     flt();
     chara_create(-1, 29, -3, 0);
@@ -3736,14 +3745,10 @@ void map_initcustom(const std::string& map_filename)
         if (cmapdata(4, cnt) == 0)
         {
             flt();
-            if (itemcreate(
-                    -1,
-                    cmapdata(0, cnt),
-                    cmapdata(1, cnt),
-                    cmapdata(2, cnt),
-                    0))
+            if (const auto item = itemcreate_extra_inv(
+                    cmapdata(0, cnt), cmapdata(1, cnt), cmapdata(2, cnt), 0))
             {
-                inv[ci].own_state = cmapdata(3, cnt);
+                item->own_state = cmapdata(3, cnt);
             }
         }
         if (cmapdata(4, cnt) == 1)

--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -1152,6 +1152,8 @@ void append_accuracy_info(int val0)
     }
 }
 
+
+
 void show_weapon_dice(int val0)
 {
     tc = cc;
@@ -1197,6 +1199,8 @@ void show_weapon_dice(int val0)
     }
     ++p(2);
 }
+
+
 
 static TurnResult _visit_quest_giver(int quest_index)
 {
@@ -1299,7 +1303,7 @@ void begin_to_believe_god(int god_id)
     if (!result.canceled && result.value)
     {
         rtval = *result.value;
-        god_proc_switching_penalty();
+        god_proc_switching_penalty(core_god::int2godid(god_id));
     }
 }
 

--- a/src/elona/quest.cpp
+++ b/src/elona/quest.cpp
@@ -647,12 +647,12 @@ int quest_generate()
             }
             flt(40, Quality::good);
             flttypemajor = choice(fsetcollect);
-            if (itemcreate(n, 0, -1, -1, 0))
+            if (const auto item = itemcreate_chara_inv(n, 0, 0))
             {
-                inv[ci].count = rq;
+                item->count = rq;
                 i(0) = n;
-                i(1) = itemid2int(inv[ci].id);
-                inv[ci].is_quest_target() = true;
+                i(1) = itemid2int(item->id);
+                item->is_quest_target() = true;
                 break;
             }
             else
@@ -1386,8 +1386,7 @@ void quest_complete()
     if (p != 0)
     {
         flt();
-        itemcreate(
-            -1, 54, cdata.player().position.x, cdata.player().position.y, p);
+        itemcreate_extra_inv(54, cdata.player().position, p);
     }
     if (quest_data[rq].id == 1002)
     {
@@ -1402,18 +1401,16 @@ void quest_complete()
         p = 2 + (rnd(100) < rnd(cdata.player().fame / 5000 + 1));
     }
     flt();
-    itemcreate(-1, 55, cdata.player().position.x, cdata.player().position.y, p);
+    itemcreate_extra_inv(55, cdata.player().position, p);
     if (quest_data[rq].id == 1009)
     {
         if (quest_data[rq].extra_info_1 * 150 / 100 <
             quest_data[rq].extra_info_2)
         {
             flt();
-            itemcreate(
-                -1,
+            itemcreate_extra_inv(
                 724,
-                cdata.player().position.x,
-                cdata.player().position.y,
+                cdata.player().position,
                 1 + quest_data[rq].extra_info_2 / 10);
         }
     }
@@ -1464,8 +1461,7 @@ void quest_complete()
             {
                 flttypemajor = quest_data[rq].reward_item_id;
             }
-            itemcreate(
-                -1, 0, cdata.player().position.x, cdata.player().position.y, 0);
+            itemcreate_extra_inv(0, cdata.player().position, 0);
         }
     }
     modify_karma(cdata.player(), 1);

--- a/src/elona/random_event.cpp
+++ b/src/elona/random_event.cpp
@@ -347,8 +347,10 @@ void run_random_event(RandomEvent event)
         break;
     case 19:
         flt();
-        itemcreate(0, 621, -1, -1, 0);
-        txt(i18n::s.get("core.common.you_put_in_your_backpack", inv[ci]));
+        if (const auto item = itemcreate_player_inv(621, 0))
+        {
+            txt(i18n::s.get("core.common.you_put_in_your_backpack", *item));
+        }
         listmax = 1;
         event_bg = u8"bg_re15";
         break;
@@ -359,8 +361,10 @@ void run_random_event(RandomEvent event)
         break;
     case 21:
         flt();
-        itemcreate(0, 721, -1, -1, 0);
-        txt(i18n::s.get("core.common.you_put_in_your_backpack", inv[ci]));
+        if (const auto item = itemcreate_player_inv(721, 0))
+        {
+            txt(i18n::s.get("core.common.you_put_in_your_backpack", *item));
+        }
         listmax = 1;
         event_bg = u8"bg_re15";
         net_send_news("ehekatl");
@@ -501,12 +505,7 @@ void run_random_event(RandomEvent event)
             {
                 flt();
                 flttypemajor = choice(fsetremain);
-                itemcreate(
-                    -1,
-                    0,
-                    cdata.player().position.x,
-                    cdata.player().position.y,
-                    0);
+                itemcreate_extra_inv(0, cdata.player().position, 0);
             }
             txt(i18n::s.get("core.common.something_is_put_on_the_ground"));
         }
@@ -527,12 +526,7 @@ void run_random_event(RandomEvent event)
                 {
                     flttypemajor = choice(fsetremain);
                 }
-                itemcreate(
-                    -1,
-                    0,
-                    cdata.player().position.x,
-                    cdata.player().position.y,
-                    0);
+                itemcreate_extra_inv(0, cdata.player().position, 0);
             }
             txt(i18n::s.get("core.common.something_is_put_on_the_ground"));
         }

--- a/src/elona/talk.cpp
+++ b/src/elona/talk.cpp
@@ -228,67 +228,6 @@ TalkResult talk_ignored()
     return TalkResult::talk_end;
 }
 
-static void _give_potion_of_cure_corruption(int stat)
-{
-    inv[stat].modify_number(-1);
-    txt(i18n::s.get("core.talk.unique.pael.give.you_give"));
-    snd("core.equip1");
-}
-
-bool talk_give_potion_of_cure_corruption()
-{
-    list(0, listmax) = 1;
-    listn(0, listmax) = i18n::s.get("core.talk.unique.pael.give.choice");
-    ++listmax;
-    list(0, listmax) = 0;
-    listn(0, listmax) = i18n::s.get("core.ui.bye");
-    ++listmax;
-    int chatval_ = talk_window_query();
-    if (chatval_ != 1)
-    {
-        return false;
-    }
-    int stat = inv_find(559, 0);
-    if (stat == -1)
-    {
-        listmax = 0;
-        buff = i18n::s.get("core.talk.unique.pael.give.do_not_have");
-        tc = tc * 1 + 0;
-        list(0, listmax) = 0;
-        listn(0, listmax) = i18n::s.get("core.ui.more");
-        ++listmax;
-        chatesc = 1;
-        talk_window_query();
-        if (scenemode)
-        {
-            if (scene_cut == 1)
-            {
-                return false;
-            }
-        }
-        return false;
-    }
-
-    _give_potion_of_cure_corruption(stat);
-
-    listmax = 0;
-    buff = i18n::s.get("core.talk.unique.pael.give.dialog", cdatan(0, 0));
-    tc = tc * 1 + 0;
-    list(0, listmax) = 0;
-    listn(0, listmax) = i18n::s.get("core.ui.more");
-    ++listmax;
-    chatesc = 1;
-    talk_window_query();
-    if (scenemode)
-    {
-        if (scene_cut == 1)
-        {
-            return false;
-        }
-    }
-    return true;
-}
-
 
 
 TalkResult talk_game_begin()
@@ -338,7 +277,7 @@ TalkResult talk_game_begin()
         snd("core.kill1");
         spillblood(28, 6, 10);
         flt();
-        itemcreate(-1, 705, 28, 6, 0);
+        itemcreate_extra_inv(705, 28, 6, 0);
         update_screen();
         await(500);
         await(500);

--- a/src/elona/talk.hpp
+++ b/src/elona/talk.hpp
@@ -55,7 +55,6 @@ TalkResult talk_busy();
 TalkResult talk_ignored();
 TalkResult talk_house_visitor();
 TalkResult talk_game_begin();
-bool talk_give_potion_of_cure_corruption();
 
 void talk_wrapper(TalkResult);
 TalkResult talk_npc();

--- a/src/elona/talk_house_visitor.cpp
+++ b/src/elona/talk_house_visitor.cpp
@@ -50,13 +50,12 @@ TalkResult _talk_hv_visitor()
 void _adventurer_give_new_year_gift()
 {
     flt();
-    if (itemcreate(
-            -1, 752, cdata.player().position.x, cdata.player().position.y, 0))
+    if (const auto item = itemcreate_extra_inv(752, cdata.player().position, 0))
     {
-        inv[ci].param3 = cdata[tc].impression + rnd(50);
+        item->param3 = cdata[tc].impression + rnd(50);
+        txt(i18n::s.get(
+            "core.talk.visitor.adventurer.new_year.throws", cdata[tc], *item));
     }
-    txt(i18n::s.get(
-        "core.talk.visitor.adventurer.new_year.throws", cdata[tc], inv[ci]));
 }
 
 TalkResult _talk_hv_adventurer_new_year()
@@ -136,7 +135,7 @@ void _adventurer_hate_action()
         for (int cnt = 0, cnt_end = (8 + rnd(6)); cnt < cnt_end; ++cnt)
         {
             flt();
-            itemcreate(-1, 704, -1, -1, 0);
+            itemcreate_extra_inv(704, -1, -1, 0);
             txt(i18n::s.get("core.food.vomits", cdata[tc]));
             snd("core.vomit");
             await(g_config.animation_wait() / 2);
@@ -172,10 +171,11 @@ void _adventurer_become_best_friend()
 {
     cdata[tc].is_best_friend() = true;
     flt();
-    itemcreate(
-        -1, 730, cdata.player().position.x, cdata.player().position.y, 0);
-    txt(i18n::s.get("core.talk.visitor.receive", inv[ci], cdata[tc]));
-    txt(i18n::s.get("core.talk.visitor.adventurer.like.wonder_if"));
+    if (const auto item = itemcreate_extra_inv(730, cdata.player().position, 0))
+    {
+        txt(i18n::s.get("core.talk.visitor.receive", *item, cdata[tc]));
+        txt(i18n::s.get("core.talk.visitor.adventurer.like.wonder_if"));
+    }
 }
 
 void _talk_hv_adventurer_best_friend()
@@ -361,10 +361,12 @@ void _adventurer_receive_coin()
             p = 622;
         }
         flt();
-        itemcreate(
-            -1, p, cdata.player().position.x, cdata.player().position.y, 0);
-        txt(i18n::s.get("core.talk.visitor.receive", inv[ci], cdata[tc]));
-        snd("core.get1");
+        if (const auto item =
+                itemcreate_extra_inv(p, cdata.player().position, 0))
+        {
+            txt(i18n::s.get("core.talk.visitor.receive", *item, cdata[tc]));
+            snd("core.get1");
+        }
     }
 }
 
@@ -392,6 +394,8 @@ TalkResult _talk_hv_adventurer_friendship()
     return TalkResult::talk_end;
 }
 
+
+
 void _adventurer_receive_souvenir()
 {
     if (inv_getfreeid(0) == -1)
@@ -402,12 +406,16 @@ void _adventurer_receive_souvenir()
     else
     {
         flt();
-        itemcreate(0, 729, -1, -1, 0);
-        txt(i18n::s.get(
-            "core.talk.visitor.adventurer.souvenir.receive", inv[ci]));
-        snd("core.get1");
+        if (const auto item = itemcreate_player_inv(729, 0))
+        {
+            txt(i18n::s.get(
+                "core.talk.visitor.adventurer.souvenir.receive", *item));
+            snd("core.get1");
+        }
     }
 }
+
+
 
 TalkResult _talk_hv_adventurer_souvenir()
 {

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -123,7 +123,7 @@ TalkResult talk_wizard_identify(int chatval_)
             if (item.identify_state != IdentifyState::completely)
             {
                 const auto result = item_identify(item, 250);
-                item_stack(0, item.index, 1);
+                item_stack(0, item, true);
                 ++p(1);
                 if (result >= IdentifyState::completely)
                 {
@@ -449,7 +449,7 @@ TalkResult talk_quest_delivery()
     inv[ti].set_number(1);
     ci = ti;
     rc = tc;
-    chara_set_item_which_will_be_used(cdata[tc]);
+    chara_set_item_which_will_be_used(cdata[tc], inv[ci]);
     rq = deliver;
     inv[deliver(1)].modify_number(-1);
     txt(i18n::s.get("core.talk.npc.common.hand_over", inv[deliver(1)]));
@@ -468,7 +468,7 @@ TalkResult talk_quest_supply()
     cdata[tc].was_passed_item_by_you_just_now() = true;
     ci = ti;
     rc = tc;
-    chara_set_item_which_will_be_used(cdata[tc]);
+    chara_set_item_which_will_be_used(cdata[tc], inv[ci]);
     inv[supply].modify_number(-1);
     txt(i18n::s.get("core.talk.npc.common.hand_over", inv[supply]));
     quest_set_data(3);
@@ -499,13 +499,15 @@ TalkResult talk_shop_attack()
 TalkResult talk_guard_return_item()
 {
     listmax = 0;
-    p = itemfind(0, 284);
-    if (p == -1)
+    auto wallet_opt = itemfind(0, 284);
+    if (!wallet_opt)
     {
-        p = itemfind(0, 283);
+        wallet_opt = itemfind(0, 283);
     }
-    inv[p].modify_number(-1);
-    if (inv[p].param1 == 0)
+    Item& wallet = *wallet_opt;
+    p = wallet.index;
+    wallet.modify_number(-1);
+    if (wallet.param1 == 0)
     {
         buff = i18n::s.get("core.talk.npc.guard.lost.empty.dialog", cdata[tc]);
         ELONA_APPEND_RESPONSE(
@@ -1629,12 +1631,7 @@ TalkResult talk_quest_giver()
             ++quest_data[quest_data[rq].target_chara_index]
                   .delivery_has_package_flag;
             flt();
-            itemcreate(
-                0,
-                quest_data[rq].target_item_id,
-                cdata.player().position.x,
-                cdata.player().position.y,
-                0);
+            itemcreate_player_inv(quest_data[rq].target_item_id, 0);
             txt(i18n::s.get("core.common.you_put_in_your_backpack", inv[ci]));
             snd("core.inv");
             refresh_burden_state();
@@ -1960,12 +1957,12 @@ TalkResult talk_npc()
                         cdata[rtval(cnt)]));
             }
         }
-        if (itemfind(0, 284) != -1)
+        if (itemfind(0, 284))
         {
             ELONA_APPEND_RESPONSE(
                 32, i18n::s.get("core.talk.npc.guard.choices.lost_wallet"));
         }
-        else if (itemfind(0, 283) != -1)
+        else if (itemfind(0, 283))
         {
             ELONA_APPEND_RESPONSE(
                 32, i18n::s.get("core.talk.npc.guard.choices.lost_suitcase"));

--- a/src/elona/turn_sequence.cpp
+++ b/src/elona/turn_sequence.cpp
@@ -1110,7 +1110,7 @@ TurnResult pass_one_turn(bool time_passing)
         }
         if (cdata[cc].has_cursed_equipments())
         {
-            proc_negative_equipments();
+            proc_negative_enchantments(cdata[cc]);
         }
         if (cdata[cc].is_pregnant())
         {

--- a/src/elona/variables.hpp
+++ b/src/elona/variables.hpp
@@ -16,6 +16,7 @@
 namespace elona
 {
 
+struct Item;
 struct Character;
 
 
@@ -580,7 +581,7 @@ void gain_race_feat();
 //// Items
 
 // Item status querying
-int cargocheck();
+bool cargocheck(const Item& item);
 
 // Item manipulation
 int convertartifact(int = 0, int = 0);
@@ -641,7 +642,7 @@ int can_evade_trap();
 int try_to_disarm_trap();
 int try_to_perceive_npc(int);
 
-int read_textbook();
+bool read_textbook(Item& textbook);
 int decode_book();
 int read_normal_book();
 
@@ -659,11 +660,11 @@ int unlock_box(int);
 void do_ranged_attack();
 
 //// Command
-TurnResult step_into_gate();
+TurnResult step_into_gate(Item& moon_gate);
 optional<TurnResult> check_angband();
 TurnResult do_bash();
 TurnResult do_enter_strange_gate();
-TurnResult do_gatcha();
+TurnResult do_gatcha(Item& gatcha_machine);
 TurnResult do_use_magic();
 TurnResult do_use_stairs_command(int);
 TurnResult try_interact_with_npc();
@@ -717,7 +718,7 @@ void make_sound(int = 0, int = 0, int = 0, int = 0, int = 0, int = 0);
 
 //// pass_one_turn
 void proc_pregnant();
-void proc_negative_equipments();
+void proc_negative_enchantments(Character& chara);
 void damage_by_cursed_equipments();
 
 
@@ -909,9 +910,6 @@ void dump_player_info();
 //// dmgheal
 void character_drops_item();
 void check_kill(int = 0, int = 0);
-
-// character_drops_item
-void remain_make(int = 0, int = 0);
 
 
 //// Journal

--- a/src/elona/wish.cpp
+++ b/src/elona/wish.cpp
@@ -273,13 +273,14 @@ void wish_for_card()
     flt();
     chara_create(56, dbid, -3, 0);
     flt();
-    itemcreate(
-        -1, 504, cdata.player().position.x, cdata.player().position.y, 0);
-    inv[ci].subname = charaid2int(cdata.tmp().id);
-    inv[ci].param1 = cdata.tmp().image;
-    chara_vanquish(56);
-    cell_refresh(cdata.player().position.x, cdata.player().position.y);
-    txt(i18n::s.get("core.wish.something_appears_from_nowhere", inv[ci]));
+    if (const auto item = itemcreate_extra_inv(504, cdata.player().position, 0))
+    {
+        item->subname = charaid2int(cdata.tmp().id);
+        item->param1 = cdata.tmp().image;
+        chara_vanquish(56);
+        cell_refresh(cdata.player().position.x, cdata.player().position.y);
+        txt(i18n::s.get("core.wish.something_appears_from_nowhere", *item));
+    }
 }
 
 
@@ -290,13 +291,14 @@ void wish_for_figure()
     flt();
     chara_create(56, dbid, -3, 0);
     flt();
-    itemcreate(
-        -1, 503, cdata.player().position.x, cdata.player().position.y, 0);
-    inv[ci].subname = charaid2int(cdata.tmp().id);
-    inv[ci].param1 = cdata.tmp().image;
-    chara_vanquish(56);
-    cell_refresh(cdata.player().position.x, cdata.player().position.y);
-    txt(i18n::s.get("core.wish.something_appears_from_nowhere", inv[ci]));
+    if (const auto item = itemcreate_extra_inv(503, cdata.player().position, 0))
+    {
+        item->subname = charaid2int(cdata.tmp().id);
+        item->param1 = cdata.tmp().image;
+        chara_vanquish(56);
+        cell_refresh(cdata.player().position.x, cdata.player().position.y);
+        txt(i18n::s.get("core.wish.something_appears_from_nowhere", *item));
+    }
 }
 
 
@@ -451,11 +453,9 @@ bool grant_special_wishing(const std::string& wish)
         txt(i18n::s.get("core.wish.wish_gold"),
             Message::color{ColorIndex::orange});
         flt();
-        itemcreate(
-            -1,
+        itemcreate_extra_inv(
             54,
-            cdata.player().position.x,
-            cdata.player().position.y,
+            cdata.player().position,
             (cdata.player().level / 3 + 1) * 10000);
     }
     else if (match_special_wish(
@@ -466,20 +466,14 @@ bool grant_special_wishing(const std::string& wish)
         txt(i18n::s.get("core.wish.wish_small_medal"),
             Message::color{ColorIndex::orange});
         flt();
-        itemcreate(
-            -1,
-            622,
-            cdata.player().position.x,
-            cdata.player().position.y,
-            3 + rnd(3));
+        itemcreate_extra_inv(622, cdata.player().position, 3 + rnd(3));
     }
     else if (match_special_wish(wish, "platinum", {"platinum", "platina"}))
     {
         txt(i18n::s.get("core.wish.wish_platinum"),
             Message::color{ColorIndex::orange});
         flt();
-        itemcreate(
-            -1, 55, cdata.player().position.x, cdata.player().position.y, 5);
+        itemcreate_extra_inv(55, cdata.player().position, 5);
     }
     else if (game_data.wizard)
     {
@@ -573,7 +567,7 @@ bool wish_for_item(const std::string& input)
     if (selector.empty())
         return false;
 
-    while (1)
+    while (true)
     {
         const auto opt_id = selector.get();
         if (!opt_id)
@@ -593,76 +587,87 @@ bool wish_for_item(const std::string& input)
 
         nostack = 1;
         nooracle = 1;
-        itemcreate(-1, id, cdata[cc].position.x, cdata[cc].position.y, 0);
+        auto item = itemcreate_extra_inv(id, cdata[cc].position, 0);
         nooracle = 0;
 
+        if (!item)
+            continue;
+
         // Unwishable item
-        if (inv[ci].is_precious() || inv[ci].quality == Quality::special)
+        if (item->is_precious() || item->quality == Quality::special)
         {
             if (!game_data.wizard)
             {
                 // Remove this item and retry.
                 selector.remove(id);
-                inv[ci].remove();
-                --itemmemory(1, itemid2int(inv[ci].id));
-                cell_refresh(inv[ci].position.x, inv[ci].position.y);
+                item->remove();
+                --itemmemory(1, itemid2int(item->id));
+                cell_refresh(item->position.x, item->position.y);
                 continue;
             }
         }
 
-        if (inv[ci].id == ItemId::gold_piece)
+        if (item->id == ItemId::gold_piece)
         {
-            inv[ci].set_number(
+            item->set_number(
                 cdata.player().level * cdata.player().level * 50 + 20000);
         }
-        else if (inv[ci].id == ItemId::platinum_coin)
+        else if (item->id == ItemId::platinum_coin)
         {
-            inv[ci].set_number(8 + rnd(5));
+            item->set_number(8 + rnd(5));
         }
-        else if (inv[ci].id == ItemId::holy_well)
+        else if (item->id == ItemId::holy_well)
         {
-            inv[ci].remove();
+            item->remove();
             flt();
-            itemcreate(-1, 516, cdata[cc].position.x, cdata[cc].position.y, 3);
-            inv[ci].curse_state = CurseState::blessed;
-            txt(i18n::s.get("core.wish.it_is_sold_out"));
+            if (const auto well =
+                    itemcreate_extra_inv(516, cdata[cc].position, 3))
+            {
+                well->curse_state = CurseState::blessed;
+                txt(i18n::s.get("core.wish.it_is_sold_out"));
+                item = well;
+            }
+            else
+            {
+                continue;
+            }
         }
-        if (the_item_db[itemid2int(inv[ci].id)]->category == 52000 ||
-            the_item_db[itemid2int(inv[ci].id)]->category == 53000)
+        if (the_item_db[itemid2int(item->id)]->category == 52000 ||
+            the_item_db[itemid2int(item->id)]->category == 53000)
         {
-            inv[ci].set_number(3 + rnd(2));
-            if (inv[ci].value >= 20000)
+            item->set_number(3 + rnd(2));
+            if (item->value >= 20000)
             {
-                inv[ci].set_number(1);
+                item->set_number(1);
             }
-            else if (inv[ci].value >= 10000)
+            else if (item->value >= 10000)
             {
-                inv[ci].set_number(2);
+                item->set_number(2);
             }
-            else if (inv[ci].value >= 5000)
+            else if (item->value >= 5000)
             {
-                inv[ci].set_number(3);
+                item->set_number(3);
             }
-            switch (itemid2int(inv[ci].id))
+            switch (itemid2int(item->id))
             {
-            case 559: inv[ci].set_number(2 + rnd(2)); break;
-            case 502: inv[ci].set_number(2); break;
-            case 243: inv[ci].set_number(1); break;
-            case 621: inv[ci].set_number(1); break;
-            case 706: inv[ci].set_number(1); break;
+            case 559: item->set_number(2 + rnd(2)); break;
+            case 502: item->set_number(2); break;
+            case 243: item->set_number(1); break;
+            case 621: item->set_number(1); break;
+            case 706: item->set_number(1); break;
             }
         }
         if (debug::voldemort && number_of_items != 0)
         {
-            inv[ci].set_number(number_of_items);
+            item->set_number(number_of_items);
         }
         if (debug::voldemort && curse_state)
         {
-            inv[ci].curse_state = curse_state.get();
+            item->curse_state = curse_state.get();
         }
 
-        item_identify(inv[ci], IdentifyState::completely);
-        txt(i18n::s.get("core.wish.something_appears", inv[ci]));
+        item_identify(*item, IdentifyState::completely);
+        txt(i18n::s.get("core.wish.something_appears", *item));
         return true;
     }
 

--- a/src/tests/item.cpp
+++ b/src/tests/item.cpp
@@ -11,7 +11,8 @@ TEST_CASE("Test that index of copied item is set", "[C++: Item]")
     testing::start_in_debug_map();
     int amount = 1;
 
-    REQUIRE_SOME(itemcreate(-1, itemid2int(PUTITORO_PROTO_ID), 4, 8, amount));
+    REQUIRE_SOME(
+        itemcreate_extra_inv(itemid2int(PUTITORO_PROTO_ID), 4, 8, amount));
     Item& i = elona::inv[elona::ci];
 
     int ti = elona::inv_getfreeid(-1);

--- a/src/tests/lua_callbacks.cpp
+++ b/src/tests/lua_callbacks.cpp
@@ -271,7 +271,8 @@ mod.store.global.items = {}
 Event.register("core.item_created", my_item_created_handler)
 )"));
 
-    REQUIRE_SOME(elona::itemcreate(-1, itemid2int(PUTITORO_PROTO_ID), 4, 8, 3));
+    REQUIRE_SOME(
+        elona::itemcreate_extra_inv(itemid2int(PUTITORO_PROTO_ID), 4, 8, 3));
     int idx = elona::ci;
     REQUIRE(idx != -1);
     elona::lua::lua->get_mod_manager()

--- a/src/tests/lua_handles.cpp
+++ b/src/tests/lua_handles.cpp
@@ -36,7 +36,8 @@ TEST_CASE("Test that handle properties can be read", "[Lua: Handles]")
     }
     SECTION("Items")
     {
-        REQUIRE_SOME(itemcreate(-1, itemid2int(PUTITORO_PROTO_ID), 4, 8, 3));
+        REQUIRE_SOME(
+            itemcreate_extra_inv(itemid2int(PUTITORO_PROTO_ID), 4, 8, 3));
         int idx = elona::ci;
         Item& item = elona::inv[idx];
         auto handle = handle_mgr.get_handle(item);
@@ -77,7 +78,8 @@ TEST_CASE("Test that handle properties can be written", "[Lua: Handles]")
     }
     SECTION("Items")
     {
-        REQUIRE_SOME(itemcreate(-1, itemid2int(PUTITORO_PROTO_ID), 0, 0, 1));
+        REQUIRE_SOME(
+            itemcreate_extra_inv(itemid2int(PUTITORO_PROTO_ID), 0, 0, 1));
         Item& item = elona::inv[elona::ci];
         auto handle = handle_mgr.get_handle(item);
         elona::lua::lua->get_state()->set("item", handle);
@@ -149,7 +151,8 @@ TEST_CASE("Test that handles go invalid", "[Lua: Handles]")
     }
     SECTION("Items")
     {
-        REQUIRE_SOME(itemcreate(-1, itemid2int(PUTITORO_PROTO_ID), 4, 8, 3));
+        REQUIRE_SOME(
+            itemcreate_extra_inv(itemid2int(PUTITORO_PROTO_ID), 4, 8, 3));
         Item& item = elona::inv[elona::ci];
         auto handle = handle_mgr.get_handle(item);
         elona::lua::lua->get_state()->set("item", handle);
@@ -195,7 +198,8 @@ TEST_CASE("Test invalid references to handles in store table", "[Lua: Handles]")
     }
     SECTION("Items")
     {
-        REQUIRE_SOME(itemcreate(-1, itemid2int(PUTITORO_PROTO_ID), 4, 8, 3));
+        REQUIRE_SOME(
+            itemcreate_extra_inv(itemid2int(PUTITORO_PROTO_ID), 4, 8, 3));
         Item& item = elona::inv[elona::ci];
         auto handle = handle_mgr.get_handle(item);
 
@@ -286,7 +290,8 @@ print(Chara.is_ally(mod.store.global.charas[0]))
     }
     SECTION("Items")
     {
-        REQUIRE_SOME(itemcreate(-1, itemid2int(PUTITORO_PROTO_ID), 4, 8, 3));
+        REQUIRE_SOME(
+            itemcreate_extra_inv(itemid2int(PUTITORO_PROTO_ID), 4, 8, 3));
         Item& item = elona::inv[elona::ci];
         auto handle = handle_mgr.get_handle(item);
 
@@ -360,7 +365,7 @@ TEST_CASE(
     start_in_debug_map();
     auto& handle_mgr = elona::lua::lua->get_handle_manager();
 
-    REQUIRE_SOME(itemcreate(-1, itemid2int(PUTITORO_PROTO_ID), 4, 8, 1));
+    REQUIRE_SOME(itemcreate_extra_inv(itemid2int(PUTITORO_PROTO_ID), 4, 8, 1));
     elona::cc = 0;
     elona::in = inv[elona::ci].number();
 
@@ -526,7 +531,8 @@ TEST_CASE(
     auto& handle_mgr = elona::lua::lua->get_handle_manager();
     int amount = 2;
 
-    REQUIRE_SOME(itemcreate(-1, itemid2int(PUTITORO_PROTO_ID), 4, 8, amount));
+    REQUIRE_SOME(
+        itemcreate_extra_inv(itemid2int(PUTITORO_PROTO_ID), 4, 8, amount));
     Item& i = elona::inv[elona::ci];
     auto handle = handle_mgr.get_handle(i);
     auto old_uuid = handle["__uuid"].get<std::string>();
@@ -559,7 +565,8 @@ TEST_CASE("Test separation of item handles", "[Lua: Handles]")
     auto& handle_mgr = elona::lua::lua->get_handle_manager();
     int amount = 3;
 
-    REQUIRE_SOME(itemcreate(-1, itemid2int(PUTITORO_PROTO_ID), 4, 8, amount));
+    REQUIRE_SOME(
+        itemcreate_extra_inv(itemid2int(PUTITORO_PROTO_ID), 4, 8, amount));
     Item& i = elona::inv[elona::ci];
     sol::table handle = handle_mgr.get_handle(i);
 
@@ -582,7 +589,8 @@ TEST_CASE("Test copying of item handles", "[Lua: Handles]")
     auto& handle_mgr = elona::lua::lua->get_handle_manager();
     int amount = 1;
 
-    REQUIRE_SOME(itemcreate(-1, itemid2int(PUTITORO_PROTO_ID), 4, 8, amount));
+    REQUIRE_SOME(
+        itemcreate_extra_inv(itemid2int(PUTITORO_PROTO_ID), 4, 8, amount));
     Item& i = elona::inv[elona::ci];
     sol::table handle = handle_mgr.get_handle(i);
 
@@ -614,10 +622,12 @@ TEST_CASE("Test copying of item handles after removal", "[Lua: Handles]")
     auto& handle_mgr = elona::lua::lua->get_handle_manager();
     int amount = 1;
 
-    REQUIRE_SOME(itemcreate(-1, itemid2int(PUTITORO_PROTO_ID), 4, 8, amount));
+    REQUIRE_SOME(
+        itemcreate_extra_inv(itemid2int(PUTITORO_PROTO_ID), 4, 8, amount));
     Item& a = elona::inv[elona::ci];
 
-    REQUIRE_SOME(itemcreate(-1, itemid2int(PUTITORO_PROTO_ID), 4, 9, amount));
+    REQUIRE_SOME(
+        itemcreate_extra_inv(itemid2int(PUTITORO_PROTO_ID), 4, 9, amount));
     Item& b = elona::inv[elona::ci];
 
     // Mark the handle in b's slot as invalid.
@@ -633,11 +643,11 @@ TEST_CASE("Test swapping of item handles", "[Lua: Handles]")
     start_in_debug_map();
     auto& handle_mgr = elona::lua::lua->get_handle_manager();
 
-    REQUIRE_SOME(itemcreate(-1, itemid2int(PUTITORO_PROTO_ID), 4, 8, 1));
+    REQUIRE_SOME(itemcreate_extra_inv(itemid2int(PUTITORO_PROTO_ID), 4, 8, 1));
     Item& item_a = elona::inv[elona::ci];
     sol::table handle_a = handle_mgr.get_handle(item_a);
 
-    REQUIRE_SOME(itemcreate(-1, itemid2int(PUTITORO_PROTO_ID), 4, 9, 1));
+    REQUIRE_SOME(itemcreate_extra_inv(itemid2int(PUTITORO_PROTO_ID), 4, 9, 1));
     Item& item_b = elona::inv[elona::ci];
     sol::table handle_b = handle_mgr.get_handle(item_b);
 

--- a/src/tests/serialization.cpp
+++ b/src/tests/serialization.cpp
@@ -37,7 +37,8 @@ TEST_CASE("Test item saving and reloading", "[C++: Serialization]")
     int x = 4;
     int y = 8;
     int number = 3;
-    REQUIRE_SOME(itemcreate(-1, itemid2int(PUTITORO_PROTO_ID), x, y, number));
+    REQUIRE_SOME(
+        itemcreate_extra_inv(itemid2int(PUTITORO_PROTO_ID), x, y, number));
     int index = elona::ci;
     elona::inv[index].is_aphrodisiac() = true;
     elona::inv[index].curse_state = CurseState::blessed;
@@ -79,7 +80,7 @@ TEST_CASE("Test other character index preservation", "[C++: Serialization]")
 TEST_CASE("Test item index preservation", "[C++: Serialization]")
 {
     start_in_debug_map();
-    REQUIRE_SOME(itemcreate(-1, itemid2int(PUTITORO_PROTO_ID), 0, 0, 0));
+    REQUIRE_SOME(itemcreate_extra_inv(itemid2int(PUTITORO_PROTO_ID), 0, 0, 0));
     int index = elona::ci;
 
     save_and_reload();

--- a/src/tests/util.cpp
+++ b/src/tests/util.cpp
@@ -54,7 +54,7 @@ void normalize_item(Item& i)
 
 std::string test_itemname(int id, int number, bool prefix)
 {
-    REQUIRE_SOME(itemcreate(-1, id, 0, 0, number));
+    REQUIRE_SOME(itemcreate_extra_inv(id, 0, 0, number));
     int index = elona::ci;
     normalize_item(elona::inv[index]);
     std::string name = itemname(index, number, prefix ? 0 : 1);
@@ -71,7 +71,7 @@ Character& create_chara(int id, int x, int y)
 
 Item& create_item(int id, int number)
 {
-    REQUIRE_SOME(itemcreate(-1, id, 0, 0, number));
+    REQUIRE_SOME(itemcreate_extra_inv(id, 0, 0, number));
     normalize_item(elona::inv[elona::ci]);
     return elona::inv[elona::ci];
 }
@@ -87,7 +87,7 @@ void invalidate_item(Item& item)
     item_delete(inv[old_index]);
     do
     {
-        REQUIRE_SOME(itemcreate(-1, old_id, old_x, old_y, 3));
+        REQUIRE_SOME(itemcreate_extra_inv(old_id, old_x, old_y, 3));
     } while (elona::ci != old_index);
 }
 


### PR DESCRIPTION
# Summary

Avoid index access of `inv`, instead, use `Item&`.


## Bug fix

When a character wears an equipment with enchantment "It attracts monsters" and the summoned monster equips some gears, the item which is being processed changes.

Cause:

`ci` (processing item) is overwritten by character generation.