### PR TITLE
Limit some of rnd()'s range to emulate vanilla rnd() function.

### DIFF
--- a/doc/api/config.luadoc
+++ b/doc/api/config.luadoc
@@ -16,7 +16,7 @@ function set(key, value) end
 --  @raise if the config item does not exist or is not a boolean, an integer, or
 --  a string.
 --  @function get
-function get(key, s) end
+function get(key) end
 
 --- Saves the current sate of the config to the config options file. Be sure to
 --  call this when you modify the config using this API.

--- a/doc/api/json5.luadoc
+++ b/doc/api/json5.luadoc
@@ -1,0 +1,11 @@
+--- Parse/stringify JSON5 format.
+--  @usage local JSON5 = require("game.JSON5")
+module "JSON5"
+
+--- Parses JSON5 text.
+--  @function parse
+function parse(source, state) end
+
+--- Stringify arbitary value as JSON5.
+--  @function stringify
+function stringify(value, opts) end

--- a/doc/api/rand.luadoc
+++ b/doc/api/rand.luadoc
@@ -8,6 +8,13 @@ module "Rand"
 --  @function rnd
 function rnd(n) end
 
+--- Returns a random number from 0 to min(n, 32768), exclusive. It emulates
+--  vanilla's random number generation, capped by the upper limit.
+--  @tparam num n
+--  @treturn num a number in [0, min(n, 32768))
+--  @function rnd_capped
+function rnd_capped(n) end
+
 --- Returns true one out of every n times.
 --  @tparam num n
 --  @treturn bool true one out of every n times

--- a/runtime/mod/core/data/chara_drop.lua
+++ b/runtime/mod/core/data/chara_drop.lua
@@ -194,7 +194,7 @@ data:add_multi(
          id = "gold_bell",
          drops = {{
                on_create = function(args)
-                  Item.create(args.chara.position, "core.gold_piece", 2500 + Rand.rnd((Chara.player().fame + 1000)))
+                  Item.create(args.chara.position, "core.gold_piece", 2500 + Rand.rnd_capped(Chara.player().fame + 1000))
                end
          }}
       },

--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -85,7 +85,7 @@ void search_material_spot()
         atxlv = cdata.player().level / 2 + rnd(10);
         if (atxlv > 30)
         {
-            atxlv = 30 + rnd((rnd(atxlv - 30) + 1));
+            atxlv = 30 + rnd(rnd_capped(atxlv - 30) + 1);
         }
         if (4 <= game_data.stood_world_map_tile &&
             game_data.stood_world_map_tile < 9)
