### PR TITLE
Fix Elona crash related to config options

### DIFF
--- a/runtime/data/script/kernel/config.lua
+++ b/runtime/data/script/kernel/config.lua
@@ -253,7 +253,11 @@ end
 
 
 function Config.get_children_keys(option_key)
-   return _schemas[option_key].children_keys
+   if _schemas[option_key] then
+      return _schemas[option_key].children_keys
+   else
+      return {}
+   end
 end
 
 

--- a/src/elona/config.cpp
+++ b/src/elona/config.cpp
@@ -566,9 +566,12 @@ void config_load_all_schema()
     {
         const auto manifest = lua::ModManifest::load(mod_dir / "mod.json");
         const auto path = mod_dir / "config-schema.lua";
-        std::ifstream in{path.native()};
-        lua::lua->get_config_manager().load_schema(
-            in, filepathutil::to_utf8_path(path), SharedId{manifest.id});
+        if (fs::exists(path))
+        {
+            std::ifstream in{path.native()};
+            lua::lua->get_config_manager().load_schema(
+                in, filepathutil::to_utf8_path(path), SharedId{manifest.id});
+        }
     }
 }
 

--- a/src/elona/config_menu.cpp
+++ b/src/elona/config_menu.cpp
@@ -451,8 +451,9 @@ std::vector<std::string> ConfigScreenCreator::get_sorted_mod_list()
 {
     auto mods = lua::lua->get_mod_manager().enabled_mods();
     std::vector<std::string> ret;
-    range::transform(
-        mods, std::back_inserter(ret), [](const auto& m) { return m.first; });
+    range::transform(mods, std::back_inserter(ret), [](const auto& m) {
+        return m.second->manifest.id;
+    });
     range::sort(ret, lib::natural_order_comparator{});
     return ret;
 }


### PR DESCRIPTION
# Summary


Fix two crashes:

- Fix crash on opening Option menu.
- Allow mods to have no config options.