### PR TITLE
Add missing #include directive

### DIFF
--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -1,3 +1,4 @@
+#include <stack>
 #include "../util/scope_guard.hpp"
 #include "ability.hpp"
 #include "activity.hpp"


### PR DESCRIPTION
The old source that lacks `#include` compiles, but it depends on compilers and their version.