### PR TITLE
Do not set quest ID to Item::count property of quest target item

### DIFF
--- a/src/elona/quest.cpp
+++ b/src/elona/quest.cpp
@@ -647,7 +647,6 @@ int quest_generate()
             flttypemajor = choice(fsetcollect);
             if (const auto item = itemcreate_chara_inv(n, 0, 0))
             {
-                item->count = rq;
                 i(0) = n;
                 i(1) = itemid2int(item->id);
                 item->is_quest_target() = true;


### PR DESCRIPTION
# Summary

The property might be for checking whether you trade the very item that the client asks, but for now such thing is not checked. To stack quest target items with ease, quest IDs should not be saved.
