### PR TITLE
Remove unnecessary assertion error which causes crash

### DIFF
--- a/src/elona/quest.cpp
+++ b/src/elona/quest.cpp
@@ -75,8 +75,6 @@ void Quest::clear()
 
 Quest& QuestData::immediate()
 {
-    assert(game_data.executing_immediate_quest != 0);
-
     return quest_data[game_data.executing_immediate_quest];
 }
 


### PR DESCRIPTION
# Related issues

fix #1481

# Summary

Cause and solution:
  `QuestData::immediate()` asserts that `game_data.executing_immediate_quest` must not be zero, but 0 is valid as an index of `quest_data`. Remove the `assert()` macro.
