### PR TITLE
Fix various config error

### DIFF
--- a/runtime/data/script/kernel/config.lua
+++ b/runtime/data/script/kernel/config.lua
@@ -95,7 +95,7 @@ end
 
 local function load_default_values_if_unset()
    for option_key, schema in pairs(_schemas) do
-      if not Config.get(option_key) then
+      if Config.get(option_key) == nil then
          -- Almost all of options have thier own default values, but there are some exceptions:
          -- * Sections
          -- * Option "core.screen.display_mode" in headless mode

--- a/runtime/mod/core/config-schema.lua
+++ b/runtime/mod/core/config-schema.lua
@@ -2,7 +2,7 @@ config {
    section "game", {
       option "extra_help", true,
 
-      option "attack_neutral_npcs", true,
+      option "attack_neutral_npcs", false,
 
       option "default_save", "",
 

--- a/src/elona/config.cpp
+++ b/src/elona/config.cpp
@@ -185,16 +185,16 @@ json5::value::object_type parse_json5_file(const fs::path& path)
     }
     catch (json5::syntax_error& err)
     {
-        ELONA_WARN("warn") << "JSON5 syntax error in '"
-                           << filepathutil::to_utf8_path(path)
-                           << "': " << err.what();
+        ELONA_WARN("config")
+            << "JSON5 syntax error in '" << filepathutil::to_utf8_path(path)
+            << "': " << err.what();
         return {};
     }
     catch (json5::invalid_type_error& err)
     {
-        ELONA_WARN("warn") << "JSON5 type error in '"
-                           << filepathutil::to_utf8_path(path)
-                           << "': " << err.what();
+        ELONA_WARN("config")
+            << "JSON5 type error in '" << filepathutil::to_utf8_path(path)
+            << "': " << err.what();
         return {};
     }
 }
@@ -594,19 +594,23 @@ void config_load_preinit_options()
     do \
     { \
         g_config.set_##option(get_value_by_nesting_key( \
-            obj, {#category, #option}, json5::T##_type{default_value})); \
+            obj, \
+            {"core", #category, #option}, \
+            json5::T##_type{default_value})); \
     } while (0)
 
 
     // screen.fullscreen (default: "windowed")
     g_config.set_fullscreen(convert_to_fullscreen(get_value_by_nesting_key(
-        obj, {"screen", "fullscreen"}, json5::string_type{"windowed"})));
+        obj,
+        {"core", "screen", "fullscreen"},
+        json5::string_type{"windowed"})));
 
     if (defines::is_android)
     {
         // screen.window_mode (default: "")
         g_config.set_display_mode(get_value_by_nesting_key(
-            obj, {"screen", "window_mode"}, json5::string_type{""}));
+            obj, {"core", "screen", "window_mode"}, json5::string_type{""}));
     }
     else
     {

--- a/src/elona/config_menu.hpp
+++ b/src/elona/config_menu.hpp
@@ -239,6 +239,7 @@ public:
     {
         _index =
             clamp(_index + delta, 0, static_cast<int>(_choices.size() - 1));
+        config_set_string(_key, _choices[_index].value);
     }
 
 


### PR DESCRIPTION
# Related Issues

closing #1473

# Summary

Issue #1473:
- Fix preinit options not loaded (path to JSON value were wrong).
- Fix string options not modifiable via Options menu.

Others:
- Fix default value of `core.game.attack_neutral_npcs`: true -> false
- Fix options whose default value is false not loaded.
- Fix log output's tag: warn -> config