@@ -133,7 +133,7 @@ void search_material_spot()
             i = 5;
             if (atxspot == 14)
             {
-                if (sdata(163, 0) < rnd(atxlv * 2 + 1) || rnd(10) == 0)
+                if (sdata(163, 0) < rnd_capped(atxlv * 2 + 1) || rnd(10) == 0)
                 {
                     txt(i18n::s.get("core.activity.material.digging.fails"));
                     break;
@@ -143,7 +143,7 @@ void search_material_spot()
             }
             if (atxspot == 13)
             {
-                if (sdata(185, 0) < rnd(atxlv * 2 + 1) || rnd(10) == 0)
+                if (sdata(185, 0) < rnd_capped(atxlv * 2 + 1) || rnd(10) == 0)
                 {
                     txt(i18n::s.get("core.activity.material.fishing.fails"));
                     break;
@@ -153,7 +153,7 @@ void search_material_spot()
             }
             if (atxspot == 15)
             {
-                if (sdata(180, 0) < rnd(atxlv * 2 + 1) || rnd(10) == 0)
+                if (sdata(180, 0) < rnd_capped(atxlv * 2 + 1) || rnd(10) == 0)
                 {
                     txt(i18n::s.get("core.activity.material.searching.fails"));
                     break;
@@ -403,7 +403,7 @@ std::pair<bool, int> activity_perform_proc_audience(
                     Message::color{ColorIndex::cyan});
                 txt(i18n::s.get("core.activity.perform.throws_rock", audience));
             }
-            dmg = rnd(audience.level + 1) + 1;
+            dmg = rnd_capped(audience.level + 1) + 1;
             if (audience.id == CharaId::loyter)
             {
                 dmg = audience.level * 2 + rnd(100);
@@ -429,7 +429,7 @@ std::pair<bool, int> activity_perform_proc_audience(
     {
         return std::make_pair(false, gold);
     }
-    if (rnd(performer_skill + 1) > rnd(audience.level * 2 + 1))
+    if (rnd_capped(performer_skill + 1) > rnd_capped(audience.level * 2 + 1))
     {
         if (game_data.executing_immediate_quest_type == 1009)
         {
@@ -439,7 +439,7 @@ std::pair<bool, int> activity_perform_proc_audience(
                 calcpartyscore();
             }
         }
-        const auto p = rnd(audience.level + 1) + 1;
+        const auto p = rnd_capped(audience.level + 1) + 1;
         if (rnd(2) == 0)
         {
             performer.quality_of_performance += p;
@@ -456,7 +456,7 @@ std::pair<bool, int> activity_perform_proc_audience(
             status_ailment_damage(audience, StatusAilment::drunk, 500);
         }
     }
-    if (rnd(performer_skill + 1) > rnd(audience.level * 5 + 1))
+    if (rnd_capped(performer_skill + 1) > rnd_capped(audience.level * 5 + 1))
     {
         if (rnd(3) == 0)
         {
@@ -471,7 +471,7 @@ std::pair<bool, int> activity_perform_proc_audience(
             performer.quality_of_performance += audience.level + 5;
             if (performer.index == 0 && audience.index >= 16)
             {
-                if (rnd(performance_tips * 2 + 2) == 0)
+                if (rnd_capped(performance_tips * 2 + 2) == 0)
                 {
                     activity_perform_generate_item(
                         performer, audience, instrument);
@@ -854,7 +854,7 @@ void activity_others_doing(Character& doer)
                     continue;
                 }
             }
-            p = rnd((i + 1)) *
+            p = rnd_capped(i + 1) *
                 (80 + (is_in_fov(cdata[cnt]) == 0) * 50 +
                  dist(
                      cdata[cnt].position.x,
@@ -867,7 +867,7 @@ void activity_others_doing(Character& doer)
             {
                 p = p * 2 / 3;
             }
-            if (rnd(sdata(13, cnt) + 1) > p)
+            if (rnd_capped(sdata(13, cnt) + 1) > p)
             {
                 if (is_in_fov(cdata[cnt]))
                 {
@@ -1678,7 +1678,7 @@ void spot_fishing()
                     await(g_config.animation_wait() * 2);
                 }
             }
-            if (the_fish_db[fish]->difficulty >= rnd(sdata(185, 0) + 1))
+            if (the_fish_db[fish]->difficulty >= rnd_capped(sdata(185, 0) + 1))
             {
                 fishstat = 0;
             }

--- a/src/elona/adventurer.cpp
+++ b/src/elona/adventurer.cpp
@@ -38,7 +38,7 @@ void create_all_adventurers()
 void create_adventurer()
 {
     flt(0, Quality::miracle);
-    initlv = rnd(60 + cdata.player().level) + 1;
+    initlv = rnd_capped(60 + cdata.player().level) + 1;
     p(0) = 75;
     p(1) = 41;
     p(2) = 160;
@@ -74,7 +74,7 @@ void create_adventurer()
     cdata[rc].current_map = p;
     cdata[rc].current_dungeon_level = 1;
     cdata[rc].fame = cdata[rc].level * cdata[rc].level * 30 +
-        rnd((cdata[rc].level * 200 + 100)) + rnd(500);
+        rnd_capped(cdata[rc].level * 200 + 100) + rnd(500);
 }
 
 
@@ -287,14 +287,16 @@ void adventurer_update()
         }
         if (rnd(20) == 0)
         {
-            cdata[rc].fame += rnd(cdata[rc].level * cdata[rc].level / 40 + 5) -
-                rnd((cdata[rc].level * cdata[rc].level / 50 + 5));
+            cdata[rc].fame +=
+                rnd_capped(cdata[rc].level * cdata[rc].level / 40 + 5) -
+                rnd_capped(cdata[rc].level * cdata[rc].level / 50 + 5);
         }
         if (rnd(2000) == 0)
         {
             cdata[rc].experience += clamp(cdata[rc].level, 1, 1000) *
                 clamp(cdata[rc].level, 1, 1000) * 100;
-            int fame = rnd(cdata[rc].level * cdata[rc].level / 20 + 10) + 10;
+            int fame =
+                rnd_capped(cdata[rc].level * cdata[rc].level / 20 + 10) + 10;
             cdata[rc].fame += fame;
             addnews(4, rc, fame);
             adventurer_discover_equipment();

--- a/src/elona/buff.cpp
+++ b/src/elona/buff.cpp
@@ -161,7 +161,7 @@ void buff_add(
     if (buff->type == BuffType::hex)
     {
         bool resists{};
-        if (sdata(60, chara.index) / 2 > rnd(power * 2 + 100))
+        if (sdata(60, chara.index) / 2 > rnd_capped(power * 2 + 100))
         {
             resists = true;
         }
@@ -191,7 +191,7 @@ void buff_add(
         if (const auto& holy_veil = buff_find(chara, "core.holy_veil"))
         {
             if (holy_veil->power + 50 > power * 5 / 2 ||
-                rnd(holy_veil->power + 50) > rnd(power + 1))
+                rnd_capped(holy_veil->power + 50) > rnd_capped(power + 1))
             {
                 txt(i18n::s.get("core.magic.buff.holy_veil_repels"));
                 return;

--- a/src/elona/building.cpp
+++ b/src/elona/building.cpp
@@ -1083,7 +1083,7 @@ void show_shop_log()
         {
             continue;
         }
-        if (rnd(val0) > shoplv * 100 + 500)
+        if (rnd_capped(val0) > shoplv * 100 + 500)
         {
             continue;
         }
@@ -1095,7 +1095,7 @@ void show_shop_log()
         {
             continue;
         }
-        in = rnd(inv[ci].number()) + 1;
+        in = rnd_capped(inv[ci].number()) + 1;
         inv[ci].modify_number((-in));
         sold += in;
         val0 = val0 * in;

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -304,7 +304,7 @@ int calcfame(int cc, int base)
 int decfame(int cc, int base)
 {
     int ret = cdata[cc].fame / base + 5;
-    ret = ret + rnd(ret / 2) - rnd(ret / 2);
+    ret = ret + rnd_capped(ret / 2) - rnd_capped(ret / 2);
     cdata[cc].fame -= ret;
     if (cdata[cc].fame < 0)
     {
@@ -558,21 +558,21 @@ int calcattackhit()
             int evaderef = evasion * 100 / clamp(tohit, 1, tohit);
             if (evaderef > 300)
             {
-                if (rnd(sdata(187, tc) + 250) > 100)
+                if (rnd_capped(sdata(187, tc) + 250) > 100)
                 {
                     return -2;
                 }
             }
             if (evaderef > 200)
             {
-                if (rnd(sdata(187, tc) + 250) > 150)
+                if (rnd_capped(sdata(187, tc) + 250) > 150)
                 {
                     return -2;
                 }
             }
             if (evaderef > 150)
             {
-                if (rnd(sdata(187, tc) + 250) > 200)
+                if (rnd_capped(sdata(187, tc) + 250) > 200)
                 {
                     return -2;
                 }
@@ -605,7 +605,7 @@ int calcattackhit()
     {
         return 1;
     }
-    if (rnd(tohit) > rnd(evasion * 3 / 2))
+    if (rnd_capped(tohit) > rnd_capped(evasion * 3 / 2))
     {
         return 1;
     }
@@ -1070,7 +1070,7 @@ int calchirecost(int cc)
 
 void generatemoney(int cc)
 {
-    int gold = rnd(100) + rnd(cdata[cc].level * 50 + 1);
+    int gold = rnd(100) + rnd_capped(cdata[cc].level * 50 + 1);
     if ((cdata[cc].character_role >= 1000 && cdata[cc].character_role < 2000) ||
         cdata[cc].character_role == 2003)
     {
@@ -1298,7 +1298,8 @@ int calcinitgold(int owner)
 {
     if (owner < 0)
     {
-        return rnd(game_data.current_dungeon_level * 25 *
+        return rnd_capped(
+                   game_data.current_dungeon_level * 25 *
                        (game_data.current_map != mdata_t::MapId::shelter_) +
                    10) +
             1;
@@ -1309,7 +1310,7 @@ int calcinitgold(int owner)
     case 183: return 5000 + rnd(11000);
     case 184: return 2000 + rnd(5000);
     case 185: return 1000 + rnd(3000);
-    default: return rnd(cdata[owner].level * 25 + 10) + 1;
+    default: return rnd_capped(cdata[owner].level * 25 + 10) + 1;
     }
 }
 
@@ -1699,7 +1700,8 @@ int calc_chara_exp_from_skill_exp(
     int skill_exp,
     int divisor)
 {
-    return rnd(int(double(chara.required_experience) * skill_exp / 1000 /
+    return rnd_capped(
+               int(double(chara.required_experience) * skill_exp / 1000 /
                    (chara.level + divisor)) +
                1) +
         rnd(2);

--- a/src/elona/casino.cpp
+++ b/src/elona/casino.cpp
@@ -649,7 +649,7 @@ bool casino_blackjack()
                 {
                     if (pileremain() > 10)
                     {
-                        if (rnd(sdata(19, 0)) > 40)
+                        if (rnd_capped(sdata(19, 0)) > 40)
                         {
                             txt(i18n::s.get(
                                 "core.casino.blackjack.game.bad_feeling"));
@@ -676,7 +676,7 @@ bool casino_blackjack()
             {
                 p = 60;
             }
-            if (rnd(sdata(12, 0)) < rnd(p(0)))
+            if (rnd_capped(sdata(12, 0)) < rnd(p(0)))
             {
                 atxinit();
                 noteadd(i18n::s.get("core.casino.blackjack.game.cheat.dialog"));

--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -571,8 +571,9 @@ void initialize_character()
     {
         cdata[rc].nutrition = 5000 + rnd(4000);
     }
-    cdata[rc].height = cdata[rc].height + rnd((cdata[rc].height / 5 + 1)) -
-        rnd((cdata[rc].height / 5 + 1));
+    cdata[rc].height = cdata[rc].height +
+        rnd_capped((cdata[rc].height / 5 + 1)) -
+        rnd_capped((cdata[rc].height / 5 + 1));
     cdata[rc].weight =
         cdata[rc].height * cdata[rc].height * (rnd(6) + 18) / 10000;
     update_required_experience(cdata[rc]);

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -735,7 +735,7 @@ TurnResult do_throw_command()
         txt(i18n::s.get("core.action.throw.execute", cdata[cc], inv[ci]));
     }
     if (dist(cdata[cc].position.x, cdata[cc].position.y, tlocx, tlocy) * 4 >
-            rnd(sdata(111, cc) + 10) + sdata(111, cc) / 4 ||
+            rnd_capped(sdata(111, cc) + 10) + sdata(111, cc) / 4 ||
         rnd(10) == 0)
     {
         x = tlocx + rnd(2) - rnd(2);

--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -247,7 +247,7 @@ int damage_hp(
     }
     if (victim.is_metal())
     {
-        dmg_at_m141 = rnd(dmg_at_m141 / 10 + 2);
+        dmg_at_m141 = rnd_capped(dmg_at_m141 / 10 + 2);
     }
     if (victim.is_contracting_with_reaper())
     {
@@ -321,7 +321,8 @@ int damage_hp(
                 heal_hp(
                     *attacker,
                     clamp(
-                        rnd(dmg_at_m141 * (150 + element_power * 2) / 1000 +
+                        rnd_capped(
+                            dmg_at_m141 * (150 + element_power * 2) / 1000 +
                             10),
                         1,
                         attacker->max_hp / 10 + rnd(5)));
@@ -547,35 +548,35 @@ int damage_hp(
                     status_ailment_damage(
                         victim,
                         StatusAilment::blinded,
-                        rnd(element_power / 3 * 2 + 1));
+                        rnd_capped(element_power / 3 * 2 + 1));
                 }
                 if (rnd(20) < element_power / 50 + 4)
                 {
                     status_ailment_damage(
                         victim,
                         StatusAilment::paralyzed,
-                        rnd(element_power / 3 * 2 + 1));
+                        rnd_capped(element_power / 3 * 2 + 1));
                 }
                 if (rnd(20) < element_power / 50 + 4)
                 {
                     status_ailment_damage(
                         victim,
                         StatusAilment::confused,
-                        rnd(element_power / 3 * 2 + 1));
+                        rnd_capped(element_power / 3 * 2 + 1));
                 }
                 if (rnd(20) < element_power / 50 + 4)
                 {
                     status_ailment_damage(
                         victim,
                         StatusAilment::poisoned,
-                        rnd(element_power / 3 * 2 + 1));
+                        rnd_capped(element_power / 3 * 2 + 1));
                 }
                 if (rnd(20) < element_power / 50 + 4)
                 {
                     status_ailment_damage(
                         victim,
                         StatusAilment::sleep,
-                        rnd(element_power / 3 * 2 + 1));
+                        rnd_capped(element_power / 3 * 2 + 1));
                 }
             }
             if (element == 52)
@@ -588,38 +589,50 @@ int damage_hp(
             if (element == 53)
             {
                 status_ailment_damage(
-                    victim, StatusAilment::blinded, rnd(element_power + 1));
+                    victim,
+                    StatusAilment::blinded,
+                    rnd_capped(element_power + 1));
             }
             if (element == 58)
             {
                 status_ailment_damage(
-                    victim, StatusAilment::paralyzed, rnd(element_power + 1));
+                    victim,
+                    StatusAilment::paralyzed,
+                    rnd_capped(element_power + 1));
             }
             if (element == 54)
             {
                 status_ailment_damage(
-                    victim, StatusAilment::confused, rnd(element_power + 1));
+                    victim,
+                    StatusAilment::confused,
+                    rnd_capped(element_power + 1));
             }
             if (element == 57)
             {
                 status_ailment_damage(
-                    victim, StatusAilment::confused, rnd(element_power + 1));
+                    victim,
+                    StatusAilment::confused,
+                    rnd_capped(element_power + 1));
             }
             if (element == 55)
             {
                 status_ailment_damage(
-                    victim, StatusAilment::poisoned, rnd(element_power + 1));
+                    victim,
+                    StatusAilment::poisoned,
+                    rnd_capped(element_power + 1));
             }
             if (element == 61)
             {
                 status_ailment_damage(
-                    victim, StatusAilment::bleeding, rnd(element_power + 1));
+                    victim,
+                    StatusAilment::bleeding,
+                    rnd_capped(element_power + 1));
             }
             if (element == 62)
             {
                 if (victim.index == 0)
                 {
-                    modify_ether_disease_stage(rnd(element_power + 1));
+                    modify_ether_disease_stage(rnd_capped(element_power + 1));
                 }
             }
             if (element == 63)
@@ -926,7 +939,8 @@ int damage_hp(
                 {
                     heal_hp(
                         *attacker,
-                        rnd(dmg_at_m141 * (200 + element_power) / 1000 + 5));
+                        rnd_capped(
+                            dmg_at_m141 * (200 + element_power) / 1000 + 5));
                 }
             }
         }
@@ -1304,7 +1318,8 @@ void damage_insanity(Character& cc, int delta)
     }
     delta = std::max(delta, 0);
     cc.insanity += delta;
-    if (rnd(10) == 0 || rnd(delta + 1) > 5 || rnd(cc.insanity + 1) > 50)
+    if (rnd(10) == 0 || rnd_capped(delta + 1) > 5 ||
+        rnd_capped(cc.insanity + 1) > 50)
     {
         status_ailment_damage(cc, StatusAilment::insane, 100);
     }

--- a/src/elona/elonacore.cpp
+++ b/src/elona/elonacore.cpp
@@ -513,9 +513,9 @@ void gain_race_feat()
 int roundmargin(int x, int y)
 {
     if (x > y)
-        return x - rnd(x - y);
+        return x - rnd_capped(x - y);
     else if (x < y)
-        return x + rnd(y - x);
+        return x + rnd_capped(y - x);
     else
         return x;
 }
@@ -1096,7 +1096,7 @@ int roll(int x, int y, int z)
     int ret = 0;
     for (int i = 0; i < x; ++i)
     {
-        ret += rnd(y) + 1;
+        ret += rnd_capped(y) + 1;
     }
     return ret + z;
 }
@@ -1894,7 +1894,7 @@ int try_to_cast_spell()
         {
             r4 = sdata(the_ability_db[r3]->related_basic_attribute, cc);
         }
-        if (rnd(sdata(150, cc) * r4 * 4 + 250) < rnd(r2 + 1))
+        if (rnd_capped(sdata(150, cc) * r4 * 4 + 250) < rnd_capped(r2 + 1))
         {
             if (rnd(7) == 0)
             {
@@ -1902,21 +1902,21 @@ int try_to_cast_spell()
             }
             if (r4 * 10 < r2)
             {
-                if (rnd(r4 * 10 + 1) < rnd(r2 + 1))
+                if (rnd_capped(r4 * 10 + 1) < rnd_capped(r2 + 1))
                 {
                     f = 0;
                 }
             }
             if (r4 * 20 < r2)
             {
-                if (rnd(r4 * 20 + 1) < rnd(r2 + 1))
+                if (rnd_capped(r4 * 20 + 1) < rnd_capped(r2 + 1))
                 {
                     f = 0;
                 }
             }
             if (r4 * 30 < r2)
             {
-                if (rnd(r4 * 30 + 1) < rnd(r2 + 1))
+                if (rnd_capped(r4 * 30 + 1) < rnd_capped(r2 + 1))
                 {
                     f = 0;
                 }
@@ -1999,8 +1999,8 @@ int try_to_cast_spell()
 
 int try_to_reveal()
 {
-    if (rnd(sdata(159, cc) * 15 + 20 + sdata(13, cc)) >
-        rnd(game_data.current_dungeon_level * 8 + 60))
+    if (rnd_capped(sdata(159, cc) * 15 + 20 + sdata(13, cc)) >
+        rnd_capped(game_data.current_dungeon_level * 8 + 60))
     {
         chara_gain_exp_detection(cdata[cc]);
         return 1;
@@ -2018,7 +2018,7 @@ int can_evade_trap()
     }
     if (cc < 16)
     {
-        if (rnd(refdiff + 1) < sdata(13, cc) + sdata(159, cc) * 4)
+        if (rnd_capped(refdiff + 1) < sdata(13, cc) + sdata(159, cc) * 4)
         {
             return 1;
         }
@@ -2034,8 +2034,8 @@ int can_evade_trap()
 
 int try_to_disarm_trap()
 {
-    if (rnd(sdata(175, cc) * 15 + 20 + sdata(12, cc)) >
-        rnd(game_data.current_dungeon_level * 12 + 100))
+    if (rnd_capped(sdata(175, cc) * 15 + 20 + sdata(12, cc)) >
+        rnd_capped(game_data.current_dungeon_level * 12 + 100))
     {
         chara_gain_exp_disarm_trap(cdata[cc]);
         return 1;
@@ -2066,7 +2066,7 @@ int try_to_perceive_npc(int cc)
                     cdata[r2].position.y) *
                     150 +
                 (sdata(157, cc) * 100 + 150) + 1;
-            if (rnd(p(0)) < rnd(sdata(13, r2) * 60 + 150))
+            if (rnd_capped(p(0)) < rnd_capped(sdata(13, r2) * 60 + 150))
             {
                 return 1;
             }
@@ -2101,7 +2101,7 @@ void proc_turn_end(int cc)
     }
     if (cdata[cc].poisoned > 0)
     {
-        damage_hp(cdata[cc], rnd(2 + sdata(11, cc) / 10), -4);
+        damage_hp(cdata[cc], rnd_capped(2 + sdata(11, cc) / 10), -4);
         status_ailment_heal(cdata[cc], StatusAilment::poisoned, 1);
         if (cdata[cc].poisoned > 0)
         {
@@ -2230,7 +2230,8 @@ void proc_turn_end(int cc)
     {
         damage_hp(
             cdata[cc],
-            rnd(cdata[cc].hp * (1 + cdata[cc].bleeding / 4) / 100 + 3) + 1,
+            rnd_capped(cdata[cc].hp * (1 + cdata[cc].bleeding / 4) / 100 + 3) +
+                1,
             -13);
         status_ailment_heal(
             cdata[cc],
@@ -2351,11 +2352,11 @@ void proc_turn_end(int cc)
     {
         if (rnd(6) == 0)
         {
-            heal_hp(cdata[cc], rnd(sdata(154, cc) / 3 + 1) + 1);
+            heal_hp(cdata[cc], rnd_capped(sdata(154, cc) / 3 + 1) + 1);
         }
         if (rnd(5) == 0)
         {
-            heal_mp(cdata[cc], rnd(sdata(155, cc) / 2 + 1) + 1);
+            heal_mp(cdata[cc], rnd_capped(sdata(155, cc) / 2 + 1) + 1);
         }
     }
 }
@@ -3568,7 +3569,7 @@ void damage_by_cursed_equipments()
     {
         if (cdata[cc].gold > 0)
         {
-            p = rnd(cdata[cc].gold) / 100 + rnd(10) + 1;
+            p = rnd_capped(cdata[cc].gold) / 100 + rnd(10) + 1;
             if (p > cdata[cc].gold)
             {
                 p = cdata[cc].gold;
@@ -4821,8 +4822,8 @@ void supply_income()
         {
             continue;
         }
-        p = calcincome(cnt) + rnd((calcincome(cnt) / 3 + 1)) -
-            rnd((calcincome(cnt) / 3 + 1));
+        p = calcincome(cnt) + rnd_capped(calcincome(cnt) / 3 + 1) -
+            rnd_capped(calcincome(cnt) / 3 + 1);
         income += p;
         flt();
         itemcreate_extra_inv(54, -1, -1, p);
@@ -6507,7 +6508,9 @@ bool move_character_internal(Character& chara)
             else
             {
                 damage_hp(
-                    chara, rnd(game_data.current_dungeon_level * 2 + 10), -1);
+                    chara,
+                    rnd_capped(game_data.current_dungeon_level * 2 + 10),
+                    -1);
             }
         }
         if (feat(2) == 1)
@@ -7207,13 +7210,13 @@ int calcmagiccontrol(int caster_chara_index, int target_chara_index)
         if (belong_to_same_team(
                 cdata[caster_chara_index], cdata[target_chara_index]))
         {
-            if (sdata(188, caster_chara_index) * 5 > rnd(dmg + 1))
+            if (sdata(188, caster_chara_index) * 5 > rnd_capped(dmg + 1))
             {
                 dmg = 0;
             }
             else
             {
-                dmg = rnd(
+                dmg = rnd_capped(
                     dmg * 100 / (100 + sdata(188, caster_chara_index) * 10) +
                     1);
             }
@@ -7578,7 +7581,9 @@ int drink_well()
         {
             flt();
             itemcreate_extra_inv(
-                54, cdata[cc].position, rnd(sdata(159, cc) / 2 * 50 + 100) + 1);
+                54,
+                cdata[cc].position,
+                rnd_capped(sdata(159, cc) / 2 * 50 + 100) + 1);
             txt(i18n::s.get(
                 "core.action.drink.well.effect.finds_gold", cdata[cc]));
             break;
@@ -8739,7 +8744,7 @@ TurnResult do_bash()
             {
                 p *= 20;
             }
-            if (rnd(p(0)) < sdata(10, cc) && rnd(2))
+            if (rnd_capped(p(0)) < sdata(10, cc) && rnd(2))
             {
                 txt(i18n::s.get("core.action.bash.door.destroyed"));
                 if (feat(2) > sdata(10, cc))
@@ -8948,7 +8953,8 @@ TurnResult proc_movement_event()
                         encounter = 2;
                     }
                 }
-                if (rnd(220 + cdata.player().level * 10 -
+                if (rnd_capped(
+                        220 + cdata.player().level * 10 -
                         clamp(
                             game_data.cargo_weight * 150 /
                                 (game_data.current_cart_limit + 1),
@@ -9437,7 +9443,7 @@ int unlock_box(int difficulty)
         {
             txt(i18n::s.get("core.action.unlock.easy"));
         }
-        else if (rnd(rnd(i * 2) + 1) < difficulty)
+        else if (rnd(rnd_capped(i * 2) + 1) < difficulty)
         {
             txt(i18n::s.get("core.action.unlock.fail"));
             f = 1;
@@ -9573,7 +9579,7 @@ void open_box()
             }
             else
             {
-                in = rnd(inv[ci].value / 10 + 1) + 1;
+                in = rnd_capped(inv[ci].value / 10 + 1) + 1;
             }
         }
         if (inv[ri].id == ItemId::wallet)
@@ -10024,7 +10030,7 @@ void try_to_melee_attack()
                 txt(i18n::s.get(
                     "core.action.melee.shield_bash", cdata[cc], cdata[tc]));
             }
-            damage_hp(cdata[tc], rnd(sdata(168, cc)) + 1, cc);
+            damage_hp(cdata[tc], rnd_capped(sdata(168, cc)) + 1, cc);
             status_ailment_damage(
                 cdata[tc],
                 StatusAilment::dimmed,
@@ -10490,7 +10496,8 @@ bool do_physical_attack_internal()
             {
                 if (inv[cw].param2 < calcexpalive(inv[cw].param1))
                 {
-                    inv[cw].param2 += rnd(cdata[tc].level / inv[cw].param1 + 1);
+                    inv[cw].param2 +=
+                        rnd_capped(cdata[tc].level / inv[cw].param1 + 1);
                     if (inv[cw].param2 >= calcexpalive(inv[cw].param1))
                     {
                         snd("core.ding3");
@@ -10546,14 +10553,14 @@ void proc_weapon_enchantments()
         enc = inv[cw].enchantments[cnt].id;
         if (enc == 36)
         {
-            p = rnd(inv[cw].enchantments[cnt].power / 50 + 1) + 1;
+            p = rnd_capped(inv[cw].enchantments[cnt].power / 50 + 1) + 1;
             heal_sp(cdata[cc], p);
             damage_sp(cdata[tc], p / 2);
             continue;
         }
         if (enc == 38)
         {
-            p = rnd(inv[cw].enchantments[cnt].power / 25 + 1) + 1;
+            p = rnd_capped(inv[cw].enchantments[cnt].power / 25 + 1) + 1;
             heal_mp(cdata[cc], p / 5);
             if (cdata[tc].state() != Character::State::alive)
             {
@@ -10632,7 +10639,8 @@ void proc_weapon_enchantments()
                 game_data.proc_damage_events_flag = 1;
                 damage_hp(
                     cdata[tc],
-                    rnd(orgdmg * (100 + inv[cw].enchantments[cnt].power) /
+                    rnd_capped(
+                        orgdmg * (100 + inv[cw].enchantments[cnt].power) /
                             1000 +
                         1) +
                         5,

--- a/src/elona/food.cpp
+++ b/src/elona/food.cpp
@@ -84,7 +84,7 @@ void _food_gets_rotten(int chara_idx, Item& food)
         if (rnd(3) == 0)
         {
             txt(i18n::s.get("core.misc.extract_seed", food));
-            const auto seed_num = rnd(food.number()) + 1;
+            const auto seed_num = rnd_capped(food.number()) + 1;
             food.modify_number(-food.number());
             flt(calcobjlv(cdata.player().level));
             flttypeminor = 58500;
@@ -271,7 +271,7 @@ void chara_vomit(Character& cc)
                 }
             }
         }
-        if (rnd(p * p * p) == 0 || cc.index == 0)
+        if (rnd_capped(p * p * p) == 0 || cc.index == 0)
         {
             flt();
             if (const auto item = itemcreate_extra_inv(704, cc.position, 0))
@@ -409,7 +409,8 @@ void cook(Item& cook_tool, Item& food)
 
     const auto item_name_prev = itemname(food.index);
 
-    int dish_rank = rnd(sdata(184, cc) + 6) + rnd(cook_tool.param1 / 50 + 1);
+    int dish_rank =
+        rnd_capped(sdata(184, cc) + 6) + rnd(cook_tool.param1 / 50 + 1);
     if (dish_rank > sdata(184, cc) / 5 + 7)
     {
         dish_rank = sdata(184, cc) / 5 + 7;
@@ -1232,13 +1233,15 @@ void apply_general_eating_effect(Character& eater, Item& food)
         {
             txt(i18n::s.get("core.food.effect.little_sister", eater),
                 Message::color{ColorIndex::green});
-            if (rnd(sdata.get(2, eater.index).original_level *
+            if (rnd_capped(
+                    sdata.get(2, eater.index).original_level *
                         sdata.get(2, eater.index).original_level +
                     1) < 2000)
             {
                 chara_gain_fixed_skill_exp(eater, 2, 1000);
             }
-            if (rnd(sdata.get(3, eater.index).original_level *
+            if (rnd_capped(
+                    sdata.get(3, eater.index).original_level *
                         sdata.get(3, eater.index).original_level +
                     1) < 2000)
             {
@@ -1343,13 +1346,13 @@ void apply_general_eating_effect(Character& eater, Item& food)
         enc = food.enchantments[cnt].id;
         if (enc == 36)
         {
-            p = rnd(food.enchantments[cnt].power / 50 + 1) + 1;
+            p = rnd_capped(food.enchantments[cnt].power / 50 + 1) + 1;
             heal_sp(eater, p);
             continue;
         }
         if (enc == 38)
         {
-            p = rnd(food.enchantments[cnt].power / 25 + 1) + 1;
+            p = rnd_capped(food.enchantments[cnt].power / 25 + 1) + 1;
             heal_mp(eater, p / 5);
             continue;
         }

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -1883,7 +1883,7 @@ bool item_fire(int owner, optional_ref<Item> burned_item)
             continue;
         }
 
-        int p_ = rnd(item.number()) / 2 + 1;
+        int p_ = rnd_capped(item.number()) / 2 + 1;
         if (owner != -1)
         {
             if (item.body_part != 0)
@@ -2065,7 +2065,7 @@ bool item_cold(int owner, optional_ref<Item> destroyed_item)
             }
             continue;
         }
-        int p_ = rnd(item.number()) / 2 + 1;
+        int p_ = rnd_capped(item.number()) / 2 + 1;
         if (owner != -1)
         {
             if (is_in_fov(cdata[owner]))

--- a/src/elona/itemgen.cpp
+++ b/src/elona/itemgen.cpp
@@ -366,7 +366,7 @@ optional_ref<Item> do_create_item(int slot, int x, int y)
 
     if (item.id == ItemId::monster_ball)
     {
-        item.param2 = rnd(objlv + 1) + 1;
+        item.param2 = rnd_capped(objlv + 1) + 1;
         item.value = 2000 + item.param2 * item.param2 + item.param2 * 100;
     }
 
@@ -377,7 +377,7 @@ optional_ref<Item> do_create_item(int slot, int x, int y)
 
     if (item.id == ItemId::ancient_book)
     {
-        item.param1 = rnd(rnd(clamp(objlv / 2, 1, 15)) + 1);
+        item.param1 = rnd(rnd_capped(clamp(objlv / 2, 1, 15)) + 1);
     }
 
     if (item.id == ItemId::sisters_love_fueled_lunch)
@@ -425,10 +425,10 @@ optional_ref<Item> do_create_item(int slot, int x, int y)
         {
             item.param1 = cdata.player().level;
         }
-        item.param2 =
-            rnd(std::abs(game_data.current_dungeon_level) *
-                    (game_data.current_map != mdata_t::MapId::shelter_) +
-                1);
+        item.param2 = rnd_capped(
+            std::abs(game_data.current_dungeon_level) *
+                (game_data.current_map != mdata_t::MapId::shelter_) +
+            1);
         if (item.id == ItemId::wallet || item.id == ItemId::suitcase)
         {
             item.param2 = rnd(15);
@@ -503,7 +503,7 @@ optional_ref<Item> do_create_item(int slot, int x, int y)
     {
         if (reftype < 50000)
         {
-            if (rnd(sdata(162, 0) + 1) > 5)
+            if (rnd_capped(sdata(162, 0) + 1) > 5)
             {
                 item.identify_state = IdentifyState::almost;
             }

--- a/src/elona/lua_env/lua_api/lua_api_rand.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_rand.cpp
@@ -20,6 +20,19 @@ int LuaApiRand::rnd(int n)
 /**
  * @luadoc
  *
+ * Returns a random number from 0 to min(n, 32768), exclusive. It emulates
+ * vanilla's random number generation, capped by the upper limit.
+ * @tparam num n
+ * @treturn num a number in [0, min(n, 32768))
+ */
+int LuaApiRand::rnd_capped(int n)
+{
+    return elona::rnd_capped(n);
+}
+
+/**
+ * @luadoc
+ *
  * Returns true one out of every n times.
  * @tparam num n
  * @treturn bool true one out of every n times
@@ -78,6 +91,7 @@ sol::object LuaApiRand::choice(sol::table table)
 void LuaApiRand::bind(sol::table& api_table)
 {
     LUA_API_BIND_FUNCTION(api_table, LuaApiRand, rnd);
+    LUA_API_BIND_FUNCTION(api_table, LuaApiRand, rnd_capped);
     LUA_API_BIND_FUNCTION(api_table, LuaApiRand, one_in);
     LUA_API_BIND_FUNCTION(api_table, LuaApiRand, coinflip);
     LUA_API_BIND_FUNCTION(api_table, LuaApiRand, between);

--- a/src/elona/lua_env/lua_api/lua_api_rand.hpp
+++ b/src/elona/lua_env/lua_api/lua_api_rand.hpp
@@ -14,6 +14,7 @@ namespace lua
 namespace LuaApiRand
 {
 int rnd(int n);
+int rnd_capped(int n);
 
 bool one_in(int n);
 

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -48,7 +48,7 @@ bool _magic_636()
 {
     txt(i18n::s.get("core.magic.insanity", cdata[cc], cdata[tc]),
         Message::color{ColorIndex::purple});
-    damage_insanity(cdata[tc], rnd(roll(dice1, dice2, bonus) + 1));
+    damage_insanity(cdata[tc], rnd_capped(roll(dice1, dice2, bonus) + 1));
     return true;
 }
 
@@ -763,7 +763,7 @@ bool _magic_406_407()
         {
             continue;
         }
-        if (rnd(efp * 2 + 1) > rnd(cdata[tc].buffs[i].power + 1))
+        if (rnd_capped(efp * 2 + 1) > rnd_capped(cdata[tc].buffs[i].power + 1))
         {
             buff_delete(cdata[tc], i);
             ++p;
@@ -1657,7 +1657,7 @@ bool _magic_430_429()
                     }
                     continue;
                 }
-                if (p < 7 || rnd(efp + 1) > rnd(p * 8 + 1) ||
+                if (p < 7 || rnd_capped(efp + 1) > rnd(p * 8 + 1) ||
                     efstatus == CurseState::blessed)
                 {
                     if (efid == 429)
@@ -1914,7 +1914,7 @@ bool _magic_428()
 
 bool _magic_621()
 {
-    heal_mp(cdata[tc], efp / 2 + rnd((efp / 2 + 1)));
+    heal_mp(cdata[tc], efp / 2 + rnd_capped(efp / 2 + 1));
     if (is_in_fov(cdata[tc]))
     {
         txt(i18n::s.get("core.magic.harvest_mana", cdata[tc]));
@@ -2025,7 +2025,7 @@ bool _magic_645_1114()
     {
         p += *anticurse / 2;
     }
-    if (rnd(p(0)) > efp / 2 + (is_cursed(efstatus)) * 100)
+    if (rnd_capped(p(0)) > efp / 2 + (is_cursed(efstatus)) * 100)
     {
         return true;
     }
@@ -2199,7 +2199,7 @@ bool _magic_435()
             efp = efp * 3 / 2;
         }
     }
-    if (rnd(efp / 15 + 5) < cdata[tc].level)
+    if (rnd_capped(efp / 15 + 5) < cdata[tc].level)
     {
         f = 0;
     }
@@ -2232,32 +2232,32 @@ bool _magic_436_437_455_634_456()
     if (efid == 436)
     {
         p(0) = 3;
-        p(1) = 2 + rnd((efp / 50 + 1));
+        p(1) = 2 + rnd_capped(efp / 50 + 1);
         txt(i18n::s.get("core.magic.map_effect.web"));
     }
     if (efid == 437)
     {
         txt(i18n::s.get("core.magic.map_effect.fog"));
         p(0) = 3;
-        p(1) = 2 + rnd((efp / 50 + 1));
+        p(1) = 2 + rnd_capped(efp / 50 + 1);
     }
     if (efid == 455)
     {
         txt(i18n::s.get("core.magic.map_effect.acid"));
         p(0) = 2;
-        p(1) = 2 + rnd((efp / 50 + 1));
+        p(1) = 2 + rnd_capped(efp / 50 + 1);
     }
     if (efid == 456)
     {
         txt(i18n::s.get("core.magic.map_effect.fire"));
         p(0) = 2;
-        p(1) = 2 + rnd((efp / 50 + 1));
+        p(1) = 2 + rnd_capped(efp / 50 + 1);
     }
     if (efid == 634)
     {
         txt(i18n::s.get("core.magic.map_effect.ether_mist"));
         p(0) = 2;
-        p(1) = 1 + rnd((efp / 100 + 2));
+        p(1) = 1 + rnd_capped(efp / 100 + 2);
     }
     snd("core.web");
     for (int cnt = 0, cnt_end = (p(1)); cnt < cnt_end; ++cnt)
@@ -2308,7 +2308,7 @@ bool _magic_436_437_455_634_456()
         }
         if (efid == 437)
         {
-            mef_add(x, y, 2, 30, 8 + rnd((15 + efp / 25)), efp);
+            mef_add(x, y, 2, 30, 8 + rnd_capped(15 + efp / 25), efp);
         }
     }
     return true;
@@ -2512,7 +2512,7 @@ bool _magic_1128()
         return true;
     }
     snd("core.ding2");
-    p = rnd((efp + 1)) / 100 + 1;
+    p = rnd_capped(efp + 1) / 100 + 1;
     game_data.rights_to_succeed_to += p;
     txt(i18n::s.get("core.magic.deed_of_inheritance.claim", p(0)),
         Message::color{ColorIndex::orange});
@@ -2618,7 +2618,7 @@ bool _magic_630_1129()
                     "core.magic.fill_charge.cannot_recharge_anymore", inv[ci]));
                 return true;
             }
-            if (rnd(efp / 25 + 1) == 0)
+            if (rnd_capped(efp / 25 + 1) == 0)
             {
                 f = 0;
             }
@@ -2971,7 +2971,7 @@ bool _magic_457_438()
                 return true;
             }
             txt(i18n::s.get("core.magic.create.door.apply"));
-            cell_featset(x, y, tile_doorclosed, 21, rnd(efp / 10 + 1));
+            cell_featset(x, y, tile_doorclosed, 21, rnd_capped(efp / 10 + 1));
             if (chip_data.for_cell(x, y).effect & 4)
             {
                 cell_data.at(x, y).chip_id_actual = tile_tunnel;
@@ -3374,12 +3374,12 @@ bool _magic_464()
     std::string messages;
 
     animeload(10, tc);
-    for (int i = 0, n = clamp(4 + rnd(efp / 50 + 1), 1, 15); i < n; ++i)
+    for (int i = 0, n = clamp(4 + rnd_capped(efp / 50 + 1), 1, 15); i < n; ++i)
     {
         snd("core.pray1");
         flt(calcobjlv(efp / 10), calcfixlv(Quality::good));
         dbid = 54;
-        int number = 400 + rnd(efp);
+        int number = 400 + rnd_capped(efp);
         if (rnd(30) == 0)
         {
             dbid = 55;
@@ -4260,8 +4260,8 @@ optional<bool> _proc_general_magic()
                 }
                 return true;
             }
-            p = rnd(cdata[tc].gold / 10 + 1);
-            if (rnd(sdata(13, tc)) > rnd(sdata(12, cc) * 4) ||
+            p = rnd_capped(cdata[tc].gold / 10 + 1);
+            if (rnd_capped(sdata(13, tc)) > rnd_capped(sdata(12, cc) * 4) ||
                 cdata[tc].is_protected_from_thieves() == 1)
             {
                 txt(i18n::s.get(

--- a/src/elona/map.cpp
+++ b/src/elona/map.cpp
@@ -136,7 +136,7 @@ void _map_randsite()
         }
         if (rnd(18) == 0)
         {
-            flt(calcobjlv(rnd(cdata.player().level + 10)),
+            flt(calcobjlv(rnd_capped(cdata.player().level + 10)),
                 calcfixlv(Quality::good));
             flttypemajor = choice(fsetwear);
             itemcreate_extra_inv(0, *pos, 0);
@@ -1243,7 +1243,7 @@ static void _create_nefia(int index, int x, int y)
     area.type = static_cast<int>(mdata_t::MapType::dungeon) + rnd(4);
     if (rnd(3))
     {
-        area.danger_level = rnd(cdata.player().level + 5) + 1;
+        area.danger_level = rnd_capped(cdata.player().level + 5) + 1;
     }
     else
     {

--- a/src/elona/mapgen.cpp
+++ b/src/elona/mapgen.cpp
@@ -961,7 +961,8 @@ void map_createroomdoor()
                     y,
                     tile_doorclosed,
                     21,
-                    rnd(std::abs(game_data.current_dungeon_level * 3 / 2) + 1));
+                    rnd_capped(
+                        std::abs(game_data.current_dungeon_level * 3 / 2) + 1));
             }
             break;
         }
@@ -1572,7 +1573,8 @@ void map_makedoor()
                 dy,
                 tile_doorclosed,
                 21,
-                rnd(std::abs(game_data.current_dungeon_level * 3 / 2) + 1));
+                rnd_capped(
+                    std::abs(game_data.current_dungeon_level * 3 / 2) + 1));
         }
     }
 }
@@ -2774,7 +2776,8 @@ int initialize_quest_map_party()
         ry = roomy(cnt) + 1;
         rh = roomheight(cnt) - 2;
         rdsize = rw * rh;
-        roomdiff = clamp(rnd(quest_data.immediate().difficulty / 3 + 3), 0, 9);
+        roomdiff =
+            clamp(rnd_capped(quest_data.immediate().difficulty / 3 + 3), 0, 9);
         if (rnd(2) == 0)
         {
             x = rnd(rw) + rx;
@@ -3475,7 +3478,8 @@ void initialize_random_nefia_rdtype10()
                                 y,
                                 tile_doorclosed,
                                 21,
-                                rnd(std::abs(
+                                rnd_capped(
+                                    std::abs(
                                         game_data.current_dungeon_level * 3 /
                                         2) +
                                     1));
@@ -3497,7 +3501,8 @@ void initialize_random_nefia_rdtype10()
                                 y,
                                 tile_doorclosed,
                                 21,
-                                rnd(std::abs(
+                                rnd_capped(
+                                    std::abs(
                                         game_data.current_dungeon_level * 3 /
                                         2) +
                                     1));

--- a/src/elona/mef.cpp
+++ b/src/elona/mef.cpp
@@ -227,7 +227,7 @@ void mef_proc(int tc)
                 }
                 int stat = damage_hp(
                     cdata[tc],
-                    rnd(mef(5, ef) / 25 + 5) + 1,
+                    rnd_capped(mef(5, ef) / 25 + 5) + 1,
                     -15,
                     63,
                     mef(5, ef));
@@ -253,7 +253,7 @@ void mef_proc(int tc)
             }
         }
         int stat = damage_hp(
-            cdata[tc], rnd(mef(5, ef) / 15 + 5) + 1, -9, 50, mef(5, ef));
+            cdata[tc], rnd_capped(mef(5, ef) / 15 + 5) + 1, -9, 50, mef(5, ef));
         if (stat == 0)
         {
             check_kill(mef(6, ef), tc);
@@ -303,7 +303,8 @@ bool mef_proc_from_movement(int cc)
     {
         if (cdatan(2, cc) != u8"core.spider"s)
         {
-            if (rnd(mef(5, i) + 25) < rnd(sdata(10, cc) + sdata(12, cc) + 1) ||
+            if (rnd_capped(mef(5, i) + 25) <
+                    rnd_capped(sdata(10, cc) + sdata(12, cc) + 1) ||
                 cdata[cc].weight > 100)
             {
                 if (is_in_fov(cdata[cc]))

--- a/src/elona/quest.cpp
+++ b/src/elona/quest.cpp
@@ -678,8 +678,8 @@ int quest_generate()
     {
         if (rnd(13) == 0)
         {
-            quest_data[rq].difficulty = rnd(cdata.player().level + 10) +
-                rnd((cdata.player().fame / 2500 + 1));
+            quest_data[rq].difficulty = rnd_capped(cdata.player().level + 10) +
+                rnd_capped(cdata.player().fame / 2500 + 1);
             quest_data[rq].difficulty =
                 roundmargin(quest_data[rq].difficulty, cdata.player().level);
             minlevel = clamp(quest_data[rq].difficulty / 7, 5, 30);
@@ -714,8 +714,8 @@ int quest_generate()
     {
         if (rnd(20) == 0)
         {
-            quest_data[rq].difficulty = rnd(cdata.player().level + 10) +
-                rnd((cdata.player().fame / 2500 + 1));
+            quest_data[rq].difficulty = rnd_capped(cdata.player().level + 10) +
+                rnd_capped(cdata.player().fame / 2500 + 1);
             quest_data[rq].difficulty =
                 roundmargin(quest_data[rq].difficulty, cdata.player().level);
             minlevel = clamp(quest_data[rq].difficulty / 4, 5, 30);
@@ -775,8 +775,8 @@ int quest_generate()
                     2;
             quest_data[rq].deadline_days = rnd(8) + 6;
             quest_data[rq].difficulty = clamp(
-                rnd(cdata.player().level + 10) +
-                    rnd((cdata.player().fame / 500 + 1)) + 1,
+                rnd_capped(cdata.player().level + 10) +
+                    rnd_capped(cdata.player().fame / 500 + 1) + 1,
                 1,
                 80);
         }
@@ -815,7 +815,7 @@ int quest_generate()
         (game_data.current_map == mdata_t::MapId::palmia && rnd(8) == 0))
     {
         quest_data[rq].difficulty = clamp(
-            rnd(sdata(183, 0) + 10),
+            rnd_capped(sdata(183, 0) + 10),
             int(1.5 * std::sqrt(sdata(183, 0))) + 1,
             cdata.player().fame / 1000 + 10);
         quest_data[rq].deadline_hours =
@@ -835,8 +835,8 @@ int quest_generate()
         (game_data.current_map == mdata_t::MapId::yowyn && rnd(2) == 0))
     {
         quest_data[rq].difficulty = clamp(
-            rnd(cdata.player().level + 5) +
-                rnd((cdata.player().fame / 800 + 1)) + 1,
+            rnd_capped(cdata.player().level + 5) +
+                rnd_capped(cdata.player().fame / 800 + 1) + 1,
             1,
             50);
         quest_data[rq].deadline_hours =
@@ -854,8 +854,8 @@ int quest_generate()
     if (rnd(8) == 0)
     {
         quest_data[rq].difficulty = clamp(
-            rnd(cdata.player().level + 10) +
-                rnd((cdata.player().fame / 500 + 1)) + 1,
+            rnd_capped(cdata.player().level + 10) +
+                rnd_capped(cdata.player().fame / 500 + 1) + 1,
             1,
             80);
         quest_data[rq].difficulty =
@@ -1004,7 +1004,7 @@ int quest_generate()
         quest_data[rq].reward_item_id = 5;
         quest_data[rq].target_item_id = dbid;
         quest_data[rq].difficulty =
-            clamp(rnd(cdata.player().level + 5) + 1, 1, 30);
+            clamp(rnd_capped(cdata.player().level + 5) + 1, 1, 30);
         rewardfix = 65 + quest_data[rq].difficulty;
         return 0;
     }
@@ -1015,7 +1015,7 @@ void quest_gen_scale_by_level()
 {
     quest_data[rq].reward_gold =
         ((quest_data[rq].difficulty + 3) * 100 +
-         rnd((quest_data[rq].difficulty * 30 + 200)) + 400) *
+         rnd_capped(quest_data[rq].difficulty * 30 + 200) + 400) *
         rewardfix / 100;
     quest_data[rq].reward_gold = quest_data[rq].reward_gold * 100 /
         (100 + quest_data[rq].difficulty * 2 / 3);
@@ -1396,7 +1396,7 @@ void quest_complete()
     }
     if (quest_data[rq].id == 1008 || quest_data[rq].id == 1010)
     {
-        p = 2 + (rnd(100) < rnd(cdata.player().fame / 5000 + 1));
+        p = 2 + (rnd(100) < rnd_capped(cdata.player().fame / 5000 + 1));
     }
     flt();
     itemcreate_extra_inv(55, cdata.player().position, p);

--- a/src/elona/random.hpp
+++ b/src/elona/random.hpp
@@ -18,7 +18,6 @@
 namespace elona
 {
 
-
 namespace detail
 {
 extern xoshiro256::xoshiro256_engine engine;
@@ -47,6 +46,20 @@ inline Integer rnd(Integer max)
 {
     using Dist = boostrandom::uniform_int_distribution<Integer>;
     return Dist{Integer{0}, std::max(Integer{0}, max - 1)}(detail::engine);
+}
+
+
+
+// [0, M) where M is min { max, 32768 }
+// Vanilla-compatible rnd() function. HSP rnd() returns [0, 32768). The upper
+// limit comes from RAND_MAX in C lang.
+template <
+    typename Integer,
+    std::enable_if_t<std::is_integral<Integer>::value, std::nullptr_t> =
+        nullptr>
+inline Integer rnd_capped(Integer max)
+{
+    return rnd(std::min<Integer>(max, 32768));
 }
 
 

--- a/src/elona/random_event.cpp
+++ b/src/elona/random_event.cpp
@@ -38,7 +38,7 @@ struct RandomEvent
 
     bool is_evadable(int luck) const
     {
-        return luck_threshold != 0 && rnd(luck + 1) > luck_threshold;
+        return luck_threshold != 0 && rnd_capped(luck + 1) > luck_threshold;
     }
 };
 
@@ -404,7 +404,7 @@ void run_random_event(RandomEvent event)
         event_bg = u8"bg_re5";
         break;
     case 8:
-        p = rnd(cdata.player().gold / 8 + 1);
+        p = rnd_capped(cdata.player().gold / 8 + 1);
         if (cdata.player().is_protected_from_thieves())
         {
             p = 0;
@@ -458,7 +458,7 @@ void run_random_event(RandomEvent event)
         event_bg = u8"bg_re1";
         break;
     case 16:
-        p = rnd(cdata.player().gold / 10 + 1000) + 1;
+        p = rnd_capped(cdata.player().gold / 10 + 1000) + 1;
         earn_gold(cdata.player(), p);
         txt(i18n::s.get_enum_property(
             "core.event.popup", "you_pick_up", 16, p(0)));

--- a/src/elona/status_ailment.cpp
+++ b/src/elona/status_ailment.cpp
@@ -23,8 +23,8 @@ namespace
 int calc_power_decreased_by_resistance(int cc, int power, Element element)
 {
     const auto resistance_level = sdata(int(element), cc) / 50;
-    power =
-        (rnd(power / 2 + 1) + power / 2) * 100 / (50 + resistance_level * 50);
+    power = (rnd_capped(power / 2 + 1) + power / 2) * 100 /
+        (50 + resistance_level * 50);
 
     if (resistance_level >= 3 && power < 40)
     {
@@ -55,7 +55,7 @@ void status_ailment_damage(
     case StatusAilment::blinded:
         if (chara.is_immune_to_blindness())
             return;
-        if (chara.quality > Quality::great && rnd(chara.level / 2 + 1))
+        if (chara.quality > Quality::great && rnd_capped(chara.level / 2 + 1))
             return;
         power = calc_power_decreased_by_resistance(
             chara.index, power, Element::darkness);
@@ -83,7 +83,7 @@ void status_ailment_damage(
             return;
         if (buff_has(chara, "core.hero"))
             return;
-        if (chara.quality > Quality::great && rnd(chara.level / 2 + 1))
+        if (chara.quality > Quality::great && rnd_capped(chara.level / 2 + 1))
             return;
         power = calc_power_decreased_by_resistance(
             chara.index, power, Element::mind);
@@ -109,7 +109,7 @@ void status_ailment_damage(
     case StatusAilment::paralyzed:
         if (chara.is_immune_to_paralyzation())
             return;
-        if (chara.quality > Quality::great && rnd(chara.level + 1))
+        if (chara.quality > Quality::great && rnd_capped(chara.level + 1))
             return;
         power = calc_power_decreased_by_resistance(
             chara.index, power, Element::nerve);
@@ -135,7 +135,7 @@ void status_ailment_damage(
     case StatusAilment::poisoned:
         if (chara.is_immune_to_poison())
             return;
-        if (chara.quality > Quality::great && rnd(chara.level / 3 + 1))
+        if (chara.quality > Quality::great && rnd_capped(chara.level / 3 + 1))
             return;
         power = calc_power_decreased_by_resistance(
             chara.index, power, Element::poison);
@@ -161,7 +161,7 @@ void status_ailment_damage(
     case StatusAilment::sleep:
         if (chara.is_immune_to_sleep())
             return;
-        if (chara.quality > Quality::great && rnd(chara.level / 5 + 1))
+        if (chara.quality > Quality::great && rnd_capped(chara.level / 5 + 1))
             return;
         power = calc_power_decreased_by_resistance(
             chara.index, power, Element::nerve);
@@ -191,7 +191,7 @@ void status_ailment_damage(
             return;
         if (buff_has(chara, "core.hero"))
             return;
-        if (chara.quality > Quality::great && rnd(chara.level / 5 + 1))
+        if (chara.quality > Quality::great && rnd_capped(chara.level / 5 + 1))
             return;
         power = calc_power_decreased_by_resistance(
             chara.index, power, Element::mind);
@@ -208,7 +208,7 @@ void status_ailment_damage(
         }
         return;
     case StatusAilment::dimmed:
-        if (chara.quality > Quality::great && rnd(chara.level / 3 + 1))
+        if (chara.quality > Quality::great && rnd_capped(chara.level / 3 + 1))
             return;
         if (cdatan(2, chara.index) == u8"golem"s)
             return;

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -1722,7 +1722,7 @@ TalkResult talk_npc()
                     {
                         if (cdata[tc].impression < 100)
                         {
-                            if (rnd(sdata(17, 0) + 1) > 10)
+                            if (rnd_capped(sdata(17, 0) + 1) > 10)
                             {
                                 chara_modify_impression(cdata[tc], rnd(3));
                             }

--- a/src/elona/turn_sequence.cpp
+++ b/src/elona/turn_sequence.cpp
@@ -402,7 +402,7 @@ optional<TurnResult> npc_turn_misc(Character& chara)
         }
     }
 
-    // Chocked
+    // Choked
     if (chara.relationship >= 0)
     {
         if (cdata.player().choked)


### PR DESCRIPTION
# Related Issues

#1480  (see [this comment](https://github.com/elonafoobar/elonafoobar/issues/1480#issuecomment-564053028))

# Summary

`rnd()` is one of the HSP built-in functions, whose result is capped by `RAND_MAX` in C lang. To emulate it, some of `rnd()` in foobar's codebase are substituted by `rnd_capped()` that has the same upper limit.

`rnd_capped(n)` returns `k` in `[0, m)` where `m` is `min(n, RAND_MAX)`.

The capped version is also added to Lua `Rand` module. The usage is exactly the same as `Rand.rnd()`.



This change will make random number generation in foobar closer to that in vanilla.