### PR TITLE
Implement mod list file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ if(ELONA_BUILD_TARGET STREQUAL "TESTS")
     src/tests/lua_events.cpp
     src/tests/lua_exports.cpp
     src/tests/lua_handles.cpp
+    src/tests/lua_mod_resolve.cpp
     src/tests/lua_mods.cpp
     src/tests/lua_data.cpp
     src/tests/lua_data_character.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,6 +422,14 @@ function(copy_dir source target)
     ${target})
 endfunction()
 
+function(copy_mod_dirs mod_root_dir target)
+  add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+    COMMAND ${CMAKE_COMMAND}
+    -Dmod_root_dir=${mod_root_dir}
+    -Dtarget=${target}
+    -P ${CMAKE_MODULE_PATH}/copy_mod_dirs.cmake)
+endfunction()
+
 function(copy_file source target)
   add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy
@@ -444,17 +452,16 @@ copy_dir(${CMAKE_SOURCE_DIR}/runtime/font/ "${RUNTIME_DIR}/font/")
 copy_dir(${CMAKE_SOURCE_DIR}/runtime/graphic/ "${RUNTIME_DIR}/graphic/")
 copy_dir(${CMAKE_SOURCE_DIR}/runtime/locale/ "${RUNTIME_DIR}/locale/")
 copy_dir(${CMAKE_SOURCE_DIR}/runtime/map/ "${RUNTIME_DIR}/map/")
-copy_dir(${CMAKE_SOURCE_DIR}/runtime/mod/ "${RUNTIME_DIR}/mod/")
+copy_mod_dirs(${CMAKE_SOURCE_DIR}/runtime/mod/ "${RUNTIME_DIR}/mod/")
 copy_dir(${CMAKE_SOURCE_DIR}/runtime/profile/ "${RUNTIME_DIR}/profile/")
 
 # Copy assets from Elona 1.22 if they are present.
 if(EXISTS "${CMAKE_PREFIX_PATH}/elona")
   copy_dir("${CMAKE_PREFIX_PATH}/elona/graphic" "${ASSET_DIR}/graphic")
   copy_dir("${CMAKE_PREFIX_PATH}/elona/sound" "${ASSET_DIR}/sound")
-  copy_dir("${CMAKE_PREFIX_PATH}/elona/user" "${ASSET_DIR}/user")
   message("Elona 1.22 distribution found.")
 else()
-  message(WARNING "Elona 1.22 distribution not found at ${CMAKE_PREFIX_PATH}/elona. The game cannot be run without assets. Please manually copy the 'graphic', 'sound' and 'user' directories from Elona 1.22 to the ${PROJECT_NAME} output path after building.")
+  message(WARNING "Elona 1.22 distribution not found at ${CMAKE_PREFIX_PATH}/elona. The game cannot be run without assets. Please manually copy the 'graphic' and 'sound' directories from Elona 1.22 to the ${PROJECT_NAME} output path after building.")
 endif()
 
 if((ELONA_BUILD_TARGET STREQUAL "TESTS") OR (ELONA_BUILD_TARGET STREQUAL "BENCH"))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -90,7 +90,6 @@ after_build:
   - rd /q /s bin\Elona_foobar\sound
   - rd /q /s bin\Elona_foobar\tests
   - rd /q /s bin\Elona_foobar\tmp
-  - rd /q /s bin\Elona_foobar\user
   - xcopy /s /e /y runtime\* bin\Elona_foobar
   - ps: "$env:ELONAFOOBAR_VERSION=(Select-String 'project\\(Elona_foobar VERSION (.*)\\)' CMakeLists.txt).Matches.Groups[1].Value"
   - cd bin

--- a/cmake/copy_mod_dirs.cmake
+++ b/cmake/copy_mod_dirs.cmake
@@ -1,0 +1,27 @@
+# Copy all mods under runtime/mod with their versions.
+# Example: mod "core" version 1.2.3 is copied to mod/core-1.2.3
+#
+# Arguments
+# =========
+# mod_root_dir   The source folder.
+# target         The destination folder.
+
+
+file(GLOB mod_dirs ${mod_root_dir}/*)
+foreach(mod_dir IN LISTS mod_dirs)
+  get_filename_component(mod_id ${mod_dir} NAME)
+  set(manifest_file ${mod_dir}/mod.json)
+  if(EXISTS ${manifest_file})
+    file(READ ${manifest_file} manifest)
+    if(${manifest} MATCHES "version: \"([^\"]*)\"")
+      set(mod_version ${CMAKE_MATCH_1})
+      set(new_dir_name ${mod_id}-${mod_version})
+      message(STATUS "Copy mod: ${new_dir_name}")
+      execute_process(
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${mod_dir} ${target}/${new_dir_name})
+    else()
+      message(FATAL_ERROR "Failed to get mod version: ${manifest}")
+    endif()
+  endif()
+endforeach()

--- a/src/bench/lua_callbacks.cpp
+++ b/src/bench/lua_callbacks.cpp
@@ -40,7 +40,8 @@ public:
 
     void AddCallbacks(int amount)
     {
-        elona::lua::lua->get_mod_manager().load_mod_from_script("bench", "");
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "bench", "");
         for (int i = 0; i < amount; i++)
         {
             elona::lua::lua->get_mod_manager().run_in_mod("bench", R"(

--- a/src/elona/CMakeLists.txt
+++ b/src/elona/CMakeLists.txt
@@ -117,6 +117,7 @@ set(ELONA_SOURCES
   lua_env/mod_manager.cpp
   lua_env/mod_manifest.cpp
   lua_env/mod_serializer.cpp
+  lua_env/mod_version_resolver.cpp
 
   lua_env/enums/enums.cpp
 

--- a/src/elona/config.cpp
+++ b/src/elona/config.cpp
@@ -2,6 +2,7 @@
 #include <cassert>
 #include <fstream>
 #include <functional>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include "../snail/application.hpp"
@@ -130,12 +131,13 @@ std::string read_whole_file(std::istream& in)
 
 
 
-json5::value::object_type parse_json5_file(const fs::path& path)
+json5::value::object_type parse_json5_file(
+    std::istream& in,
+    const std::string& filepath)
 {
-    if (!fs::exists(path))
+    if (!in)
         return {};
 
-    std::ifstream in{path.native()};
     const auto file_content = read_whole_file(in);
     try
     {
@@ -144,15 +146,13 @@ json5::value::object_type parse_json5_file(const fs::path& path)
     catch (json5::syntax_error& err)
     {
         ELONA_WARN("config")
-            << "JSON5 syntax error in '" << filepathutil::to_utf8_path(path)
-            << "': " << err.what();
+            << "JSON5 syntax error in '" << filepath << "': " << err.what();
         return {};
     }
     catch (json5::invalid_type_error& err)
     {
         ELONA_WARN("config")
-            << "JSON5 type error in '" << filepathutil::to_utf8_path(path)
-            << "': " << err.what();
+            << "JSON5 type error in '" << filepath << "': " << err.what();
         return {};
     }
 }
@@ -297,21 +297,16 @@ void inject_languages()
  * Validate the display mode setting. If the display mode is unavailable, set
  * the default value.
  */
-void validate_display_mode()
+std::string validate_display_mode(const std::string& current_value)
 {
-    const auto display_modes =
-        snail::Application::instance().get_display_modes();
-    const auto default_display_mode =
-        snail::Application::instance().get_default_display_mode();
+    auto& app = snail::Application::instance();
+    const auto display_modes = app.get_display_modes();
+    const auto default_display_mode = app.get_default_display_mode();
 
     const auto found = range::any_of(
-        display_modes, [current = g_config.display_mode()](const auto& d) {
-            return d.first == current;
-        });
-    if (!found)
-    {
-        g_config.set_display_mode(default_display_mode);
-    }
+        display_modes, [&](const auto& d) { return d.first == current_value; });
+
+    return found ? current_value : default_display_mode;
 }
 
 
@@ -524,39 +519,46 @@ Config g_config;
 
 
 
-void config_load_preinit_options()
+PreinitConfigOptions PreinitConfigOptions::from_file(const fs::path& path)
 {
-    const auto obj =
-        parse_json5_file(filesystem::files::profile_local_config());
+    std::ifstream in{path.native()};
+    return from_stream(in, filepathutil::to_utf8_path(path));
+}
 
-#define ELONA_PREINIT_OPT(category, option, T, default_value) \
-    do \
-    { \
-        g_config.set_##option(get_value_by_nesting_key( \
-            obj, \
-            {"core", #category, #option}, \
-            json5::T##_type{default_value})); \
-    } while (0)
 
+
+PreinitConfigOptions PreinitConfigOptions::from_string(const std::string& str)
+{
+    std::istringstream in{str};
+    return from_stream(in, "[string]");
+}
+
+
+
+PreinitConfigOptions PreinitConfigOptions::from_stream(
+    std::istream& in,
+    const std::string& filepath)
+{
+    const auto obj = parse_json5_file(in, filepath);
 
     // screen.fullscreen (default: "windowed")
-    g_config.set_fullscreen(convert_to_fullscreen(get_value_by_nesting_key(
-        obj,
-        {"core", "screen", "fullscreen"},
-        json5::string_type{"windowed"})));
+    auto fullscreen = convert_to_fullscreen(get_value_by_nesting_key(
+        obj, {"core", "screen", "fullscreen"}, json5::string_type{"windowed"}));
 
     // screen.display_mode (default: "")
-    ELONA_PREINIT_OPT(screen, display_mode, string, "");
+    auto display_mode = get_value_by_nesting_key(
+        obj, {"core", "screen", "display_mode"}, json5::string_type{""});
 
-#undef ELONA_PREINIT_OPT
+    display_mode = validate_display_mode(display_mode);
 
-
-    validate_display_mode();
 
     // TODO: move it somewhere else or make it constant. "inf_tiles" is too
     // frequently used to find out where it should be initialized. Thus, it is
     // initialized as close to the previous position as possilbe.
     inf_tiles = 48;
+
+
+    return PreinitConfigOptions{fullscreen, display_mode};
 }
 
 

--- a/src/elona/config.cpp
+++ b/src/elona/config.cpp
@@ -565,15 +565,20 @@ PreinitConfigOptions PreinitConfigOptions::from_stream(
 
 void config_load_all_schema()
 {
-    for (const auto& mod_dir : lua::normal_mod_dirs(filesystem::dirs::mod()))
+    for (const auto& pair : lua::lua->get_mod_manager().mods())
     {
-        const auto manifest = lua::ModManifest::load(mod_dir / "mod.json");
-        const auto path = mod_dir / "config-schema.lua";
-        if (fs::exists(path))
+        const auto& mod_manifest = pair.second.manifest;
+        if (mod_manifest.path)
         {
-            std::ifstream in{path.native()};
-            lua::lua->get_config_manager().load_schema(
-                in, filepathutil::to_utf8_path(path), SharedId{manifest.id});
+            const auto schema_path = *mod_manifest.path / "config-schema.lua";
+            if (fs::exists(schema_path))
+            {
+                std::ifstream in{schema_path.native()};
+                lua::lua->get_config_manager().load_schema(
+                    in,
+                    filepathutil::to_utf8_path(schema_path),
+                    SharedId{mod_manifest.id});
+            }
         }
     }
 }

--- a/src/elona/config.hpp
+++ b/src/elona/config.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include "../snail/window.hpp"
+#include "filesystem.hpp"
 #include "shared_id.hpp"
 
 
@@ -9,12 +10,46 @@
 namespace elona
 {
 
-/***
- * Loads config options that are marked to be loaded before the application
- * instance is initialized, like screen size. The config file is loaded from the
- * current profile.
- */
-void config_load_preinit_options();
+struct PreinitConfigOptions
+{
+public:
+    static PreinitConfigOptions from_file(const fs::path& path);
+
+    // for testing
+    static PreinitConfigOptions from_string(const std::string& str);
+    static PreinitConfigOptions from_stream(
+        std::istream& in,
+        const std::string& filepath);
+
+
+    snail::Window::FullscreenMode fullscreen() const noexcept
+    {
+        return _fullscreen;
+    }
+
+
+    const std::string& display_mode() const noexcept
+    {
+        return _display_mode;
+    }
+
+
+
+private:
+    snail::Window::FullscreenMode _fullscreen;
+    std::string _display_mode;
+
+
+    PreinitConfigOptions(
+        snail::Window::FullscreenMode fullscreen,
+        const std::string& display_mode)
+        : _fullscreen(fullscreen)
+        , _display_mode(display_mode)
+    {
+    }
+};
+
+
 
 void config_load_all_schema();
 

--- a/src/elona/config_menu.cpp
+++ b/src/elona/config_menu.cpp
@@ -449,11 +449,9 @@ void ConfigScreenCreator::add_item_section(
 
 std::vector<std::string> ConfigScreenCreator::get_sorted_mod_list()
 {
-    auto mods = lua::lua->get_mod_manager().enabled_mods();
-    std::vector<std::string> ret;
-    range::transform(mods, std::back_inserter(ret), [](const auto& m) {
-        return m.second->manifest.id;
-    });
+    // Note: The result of ModManager::sorted_mods() is sorted by the loading
+    // order. The function returns the list of mod IDs sorted in natural order.
+    auto ret = lua::lua->get_mod_manager().sorted_mods();
     range::sort(ret, lib::natural_order_comparator{});
     return ret;
 }

--- a/src/elona/ctrl_file.cpp
+++ b/src/elona/ctrl_file.cpp
@@ -790,7 +790,7 @@ void fmode_7_8(bool read, const fs::path& dir)
                 std::ifstream in{filepath.native(), std::ios::binary};
                 putit::BinaryIArchive ar{in};
                 mod_serializer.load_mod_store_data(
-                    ar, lua::ModInfo::StoreType::global);
+                    ar, lua::ModEnv::StoreType::global);
             }
         }
         else
@@ -798,7 +798,7 @@ void fmode_7_8(bool read, const fs::path& dir)
             std::ofstream out{filepath.native(), std::ios::binary};
             putit::BinaryOArchive ar{out};
             mod_serializer.save_mod_store_data(
-                ar, lua::ModInfo::StoreType::global);
+                ar, lua::ModEnv::StoreType::global);
         }
     }
 
@@ -810,7 +810,7 @@ void fmode_7_8(bool read, const fs::path& dir)
             putit::BinaryIArchive ar{in};
             std::tie(index_start, index_end) =
                 mod_serializer.load_handles<Character>(
-                    ar, lua::ModInfo::StoreType::global);
+                    ar, lua::ModEnv::StoreType::global);
 
             auto& handle_mgr = lua::lua->get_handle_manager();
             for (int i = index_start; i < index_end; i++)
@@ -823,7 +823,7 @@ void fmode_7_8(bool read, const fs::path& dir)
             std::ofstream out{filepath.native(), std::ios::binary};
             putit::BinaryOArchive ar{out};
             mod_serializer.save_handles<Character>(
-                ar, lua::ModInfo::StoreType::global);
+                ar, lua::ModEnv::StoreType::global);
         }
     }
 
@@ -835,7 +835,7 @@ void fmode_7_8(bool read, const fs::path& dir)
             putit::BinaryIArchive ar{in};
             std::tie(index_start, index_end) =
                 mod_serializer.load_handles<Item>(
-                    ar, lua::ModInfo::StoreType::global);
+                    ar, lua::ModEnv::StoreType::global);
 
             auto& handle_mgr = lua::lua->get_handle_manager();
             for (int i = index_start; i < index_end; i++)
@@ -848,7 +848,7 @@ void fmode_7_8(bool read, const fs::path& dir)
             std::ofstream out{filepath.native(), std::ios::binary};
             putit::BinaryOArchive ar{out};
             mod_serializer.save_handles<Item>(
-                ar, lua::ModInfo::StoreType::global);
+                ar, lua::ModEnv::StoreType::global);
         }
     }
 }
@@ -1179,8 +1179,7 @@ void fmode_1_2(bool read)
 
             std::ifstream in{filepath.native(), std::ios::binary};
             putit::BinaryIArchive ar{in};
-            mod_serializer.load_mod_store_data(
-                ar, lua::ModInfo::StoreType::map);
+            mod_serializer.load_mod_store_data(ar, lua::ModEnv::StoreType::map);
         }
         else
         {
@@ -1189,8 +1188,7 @@ void fmode_1_2(bool read)
 
             std::ofstream out{filepath.native(), std::ios::binary};
             putit::BinaryOArchive ar{out};
-            mod_serializer.save_mod_store_data(
-                ar, lua::ModInfo::StoreType::map);
+            mod_serializer.save_mod_store_data(ar, lua::ModEnv::StoreType::map);
         }
     }
 
@@ -1205,7 +1203,7 @@ void fmode_1_2(bool read)
             putit::BinaryIArchive ar{in};
             std::tie(index_start, index_end) =
                 mod_serializer.load_handles<Character>(
-                    ar, lua::ModInfo::StoreType::map);
+                    ar, lua::ModEnv::StoreType::map);
 
             auto& handle_mgr = lua::lua->get_handle_manager();
             for (int i = index_start; i < index_end; i++)
@@ -1221,7 +1219,7 @@ void fmode_1_2(bool read)
             std::ofstream out{filepath.native(), std::ios::binary};
             putit::BinaryOArchive ar{out};
             mod_serializer.save_handles<Character>(
-                ar, lua::ModInfo::StoreType::map);
+                ar, lua::ModEnv::StoreType::map);
         }
     }
 }
@@ -1350,7 +1348,7 @@ void fmode_3_4(bool read, const fs::path& filename)
         std::ifstream in{mod_filepath.native(), std::ios::binary};
         putit::BinaryIArchive ar{in};
         std::tie(index_start, index_end) =
-            mod_serializer.load_handles<Item>(ar, lua::ModInfo::StoreType::map);
+            mod_serializer.load_handles<Item>(ar, lua::ModEnv::StoreType::map);
 
         auto& handle_mgr = lua::lua->get_handle_manager();
         for (int i = index_start; i < index_end; i++)
@@ -1365,7 +1363,7 @@ void fmode_3_4(bool read, const fs::path& filename)
 
         std::ofstream out{mod_filepath.native(), std::ios::binary};
         putit::BinaryOArchive ar{out};
-        mod_serializer.save_handles<Item>(ar, lua::ModInfo::StoreType::map);
+        mod_serializer.save_handles<Item>(ar, lua::ModEnv::StoreType::map);
     }
 }
 

--- a/src/elona/data/types/type_asset.cpp
+++ b/src/elona/data/types/type_asset.cpp
@@ -1,4 +1,5 @@
 #include "type_asset.hpp"
+#include "../../lua_env/interface.hpp"
 
 
 namespace
@@ -64,7 +65,7 @@ AssetData AssetDB::convert(const lua::ConfigTable& data, const std::string& id)
     optional<fs::path> file_path = none;
     if (file)
     {
-        file_path = filesystem::resolve_path_for_mod(*file);
+        file_path = lua::resolve_path_for_mod(*file);
     }
 
     return AssetData{SharedId{id},

--- a/src/elona/data/types/type_chara_chip.cpp
+++ b/src/elona/data/types/type_chara_chip.cpp
@@ -1,5 +1,8 @@
 #include "type_chara_chip.hpp"
+#include "../../lua_env/interface.hpp"
 #include "../../variables.hpp"
+
+
 
 namespace elona
 {
@@ -32,7 +35,7 @@ CharaChipData CharaChipDB::convert(
     else
     {
         std::string filepath_str = source.as<std::string>();
-        filepath = filesystem::resolve_path_for_mod(filepath_str);
+        filepath = lua::resolve_path_for_mod(filepath_str);
         if (!fs::exists(*filepath))
         {
             throw std::runtime_error(

--- a/src/elona/data/types/type_item_chip.cpp
+++ b/src/elona/data/types/type_item_chip.cpp
@@ -1,5 +1,8 @@
 #include "type_item_chip.hpp"
+#include "../../lua_env/interface.hpp"
 #include "../../variables.hpp"
+
+
 
 namespace elona
 {
@@ -37,7 +40,7 @@ ItemChipData ItemChipDB::convert(
     else
     {
         std::string filepath_str = source.as<std::string>();
-        filepath = filesystem::resolve_path_for_mod(filepath_str);
+        filepath = lua::resolve_path_for_mod(filepath_str);
         if (!fs::exists(*filepath))
         {
             throw std::runtime_error(

--- a/src/elona/data/types/type_map_chip.cpp
+++ b/src/elona/data/types/type_map_chip.cpp
@@ -1,5 +1,8 @@
 #include "type_map_chip.hpp"
+#include "../../lua_env/interface.hpp"
 #include "../../variables.hpp"
+
+
 
 namespace elona
 {
@@ -42,7 +45,7 @@ MapChip MapChipDB::convert(const lua::ConfigTable& data, const std::string& id)
     else
     {
         std::string filepath_str = source.as<std::string>();
-        filepath = filesystem::resolve_path_for_mod(filepath_str);
+        filepath = lua::resolve_path_for_mod(filepath_str);
         if (!fs::exists(*filepath))
         {
             throw std::runtime_error(

--- a/src/elona/data/types/type_music.cpp
+++ b/src/elona/data/types/type_music.cpp
@@ -1,4 +1,5 @@
 #include "type_music.hpp"
+#include "../../lua_env/interface.hpp"
 
 namespace elona
 {
@@ -13,7 +14,7 @@ MusicData MusicDB::convert(const lua::ConfigTable& data, const std::string& id)
     auto legacy_id = data.required<int>("legacy_id");
     DATA_REQ(file, std::string);
 
-    const fs::path music_file = filesystem::resolve_path_for_mod(file);
+    const fs::path music_file = lua::resolve_path_for_mod(file);
     if (!fs::exists(music_file))
     {
         throw std::runtime_error(

--- a/src/elona/data/types/type_portrait.cpp
+++ b/src/elona/data/types/type_portrait.cpp
@@ -1,5 +1,6 @@
 #include "type_portrait.hpp"
 #include <iostream>
+#include "../../lua_env/interface.hpp"
 
 
 
@@ -46,7 +47,7 @@ PortraitData _PortraitDBBase::convert(
     else
     {
         std::string filepath_str = source.as<std::string>();
-        filepath = filesystem::resolve_path_for_mod(filepath_str);
+        filepath = lua::resolve_path_for_mod(filepath_str);
         if (!fs::exists(*filepath))
         {
             throw std::runtime_error(

--- a/src/elona/data/types/type_sound.cpp
+++ b/src/elona/data/types/type_sound.cpp
@@ -1,4 +1,5 @@
 #include "type_sound.hpp"
+#include "../../lua_env/interface.hpp"
 
 namespace elona
 {
@@ -13,7 +14,7 @@ SoundData SoundDB::convert(const lua::ConfigTable& data, const std::string& id)
     auto legacy_id = data.required<int>("legacy_id");
     DATA_REQ(file, std::string);
 
-    const fs::path sound_file = filesystem::resolve_path_for_mod(file);
+    const fs::path sound_file = lua::resolve_path_for_mod(file);
     if (!fs::exists(sound_file))
     {
         throw std::runtime_error(

--- a/src/elona/filesystem.cpp
+++ b/src/elona/filesystem.cpp
@@ -158,6 +158,13 @@ fs::path keybinding_config()
     return path("keybindings.json");
 }
 
+
+
+fs::path mod_list()
+{
+    return dirs::current_profile() / "mods.json";
+}
+
 } // namespace files
 
 

--- a/src/elona/filesystem.cpp
+++ b/src/elona/filesystem.cpp
@@ -2,6 +2,7 @@
 #include "../util/strutil.hpp"
 #include "config.hpp"
 #include "defines.hpp"
+#include "semver.hpp"
 
 
 
@@ -110,9 +111,9 @@ void set_base_user_directory(const fs::path& base_user_dir)
 
 
 
-fs::path for_mod(const std::string& mod_id)
+fs::path for_mod(const std::string& id, const semver::Version& version)
 {
-    return mod() / filepathutil::u8path(mod_id);
+    return mod() / filepathutil::u8path(id + "-" + version.to_string());
 }
 
 
@@ -164,38 +165,6 @@ fs::path keybinding_config()
 fs::path path(const std::string& str)
 {
     return get_executable_dir() / filepathutil::u8path(str);
-}
-
-
-
-fs::path resolve_path_for_mod(const std::string& mod_local_path)
-{
-    // TODO: standardize mod naming convention.
-    std::regex mod_id_regex("^<([a-zA-Z0-9_]+)>/(.*)");
-    std::smatch match;
-    std::string mod_id, rest;
-
-    if (std::regex_match(mod_local_path, match, mod_id_regex) &&
-        match.size() == 3)
-    {
-        mod_id = match.str(1);
-        rest = match.str(2);
-    }
-    else
-    {
-        throw std::runtime_error("Invalid filepath syntax: " + mod_local_path);
-    }
-
-    rest = strutil::replace(rest, "<LANGUAGE>", g_config.language());
-
-    if (mod_id == "_builtin_")
-    {
-        return dirs::exe() / rest;
-    }
-    else
-    {
-        return dirs::for_mod(mod_id) / rest;
-    }
 }
 
 

--- a/src/elona/filesystem.hpp
+++ b/src/elona/filesystem.hpp
@@ -75,6 +75,7 @@ namespace files
 
 fs::path profile_local_config();
 fs::path keybinding_config();
+fs::path mod_list();
 
 } // namespace files
 

--- a/src/elona/filesystem.hpp
+++ b/src/elona/filesystem.hpp
@@ -28,9 +28,15 @@ struct hash<fs::path>
 
 namespace elona
 {
+
+namespace semver
+{
+struct Version;
+}
+
+
 namespace filesystem
 {
-
 
 // Pre-defined directories.
 namespace dirs
@@ -43,7 +49,7 @@ fs::path locale();
 fs::path log();
 fs::path map();
 fs::path mod();
-fs::path for_mod(const std::string& mod_id);
+fs::path for_mod(const std::string& id, const semver::Version& version);
 fs::path profile_root();
 fs::path current_profile();
 fs::path save();
@@ -75,7 +81,6 @@ fs::path keybinding_config();
 
 
 fs::path path(const std::string&);
-fs::path resolve_path_for_mod(const std::string& mod_local_path);
 
 
 

--- a/src/elona/init.cpp
+++ b/src/elona/init.cpp
@@ -44,9 +44,11 @@ namespace
 
 void initialize_directories()
 {
-    const boost::filesystem::path paths[] = {filesystem::dirs::save(),
-                                             filesystem::dirs::screenshot(),
-                                             filesystem::dirs::tmp()};
+    const fs::path paths[] = {
+        filesystem::dirs::save(),
+        filesystem::dirs::screenshot(),
+        filesystem::dirs::tmp(),
+    };
 
     for (const auto& path : paths)
     {
@@ -118,8 +120,8 @@ namespace elona
 
 void initialize_lua()
 {
-    // Scan mods under "mods/" folder.
-    lua::lua->get_mod_manager().load_mods();
+    // Load mods.
+    lua::lua->load_mods();
 
     // Initialize "console" mod.
     lua::lua->get_console().init_environment();
@@ -149,13 +151,16 @@ void initialize_i18n()
         {filesystem::dirs::locale() / language, "core"}};
 
     // Load translations for each mod.
-    for (const auto& mod_dir : lua::normal_mod_dirs(filesystem::dirs::mod()))
+    for (const auto& pair : lua::lua->get_mod_manager().mods())
     {
-        const auto manifest = lua::ModManifest::load(mod_dir / "mod.json");
-        const auto locale_path = mod_dir / "locale" / language;
-        if (fs::exists(locale_path))
+        const auto& mod_manifest = pair.second.manifest;
+        if (mod_manifest.path)
         {
-            locations.emplace_back(locale_path, manifest.id);
+            const auto locale_path = *mod_manifest.path / "locale" / language;
+            if (fs::exists(locale_path))
+            {
+                locations.emplace_back(locale_path, mod_manifest.id);
+            }
         }
     }
 

--- a/src/elona/init.cpp
+++ b/src/elona/init.cpp
@@ -59,12 +59,12 @@ void initialize_directories()
 
 
 
-void initialize_screen()
+void initialize_screen(const PreinitConfigOptions& opts)
 {
     title(
         u8"Elona foobar version "s + latest_version.short_string(),
-        g_config.display_mode(),
-        g_config.fullscreen());
+        opts.display_mode(),
+        opts.fullscreen());
 }
 
 
@@ -622,18 +622,20 @@ void initialize_game()
 
 void init()
 {
+    const auto preinit_config_options = PreinitConfigOptions::from_file(
+        filesystem::files::profile_local_config());
+
+    initialize_screen(preinit_config_options);
+
     lua::lua = std::make_unique<lua::LuaEnv>();
-
-    config_load_preinit_options();
-    config_load_all_schema();
-
-    initialize_screen();
 
     initialize_directories();
 
+    initialize_lua();
+
+    config_load_all_schema();
     config_load_options();
 
-    initialize_lua();
     // Load translations from scanned mods.
     initialize_i18n();
 

--- a/src/elona/init.cpp
+++ b/src/elona/init.cpp
@@ -119,7 +119,7 @@ namespace elona
 void initialize_lua()
 {
     // Scan mods under "mods/" folder.
-    lua::lua->get_mod_manager().load_mods(filesystem::dirs::mod());
+    lua::lua->get_mod_manager().load_mods();
 
     // Initialize "console" mod.
     lua::lua->get_console().init_environment();

--- a/src/elona/init.hpp
+++ b/src/elona/init.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "filesystem.hpp"
+
 
 namespace elona
 {

--- a/src/elona/json5util.hpp
+++ b/src/elona/json5util.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <iostream>
+#include "../thirdparty/json5/json5.hpp"
+#include "../util/either.hpp"
+
+
+
+namespace elona
+{
+namespace json5util
+{
+
+using parse_result = either::either<std::string, json5::value>;
+
+
+
+parse_result parse_stream(std::istream& in)
+{
+    if (!in)
+    {
+        return parse_result::left_of("failed to open file");
+    }
+
+    using stream_itr = std::istreambuf_iterator<char>;
+    const std::string file_content{stream_itr{in}, stream_itr{}};
+
+    try
+    {
+        return parse_result::right_of(json5::parse(file_content));
+    }
+    catch (json5::syntax_error& err)
+    {
+        return parse_result::left_of(err.what());
+    }
+}
+
+} // namespace json5util
+} // namespace elona

--- a/src/elona/lua_env/api_manager.hpp
+++ b/src/elona/lua_env/api_manager.hpp
@@ -9,7 +9,7 @@ namespace elona
 namespace lua
 {
 
-struct ModInfo;
+struct ModEnv;
 
 
 

--- a/src/elona/lua_env/console.cpp
+++ b/src/elona/lua_env/console.cpp
@@ -594,11 +594,7 @@ void Console::_init_builtin_lua_functions()
     };
 
     funcs["ls"] = [this]() {
-        std::vector<std::string> mods;
-        range::transform(
-            lua().get_mod_manager().calculate_loading_order(),
-            std::back_inserter(mods),
-            [](const auto& mod_id) { return mod_id; });
+        auto mods = lua().get_mod_manager().sorted_mods();
         range::sort(mods);
 
         sol::table ret = env().create();

--- a/src/elona/lua_env/console.hpp
+++ b/src/elona/lua_env/console.hpp
@@ -15,7 +15,7 @@ namespace elona
 namespace lua
 {
 
-struct ModInfo;
+struct ModEnv;
 
 
 

--- a/src/elona/lua_env/data_manager.cpp
+++ b/src/elona/lua_env/data_manager.cpp
@@ -73,10 +73,9 @@ void DataManager::_init_from_mod(ModEnv& mod)
 
 void DataManager::init_from_mods()
 {
-    for (const auto& mod_id : lua().get_mod_manager().calculate_loading_order())
+    for (const auto& mod_id : lua().get_mod_manager().sorted_mods())
     {
-        const auto& mod = lua().get_mod_manager().get_enabled_mod(mod_id);
-        _init_from_mod(*mod);
+        _init_from_mod(*lua().get_mod_manager().get_mod(mod_id));
     }
 
     lua_state()->set("_MOD_ID", sol::lua_nil);

--- a/src/elona/lua_env/data_manager.cpp
+++ b/src/elona/lua_env/data_manager.cpp
@@ -29,7 +29,7 @@ void DataManager::clear()
 
 
 
-void DataManager::_init_from_mod(ModInfo& mod)
+void DataManager::_init_from_mod(ModEnv& mod)
 {
     // Bypass the metatable on the mod's environment preventing creation of
     // new global variables.

--- a/src/elona/lua_env/data_manager.hpp
+++ b/src/elona/lua_env/data_manager.hpp
@@ -13,7 +13,7 @@ namespace elona
 namespace lua
 {
 
-struct ModInfo;
+struct ModEnv;
 
 
 
@@ -44,7 +44,7 @@ public:
 
 
 private:
-    void _init_from_mod(ModInfo& mod);
+    void _init_from_mod(ModEnv& mod);
 
     DataTable _data;
 };

--- a/src/elona/lua_env/interface.cpp
+++ b/src/elona/lua_env/interface.cpp
@@ -1,6 +1,7 @@
 #include "interface.hpp"
 #include "config_table.hpp"
 #include "data_manager.hpp"
+#include "mod_manager.hpp"
 
 
 
@@ -28,6 +29,13 @@ optional<ConfigTable> data(const char* type, int legacy_id)
     }
 
     return none;
+}
+
+
+
+fs::path resolve_path_for_mod(const std::string& path)
+{
+    return lua::lua->get_mod_manager().resolve_path_for_mod(path);
 }
 
 } // namespace lua

--- a/src/elona/lua_env/interface.cpp
+++ b/src/elona/lua_env/interface.cpp
@@ -12,7 +12,7 @@ namespace lua
 
 optional<ConfigTable> data(const char* type, const std::string& id)
 {
-    if (auto table = lua::lua->get_data_manager().get().raw(type, id))
+    if (auto table = lua->get_data_manager().get().raw(type, id))
     {
         return ConfigTable(*table);
     }
@@ -23,7 +23,7 @@ optional<ConfigTable> data(const char* type, const std::string& id)
 
 optional<ConfigTable> data(const char* type, int legacy_id)
 {
-    if (auto id = lua::lua->get_data_manager().get().by_legacy(type, legacy_id))
+    if (auto id = lua->get_data_manager().get().by_legacy(type, legacy_id))
     {
         return data(type, *id);
     }
@@ -35,7 +35,7 @@ optional<ConfigTable> data(const char* type, int legacy_id)
 
 fs::path resolve_path_for_mod(const std::string& path)
 {
-    return lua::lua->get_mod_manager().resolve_path_for_mod(path);
+    return lua->get_mod_manager().resolve_path_for_mod(path);
 }
 
 } // namespace lua

--- a/src/elona/lua_env/interface.hpp
+++ b/src/elona/lua_env/interface.hpp
@@ -103,5 +103,7 @@ optional<ConfigTable> data(const char* type, const std::string& id);
  */
 optional<ConfigTable> data(const char* type, int legacy_id);
 
+fs::path resolve_path_for_mod(const std::string& path);
+
 } // namespace lua
 } // namespace elona

--- a/src/elona/lua_env/lua_env.hpp
+++ b/src/elona/lua_env/lua_env.hpp
@@ -88,16 +88,11 @@ public:
         return *config_mgr;
     }
 
-    /***
-     * Clears and reset the Lua state to directly after loading the
-     * core mod.
-     *
-     * Used when modifying startup scripts.
-     */
-    void reload();
+
+    void load_mods();
 
 
-    //****************** Methods for testing use *******************//
+    /****************** Methods for testing use *******************/
 
     /***
      * Unloads all characters and items tracked by handles.

--- a/src/elona/lua_env/mod_env.hpp
+++ b/src/elona/lua_env/mod_env.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "loaded_chunk_cache.hpp"
+#include "mod_manifest.hpp"
+
+
+
+namespace elona
+{
+namespace lua
+{
+
+/***
+ * Stores the Lua environment and internal storage for a single mod.
+ *
+ * Mods each have a sanitized environment with a whitelist of safe functions,
+ * so things like dofile can't be called. They also have storage object for
+ * storing, serializing and deserializing mod data alongside the base game
+ * data.
+ */
+struct ModEnv
+{
+    enum class StoreType
+    {
+        global,
+        map,
+    };
+
+
+
+    explicit ModEnv(const ModManifest& manifest, sol::environment env)
+        : manifest(manifest)
+        , env(env)
+    {
+        if (manifest.path)
+        {
+            chunk_cache = LoadedChunkCache{*manifest.path};
+        }
+    }
+
+
+
+    ModEnv(const ModEnv&) = delete;
+    ModEnv(ModEnv&&) = delete;
+    ModEnv& operator=(const ModEnv&) = delete;
+    ModEnv& operator=(ModEnv&&) = delete;
+    ~ModEnv() = default;
+
+
+
+    sol::object get_store(StoreType store_type) const
+    {
+        const auto table_name = convert_store_type_to_table_name(store_type);
+        return env.get<sol::object>(std::tie("mod", "store", table_name));
+    }
+
+
+
+    void set_store(StoreType store_type, sol::object data)
+    {
+        const auto table_name = convert_store_type_to_table_name(store_type);
+        // bypass metatable that forces store table reference to be
+        // unchangeable (set in mod_manager::bind_store)
+        sol::table store = env.get<sol::table>(std::tie("mod", "store"));
+        store.raw_set(table_name, data);
+    }
+
+
+
+    ModManifest manifest;
+    optional<LoadedChunkCache> chunk_cache;
+    sol::environment env;
+
+
+
+private:
+    static constexpr const char* convert_store_type_to_table_name(
+        StoreType store_type)
+    {
+        switch (store_type)
+        {
+        case StoreType::global: return "global";
+        case StoreType::map: return "map";
+        default: assert(0); return nullptr;
+        }
+    }
+};
+
+} // namespace lua
+} // namespace elona

--- a/src/elona/lua_env/mod_manager.cpp
+++ b/src/elona/lua_env/mod_manager.cpp
@@ -1,12 +1,9 @@
 #include "mod_manager.hpp"
-
 #include <map>
 #include <sstream>
 #include <unordered_set>
 #include <vector>
-
 #include "../../util/range.hpp"
-#include "../../util/topological_sorter.hpp"
 #include "../character.hpp"
 #include "../config.hpp"
 #include "../elona.hpp"
@@ -44,8 +41,9 @@ template <typename F>
 std::vector<fs::path> mod_dirs_internal(const fs::path& base_dir, F predicate)
 {
     std::vector<fs::path> result;
-    for (const auto& entry :
-         filesystem::glob_dirs(base_dir, std::regex{"[a-z][a-z0-9_]*"}))
+    // E.g., lomias-1.2.3
+    for (const auto& entry : filesystem::glob_dirs(
+             base_dir, std::regex{R"([a-z][a-z0-9_]+-[0-9]\.[0-9]\.[0-9])"}))
     {
         if (fs::exists(entry.path() / "mod.json"))
         {
@@ -58,256 +56,28 @@ std::vector<fs::path> mod_dirs_internal(const fs::path& base_dir, F predicate)
     return result;
 }
 
-} // namespace
 
 
-
-ModManager::ModManager(LuaEnv& lua)
-    : LuaSubmodule(lua)
+std::vector<fs::path> all_mod_dirs(const fs::path& base_dir)
 {
+    return mod_dirs_internal(base_dir, [](const auto&) { return true; });
 }
 
 
 
-bool ModManager::mod_id_is_reserved(const std::string& mod_id)
+std::vector<fs::path> template_mod_dirs(const fs::path& base_dir)
 {
-    return mod_id == "script" || mod_id == "_builtin_";
-}
-
-
-
-void ModManager::load_mods()
-{
-    if (stage_ != ModLoadingStage::not_started)
-    {
-        throw std::runtime_error("Mods have already been loaded.");
-    }
-
-    scan_all_mods();
-    load_lua_support_libraries();
-    load_scanned_mods();
-}
-
-
-
-void ModManager::load_mods(const std::vector<fs::path>& additional_mod_paths)
-{
-    if (stage_ != ModLoadingStage::not_started)
-    {
-        throw std::runtime_error("Mods have already been loaded.");
-    }
-
-    scan_all_mods();
-    for (const auto& path : additional_mod_paths)
-    {
-        scan_mod(path);
-    }
-    load_lua_support_libraries();
-    load_scanned_mods();
-}
-
-
-
-void ModManager::unload_mods()
-{
-    if (stage_ != ModLoadingStage::all_mods_loaded)
-    {
-        return;
-    }
-
-    mods_ = ModStorageType();
-    stage_ = ModLoadingStage::not_started;
-}
-
-
-
-void report_error(sol::error err)
-{
-    std::string what = err.what();
-    ELONA_ERROR("lua.mod") << what;
-}
-
-
-
-void ModManager::load_mod(ModEnv& mod)
-{
-    setup_and_lock_mod_globals(mod);
-
-    // Skip initializing mods not created from files, because the
-    // string passed to load_testing_mod_from_script acts as the
-    // initialization script.
-    if (!mod.manifest.path)
-    {
-        return;
-    }
-
-    auto result = safe_script_file(*mod.manifest.path / u8"init.lua", mod.env);
-
-    // Add the API table returned by the mod's init.lua, if one
-    // was returned.
-    if (result.valid())
-    {
-        sol::optional<sol::object> object = result.get<sol::object>();
-        if (object && object->is<sol::table>())
-        {
-            sol::table api_table = object->as<sol::table>();
-            lua().get_api_manager().add_api(mod.manifest.id, api_table);
-        }
-    }
-    else
-    {
-        sol::error err = result;
-        report_error(err);
-        throw std::runtime_error("Failed initializing mod "s + mod.manifest.id);
-    }
-}
-
-
-
-void ModManager::scan_mod(const fs::path& mod_dir)
-{
-    ModManifest manifest = ModManifest::load(mod_dir / "mod.json");
-
-    const std::string& mod_id = manifest.id;
-    ELONA_LOG("lua.mod") << "Found mod " << mod_id;
-
-    if (!is_valid_mod_id(mod_id))
-    {
-        throw std::runtime_error("Mod ID \"" + mod_id + "\" is invalid.");
-    }
-
-    create_mod(manifest, false);
-}
-
-
-
-void ModManager::scan_all_mods()
-{
-    if (stage_ != ModLoadingStage::not_started &&
-        stage_ != ModLoadingStage::scan_finished)
-    {
-        throw std::runtime_error("Mods have already been scanned!");
-    }
-
-    for (const auto& mod_dir : normal_mod_dirs(filesystem::dirs::mod()))
-    {
-        scan_mod(mod_dir);
-    }
-    stage_ = ModLoadingStage::scan_finished;
-}
-
-
-
-void ModManager::load_lua_support_libraries()
-{
-    if (stage_ == ModLoadingStage::not_started)
-    {
-        throw std::runtime_error("Mods haven't been scanned yet!");
-    }
-
-    // Add special API tables from data/lua to the core mod. The core
-    // mod's API table will be modified in-place by the Lua API code
-    // under data/lua.
-    lua().get_api_manager().load_lua_support_libraries();
-
-    stage_ = ModLoadingStage::lua_libraries_loaded;
-}
-
-
-
-void ModManager::load_scanned_mods()
-{
-    if (stage_ != ModLoadingStage::lua_libraries_loaded)
-    {
-        throw std::runtime_error("Lua libraries weren't loaded!");
-    }
-
-    // Ensure that mods are loaded in order, such that all mods that are
-    // depended on are loaded before their dependent mods.
-    for (const auto& mod_id : calculate_loading_order())
-    {
-        ModEnv* mod = get_enabled_mod(mod_id);
-        if (mod_id_is_reserved(mod_id))
-        {
-            // TODO warn about reserved mod IDs.
-            continue;
-        }
-        else
-        {
-            load_mod(*mod);
-        }
-        ELONA_LOG("lua.mod") << "Loaded mod " << mod->manifest.id;
-    }
-
-    lua().get_export_manager().register_all_exports();
-
-    stage_ = ModLoadingStage::all_mods_loaded;
-    lua().get_event_manager().trigger(BaseEvent("core.all_mods_loaded"));
-}
-
-
-
-void ModManager::run_startup_script(const std::string& name)
-{
-    if (stage_ < ModLoadingStage::lua_libraries_loaded)
-    {
-        throw std::runtime_error("Lua libraries weren't loaded!");
-    }
-    if (get_enabled_mod_optional(name))
-    {
-        throw std::runtime_error("Startup script was already run.");
-    }
-
-    ModEnv* script_mod = create_mod("script", none, true);
-
-    safe_script_file(filesystem::dirs::user_script() / name, script_mod->env);
-
-    // Bypass read-only metatable
-    script_mod->env.raw_set("data", lua().get_data_manager().get().storage());
-
-    ELONA_LOG("lua.mod") << "Loaded startup script " << name;
-    txt(i18n::s.get("core.mod.loaded_script", name),
-        Message::color{ColorIndex::purple});
-    Message::instance().linebreak();
-}
-
-
-
-void ModManager::clear_map_local_stores()
-{
-    for (auto&& pair : this->enabled_mods())
-    {
-        auto& mod = pair.second;
-        mod->env.get<sol::table>(std::tie("mod", "store"))
-            .raw_set("map", lua_state()->create_table());
-    }
-}
-
-
-
-void ModManager::clear_global_stores()
-{
-    for (auto&& pair : this->enabled_mods())
-    {
-        auto& mod = pair.second;
-        mod->env.get<sol::table>(std::tie("mod", "store"))
-            .raw_set("global", lua_state()->create_table());
-    }
-}
-
-
-
-void ModManager::clear_mod_stores()
-{
-    clear_map_local_stores();
-    clear_global_stores();
+    return mod_dirs_internal(base_dir, [](const auto& path) {
+        const auto id_and_version = filepathutil::to_utf8_path(path.filename());
+        return strutil::has_prefix(id_and_version, "template_");
+    });
 }
 
 
 
 // Callback to be called in Lua for preventing write access to unknown
 // globals.
-int deny(
+int deny_new_fields(
     sol::table table,
     sol::object key,
     sol::object value,
@@ -333,184 +103,245 @@ int deny(
 
 
 
-void ModManager::bind_store(sol::state& L, sol::table& table)
+sol::table create_store_table(sol::state& L)
 {
-    sol::table store = L.create_table();
-    sol::table metatable = L.create_table();
+    auto store_tbl = L.create_table();
 
-    // Bind store.global and store.map.
-    store["global"] = L.create_table();
-    store["map"] = L.create_table();
+    store_tbl["global"] = L.create_table();
+    store_tbl["map"] = L.create_table();
 
-    // Prevent creating new variables in the store table.
-    metatable[sol::meta_function::new_index] = deny;
+    auto mt = L.create_table();
+    mt[sol::meta_function::new_index] = deny_new_fields;
+    store_tbl[sol::metatable_key] = mt;
 
-    store[sol::metatable_key] = metatable;
-    table["store"] = store;
+    return store_tbl;
 }
 
 
 
-void ModManager::setup_mod_globals(ModEnv& mod, sol::table& table)
+sol::table create_mod_table(sol::state& L)
 {
-    // Create the globals "Elona" and "store" for this mod's
-    // environment.
-    sol::table mod_tbl = lua_state()->create_table();
-    sol::table metatable = lua_state()->create_table();
-    bind_store(*lua_state(), metatable);
-    // Prevent creating new variables in the store table.
-    metatable[sol::meta_function::new_index] = deny;
-    metatable[sol::meta_function::index] = metatable;
-    mod_tbl[sol::metatable_key] = metatable;
-    table["mod"] = mod_tbl;
+    auto mod_tbl = L.create_table();
+    auto mt = L.create_table();
 
-    lua().get_api_manager().bind(lua(), table);
-    table["_MOD_ID"] = mod.manifest.id;
+    mt["store"] = create_store_table(L);
 
-    // Add a list of whitelisted standard library functions to the
-    // environment.
-    setup_sandbox(*lua_state(), table);
+    mt[sol::meta_function::new_index] = deny_new_fields;
+    mt[sol::meta_function::index] = mt;
+    mod_tbl[sol::metatable_key] = mt;
+    return mod_tbl;
+}
 
-    // Add a custom version of "require" for use within mods. (Not
-    // added for scripts/console environment)
-    if (mod.chunk_cache)
+
+
+/***
+ * Whitelists functions that are safe for usage in user-written scripts.
+ */
+void setup_sandbox(sol::state& state, sol::table table)
+{
+    // This list can be expanded.
+    const char* safe_functions[] = {
+        "assert",
+        "error",
+        "ipairs",
+        "next",
+        "pairs",
+        "pcall",
+        "print",
+        "tostring",
+        "type",
+        "xpcall",
+    };
+
+    for (const auto& function_name : safe_functions)
     {
-        auto state = lua_state();
-        auto& chunk_cache = *mod.chunk_cache;
-        table["require_relative"] = [state, &chunk_cache](
-                                        const std::string& name,
-                                        sol::this_environment this_env) {
-            sol::environment env = this_env;
-            return chunk_cache.require(name, env, *state);
-        };
+        table[function_name] = state[function_name];
     }
 }
 
 
 
-void ModManager::setup_and_lock_mod_globals(ModEnv& mod)
+void report_error(sol::error err)
 {
-    sol::table env_metatable = lua_state()->create_table_with();
-
-    // Globals have to be set on the metatable, not the mod's
-    // environment itself.
-    setup_mod_globals(mod, env_metatable);
-
-    // Prevent writing of new globals.
-    env_metatable[sol::meta_function::new_index] = deny;
-    env_metatable[sol::meta_function::index] = env_metatable;
-
-    mod.env[sol::metatable_key] = env_metatable;
+    std::string what = err.what();
+    ELONA_ERROR("lua.mod") << what;
 }
 
 
 
-ModEnv* ModManager::create_mod(const ModManifest& manifest, bool readonly)
+template <typename F>
+void internal_init_mod(ModEnv& mod, APIManager& api_manager, F run_script)
 {
-    std::unique_ptr<ModEnv> info = std::make_unique<ModEnv>(
-        manifest, sol::environment(*lua_state(), sol::create));
+    auto result = run_script(mod.env);
 
-    if (readonly)
+    // Add the API table returned by the mod's init.lua, if one was returned.
+    if (result.valid())
     {
-        setup_and_lock_mod_globals(*info);
+        sol::optional<sol::object> object = result.template get<sol::object>();
+        if (object && object->is<sol::table>())
+        {
+            sol::table api_table = object->as<sol::table>();
+            api_manager.add_api(mod.manifest.id, api_table);
+        }
     }
     else
     {
-        // Set the globals directly on the environment table for testing use.
-        setup_mod_globals(*info, info->env);
+        sol::error err = result;
+        report_error(err);
+        throw std::runtime_error("Failed initializing mod "s + mod.manifest.id);
     }
+}
 
-    // TODO: Enable based on user config/dependency resolution. Always enable
-    // built-in mods.
-    enable_mod(manifest.id, manifest.version, true);
+} // namespace
 
-    auto mod_id_with_version = manifest.id + "-" + manifest.version.to_string();
-    mods_[mod_id_with_version] = std::move(info);
-    return mods_[mod_id_with_version].get();
+
+
+ModManager::ModManager(LuaEnv& lua)
+    : LuaSubmodule(lua)
+{
 }
 
 
 
-ModEnv* ModManager::create_mod(
+void ModManager::load_mods(const ResolvedModList& resolved_mod_list)
+{
+    _mod_versions = resolved_mod_list.mod_versions();
+    _sorted_mods = resolved_mod_list.sorted_mods();
+
+    lua().get_api_manager().load_lua_support_libraries();
+
+    create_all_mod_env(resolved_mod_list.mod_versions());
+
+    // Ensure that mods are loaded in order, such that all mods that are
+    // depended on are loaded before their dependent mods.
+    for (const auto& id : sorted_mods())
+    {
+        auto& mod = _mods.at(id);
+        init_mod(mod);
+        ELONA_LOG("lua.mod") << "Loaded mod " << mod.manifest.id;
+    }
+
+    lua().get_export_manager().register_all_exports();
+
+    lua().get_event_manager().trigger(BaseEvent("core.all_mods_loaded"));
+}
+
+
+
+void ModManager::init_mod(ModEnv& mod)
+{
+    if (mod.manifest.path)
+    {
+        internal_init_mod(
+            mod,
+            lua().get_api_manager(),
+            [this, path = (*mod.manifest.path / "init.lua")](auto env) {
+                return safe_script_file(path, env);
+            });
+    }
+}
+
+
+
+void ModManager::run_startup_script(const fs::path& script_filename)
+{
+    auto& script_mod = create_mod_env_from_script("script");
+
+    safe_script_file(
+        filesystem::dirs::user_script() / script_filename, script_mod.env);
+
+    ELONA_LOG("lua.mod") << "Loaded startup script " << script_filename;
+    txt(i18n::s.get(
+            "core.mod.loaded_script",
+            filepathutil::to_utf8_path(script_filename)),
+        Message::color{ColorIndex::purple});
+    Message::instance().linebreak();
+}
+
+
+
+void ModManager::clear_map_local_stores()
+{
+    for (auto&& pair : mods())
+    {
+        auto& mod = pair.second;
+        mod.env.get<sol::table>(std::tie("mod", "store"))
+            .raw_set("map", lua_state()->create_table());
+    }
+}
+
+
+
+void ModManager::clear_global_stores()
+{
+    for (auto&& pair : mods())
+    {
+        auto& mod = pair.second;
+        mod.env.get<sol::table>(std::tie("mod", "store"))
+            .raw_set("global", lua_state()->create_table());
+    }
+}
+
+
+
+void ModManager::clear_mod_stores()
+{
+    clear_map_local_stores();
+    clear_global_stores();
+}
+
+
+
+void ModManager::load_testing_mod_from_script(
     const std::string& id,
-    optional<fs::path> mod_dir,
-    bool readonly)
+    const std::string& script)
 {
-    ModManifest manifest;
-    manifest.id = id;
-    manifest.path = mod_dir;
-    manifest.version = semver::Version(0, 1, 0);
+    auto& mod = create_mod_env_from_script(id);
 
-    return create_mod(manifest, readonly);
+    internal_init_mod(mod, lua().get_api_manager(), [this, &script](auto env) {
+        return safe_script(script, env);
+    });
+
+    _mod_versions.emplace(mod.manifest.id, mod.manifest.version);
+    // Testing mods are always at the end.
+    _sorted_mods.push_back(mod.manifest.id);
 }
 
 
 
-std::vector<std::string> ModManager::calculate_loading_order()
+void ModManager::load_testing_mod_from_file(const fs::path& mod_dir)
 {
-    TopologicalSorter<std::string> sorter;
+    auto& mod = create_mod_env_from_manifest_file(mod_dir / "mod.json");
 
-    for (const auto& pair : this->enabled_mods())
+    init_mod(mod);
+
+    _mod_versions.emplace(mod.manifest.id, mod.manifest.version);
+    // Testing mods are always at the end.
+    _sorted_mods.push_back(mod.manifest.id);
+}
+
+
+
+void ModManager::run_in_mod(const std::string& id, const std::string& script)
+{
+    auto mod = get_mod(id);
+    if (!mod)
     {
-        const auto& mod = pair.second;
-        sorter.add(mod->manifest.id);
-
-        for (const auto& pair : mod->manifest.dependencies)
-        {
-            const auto& mod_id = pair.first;
-            const auto& version_req = pair.second;
-
-            const auto dependent_mod = get_enabled_mod_optional(mod_id);
-            if (!dependent_mod)
-            {
-                throw std::runtime_error(
-                    "The dependency '" + mod_id + "' of mod '" +
-                    mod->manifest.id +
-                    "' could not be found in the list of scanned mods.");
-            }
-            const auto& ver = (*dependent_mod)->manifest.version;
-            if (!version_req.is_satisfied(ver))
-            {
-                // Error message example:
-                // The dependency requirement 'base' (>= 2.0.0) of mod 'derived'
-                // could not be satisfied by 'base v1.5.0'.
-                std::stringstream ss;
-                ss << "The dependency requirement '" << mod_id << "' ("
-                   << version_req.to_string() << ") of mod '"
-                   << mod->manifest.id << "'could not be satisfied by '"
-                   << mod_id << " v" << ver.to_string() << "'.";
-                throw std::runtime_error(ss.str());
-            }
-
-            sorter.add_dependency(mod->manifest.id, mod_id);
-        }
+        throw std::runtime_error("No such mod "s + id + "."s);
     }
 
-    std::vector<std::string> result;
-    std::vector<std::string> cyclic_dependencies;
-    std::tie(result, cyclic_dependencies) = sorter.sort();
+    // Prevent outputting things in the test log on errors, but still
+    // throw if the result is invalid so tests can catch it.
+    const auto ignore_handler =
+        [](lua_State*, sol::protected_function_result pfr) { return pfr; };
 
-    if (cyclic_dependencies.size() > 0)
+    auto result = safe_script(script, mod->env, ignore_handler);
+
+    if (!result.valid())
     {
-        std::string cycle;
-
-        for (const auto& dependency : cyclic_dependencies)
-        {
-            if (cycle == "")
-            {
-                cycle = dependency;
-            }
-            else
-            {
-                cycle += " -> " + dependency;
-            }
-        }
-
-        throw std::runtime_error(
-            "Cyclic dependency detected when loading mods: " + cycle);
+        sol::error err = result;
+        throw err;
     }
-
-    return result;
 }
 
 
@@ -557,76 +388,6 @@ bool ModManager::exists(const std::string& mod_id)
 
 
 
-// For testing use
-void ModManager::load_testing_mod_from_script(
-    const std::string& name,
-    const std::string& script,
-    bool readonly)
-{
-    if (stage_ < ModLoadingStage::lua_libraries_loaded)
-    {
-        throw std::runtime_error("Lua libraries weren't loaded!");
-    }
-    {
-        auto val = get_enabled_mod_optional(name);
-        if (val)
-        {
-            throw std::runtime_error(
-                "Mod "s + name + " was already initialized."s);
-        }
-    }
-
-    ModEnv* mod = create_mod(name, none, readonly);
-
-    // Run the provided script string.
-    auto result = safe_script(script, mod->env);
-
-    // Add the API table returned by the mod's initialization script,
-    // if one was returned.
-    if (result.valid())
-    {
-        sol::optional<sol::object> object = result.get<sol::object>();
-        if (object && object->is<sol::table>())
-        {
-            sol::table api_table = object->as<sol::table>();
-            lua().get_api_manager().add_api(name, api_table);
-        }
-    }
-    else
-    {
-        sol::error err = result;
-        report_error(err);
-        throw std::runtime_error("Failed initializing mod "s + name);
-    }
-}
-
-
-
-void ModManager::run_in_mod(const std::string& name, const std::string& script)
-{
-    auto val = get_enabled_mod_optional(name);
-    if (!val)
-    {
-        throw std::runtime_error("No such mod "s + name + "."s);
-    }
-
-    // Prevent outputting things in the test log on errors, but still
-    // throw if the result is invalid so tests can catch it.
-    auto ignore_handler = [](lua_State*, sol::protected_function_result pfr) {
-        return pfr;
-    };
-
-    auto result = safe_script(script, (*val)->env, ignore_handler);
-
-    if (!result.valid())
-    {
-        sol::error err = result;
-        throw err;
-    }
-}
-
-
-
 fs::path ModManager::resolve_path_for_mod(const std::string& path)
 {
     // TODO: standardize mod naming convention.
@@ -666,29 +427,88 @@ fs::path ModManager::resolve_path_for_mod(const std::string& path)
 
 
 
-std::vector<fs::path> all_mod_dirs(const fs::path& base_dir)
+void ModManager::create_all_mod_env(
+    const ResolvedModList::ModVersionMap& mod_versions)
 {
-    return mod_dirs_internal(base_dir, [](const auto&) { return true; });
+    for (const auto& pair : mod_versions)
+    {
+        const auto& id = pair.first;
+        const auto& version = pair.second;
+
+        create_mod_env_from_manifest_file(
+            filesystem::dirs::for_mod(id, version) / "mod.json");
+    }
 }
 
 
 
-std::vector<fs::path> normal_mod_dirs(const fs::path& base_dir)
+ModEnv& ModManager::create_mod_env_from_manifest_file(
+    const fs::path& manifest_filepath)
 {
-    return mod_dirs_internal(base_dir, [](const auto& path) {
-        const auto mod_id = filepathutil::to_utf8_path(path.filename());
-        return !strutil::has_prefix(mod_id, "template_");
-    });
+    const auto manifest = ModManifest::load(manifest_filepath);
+    return create_mod_env_manifest(manifest);
 }
 
 
 
-std::vector<fs::path> template_mod_dirs(const fs::path& base_dir)
+ModEnv& ModManager::create_mod_env_from_script(const std::string& id)
 {
-    return mod_dirs_internal(base_dir, [](const auto& path) {
-        const auto mod_id = filepathutil::to_utf8_path(path.filename());
-        return strutil::has_prefix(mod_id, "template_");
-    });
+    ModManifest manifest;
+    manifest.id = id;
+    manifest.version = semver::Version{0, 1, 0};
+    return create_mod_env_manifest(manifest);
+}
+
+
+
+ModEnv& ModManager::create_mod_env_manifest(const ModManifest& manifest)
+{
+    ELONA_LOG("lua.mod") << "Found mod " << manifest.id;
+
+    const auto emplace_result = _mods.emplace(
+        std::piecewise_construct,
+        std::make_tuple(manifest.id),
+        std::make_tuple(manifest, sol::environment{*lua_state(), sol::create}));
+    assert(emplace_result.second); // The element was newly inserted just now.
+    auto& mod = emplace_result.first->second;
+    setup_mod_globals(mod);
+    return mod;
+}
+
+
+
+void ModManager::setup_mod_globals(ModEnv& mod)
+{
+    auto& L = *lua_state();
+
+    auto mt = L.create_table();
+
+    mt["mod"] = create_mod_table(L);
+
+    lua().get_api_manager().bind(lua(), mt);
+    mt["_MOD_ID"] = mod.manifest.id;
+
+    // Add a list of whitelisted standard library functions to the
+    // environment.
+    setup_sandbox(*lua_state(), mt);
+
+    // Add a custom version of "require" for use within mods. (Not
+    // added for scripts/console environment)
+    if (mod.chunk_cache)
+    {
+        auto state = lua_state();
+        auto& chunk_cache = *mod.chunk_cache;
+        mt["require_relative"] = [state, &chunk_cache](
+                                     const std::string& name,
+                                     sol::this_environment this_env) {
+            sol::environment env = this_env;
+            return chunk_cache.require(name, env, *state);
+        };
+    }
+
+    mt[sol::meta_function::new_index] = deny_new_fields;
+    mt[sol::meta_function::index] = mt;
+    mod.env[sol::metatable_key] = mt;
 }
 
 
@@ -697,7 +517,14 @@ bool is_valid_mod_id(const std::string& id)
 {
     return !id.empty() && _is_alnum_only(id) &&
         filepathutil::is_portable_path(filepathutil::u8path(id)) &&
-        !lua->get_mod_manager().mod_id_is_reserved(id);
+        !is_reserved_mod_id(id);
+}
+
+
+
+bool is_reserved_mod_id(const std::string& id)
+{
+    return id == "script" || id == "_builtin_";
 }
 
 } // namespace lua

--- a/src/elona/lua_env/mod_manager.cpp
+++ b/src/elona/lua_env/mod_manager.cpp
@@ -75,30 +75,28 @@ bool ModManager::mod_id_is_reserved(const std::string& mod_id)
 
 
 
-void ModManager::load_mods(const fs::path& mod_dir)
+void ModManager::load_mods()
 {
     if (stage_ != ModLoadingStage::not_started)
     {
         throw std::runtime_error("Mods have already been loaded.");
     }
 
-    scan_all_mods(mod_dir);
+    scan_all_mods();
     load_lua_support_libraries();
     load_scanned_mods();
 }
 
 
 
-void ModManager::load_mods(
-    const fs::path& mod_dir,
-    const std::vector<fs::path> additional_mod_paths)
+void ModManager::load_mods(const std::vector<fs::path>& additional_mod_paths)
 {
     if (stage_ != ModLoadingStage::not_started)
     {
         throw std::runtime_error("Mods have already been loaded.");
     }
 
-    scan_all_mods(mod_dir);
+    scan_all_mods();
     for (const auto& path : additional_mod_paths)
     {
         scan_mod(path);
@@ -135,7 +133,7 @@ void ModManager::load_mod(ModEnv& mod)
     setup_and_lock_mod_globals(mod);
 
     // Skip initializing mods not created from files, because the
-    // string passed to load_mod_from_script acts as the
+    // string passed to load_testing_mod_from_script acts as the
     // initialization script.
     if (!mod.manifest.path)
     {
@@ -182,7 +180,7 @@ void ModManager::scan_mod(const fs::path& mod_dir)
 
 
 
-void ModManager::scan_all_mods(const fs::path& mods_dir)
+void ModManager::scan_all_mods()
 {
     if (stage_ != ModLoadingStage::not_started &&
         stage_ != ModLoadingStage::scan_finished)
@@ -190,7 +188,7 @@ void ModManager::scan_all_mods(const fs::path& mods_dir)
         throw std::runtime_error("Mods have already been scanned!");
     }
 
-    for (const auto& mod_dir : normal_mod_dirs(mods_dir))
+    for (const auto& mod_dir : normal_mod_dirs(filesystem::dirs::mod()))
     {
         scan_mod(mod_dir);
     }
@@ -555,7 +553,7 @@ bool ModManager::exists(const std::string& mod_id)
 
 
 // For testing use
-void ModManager::load_mod_from_script(
+void ModManager::load_testing_mod_from_script(
     const std::string& name,
     const std::string& script,
     bool readonly)

--- a/src/elona/lua_env/mod_manager.hpp
+++ b/src/elona/lua_env/mod_manager.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <boost/range/adaptor/filtered.hpp>
 #include "lua_submodule.hpp"
 #include "mod_env.hpp"
+#include "mod_version_resolver.hpp"
 
 
 
@@ -11,23 +11,6 @@ namespace elona
 namespace lua
 {
 
-using namespace std::literals::string_literals;
-
-
-
-/***
- * The stage of loading the lua environment is currently in.
- */
-enum class ModLoadingStage : unsigned
-{
-    not_started,
-    scan_finished,
-    lua_libraries_loaded,
-    all_mods_loaded,
-};
-
-
-
 /***
  * The core interface to the Lua environment. Used as a central
  * interface for more specialized API handling mechanisms and for
@@ -35,187 +18,109 @@ enum class ModLoadingStage : unsigned
  */
 class ModManager : public LuaSubmodule
 {
-    using ModStorageType =
-        std::unordered_map<std::string, std::unique_ptr<ModEnv>>;
-    using ModVersionsType = std::unordered_map<std::string, semver::Version>;
-
 public:
-    using iterator = ModStorageType::iterator;
-    using const_iterator = ModStorageType::const_iterator;
+    using ModEnvMap = std::unordered_map<std::string, ModEnv>;
+    using ModVersionMap = std::unordered_map<std::string, semver::Version>;
+    using SortedModList = std::vector<std::string>;
+
+
 
     explicit ModManager(LuaEnv&);
 
-    static bool mod_id_is_reserved(const std::string& id);
 
-    size_t enabled_mod_count() const
+
+    const ModEnvMap& mods() const noexcept
     {
-        return enabled_versions_.size();
+        return _mods;
     }
 
-    // Iterators for mods.
-    range::iota<ModStorageType::iterator> all_mods()
-    {
-        return {mods_.begin(), mods_.end()};
-    }
 
-    range::iota<ModStorageType::const_iterator> all_mods() const
-    {
-        return {mods_.begin(), mods_.end()};
-    }
-
-    struct EnabledRange
-    {
-    public:
-        struct iterator
-        {
-        private:
-            using base_iterator_type = typename ModStorageType::const_iterator;
-
-        public:
-            using value_type = base_iterator_type::value_type;
-            using difference_type =
-                typename base_iterator_type::difference_type;
-            using pointer = const value_type*;
-            using reference = const value_type&;
-            using iterator_category =
-                typename base_iterator_type::iterator_category;
-
-
-            iterator(
-                const ModStorageType& map,
-                const typename ModVersionsType::const_iterator& itr)
-                : map(map)
-                , itr(itr)
-            {
-            }
-
-            reference operator*() const
-            {
-                auto id_and_version =
-                    itr->first + "-" + itr->second.to_string();
-                return *map.find(id_and_version);
-            }
-
-            pointer operator->() const
-            {
-                auto id_and_version =
-                    itr->first + "-" + itr->second.to_string();
-                return map.find(id_and_version).operator->();
-            }
-
-            void operator++()
-            {
-                ++itr;
-            }
-
-            bool operator!=(const iterator& other) const
-            {
-                return itr != other.itr;
-            }
-
-        private:
-            const ModStorageType& map;
-            typename ModVersionsType::const_iterator itr;
-        };
-
-        EnabledRange(const ModStorageType& map, const ModVersionsType& ver)
-            : map(map)
-            , ver(ver)
-        {
-        }
-
-        iterator begin()
-        {
-            return iterator(map, ver.begin());
-        }
-
-        iterator end()
-        {
-            return iterator(map, ver.end());
-        }
-
-    private:
-        const ModStorageType& map;
-        const ModVersionsType& ver;
-    };
-
-    EnabledRange enabled_mods() const
-    {
-        return EnabledRange(mods_, enabled_versions_);
-    }
-
-    optional<semver::Version> get_enabled_version(const std::string& id)
-    {
-        auto it = enabled_versions_.find(id);
-        if (it != enabled_versions_.end())
-            return it->second;
-        return none;
-    }
-
-    void enable_mod(
-        const std::string& id,
-        const semver::Version& version,
-        bool fail_on_conflict = false)
-    {
-        auto it = enabled_versions_.find(id);
-        if (it != enabled_versions_.end())
-        {
-            if (fail_on_conflict)
-            {
-                throw std::runtime_error(
-                    "Mod " + id +
-                    " is already enabled. Wanted: " + version.to_string() +
-                    ", enabled version: " + it->second.to_string());
-            }
-            else
-            {
-
-                disable_mod(id);
-            }
-        }
-
-        enabled_versions_[id] = version;
-    }
-
-    void disable_mod(const std::string& id)
-    {
-        enabled_versions_.erase(id);
-    }
-
-    /***
-     * Scans and loads all mods at the the given mods/ root directory,
-     * binding their APIs to the API manager.
+    /**
+     * Finds the mod that is currently loaded.
      */
-    void load_mods();
+    optional_ref<const ModEnv> get_mod(const std::string& id) const noexcept
+    {
+        const auto itr = mods().find(id);
+        if (itr == std::end(mods()))
+        {
+            return none;
+        }
+        else
+        {
+            return itr->second;
+        }
+    }
 
-    /***
-     * Wipes the entire state of all mods.
+
+    /**
+     * Finds the mod that is currently loaded.
      */
-    void unload_mods();
+    optional_ref<ModEnv> get_mod(const std::string& id) noexcept
+    {
+        const auto itr = _mods.find(id);
+        if (itr == std::end(_mods))
+        {
+            return none;
+        }
+        else
+        {
+            return itr->second;
+        }
+    }
 
-    /***
-     * Runs the startup script with the given filename. It is expected
-     * to be found under the data/script/ folder.
+
+    const ModVersionMap& mod_versions() const noexcept
+    {
+        return _mod_versions;
+    }
+
+
+    const SortedModList& sorted_mods() const noexcept
+    {
+        return _sorted_mods;
+    }
+
+
+    optional_ref<const semver::Version> get_enabled_version(
+        const std::string& id) const noexcept
+    {
+        const auto itr = mod_versions().find(id);
+        if (itr == std::end(mod_versions()))
+        {
+            return none;
+        }
+        else
+        {
+            return itr->second;
+        }
+    }
+
+
+    void load_mods(const ResolvedModList& resolved_mod_list);
+
+
+    /**
+     * Runs the startup script with the given filename. It is expected to be
+     * found under `filesystem::dirs::user_script()` folder.
      *
-     * Currently, this is always executed after the map has been
-     * initialized. This will also re-run game, map and character
-     * initialization hooks, because they would have been run already
-     * by that point.
+     * Currently, this is always executed after the map has been initialized.
+     * This will also re-run game, map and character initialization hooks,
+     * because they would have been run already by that point.
      */
-    void run_startup_script(const std::string&);
+    void run_startup_script(const fs::path& script_filename);
 
 
-    /***
+    /**
      * Clears all map-local mod storages.
      */
     void clear_map_local_stores();
 
-    /***
+    /**
      * Clears all global mod storages.
      */
     void clear_global_stores();
 
-    /***
+    /**
      * Clears the internal storage for each loaded mod. This is used
      * when transitioning between maps, because most data in the store
      * will become invalid after transitioning.
@@ -223,28 +128,25 @@ public:
     void clear_mod_stores();
 
 
-    //****************** Methods for testing use *******************//
+    /****************** Methods for testing use *******************/
 
-    /***
-     * Same as load_mods, but also inject an additional mod to be
-     * loaded. The additional mod's path points directly to the
-     * subfolder under mods/ where its init.lua is located.
-     *
-     * For testing use only.
-     */
-    void load_mods(const std::vector<fs::path>&);
-
-    /***
+    /**
      * Instantiates a new mod by running the given Lua code.
      *
      * For testing use only.
      */
     void load_testing_mod_from_script(
         const std::string& id,
-        const std::string& script,
-        bool readonly = false);
+        const std::string& script);
 
-    /***
+    /**
+     * Instantiates a new mod.
+     *
+     * For testing use only.
+     */
+    void load_testing_mod_from_file(const fs::path& mod_dir);
+
+    /**
      * Runs the given Lua code in an existing mod.
      *
      * Will throw if the mod doesn't exist.
@@ -253,96 +155,7 @@ public:
      */
     void run_in_mod(const std::string& id, const std::string& script);
 
-    /***
-     * Creates a new mod, optionally setting its global environment to be read
-     * only.
-     *
-     * Will throw if a mod with the same ID already exists.
-     *
-     * @return a pointer to the created mod.
-     */
-    ModEnv* create_mod(const ModManifest& manifest, bool readonly);
 
-    /***
-     * Creates a new mod, optionally setting its global environment to be read
-     * only.
-     *
-     * Will throw if a mod with the same ID already exists.
-     *
-     * @return a pointer to the created mod.
-     */
-    ModEnv* create_mod(
-        const std::string& id,
-        optional<fs::path> mod_dir = none,
-        bool readonly = false);
-
-    /***
-     * Retrieves a pointer to an instantiated mod. @a id_and_version is of
-     * format "mod_id-0.1.0".
-     */
-    optional<ModEnv*> get_mod_optional(const std::string& id_and_version)
-    {
-        auto val = mods_.find(id_and_version);
-        if (val == mods_.end())
-            return none;
-        return val->second.get();
-    }
-
-    /***
-     * Retrieves a pointer to an instantiated mod. @a id_and_version is of
-     * format "mod_id-0.1.0".
-     *
-     * Will throw if the mod doesn't exist.
-     *
-     * For testing use only.
-     */
-    ModEnv* get_mod(const std::string& id_and_version)
-    {
-        auto val = mods_.find(id_and_version);
-        if (val == mods_.end())
-            throw std::runtime_error("No such mod "s + id_and_version + "."s);
-        return val->second.get();
-    }
-
-    /***
-     * Finds the mod info of a mod that is currently enabled. Only one version
-     * of any given mod can be enabled at a time. @a id is of format "mod_id".
-     *
-     * Will throw if no such mod matches and is enabled.
-     */
-    ModEnv* get_enabled_mod(const std::string& id)
-    {
-        auto val = get_enabled_mod_optional(id);
-        if (!val)
-            throw std::runtime_error("No mod "s + id + " was enabled."s);
-        return *val;
-    }
-
-    /***
-     * Finds the mod info of a mod that is currently enabled. Only one version
-     * of any given mod can be enabled at a time. @a id is of format "mod_id".
-     */
-    optional<ModEnv*> get_enabled_mod_optional(const std::string& id)
-    {
-        auto version = get_enabled_version(id);
-        if (!version)
-            return none;
-        return get_mod_optional(id + "-" + version->to_string());
-    }
-
-    /***
-     * Calculates the order in which mods should be loaded such that all the
-     * needed dependencies of a mod are loaded by the time that mod is loaded.
-     *
-     * The set of mods enabled is assumed to be valid with no version
-     * conflicts/duplicates.
-     *
-     * @return a list of mod ids, ordered by loading order
-     * @throws if there is a cyclic dependency, a dependency is unknown, a
-     * dependency's version requirements cannot be satisfied, or more than one
-     * version of the same mod is enabled
-     */
-    std::vector<std::string> calculate_loading_order();
 
     std::vector<ModManifest> get_templates();
 
@@ -355,47 +168,24 @@ public:
     fs::path resolve_path_for_mod(const std::string& path);
 
 
+
 private:
-    //********************* Lifecycle methods **********************//
-
-    /***
-     * Builds a list of all available mods in the user's mods/ folder.
-     * No mod loading happens here.
-     *
-     * Stage before is not_started or scan_finished (to support
-     * scanning multiple directories).
-     * Stage after is scan_finished.
-     */
-    void scan_all_mods();
-
-    /***
-     * Adds the parts of the API implemented in Lua to the API
-     * manager's API table.
-     *
-     * Stage before is scan_finished.
-     * Stage after is lua_libraries_loaded.
-     */
-    void load_lua_support_libraries();
-
-    /***
-     * Loads all mods that were scanned during the scanning stage.
-     *
-     * Stage before is lua_libraries_loaded.
-     * Stage after is all_mods_loaded.
-     */
-    void load_scanned_mods();
+    ModEnvMap _mods;
+    ModVersionMap _mod_versions;
+    SortedModList _sorted_mods;
 
 
-    //********************** Mod loading related ***********************//
+    void create_all_mod_env(const ModVersionMap& mod_versions);
 
-    /***
-     * Adds the mod under the given path to the list of known mods to
-     * be loaded. The provided path is the subfolder under mods/ that
-     * contains the mod's init.lua script.
-     */
-    void scan_mod(const fs::path&);
+    ModEnv& create_mod_env_from_manifest_file(
+        const fs::path& manifest_filepath);
+    ModEnv& create_mod_env_from_script(const std::string& id);
+    ModEnv& create_mod_env_manifest(const ModManifest& manifest);
 
-    /***
+
+    /********************** Mod loading related ***********************/
+
+    /**
      * Runs the init script for the given mod. The mod will have been
      * scanned and its environment set up by this point.
      *
@@ -403,73 +193,19 @@ private:
      */
     void load_mod(ModEnv& mod);
 
-    /***
-     * Sets up the global variables of a mod and locks them so they
-     * cannot be overwritten.
-     */
-    void setup_and_lock_mod_globals(ModEnv&);
 
-    /***
-     * Sets the global variables of a mod on the given table.
-     */
-    void setup_mod_globals(ModEnv& mod, sol::table&);
-
-
-    /***
-     * Binds the store variable to a mod table.
-     */
-    static void bind_store(sol::state&, sol::table&);
-
-    /***
-     * Whitelists functions that are safe for usage in user-written scripts.
-     */
-    static void setup_sandbox(const sol::state& state, sol::table& metatable)
-    {
-        // This list can be expanded.
-        static const std::string safe_functions[] = {"assert",
-                                                     "type",
-                                                     "pairs",
-                                                     "ipairs",
-                                                     "next",
-                                                     "print",
-                                                     "pcall",
-                                                     "xpcall",
-                                                     "tostring",
-                                                     "error"};
-
-        for (const std::string& function_name : safe_functions)
-        {
-            metatable[function_name] = state[function_name];
-        }
-    }
-
-private:
     /**
-     * Map from id and version (mod_id-0.1.0) to mod info.
+     * Sets the global variables of a mod.
      */
-    ModStorageType mods_;
+    void setup_mod_globals(ModEnv& mod);
 
-    /***
-     * Map from base mod id to its enabled version, if the mod is enabled.
-     * This ensures each mod has at most one version enabled.
-     */
-    ModVersionsType enabled_versions_;
-
-    /***
-     * The loading stage the environment is currently in. Used for
-     * tracking the lifecycle of mod loading and ensuring the loading
-     * functions are run in the correct order.
-     */
-    ModLoadingStage stage_ = ModLoadingStage::not_started;
+    void init_mod(ModEnv& mod);
 };
 
 
 
-std::vector<fs::path> all_mod_dirs(const fs::path& base_dir);
-std::vector<fs::path> normal_mod_dirs(const fs::path& base_dir);
-std::vector<fs::path> template_mod_dirs(const fs::path& base_dir);
-
 bool is_valid_mod_id(const std::string& id);
+bool is_reserved_mod_id(const std::string& id);
 
 } // namespace lua
 } // namespace elona

--- a/src/elona/lua_env/mod_manager.hpp
+++ b/src/elona/lua_env/mod_manager.hpp
@@ -186,7 +186,7 @@ public:
      * Scans and loads all mods at the the given mods/ root directory,
      * binding their APIs to the API manager.
      */
-    void load_mods(const fs::path&);
+    void load_mods();
 
     /***
      * Wipes the entire state of all mods.
@@ -232,14 +232,14 @@ public:
      *
      * For testing use only.
      */
-    void load_mods(const fs::path&, const std::vector<fs::path>);
+    void load_mods(const std::vector<fs::path>&);
 
     /***
      * Instantiates a new mod by running the given Lua code.
      *
      * For testing use only.
      */
-    void load_mod_from_script(
+    void load_testing_mod_from_script(
         const std::string& id,
         const std::string& script,
         bool readonly = false);
@@ -364,7 +364,7 @@ private:
      * scanning multiple directories).
      * Stage after is scan_finished.
      */
-    void scan_all_mods(const fs::path&);
+    void scan_all_mods();
 
     /***
      * Adds the parts of the API implemented in Lua to the API

--- a/src/elona/lua_env/mod_manager.hpp
+++ b/src/elona/lua_env/mod_manager.hpp
@@ -352,6 +352,8 @@ public:
 
     bool exists(const std::string& mod_id);
 
+    fs::path resolve_path_for_mod(const std::string& path);
+
 
 private:
     //********************* Lifecycle methods **********************//

--- a/src/elona/lua_env/mod_serializer.cpp
+++ b/src/elona/lua_env/mod_serializer.cpp
@@ -9,14 +9,14 @@ namespace lua
 
 std::pair<int, int> get_start_end_indices(
     const std::string& kind,
-    ModInfo::StoreType store_type)
+    ModEnv::StoreType store_type)
 {
     if (kind == Character::lua_type())
     {
         switch (store_type)
         {
-        case ModInfo::StoreType::global: return {0, ELONA_MAX_PARTY_CHARACTERS};
-        case ModInfo::StoreType::map:
+        case ModEnv::StoreType::global: return {0, ELONA_MAX_PARTY_CHARACTERS};
+        case ModEnv::StoreType::map:
             return {ELONA_MAX_PARTY_CHARACTERS, ELONA_MAX_CHARACTERS};
         }
     }
@@ -24,9 +24,9 @@ std::pair<int, int> get_start_end_indices(
     {
         switch (store_type)
         {
-        case ModInfo::StoreType::global:
+        case ModEnv::StoreType::global:
             return {0, ELONA_OTHER_INVENTORIES_INDEX};
-        case ModInfo::StoreType::map:
+        case ModEnv::StoreType::map:
             return {ELONA_OTHER_INVENTORIES_INDEX, ELONA_MAX_ITEMS};
         }
     }
@@ -35,12 +35,12 @@ std::pair<int, int> get_start_end_indices(
     return {0, 0};
 }
 
-std::string get_store_name(ModInfo::StoreType store_type)
+std::string get_store_name(ModEnv::StoreType store_type)
 {
     switch (store_type)
     {
-    case ModInfo::StoreType::map: return "map local";
-    case ModInfo::StoreType::global: return "global";
+    case ModEnv::StoreType::map: return "map local";
+    case ModEnv::StoreType::global: return "global";
     }
 
     assert(false);

--- a/src/elona/lua_env/mod_serializer.hpp
+++ b/src/elona/lua_env/mod_serializer.hpp
@@ -16,9 +16,9 @@ namespace lua
 
 std::pair<int, int> get_start_end_indices(
     const std::string& kind,
-    ModInfo::StoreType store_type);
+    ModEnv::StoreType store_type);
 
-std::string get_store_name(ModInfo::StoreType store_type);
+std::string get_store_name(ModEnv::StoreType store_type);
 
 
 
@@ -33,7 +33,7 @@ public:
     }
 
     template <typename T, typename Archive>
-    void save_handles(Archive& putit_archive, ModInfo::StoreType store_type)
+    void save_handles(Archive& putit_archive, ModEnv::StoreType store_type)
     {
         int index_start, index_end;
         std::tie(index_start, index_end) =
@@ -53,7 +53,7 @@ public:
     template <typename T, typename Archive>
     std::pair<int, int> load_handles(
         Archive& putit_archive,
-        ModInfo::StoreType store_type)
+        ModEnv::StoreType store_type)
     {
         int index_start, index_end;
         std::tie(index_start, index_end) =
@@ -75,7 +75,7 @@ public:
     template <typename Archive>
     void save_mod_store_data(
         Archive& putit_archive,
-        ModInfo::StoreType store_type)
+        ModEnv::StoreType store_type)
     {
         const auto& mod_mgr = lua().get_mod_manager();
 
@@ -102,7 +102,7 @@ public:
     template <typename Archive>
     void load_mod_store_data(
         Archive& putit_archive,
-        ModInfo::StoreType store_type)
+        ModEnv::StoreType store_type)
     {
         auto& mod_mgr = lua().get_mod_manager();
 

--- a/src/elona/lua_env/mod_version_resolver.cpp
+++ b/src/elona/lua_env/mod_version_resolver.cpp
@@ -1,0 +1,307 @@
+#include "mod_version_resolver.hpp"
+#include "../../util/topological_sorter.hpp"
+#include "../json5util.hpp"
+#include "../log.hpp"
+
+
+
+namespace elona
+{
+namespace lua
+{
+
+namespace
+{
+
+auto parse_mod_list(std::istream& in)
+{
+    using Result = either::either<std::string, ModList::RequirementList>;
+
+    const auto parse_result = json5util::parse_stream(in);
+    if (!parse_result)
+    {
+        return Result::left_of(parse_result.left());
+    }
+
+    const auto& json5_value = parse_result.right();
+    if (!json5_value.is_object())
+    {
+        return Result::left_of("the top level item must be an object");
+    }
+    const auto& root_obj = json5_value.get_object();
+    const auto mods_obj_itr = root_obj.find("mods");
+    if (mods_obj_itr == std::end(root_obj))
+    {
+        return Result::left_of("\"mods\" field is required");
+    }
+    const auto& mods_obj_value = mods_obj_itr->second;
+    if (!mods_obj_value.is_object())
+    {
+        return Result::left_of("\"mods\" field mut be an object");
+    }
+    const auto& mods_obj = mods_obj_value.get_object();
+
+    ModList::RequirementList ret;
+    for (const auto& pair : mods_obj)
+    {
+        const auto& mod_id = pair.first;
+        const auto& mod_req_value = pair.second;
+        if (!mod_req_value.is_string())
+        {
+            return Result::left_of("mod version requirement must be a string");
+        }
+        const auto mod_requirement =
+            semver::VersionRequirement::parse(mod_req_value.get_string());
+        if (!mod_requirement)
+        {
+            return Result::left_of(mod_requirement.left());
+        }
+        ret.emplace(mod_id, mod_requirement.right());
+    }
+
+    return Result::right_of(ret);
+}
+
+
+
+auto calculate_loading_order(
+    const ResolvedModList::ModVersionMap& mod_versions,
+    const ModIndex& index)
+{
+    using Result = either::
+        either<std::vector<std::string>, ResolvedModList::SortedModList>;
+
+    TopologicalSorter<std::string> sorter;
+
+    for (const auto& pair : mod_versions)
+    {
+        const auto& mod = pair.first;
+        const auto& version = pair.second;
+        sorter.add(mod);
+
+        for (const auto& dep_mod_id : index.get_dependencies(mod, version))
+        {
+            sorter.add_dependency(mod, dep_mod_id);
+        }
+    }
+
+    std::vector<std::string> result;
+    std::vector<std::string> cyclic_dependencies;
+    std::tie(result, cyclic_dependencies) = sorter.sort();
+
+    if (cyclic_dependencies.empty())
+    {
+        return Result::right_of(result);
+    }
+    else
+    {
+        return Result::left_of(cyclic_dependencies);
+    }
+}
+
+} // namespace
+
+
+
+ModList ModList::from_file(const fs::path& path)
+{
+    std::ifstream in{path.native()};
+    return from_stream(in, filepathutil::to_utf8_path(path));
+}
+
+
+
+ModList ModList::from_string(const std::string& str)
+{
+    std::istringstream in{str};
+    return from_stream(in, "[string]");
+}
+
+
+
+ModList ModList::from_stream(std::istream& in, const std::string& filepath)
+{
+    RequirementList mods;
+    if (in)
+    {
+        auto result = parse_mod_list(in);
+        if (result)
+        {
+            mods = std::move(result.right());
+        }
+        else
+        {
+            ELONA_WARN("mod") << "failed to load mod list file (" << filepath
+                              << "): " << result.left();
+        }
+    }
+    mods.emplace(std::make_pair(
+        "core", semver::VersionRequirement::parse("= 0.2.6").right()));
+    return ModList{mods};
+}
+
+
+
+ModIndex::QueryResult ModIndex::query_latest(
+    const std::string& id,
+    const semver::VersionRequirement& requirement) const
+{
+    const auto itr = _mods.find(id);
+    if (itr == std::end(_mods))
+    {
+        return QueryResult::left_of("Mod not found: " + id);
+    }
+    const auto& versions = itr->second;
+    for (auto i = versions.rbegin(), end = versions.rend(); i != end; ++i)
+    {
+        if (requirement.is_satisfied(i->version))
+        {
+            return QueryResult::right_of(*i);
+        }
+    }
+    return QueryResult::left_of(
+        "Mod not found: " + id + " (" + requirement.to_string() + ")");
+}
+
+
+
+std::vector<std::string> ModIndex::get_dependencies(
+    const std::string& id,
+    const semver::Version& version) const
+{
+    const auto itr = _mods.find(id);
+    if (itr == std::end(_mods))
+    {
+        throw std::runtime_error{"Mod not found: " + id};
+    }
+    const auto& versions = itr->second;
+    for (const auto& v : versions)
+    {
+        if (v.version == version)
+        {
+            std::vector<std::string> ret;
+            for (const auto& pair : v.dependencies)
+            {
+                ret.push_back(pair.first);
+            }
+            return ret;
+        }
+    }
+    throw std::runtime_error{
+        "Mod '" + id + "' does not have the version: " + version.to_string()};
+}
+
+
+
+std::string ModIndex::to_string() const
+{
+    std::ostringstream ss;
+    ss << "Mod Index" << std::endl;
+    ss << "=========" << std::endl;
+    for (const auto& pair : _mods)
+    {
+        const auto& id = pair.first;
+        const auto& versions = pair.second;
+        for (const auto& mod : versions)
+        {
+            ss << "* " << id << "-" << mod.version.to_string() << std::endl;
+            for (const auto& dep_pair : mod.dependencies)
+            {
+                const auto& dep_id = dep_pair.first;
+                const auto& dep_req = dep_pair.second;
+                ss << "  -> " << dep_id << " (" << dep_req.to_string() << ")"
+                   << std::endl;
+            }
+        }
+        ss << std::endl;
+    }
+    return ss.str();
+}
+
+
+
+// TODO: check that the mod identifiers are valid.
+ModVersionResolver::ResolveResult ModVersionResolver::resolve(
+    const ModList& list,
+    const ModLock& lock,
+    const ModIndex& index)
+{
+    (void)lock; // TODO
+
+    auto pending_dependencies = list.mods();
+    ResolvedModList::ModVersionMap resolved_dependencies;
+
+    while (!pending_dependencies.empty())
+    {
+        const auto deps = pending_dependencies;
+        pending_dependencies.clear();
+        for (const auto& pair : deps)
+        {
+            const auto& mod_id = pair.first;
+            const auto& requirement = pair.second;
+            const auto existing_dependency = resolved_dependencies.find(mod_id);
+            if (existing_dependency != std::end(resolved_dependencies))
+            {
+                if (requirement.is_satisfied(existing_dependency->second))
+                {
+                    continue;
+                }
+                else
+                {
+                    // TODO: backtrack to find the version which satisfies the
+                    // requirement.
+                    return ResolveResult::left_of(
+                        "failed to resolve mod dependencies: " + mod_id + " (" +
+                        requirement.to_string() + ")");
+                }
+            }
+            else
+            {
+                const auto index_query_result =
+                    index.query_latest(mod_id, requirement);
+                if (index_query_result)
+                {
+                    const auto& mod = index_query_result.right().get();
+                    resolved_dependencies.emplace(mod_id, mod.version);
+                    for (const auto& pair : mod.dependencies)
+                    {
+                        const auto& id = pair.first;
+                        const auto& req = pair.second;
+                        pending_dependencies.emplace(id, req);
+                    }
+                }
+                else
+                {
+                    // TODO: backtrack to find the version which satisfies the
+                    // requirement.
+                    return ResolveResult::left_of(index_query_result.left());
+                }
+            }
+        }
+    }
+
+    const auto sort_result =
+        calculate_loading_order(resolved_dependencies, index);
+    if (sort_result)
+    {
+        return ResolveResult::right_of(
+            ResolvedModList{resolved_dependencies, sort_result.right()});
+    }
+    else
+    {
+        std::string error_message;
+        for (const auto& id : sort_result.left())
+        {
+            if (!error_message.empty())
+            {
+                error_message += " -> ";
+            }
+            error_message += id;
+        }
+        return ResolveResult::left_of(
+            "cyclic dependencies are detected: " + error_message);
+    }
+}
+
+} // namespace lua
+} // namespace elona

--- a/src/elona/lua_env/mod_version_resolver.hpp
+++ b/src/elona/lua_env/mod_version_resolver.hpp
@@ -1,0 +1,145 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include "../filesystem.hpp"
+#include "../semver.hpp"
+
+
+
+namespace elona
+{
+namespace lua
+{
+
+struct ModList
+{
+public:
+    using RequirementList =
+        std::unordered_map<std::string, semver::VersionRequirement>;
+
+
+    static ModList from_file(const fs::path& path);
+
+    // for testing
+    static ModList from_string(const std::string& str);
+    static ModList from_stream(std::istream& in, const std::string& filepath);
+
+
+    const RequirementList& mods() const noexcept
+    {
+        return _mods;
+    }
+
+
+
+private:
+    RequirementList _mods;
+
+
+    ModList(const RequirementList& mods)
+        : _mods(mods)
+    {
+    }
+};
+
+
+
+struct ModLock
+{
+    // TODO
+};
+
+
+
+struct ModIndex
+{
+public:
+    struct IndexEntry
+    {
+        semver::Version version;
+        std::unordered_map<std::string, semver::VersionRequirement>
+            dependencies;
+    };
+
+
+    using QueryResult =
+        either::either<std::string, std::reference_wrapper<const IndexEntry>>;
+
+
+    ModIndex(
+        const std::unordered_map<std::string, std::vector<IndexEntry>>& mods)
+        : _mods(mods)
+    {
+    }
+
+
+    QueryResult query_latest(
+        const std::string& id,
+        const semver::VersionRequirement& requirement) const;
+
+
+    std::vector<std::string> get_dependencies(
+        const std::string& id,
+        const semver::Version& version) const;
+
+
+    // for debugging
+    std::string to_string() const;
+
+
+private:
+    std::unordered_map<std::string, std::vector<IndexEntry>> _mods;
+};
+
+
+
+struct ResolvedModList
+{
+public:
+    using ModVersionMap = std::unordered_map<std::string, semver::Version>;
+    using SortedModList = std::vector<std::string>;
+
+
+    ResolvedModList(
+        const ModVersionMap& mod_versions,
+        const SortedModList& sorted_mods)
+        : _mod_versions(mod_versions)
+        , _sorted_mods(sorted_mods)
+    {
+    }
+
+
+
+    const ModVersionMap& mod_versions() const noexcept
+    {
+        return _mod_versions;
+    }
+
+
+
+    const SortedModList& sorted_mods() const noexcept
+    {
+        return _sorted_mods;
+    }
+
+
+
+private:
+    ModVersionMap _mod_versions;
+    SortedModList _sorted_mods;
+};
+
+
+
+class ModVersionResolver
+{
+public:
+    using ResolveResult = either::either<std::string, ResolvedModList>;
+
+    ResolveResult
+    resolve(const ModList& list, const ModLock& lock, const ModIndex& index);
+};
+
+} // namespace lua
+} // namespace elona

--- a/src/elona/main_menu.cpp
+++ b/src/elona/main_menu.cpp
@@ -1484,8 +1484,9 @@ MainMenuResult main_menu_mods_develop()
     for (const auto& tmpl : lua::lua->get_mod_manager().get_templates())
     {
         list(0, template_count) = template_count;
-        listn(0, template_count) = tmpl.id;
+        listn(0, template_count) = tmpl.id + " v" + tmpl.version.to_string();
         listn(1, template_count) = tmpl.name;
+        listn(2, template_count) = tmpl.id;
         key_list(template_count) = key_select(template_count);
         ++template_count;
     }
@@ -1592,7 +1593,7 @@ MainMenuResult main_menu_mods_develop()
                 else
                 {
                     lua::lua->get_mod_manager().create_mod_from_template(
-                        new_mod_id, listn(0, p));
+                        new_mod_id, listn(2, p));
                     snd("core.write1");
                 }
                 init = true;

--- a/src/elona/semver.hpp
+++ b/src/elona/semver.hpp
@@ -467,6 +467,23 @@ private:
 } // namespace elona
 
 
+
+namespace std
+{
+
+template <>
+struct hash<::elona::semver::Version>
+{
+    size_t operator()(const ::elona::semver::Version& v) const noexcept
+    {
+        return std::hash<decltype(v.to_integer())>{}(v.to_integer());
+    }
+};
+
+} // namespace std
+
+
+
 #ifdef ELONA_MAJOR_AND_MINOR_MACRO_DEFINED
 // Restore undefined macros. See also the top of this file.
 #pragma pop_macro("major")

--- a/src/elona/testing.cpp
+++ b/src/elona/testing.cpp
@@ -176,7 +176,7 @@ void pre_init()
     fs::copy_file(
         source_config_file, config_file, fs::copy_option::overwrite_if_exists);
 
-    config_load_preinit_options();
+    (void)PreinitConfigOptions::from_file(config_file);
 
     title(u8"Elona foobar version "s + latest_version.short_string());
 

--- a/src/elona/ui/ui_menu_mod_info.cpp
+++ b/src/elona/ui/ui_menu_mod_info.cpp
@@ -48,8 +48,8 @@ void UIMenuModInfo::_build_description()
     _readme_pages.clear();
     _desc_page = 0;
 
-    auto readme_path =
-        _find_readme(filesystem::dirs::for_mod(_desc.manifest.id));
+    auto readme_path = _find_readme(
+        filesystem::dirs::for_mod(_desc.manifest.id, _desc.manifest.version));
 
     if (!readme_path)
     {
@@ -105,7 +105,8 @@ void UIMenuModInfo::_build_description()
     listmax = _readme_pages.size();
 
     auto image_path =
-        filesystem::dirs::for_mod(_desc.manifest.id) / "image.png";
+        filesystem::dirs::for_mod(_desc.manifest.id, _desc.manifest.version) /
+        "image.png";
     if (fs::exists(image_path))
     {
         _mod_image = snail::Image{image_path};

--- a/src/elona/ui/ui_menu_mods.cpp
+++ b/src/elona/ui/ui_menu_mods.cpp
@@ -87,15 +87,15 @@ void UIMenuMods::_load_mods()
     }
     else
     {
-        for (const auto& mod : lua::lua->get_mod_manager().all_mods())
+        for (const auto& pair : lua::lua->get_mod_manager().mods())
         {
-            const auto& id = mod->second->manifest.id;
+            const auto& id = pair.second.manifest.id;
 
-            if (lua::ModManager::mod_id_is_reserved(id))
+            if (lua::is_reserved_mod_id(id))
                 continue;
 
             ModDescription mod_desc{
-                mod->second->manifest,
+                pair.second.manifest,
                 static_cast<bool>(
                     lua::lua->get_mod_manager().get_enabled_version(id))};
 
@@ -136,6 +136,8 @@ void UIMenuMods::update()
 
 void UIMenuMods::_draw_key(int cnt, int index)
 {
+    (void)index;
+
     if (cnt % 2 == 0)
     {
         boxf(wx + 57, wy + 66 + cnt * 19, 640, 18, {12, 14, 16, 16});

--- a/src/tests/config.cpp
+++ b/src/tests/config.cpp
@@ -1,3 +1,59 @@
+#include "../thirdparty/catch2/catch.hpp"
+
+#include "../elona/config.hpp"
+
+using namespace std::literals::string_literals;
+using namespace elona;
+using FullscreenMode = snail::Window::FullscreenMode;
+
+
+
+namespace
+{
+
+void check_default_values(const PreinitConfigOptions& opts)
+{
+    REQUIRE(opts.fullscreen() == FullscreenMode::windowed);
+    REQUIRE(opts.display_mode() == "");
+}
+
+} // namespace
+
+
+
+TEST_CASE("Test invalid config format", "[Config: Loading]")
+{
+    check_default_values(PreinitConfigOptions::from_file("404.not_found"));
+
+    check_default_values(PreinitConfigOptions::from_string(""));
+
+    check_default_values(
+        PreinitConfigOptions::from_string("{ invalid JSON5 }"));
+
+    check_default_values(PreinitConfigOptions::from_string(
+        "{ core: { screen: { fullscreen: 42 } } }"));
+
+    check_default_values(PreinitConfigOptions::from_string(
+        "{ core: { screen: { fullscreen: \"lomias\" } } }"));
+}
+
+
+
+TEST_CASE("Test loading valid config", "[Config: Loading]")
+{
+    REQUIRE(
+        PreinitConfigOptions::from_string(
+            "{ core: { screen: { fullscreen: \"fullscreen\" } } }")
+            .fullscreen() == FullscreenMode::fullscreen);
+
+    REQUIRE(
+        PreinitConfigOptions::from_string(
+            "{ core: { screen: { display_mode: \"\" } } }")
+            .display_mode() == "");
+}
+
+
+
 // TODO don't skip these test!
 #if 0
 #include "../thirdparty/catch2/catch.hpp"

--- a/src/tests/filesystem.cpp
+++ b/src/tests/filesystem.cpp
@@ -6,30 +6,6 @@ using namespace elona;
 
 
 
-TEST_CASE("Test resolve_path_for_mod", "[C++: Filesystem]")
-{
-    using namespace filesystem;
-
-    REQUIRE(resolve_path_for_mod("<_builtin_>/dood") == dirs::exe() / "dood");
-    REQUIRE(
-        resolve_path_for_mod("<test>/dood") == dirs::for_mod("test") / "dood");
-    REQUIRE(
-        resolve_path_for_mod("<test>/<dood>/file.txt") ==
-        dirs::for_mod("test") / "<dood>" / "file.txt");
-    REQUIRE(
-        resolve_path_for_mod("<test>/file-<LANGUAGE>.txt") ==
-        dirs::for_mod("test") / "file-jp.txt");
-    REQUIRE(
-        resolve_path_for_mod("<test>/<LANGUAGE>/file-<LANGUAGE>.txt") ==
-        dirs::for_mod("test") / "jp" / "file-jp.txt");
-
-    REQUIRE_THROWS(resolve_path_for_mod("file.txt"));
-    REQUIRE_THROWS(resolve_path_for_mod("<>"));
-    REQUIRE_THROWS(resolve_path_for_mod("<$>/file.txt"));
-}
-
-
-
 TEST_CASE("Test is_portable_path", "[C++: Filesystem]")
 {
     const auto is_portable_path = [](const char* path) {

--- a/src/tests/lua_api.cpp
+++ b/src/tests/lua_api.cpp
@@ -29,7 +29,7 @@ void lua_testcase(const std::string& filename)
 TEST_CASE("test require", "[Lua: API]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods();
+    lua.load_mods();
 
     REQUIRE_NOTHROW(
         lua.get_mod_manager().load_testing_mod_from_script("test", R"(
@@ -42,8 +42,9 @@ assert(type(Rand.coinflip) == "function")
 TEST_CASE("test require from other mods", "[Lua: API]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(
-        {filesystem::dirs::exe() / u8"tests/data/mods/test_require"});
+    lua.load_mods();
+    lua.get_mod_manager().load_testing_mod_from_file(
+        filesystem::dirs::exe() / u8"tests/data/mods/test_require");
 
     REQUIRE_NOTHROW(lua.get_mod_manager().load_testing_mod_from_script(
         "test_require_from_mods", R"(
@@ -69,7 +70,7 @@ TEST_CASE("Core API: Env", "[Lua: API]")
     const auto foobar_ver = latest_version.short_string();
 
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods();
+    lua.load_mods();
     REQUIRE_NOTHROW(lua.get_mod_manager().load_testing_mod_from_script(
         "test_env",
         "local foobar_ver = '" + foobar_ver + "'\n" +

--- a/src/tests/lua_api.cpp
+++ b/src/tests/lua_api.cpp
@@ -29,9 +29,10 @@ void lua_testcase(const std::string& filename)
 TEST_CASE("test require", "[Lua: API]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(filesystem::dirs::mod());
+    lua.get_mod_manager().load_mods();
 
-    REQUIRE_NOTHROW(lua.get_mod_manager().load_mod_from_script("test", R"(
+    REQUIRE_NOTHROW(
+        lua.get_mod_manager().load_testing_mod_from_script("test", R"(
 local Rand = require("game.Rand")
 assert(Rand ~= nil)
 assert(type(Rand.coinflip) == "function")
@@ -42,11 +43,10 @@ TEST_CASE("test require from other mods", "[Lua: API]")
 {
     elona::lua::LuaEnv lua;
     lua.get_mod_manager().load_mods(
-        filesystem::dirs::mod(),
         {filesystem::dirs::exe() / u8"tests/data/mods/test_require"});
 
-    REQUIRE_NOTHROW(
-        lua.get_mod_manager().load_mod_from_script("test_require_from_mods", R"(
+    REQUIRE_NOTHROW(lua.get_mod_manager().load_testing_mod_from_script(
+        "test_require_from_mods", R"(
 local Hello = require("test_require.Hello")
 assert(Hello ~= nil)
 assert(type(Hello.hello) == "function")
@@ -69,8 +69,8 @@ TEST_CASE("Core API: Env", "[Lua: API]")
     const auto foobar_ver = latest_version.short_string();
 
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(filesystem::dirs::mod());
-    REQUIRE_NOTHROW(lua.get_mod_manager().load_mod_from_script(
+    lua.get_mod_manager().load_mods();
+    REQUIRE_NOTHROW(lua.get_mod_manager().load_testing_mod_from_script(
         "test_env",
         "local foobar_ver = '" + foobar_ver + "'\n" +
             R"(

--- a/src/tests/lua_callbacks.cpp
+++ b/src/tests/lua_callbacks.cpp
@@ -17,8 +17,9 @@ TEST_CASE("Test character created callback", "[Lua: Callbacks]")
 {
     start_in_debug_map();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
-        "test_chara_created", R"(
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "test_chara_created", R"(
 local Event = require("game.Event")
 
 local function my_chara_created_handler(e)
@@ -46,8 +47,9 @@ TEST_CASE("Test character hurt callback", "[Lua: Callbacks]")
 {
     start_in_debug_map();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
-        "test_chara_hurt", R"(
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "test_chara_hurt", R"(
 local Event = require("game.Event")
 
 local function my_chara_hurt_handler(e)
@@ -80,8 +82,9 @@ TEST_CASE("Test character removed callback", "[Lua: Callbacks]")
 {
     start_in_debug_map();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
-        "test_chara_removed", R"(
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "test_chara_removed", R"(
 local Event = require("game.Event")
 
 local function my_chara_removed_handler(e)
@@ -110,8 +113,9 @@ TEST_CASE("Test character killed callback", "[Lua: Callbacks]")
 {
     start_in_debug_map();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
-        "test_chara_killed", R"(
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "test_chara_killed", R"(
 local Event = require("game.Event")
 
 local function my_chara_killed_handler(e)
@@ -142,8 +146,9 @@ TEST_CASE(
 {
     start_in_debug_map();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
-        "test_townsperson_killed", R"(
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "test_townsperson_killed", R"(
 local Chara = require("game.Chara")
 local Event = require("game.Event")
 
@@ -186,8 +191,9 @@ TEST_CASE(
 {
     start_in_debug_map();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
-        "test_special_chara_killed", R"(
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "test_special_chara_killed", R"(
 local Event = require("game.Event")
 
 local function my_chara_removed_handler(e)
@@ -230,8 +236,9 @@ TEST_CASE("Test character refreshed callback", "[Lua: Callbacks]")
 {
     start_in_debug_map();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
-        "test_chara_refreshed", R"(
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "test_chara_refreshed", R"(
 local Event = require("game.Event")
 
 local function my_chara_refreshed_handler(e)
@@ -258,8 +265,9 @@ TEST_CASE("Test item created callback", "[Lua: Callbacks]")
 {
     start_in_debug_map();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
-        "test_item_created", R"(
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "test_item_created", R"(
 local Event = require("game.Event")
 
 local function my_item_created_handler(e)
@@ -288,8 +296,9 @@ TEST_CASE("Test map unloading callback", "[Lua: Callbacks]")
 {
     start_in_debug_map();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
-        "test_map_unloading", R"(
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "test_map_unloading", R"(
 local Event = require("game.Event")
 
 local function my_map_unloading_handler()
@@ -314,8 +323,9 @@ TEST_CASE(
 {
     start_in_debug_map();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
-        "test_map_local_chara", R"(
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "test_map_local_chara", R"(
 local Chara = require("game.Chara")
 
 mod.store.global.chara = Chara.create(24, 24, "core.putit")

--- a/src/tests/lua_callbacks.cpp
+++ b/src/tests/lua_callbacks.cpp
@@ -35,8 +35,8 @@ Event.register("core.character_created", my_chara_created_handler)
     int idx = elona::rc;
     REQUIRE(idx != -1);
     elona::lua::lua->get_mod_manager()
-        .get_enabled_mod("test_chara_created")
-        ->env.set("idx", idx);
+        .get_mod("test_chara_created")
+        ->env.raw_set("idx", idx);
 
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_chara_created",
@@ -66,8 +66,8 @@ Event.register("core.character_damaged", my_chara_hurt_handler)
     REQUIRE(elona::chara_create(-1, charaid2int(PUTIT_PROTO_ID), 4, 8));
     int idx = elona::rc;
     elona::lua::lua->get_mod_manager()
-        .get_enabled_mod("test_chara_hurt")
-        ->env.set("idx", idx);
+        .get_mod("test_chara_hurt")
+        ->env.raw_set("idx", idx);
 
     elona::damage_hp(cdata[idx], 4, -1);
     elona::heal_hp(cdata[idx], 45);
@@ -99,8 +99,8 @@ Event.register("core.character_removed", my_chara_removed_handler)
     REQUIRE(elona::chara_create(-1, charaid2int(PUTIT_PROTO_ID), 4, 8));
     int idx = elona::rc;
     elona::lua::lua->get_mod_manager()
-        .get_enabled_mod("test_chara_removed")
-        ->env.set("idx", idx);
+        .get_mod("test_chara_removed")
+        ->env.raw_set("idx", idx);
 
     testing::invalidate_chara(cdata[idx]);
 
@@ -131,8 +131,8 @@ Event.register("core.character_killed", my_chara_killed_handler)
     int idx = elona::rc;
     elona::Character& chara = elona::cdata[idx];
     elona::lua::lua->get_mod_manager()
-        .get_enabled_mod("test_chara_killed")
-        ->env.set("idx", idx);
+        .get_mod("test_chara_killed")
+        ->env.raw_set("idx", idx);
 
     elona::damage_hp(cdata[idx], chara.max_hp + 1, -11);
 
@@ -215,8 +215,8 @@ Event.register("core.character_removed", my_chara_removed_handler)
     int idx = elona::rc;
     elona::Character& chara = elona::cdata[idx];
     elona::lua::lua->get_mod_manager()
-        .get_enabled_mod("test_special_chara_killed")
-        ->env.set("idx", idx);
+        .get_mod("test_special_chara_killed")
+        ->env.raw_set("idx", idx);
 
     // Give this character a role besides a townsperson.
     chara.character_role = 2002;
@@ -251,8 +251,8 @@ Event.register("core.character_refreshed", my_chara_refreshed_handler)
     REQUIRE(elona::chara_create(-1, charaid2int(PUTIT_PROTO_ID), 4, 8));
     int idx = elona::rc;
     elona::lua::lua->get_mod_manager()
-        .get_enabled_mod("test_chara_refreshed")
-        ->env.set("idx", idx);
+        .get_mod("test_chara_refreshed")
+        ->env.raw_set("idx", idx);
 
     elona::chara_refresh(idx);
 
@@ -284,8 +284,8 @@ Event.register("core.item_created", my_item_created_handler)
     int idx = elona::ci;
     REQUIRE(idx != -1);
     elona::lua::lua->get_mod_manager()
-        .get_enabled_mod("test_item_created")
-        ->env.set("idx", idx);
+        .get_mod("test_item_created")
+        ->env.raw_set("idx", idx);
 
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_item_created",

--- a/src/tests/lua_data.cpp
+++ b/src/tests/lua_data.cpp
@@ -14,8 +14,7 @@ TEST_CASE("test reading invalid HCL file", "[Lua: Data]")
     const auto base_path = testing::get_test_data_path() / "registry";
 
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(
-        filesystem::dirs::mod(), {base_path / "invalid"});
+    lua.get_mod_manager().load_mods({base_path / "invalid"});
 
     REQUIRE_THROWS(lua.get_data_manager().init_from_mods());
 }
@@ -25,8 +24,7 @@ TEST_CASE("test declaring and loading datatype", "[Lua: Data]")
     const auto base_path = testing::get_test_data_path() / "registry";
 
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(
-        filesystem::dirs::mod(), {base_path / "putit"});
+    lua.get_mod_manager().load_mods({base_path / "putit"});
 
     REQUIRE_NOTHROW(lua.get_data_manager().init_from_mods());
 
@@ -50,8 +48,7 @@ TEST_CASE("test declaring and loading datatype", "[Lua: Data]")
 //
 //     elona::lua::LuaEnv lua;
 //     lua.get_mod_manager().load_mods(
-//         filesystem::dirs::mod(), {base_path / "putit", base_path /
-//         "putit_b"});
+//         {base_path / "putit", base_path / "putit_b"});
 //
 //     REQUIRE_NOTHROW(lua.get_data_manager().init_from_mods());
 //
@@ -69,7 +66,6 @@ TEST_CASE(
 {
     elona::lua::LuaEnv lua;
     REQUIRE_THROWS(lua.get_mod_manager().load_mods(
-        filesystem::dirs::mod(),
         {testing::get_test_data_path() / "mods" / "test_export_keys"}));
 }
 
@@ -78,8 +74,7 @@ TEST_CASE("test order of script execution", "[Lua: Data]")
     const auto base_path = testing::get_test_data_path() / "registry";
 
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(
-        filesystem::dirs::mod(), {base_path / "load_order"});
+    lua.get_mod_manager().load_mods({base_path / "load_order"});
 
     REQUIRE_NOTHROW(lua.get_data_manager().init_from_mods());
 

--- a/src/tests/lua_data.cpp
+++ b/src/tests/lua_data.cpp
@@ -14,7 +14,8 @@ TEST_CASE("test reading invalid HCL file", "[Lua: Data]")
     const auto base_path = testing::get_test_data_path() / "registry";
 
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods({base_path / "invalid"});
+    lua.load_mods();
+    lua.get_mod_manager().load_testing_mod_from_file(base_path / "invalid");
 
     REQUIRE_THROWS(lua.get_data_manager().init_from_mods());
 }
@@ -24,7 +25,8 @@ TEST_CASE("test declaring and loading datatype", "[Lua: Data]")
     const auto base_path = testing::get_test_data_path() / "registry";
 
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods({base_path / "putit"});
+    lua.load_mods();
+    lua.get_mod_manager().load_testing_mod_from_file(base_path / "putit");
 
     REQUIRE_NOTHROW(lua.get_data_manager().init_from_mods());
 
@@ -41,32 +43,33 @@ TEST_CASE("test declaring and loading datatype", "[Lua: Data]")
     REQUIRE((*red)["legacy_id"].get<int>() == 4);
 }
 
-// NOTE: requires dependencies on mods to be implemented.
-// TEST_CASE("test loading datatype originating from other mod", "[Lua: Data]")
-// {
-//     const auto base_path = testing::get_test_data_path() / "registry";
-//
-//     elona::lua::LuaEnv lua;
-//     lua.get_mod_manager().load_mods(
-//         {base_path / "putit", base_path / "putit_b"});
-//
-//     REQUIRE_NOTHROW(lua.get_data_manager().init_from_mods());
-//
-//     auto& table = lua.get_data_manager().get();
-//
-//     auto green = table.raw("putit.putit", "putit_b.green");
-//     REQUIRE_SOME(green);
-//     REQUIRE((*green)["display_name"].get<std::string>() == "green putit");
-//     REQUIRE((*green)["legacy_id"].get<int>() == 5);
-// }
+TEST_CASE("test loading datatype originating from other mod", "[Lua: Data]")
+{
+    const auto base_path = testing::get_test_data_path() / "registry";
+
+    elona::lua::LuaEnv lua;
+    lua.load_mods();
+    lua.get_mod_manager().load_testing_mod_from_file(base_path / "putit");
+    lua.get_mod_manager().load_testing_mod_from_file(base_path / "putit_b");
+
+    REQUIRE_NOTHROW(lua.get_data_manager().init_from_mods());
+
+    auto& table = lua.get_data_manager().get();
+
+    auto green = table.raw("putit.putit", "putit_b.green");
+    REQUIRE_SOME(green);
+    REQUIRE((*green)["display_name"].get<std::string>() == "green putit");
+    REQUIRE((*green)["legacy_id"].get<int>() == 5);
+}
 
 TEST_CASE(
     "test verification that Exports table only have string keys",
     "[Lua: Data]")
 {
     elona::lua::LuaEnv lua;
-    REQUIRE_THROWS(lua.get_mod_manager().load_mods(
-        {testing::get_test_data_path() / "mods" / "test_export_keys"}));
+    lua.load_mods();
+    REQUIRE_THROWS(lua.get_mod_manager().load_testing_mod_from_file(
+        testing::get_test_data_path() / "mods" / "test_export_keys"));
 }
 
 TEST_CASE("test order of script execution", "[Lua: Data]")
@@ -74,7 +77,8 @@ TEST_CASE("test order of script execution", "[Lua: Data]")
     const auto base_path = testing::get_test_data_path() / "registry";
 
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods({base_path / "load_order"});
+    lua.load_mods();
+    lua.get_mod_manager().load_testing_mod_from_file(base_path / "load_order");
 
     REQUIRE_NOTHROW(lua.get_data_manager().init_from_mods());
 

--- a/src/tests/lua_data_character.cpp
+++ b/src/tests/lua_data_character.cpp
@@ -14,7 +14,8 @@ static lua::DataTable load(elona::lua::LuaEnv& lua, const std::string& name)
 {
     const auto base_path = testing::get_test_data_path() / "registry";
 
-    lua.get_mod_manager().load_mods({base_path / name});
+    lua.load_mods();
+    lua.get_mod_manager().load_testing_mod_from_file(base_path / name);
 
     REQUIRE_NOTHROW(lua.get_data_manager().init_from_mods());
 
@@ -41,7 +42,9 @@ TEST_CASE("test reading duplicate keys", "[Lua: Data]")
     const auto base_path = testing::get_test_data_path() / "registry";
 
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods({base_path / "chara_duplicate_key"});
+    lua.load_mods();
+    lua.get_mod_manager().load_testing_mod_from_file(
+        base_path / "chara_duplicate_key");
 
     REQUIRE_THROWS(lua.get_data_manager().init_from_mods());
 }

--- a/src/tests/lua_data_character.cpp
+++ b/src/tests/lua_data_character.cpp
@@ -14,8 +14,7 @@ static lua::DataTable load(elona::lua::LuaEnv& lua, const std::string& name)
 {
     const auto base_path = testing::get_test_data_path() / "registry";
 
-    lua.get_mod_manager().load_mods(
-        filesystem::dirs::mod(), {base_path / name});
+    lua.get_mod_manager().load_mods({base_path / name});
 
     REQUIRE_NOTHROW(lua.get_data_manager().init_from_mods());
 
@@ -42,8 +41,7 @@ TEST_CASE("test reading duplicate keys", "[Lua: Data]")
     const auto base_path = testing::get_test_data_path() / "registry";
 
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(
-        filesystem::dirs::mod(), {base_path / "chara_duplicate_key"});
+    lua.get_mod_manager().load_mods({base_path / "chara_duplicate_key"});
 
     REQUIRE_THROWS(lua.get_data_manager().init_from_mods());
 }

--- a/src/tests/lua_data_item.cpp
+++ b/src/tests/lua_data_item.cpp
@@ -14,7 +14,8 @@ static lua::DataTable load(elona::lua::LuaEnv& lua, const std::string& name)
 {
     const auto base_path = testing::get_test_data_path() / "registry";
 
-    lua.get_mod_manager().load_mods({base_path / name});
+    lua.load_mods();
+    lua.get_mod_manager().load_testing_mod_from_file(base_path / name);
 
     REQUIRE_NOTHROW(lua.get_data_manager().init_from_mods());
 

--- a/src/tests/lua_data_item.cpp
+++ b/src/tests/lua_data_item.cpp
@@ -14,8 +14,7 @@ static lua::DataTable load(elona::lua::LuaEnv& lua, const std::string& name)
 {
     const auto base_path = testing::get_test_data_path() / "registry";
 
-    lua.get_mod_manager().load_mods(
-        filesystem::dirs::mod(), {base_path / name});
+    lua.get_mod_manager().load_mods({base_path / name});
 
     REQUIRE_NOTHROW(lua.get_data_manager().init_from_mods());
 

--- a/src/tests/lua_events.cpp
+++ b/src/tests/lua_events.cpp
@@ -44,9 +44,10 @@ Event.register("core.some_unknown_event", handler)
 TEST_CASE("Test registering of callback", "[Lua: Events]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(filesystem::dirs::mod());
+    lua.get_mod_manager().load_mods();
 
-    REQUIRE_NOTHROW(lua.get_mod_manager().load_mod_from_script("test", R"(
+    REQUIRE_NOTHROW(
+        lua.get_mod_manager().load_testing_mod_from_script("test", R"(
 local Event = require("game.Event")
 
 local function my_handler()
@@ -68,9 +69,10 @@ Event.register("core.all_turns_finished", my_handler)
 TEST_CASE("Test registering of callback multiple times", "[Lua: Events]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(filesystem::dirs::mod());
+    lua.get_mod_manager().load_mods();
 
-    REQUIRE_THROWS(lua.get_mod_manager().load_mod_from_script("test", R"(
+    REQUIRE_THROWS(
+        lua.get_mod_manager().load_testing_mod_from_script("test", R"(
 local Event = require("game.Event")
 
 local function my_handler()
@@ -91,9 +93,10 @@ TEST_CASE(
     "[Lua: Events]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(filesystem::dirs::mod());
+    lua.get_mod_manager().load_mods();
 
-    REQUIRE_NOTHROW(lua.get_mod_manager().load_mod_from_script("test", R"(
+    REQUIRE_NOTHROW(
+        lua.get_mod_manager().load_testing_mod_from_script("test", R"(
 local Event = require("game.Event")
 
 local function first()
@@ -120,9 +123,10 @@ Event.register("core.all_turns_finished", second)
 TEST_CASE("Test unregistering of callback", "[Lua: Events]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(filesystem::dirs::mod());
+    lua.get_mod_manager().load_mods();
 
-    REQUIRE_NOTHROW(lua.get_mod_manager().load_mod_from_script("test", R"(
+    REQUIRE_NOTHROW(
+        lua.get_mod_manager().load_testing_mod_from_script("test", R"(
 local Event = require("game.Event")
 
 local function my_handler()
@@ -144,9 +148,10 @@ Event.unregister("core.all_turns_finished", my_handler)
 TEST_CASE("Test unregistering of callback multiple times", "[Lua: Events]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(filesystem::dirs::mod());
+    lua.get_mod_manager().load_mods();
 
-    REQUIRE_NOTHROW(lua.get_mod_manager().load_mod_from_script("test", R"(
+    REQUIRE_NOTHROW(
+        lua.get_mod_manager().load_testing_mod_from_script("test", R"(
 local Event = require("game.Event")
 
 local function my_handler()
@@ -171,9 +176,10 @@ Event.unregister("core.all_turns_finished", my_handler)
 TEST_CASE("Test unregistering of callback without registering", "[Lua: Events]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(filesystem::dirs::mod());
+    lua.get_mod_manager().load_mods();
 
-    REQUIRE_NOTHROW(lua.get_mod_manager().load_mod_from_script("test", R"(
+    REQUIRE_NOTHROW(
+        lua.get_mod_manager().load_testing_mod_from_script("test", R"(
 local Event = require("game.Event")
 
 local function my_handler()
@@ -194,9 +200,10 @@ Event.unregister("core.all_turns_finished", my_handler)
 TEST_CASE("Test unregistering of callback inside callback", "[Lua: Events]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(filesystem::dirs::mod());
+    lua.get_mod_manager().load_mods();
 
-    REQUIRE_NOTHROW(lua.get_mod_manager().load_mod_from_script("test", R"(
+    REQUIRE_NOTHROW(
+        lua.get_mod_manager().load_testing_mod_from_script("test", R"(
 local Event = require("game.Event")
 
 local function my_handler()
@@ -221,9 +228,10 @@ TEST_CASE(
     "[Lua: Events]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(filesystem::dirs::mod());
+    lua.get_mod_manager().load_mods();
 
-    REQUIRE_NOTHROW(lua.get_mod_manager().load_mod_from_script("test", R"(
+    REQUIRE_NOTHROW(
+        lua.get_mod_manager().load_testing_mod_from_script("test", R"(
 local Event = require("game.Event")
 
 local function first_handler()

--- a/src/tests/lua_events.cpp
+++ b/src/tests/lua_events.cpp
@@ -44,7 +44,7 @@ Event.register("core.some_unknown_event", handler)
 TEST_CASE("Test registering of callback", "[Lua: Events]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods();
+    lua.load_mods();
 
     REQUIRE_NOTHROW(
         lua.get_mod_manager().load_testing_mod_from_script("test", R"(
@@ -69,7 +69,7 @@ Event.register("core.all_turns_finished", my_handler)
 TEST_CASE("Test registering of callback multiple times", "[Lua: Events]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods();
+    lua.load_mods();
 
     REQUIRE_THROWS(
         lua.get_mod_manager().load_testing_mod_from_script("test", R"(
@@ -93,7 +93,7 @@ TEST_CASE(
     "[Lua: Events]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods();
+    lua.load_mods();
 
     REQUIRE_NOTHROW(
         lua.get_mod_manager().load_testing_mod_from_script("test", R"(
@@ -123,7 +123,7 @@ Event.register("core.all_turns_finished", second)
 TEST_CASE("Test unregistering of callback", "[Lua: Events]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods();
+    lua.load_mods();
 
     REQUIRE_NOTHROW(
         lua.get_mod_manager().load_testing_mod_from_script("test", R"(
@@ -148,7 +148,7 @@ Event.unregister("core.all_turns_finished", my_handler)
 TEST_CASE("Test unregistering of callback multiple times", "[Lua: Events]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods();
+    lua.load_mods();
 
     REQUIRE_NOTHROW(
         lua.get_mod_manager().load_testing_mod_from_script("test", R"(
@@ -176,7 +176,7 @@ Event.unregister("core.all_turns_finished", my_handler)
 TEST_CASE("Test unregistering of callback without registering", "[Lua: Events]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods();
+    lua.load_mods();
 
     REQUIRE_NOTHROW(
         lua.get_mod_manager().load_testing_mod_from_script("test", R"(
@@ -200,7 +200,7 @@ Event.unregister("core.all_turns_finished", my_handler)
 TEST_CASE("Test unregistering of callback inside callback", "[Lua: Events]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods();
+    lua.load_mods();
 
     REQUIRE_NOTHROW(
         lua.get_mod_manager().load_testing_mod_from_script("test", R"(
@@ -228,7 +228,7 @@ TEST_CASE(
     "[Lua: Events]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods();
+    lua.load_mods();
 
     REQUIRE_NOTHROW(
         lua.get_mod_manager().load_testing_mod_from_script("test", R"(

--- a/src/tests/lua_exports.cpp
+++ b/src/tests/lua_exports.cpp
@@ -12,7 +12,7 @@
 TEST_CASE("test registering Lua functions", "[Lua: Exports]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods();
+    lua.load_mods();
 
     REQUIRE_NOTHROW(
         lua.get_mod_manager().load_testing_mod_from_script("test", R"(
@@ -105,8 +105,8 @@ return exports
     REQUIRE_NOTHROW(function->call(handle));
 
     elona::lua::lua->get_mod_manager()
-        .get_enabled_mod("test_registry_chara_callback")
-        ->env.set("index", elona::rc);
+        .get_mod("test_registry_chara_callback")
+        ->env.raw_set("index", elona::rc);
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_registry_chara_callback",
         R"(assert(mod.store.global.found_index == index))"));
@@ -116,7 +116,7 @@ TEST_CASE("test calling unknown exported function for result", "[Lua: Exports]")
 {
     elona::lua::LuaEnv lua;
 
-    lua.get_mod_manager().load_mods();
+    lua.load_mods();
     lua.get_export_manager().register_all_exports();
 
     bool result = lua.get_export_manager().call_with_result("dood", false);

--- a/src/tests/lua_exports.cpp
+++ b/src/tests/lua_exports.cpp
@@ -12,9 +12,10 @@
 TEST_CASE("test registering Lua functions", "[Lua: Exports]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(filesystem::dirs::mod());
+    lua.get_mod_manager().load_mods();
 
-    REQUIRE_NOTHROW(lua.get_mod_manager().load_mod_from_script("test", R"(
+    REQUIRE_NOTHROW(
+        lua.get_mod_manager().load_testing_mod_from_script("test", R"(
 local exports = {}
 exports.nesting = {}
 
@@ -77,8 +78,9 @@ TEST_CASE(
     "test registering Lua functions with userdata arguments",
     "[Lua: Exports]")
 {
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
-        "test_registry_chara_callback", R"(
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "test_registry_chara_callback", R"(
 local exports = {}
 
 function exports.my_callback(chara)
@@ -114,7 +116,7 @@ TEST_CASE("test calling unknown exported function for result", "[Lua: Exports]")
 {
     elona::lua::LuaEnv lua;
 
-    lua.get_mod_manager().load_mods(filesystem::dirs::mod());
+    lua.get_mod_manager().load_mods();
     lua.get_export_manager().register_all_exports();
 
     bool result = lua.get_export_manager().call_with_result("dood", false);

--- a/src/tests/lua_handles.cpp
+++ b/src/tests/lua_handles.cpp
@@ -185,7 +185,7 @@ TEST_CASE("Test invalid references to handles in store table", "[Lua: Handles]")
         Character& chara = elona::cdata[elona::rc];
         auto handle = handle_mgr.get_handle(chara);
 
-        REQUIRE_NOTHROW(mod_mgr.load_mod_from_script("test", ""));
+        REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script("test", ""));
 
         mod_mgr.get_enabled_mod("test")->env.set("chara", handle);
         REQUIRE_NOTHROW(mod_mgr.run_in_mod(
@@ -203,7 +203,7 @@ TEST_CASE("Test invalid references to handles in store table", "[Lua: Handles]")
         Item& item = elona::inv[elona::ci];
         auto handle = handle_mgr.get_handle(item);
 
-        REQUIRE_NOTHROW(mod_mgr.load_mod_from_script("test2", ""));
+        REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script("test2", ""));
 
         mod_mgr.get_enabled_mod("test2")->env.set("item", handle);
         REQUIRE_NOTHROW(
@@ -226,7 +226,8 @@ TEST_CASE("Test invalid references to handles from Lua side", "[Lua: Handles]")
 
     SECTION("Characters")
     {
-        REQUIRE_NOTHROW(mod_mgr.load_mod_from_script("test_invalid_chara", R"(
+        REQUIRE_NOTHROW(
+            mod_mgr.load_testing_mod_from_script("test_invalid_chara", R"(
 local Chara = require("game.Chara")
 local chara = Chara.create(0, 0, "core.putit")
 idx = chara.index
@@ -241,7 +242,8 @@ mod.store.global.charas = {[0]=chara}
     }
     SECTION("Items")
     {
-        REQUIRE_NOTHROW(mod_mgr.load_mod_from_script("test_invalid_item", R"(
+        REQUIRE_NOTHROW(
+            mod_mgr.load_testing_mod_from_script("test_invalid_item", R"(
 local Item = require("game.Item")
 local item = Item.create(0, 0, "core.putitoro", 3)
 idx = item.index
@@ -271,7 +273,7 @@ TEST_CASE(
         Character& chara = elona::cdata[elona::rc];
         auto handle = handle_mgr.get_handle(chara);
 
-        REQUIRE_NOTHROW(mod_mgr.load_mod_from_script(
+        REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script(
             "test_chara_arg", "mod.store.global.charas = {}"));
         mod_mgr.get_enabled_mod("test_chara_arg")->env.set("chara", handle);
 
@@ -295,7 +297,7 @@ print(Chara.is_ally(mod.store.global.charas[0]))
         Item& item = elona::inv[elona::ci];
         auto handle = handle_mgr.get_handle(item);
 
-        REQUIRE_NOTHROW(mod_mgr.load_mod_from_script(
+        REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script(
             "test_item_arg", "mod.store.global.items = {}"));
         mod_mgr.get_enabled_mod("test_item_arg")->env.set("item", handle);
 

--- a/src/tests/lua_handles.cpp
+++ b/src/tests/lua_handles.cpp
@@ -187,7 +187,7 @@ TEST_CASE("Test invalid references to handles in store table", "[Lua: Handles]")
 
         REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script("test", ""));
 
-        mod_mgr.get_enabled_mod("test")->env.set("chara", handle);
+        mod_mgr.get_mod("test")->env.raw_set("chara", handle);
         REQUIRE_NOTHROW(mod_mgr.run_in_mod(
             "test", "mod.store.global.charas = {[0]=chara}"));
 
@@ -205,7 +205,7 @@ TEST_CASE("Test invalid references to handles in store table", "[Lua: Handles]")
 
         REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script("test2", ""));
 
-        mod_mgr.get_enabled_mod("test2")->env.set("item", handle);
+        mod_mgr.get_mod("test2")->env.raw_set("item", handle);
         REQUIRE_NOTHROW(
             mod_mgr.run_in_mod("test2", "mod.store.global.items = {[0]=item}"));
 
@@ -230,10 +230,11 @@ TEST_CASE("Test invalid references to handles from Lua side", "[Lua: Handles]")
             mod_mgr.load_testing_mod_from_script("test_invalid_chara", R"(
 local Chara = require("game.Chara")
 local chara = Chara.create(0, 0, "core.putit")
-idx = chara.index
+mod.store.global.idx = chara.index
 mod.store.global.charas = {[0]=chara}
 )"));
-        int idx = mod_mgr.get_enabled_mod("test_invalid_chara")->env["idx"];
+        int idx = mod_mgr.get_mod("test_invalid_chara")
+                      ->env.get<int>(std::tie("mod", "store", "global", "idx"));
 
         testing::invalidate_chara(elona::cdata[idx]);
 
@@ -246,10 +247,11 @@ mod.store.global.charas = {[0]=chara}
             mod_mgr.load_testing_mod_from_script("test_invalid_item", R"(
 local Item = require("game.Item")
 local item = Item.create(0, 0, "core.putitoro", 3)
-idx = item.index
+mod.store.global.idx = item.index
 mod.store.global.items = {[0]=items}
 )"));
-        int idx = mod_mgr.get_enabled_mod("test_invalid_item")->env["idx"];
+        int idx = mod_mgr.get_mod("test_invalid_item")
+                      ->env.get<int>(std::tie("mod", "store", "global", "idx"));
 
         testing::invalidate_item(elona::inv[idx]);
 
@@ -275,7 +277,7 @@ TEST_CASE(
 
         REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script(
             "test_chara_arg", "mod.store.global.charas = {}"));
-        mod_mgr.get_enabled_mod("test_chara_arg")->env.set("chara", handle);
+        mod_mgr.get_mod("test_chara_arg")->env.raw_set("chara", handle);
 
         REQUIRE_NOTHROW(mod_mgr.run_in_mod("test_chara_arg", R"(
 mod.store.global.charas[0] = chara
@@ -299,7 +301,7 @@ print(Chara.is_ally(mod.store.global.charas[0]))
 
         REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script(
             "test_item_arg", "mod.store.global.items = {}"));
-        mod_mgr.get_enabled_mod("test_item_arg")->env.set("item", handle);
+        mod_mgr.get_mod("test_item_arg")->env.raw_set("item", handle);
 
         REQUIRE_NOTHROW(mod_mgr.run_in_mod("test_item_arg", R"(
 mod.store.global.items[0] = item
@@ -676,8 +678,7 @@ TEST_CASE("Test validity check of lua reference userdata", "[Lua: Handles]")
     auto& handle_mgr = elona::lua::lua->get_handle_manager();
     auto& mod_mgr = elona::lua::lua->get_mod_manager();
 
-    REQUIRE_NOTHROW(mod_mgr.create_mod("test_lua_ref"));
-    REQUIRE_NOTHROW(mod_mgr.run_in_mod("test_lua_ref", R"(
+    REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script("test_lua_ref", R"(
 local Chara = require("game.Chara")
 local chara = Chara.create(0, 0, "core.putit")
 local skill = chara:get_skill("core.attribute_strength")

--- a/src/tests/lua_mod_resolve.cpp
+++ b/src/tests/lua_mod_resolve.cpp
@@ -1,0 +1,107 @@
+#include "../thirdparty/catch2/catch.hpp"
+
+#include "../elona/lua_env/mod_version_resolver.hpp"
+
+using namespace elona::lua;
+using namespace elona::semver;
+
+
+
+TEST_CASE("Test loading invalid mod list", "[Lua: Mods]")
+{
+    const auto check = [](const ModList& list) {
+        REQUIRE(list.mods().size() == 1);
+        REQUIRE(list.mods().at("core").is_satisfied(Version{0, 2, 6}));
+    };
+
+    check(ModList::from_file("404.not_found"));
+    check(ModList::from_string(""));
+    check(ModList::from_string("{ invalid JSON5 format }"));
+    check(ModList::from_string("42"));
+    check(ModList::from_string("{ foo: 123 }"));
+    check(ModList::from_string("{ mods: null }"));
+    check(ModList::from_string("{ mods: { true: 1, false: 0 } }"));
+    check(ModList::from_string("{ mods: { a: 123, b: 456 } }"));
+    check(ModList::from_string("{ mods: { a: '1.2.3', b: 'bar' } }"));
+}
+
+
+
+TEST_CASE("Test loading valid mod list", "[Lua: Mods]")
+{
+    const auto check =
+        [](const ModList& list,
+           const std::unordered_map<std::string, std::string>& expected) {
+            const auto size = expected.size() + 1 /* +1 is for 'core' */;
+            REQUIRE(list.mods().size() == size);
+            REQUIRE(list.mods().at("core").is_satisfied(Version{0, 2, 6}));
+            for (const auto& pair : expected)
+            {
+                const auto& id = pair.first;
+                const auto& ver = pair.second;
+                REQUIRE(list.mods().at(id).is_satisfied(
+                    Version::parse(ver).right()));
+            }
+        };
+
+    check(ModList::from_string("{ mods: { a: '1.2.3' } }"), {{"a", "1.2.3"}});
+    check(ModList::from_string("{ mods: { a: '*' } }"), {{"a", "1.2.3"}});
+    check(
+        ModList::from_string("{ mods: { a: '1', b: '2' } }"),
+        {{"a", "1.2.3"}, {"b", "2.3.4"}});
+}
+
+
+#if 0
+TEST_CASE("Test calculation of loading order of mods", "[Lua: Mods]")
+{
+    elona::lua::LuaEnv lua;
+
+    _create_mods(
+        lua,
+        {
+            {"a", {{"c", "*"}}},
+            {"b", {}},
+            {"c", {{"b", "*"}, {"d", "*"}}},
+            {"d", {}},
+        });
+
+    const auto order = lua.get_mod_manager().sorted_mods();
+
+    REQUIRE(order.at(0)->manifest.id == "b");
+    REQUIRE(order.at(1)->manifest.id == "d");
+    REQUIRE(order.at(2)->manifest.id == "c");
+    REQUIRE(order.at(3)->manifest.id == "a");
+}
+
+TEST_CASE(
+    "Test failure to calculate loading order of mods (unknown dependency)",
+    "[Lua: Mods]")
+{
+    REQUIRE_THROWS([]() {
+        elona::lua::LuaEnv lua;
+        _create_mods(
+            lua,
+            {
+                {"a", {{"b", "*"}, {"c", "*"}}},
+                {"b", {}},
+            });
+    }());
+}
+
+TEST_CASE(
+    "Test failure to calculate loading order of mods (cyclic dependency)",
+    "[Lua: Mods]")
+{
+    REQUIRE_THROWS([]() {
+        elona::lua::LuaEnv lua;
+        _create_mods(
+            lua,
+            {
+                {"a", {{"b", "*"}}},
+                {"b", {{"c", "*"}}},
+                {"c", {{"a", "*"}}},
+            });
+    }());
+}
+#endif

--- a/src/tests/lua_mods.cpp
+++ b/src/tests/lua_mods.cpp
@@ -20,7 +20,7 @@ TEST_CASE("Test that _MOD_ID is defined", "[Lua: Mods]")
 {
     elona::lua::LuaEnv lua;
     auto& mod_mgr = lua.get_mod_manager();
-    mod_mgr.load_mods();
+    lua.load_mods();
 
     REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script("my_mod", ""));
 
@@ -32,9 +32,9 @@ TEST_CASE("Test that globals cannot be overwritten", "[Lua: Mods]")
 {
     elona::lua::LuaEnv lua;
     auto& mod_mgr = lua.get_mod_manager();
-    mod_mgr.load_mods();
+    lua.load_mods();
 
-    REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script("my_mod", "", true));
+    REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script("my_mod", ""));
 
     REQUIRE_THROWS(mod_mgr.run_in_mod("my_mod", R"(_MOD_ID = "dood")"));
     REQUIRE_THROWS(mod_mgr.run_in_mod("my_mod", R"(dood = "dood")"));
@@ -50,7 +50,7 @@ TEST_CASE("Test that sandboxing removes unsafe functions", "[Lua: Mods]")
 {
     elona::lua::LuaEnv lua;
     auto& mod_mgr = lua.get_mod_manager();
-    mod_mgr.load_mods();
+    lua.load_mods();
 
     REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script("my_mod", ""));
 
@@ -86,7 +86,7 @@ TEST_CASE("Test no access to os/io", "[Lua: Mods]")
 {
     elona::lua::LuaEnv lua;
     auto& mod_mgr = lua.get_mod_manager();
-    mod_mgr.load_mods();
+    lua.load_mods();
 
     REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script("my_mod", ""));
 
@@ -98,14 +98,14 @@ TEST_CASE("Test usage of store in mod", "[Lua: Mods]")
 {
     elona::lua::LuaEnv lua;
     auto& mod_mgr = lua.get_mod_manager();
-    mod_mgr.load_mods();
+    lua.load_mods();
 
     REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script(
         "test", "mod.store.global.thing = 1"));
 
     REQUIRE_NOTHROW(
         mod_mgr.run_in_mod("test", "assert(mod.store.global.thing == 1)"));
-    int thing = mod_mgr.get_enabled_mod("test")->env.get<int>(
+    int thing = mod_mgr.get_mod("test")->env.get<int>(
         std::tie("mod", "store", "global", "thing"));
     REQUIRE(thing == 1);
 }
@@ -114,7 +114,7 @@ TEST_CASE("Test invalid usage of store in main state", "[Lua: Mods]")
 {
     elona::lua::LuaEnv lua;
     auto& mod_mgr = lua.get_mod_manager();
-    mod_mgr.load_mods();
+    lua.load_mods();
 
     REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script(
         "test", "mod.store.global.thing = 1"));
@@ -128,7 +128,7 @@ TEST_CASE("Test modification of store inside callback", "[Lua: Mods]")
 {
     elona::lua::LuaEnv lua;
     auto& mod_mgr = lua.get_mod_manager();
-    mod_mgr.load_mods();
+    lua.load_mods();
 
     REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script("test", R"(
 local Event = require("game.Event")
@@ -162,7 +162,7 @@ TEST_CASE("Test isolation of mod environments", "[Lua: Mods]")
 {
     elona::lua::LuaEnv lua;
     auto& mod_mgr = lua.get_mod_manager();
-    mod_mgr.load_mods();
+    lua.load_mods();
 
     REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script(
         "first", R"(mod.store.global.thing = 42)"));
@@ -188,8 +188,7 @@ TEST_CASE("Test complex nested table assignment", "[Lua: Mods]")
 {
     elona::lua::LuaEnv lua;
     auto& mod_mgr = lua.get_mod_manager();
-    ;
-    mod_mgr.load_mods();
+    lua.load_mods();
 
     REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script("test", R"(
 local Event = require("game.Event")
@@ -228,8 +227,9 @@ Event.register("core.all_turns_finished", my_turn_handler)
 TEST_CASE("Test requiring Lua chunk multiple times", "[Lua: Mods]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(
-        {filesystem::dirs::exe() / u8"tests/data/mods/test_require_chunks"});
+    lua.load_mods();
+    lua.get_mod_manager().load_testing_mod_from_file(
+        filesystem::dirs::exe() / u8"tests/data/mods/test_require_chunks");
 
     REQUIRE_NOTHROW(lua.get_mod_manager().run_in_mod("test_require_chunks", R"(
 local a = require_relative("data/script")
@@ -250,8 +250,9 @@ TEST_CASE(
     "[Lua: Mods]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(
-        {filesystem::dirs::exe() / u8"tests/data/mods/test_require"});
+    lua.load_mods();
+    lua.get_mod_manager().load_testing_mod_from_file(
+        filesystem::dirs::exe() / u8"tests/data/mods/test_require");
 
     // Attempts to load a file outside the mod's directory.
     REQUIRE_NOTHROW(lua.get_mod_manager().run_in_mod("test_require", R"(
@@ -259,77 +260,6 @@ local a = require_relative("../test_require_chunks/data/script")
 
 assert(a == nil)
 )"));
-}
-
-
-static void _create_mod(
-    elona::lua::LuaEnv& lua,
-    const std::string& id,
-    const std::unordered_map<std::string, std::string> deps)
-{
-    elona::lua::ModManifest::Dependencies deps_(deps.size());
-    for (const auto& kvp : deps)
-    {
-        const auto& key = kvp.first;
-        const auto& value = kvp.second;
-        const auto ver = semver::VersionRequirement::parse(value);
-        if (ver)
-        {
-            deps_.emplace(key, ver.right());
-        }
-        else
-        {
-            throw std::runtime_error{ver.left()};
-        }
-    }
-
-    elona::lua::ModManifest manifest;
-    manifest.id = id;
-    manifest.dependencies = deps_;
-    lua.get_mod_manager().create_mod(manifest, false);
-};
-
-
-TEST_CASE("Test calculation of loading order of mods", "[Lua: Mods]")
-{
-    elona::lua::LuaEnv lua;
-
-    _create_mod(lua, "a", {{"c", "*"}});
-    _create_mod(lua, "b", {});
-    _create_mod(lua, "c", {{"b", "*"}, {"d", "*"}});
-    _create_mod(lua, "d", {});
-
-    auto order = lua.get_mod_manager().calculate_loading_order();
-
-    REQUIRE(order.at(0) == "b");
-    REQUIRE(order.at(1) == "d");
-    REQUIRE(order.at(2) == "c");
-    REQUIRE(order.at(3) == "a");
-}
-
-TEST_CASE(
-    "Test failure to calculate loading order of mods (unknown dependency)",
-    "[Lua: Mods]")
-{
-    elona::lua::LuaEnv lua;
-
-    _create_mod(lua, "a", {{"b", "*"}, {"c", "*"}});
-    _create_mod(lua, "b", {});
-
-    REQUIRE_THROWS(lua.get_mod_manager().calculate_loading_order());
-}
-
-TEST_CASE(
-    "Test failure to calculate loading order of mods (cyclic dependency)",
-    "[Lua: Mods]")
-{
-    elona::lua::LuaEnv lua;
-
-    _create_mod(lua, "a", {{"b", "*"}});
-    _create_mod(lua, "b", {{"c", "*"}});
-    _create_mod(lua, "c", {{"a", "*"}});
-
-    REQUIRE_THROWS(lua.get_mod_manager().calculate_loading_order());
 }
 
 

--- a/src/tests/lua_mods.cpp
+++ b/src/tests/lua_mods.cpp
@@ -331,3 +331,31 @@ TEST_CASE(
 
     REQUIRE_THROWS(lua.get_mod_manager().calculate_loading_order());
 }
+
+
+
+#if 0
+TEST_CASE("Test resolve_path_for_mod", "[Lua: Mods]")
+{
+    using namespace filesystem;
+
+    REQUIRE(
+        lua::resolve_path_for_mod("<_builtin_>/dood") == dirs::exe() / "dood");
+    REQUIRE(
+        lua::resolve_path_for_mod("<test>/dood") ==
+        dirs::for_mod("test") / "dood");
+    REQUIRE(
+        lua::resolve_path_for_mod("<test>/<dood>/file.txt") ==
+        dirs::for_mod("test") / "<dood>" / "file.txt");
+    REQUIRE(
+        lua::resolve_path_for_mod("<test>/file-<LANGUAGE>.txt") ==
+        dirs::for_mod("test") / "file-jp.txt");
+    REQUIRE(
+        lua::resolve_path_for_mod("<test>/<LANGUAGE>/file-<LANGUAGE>.txt") ==
+        dirs::for_mod("test") / "jp" / "file-jp.txt");
+
+    REQUIRE_THROWS(lua::resolve_path_for_mod("file.txt"));
+    REQUIRE_THROWS(lua::resolve_path_for_mod("<>"));
+    REQUIRE_THROWS(lua::resolve_path_for_mod("<$>/file.txt"));
+}
+#endif

--- a/src/tests/lua_mods.cpp
+++ b/src/tests/lua_mods.cpp
@@ -20,9 +20,9 @@ TEST_CASE("Test that _MOD_ID is defined", "[Lua: Mods]")
 {
     elona::lua::LuaEnv lua;
     auto& mod_mgr = lua.get_mod_manager();
-    mod_mgr.load_mods(filesystem::dirs::mod());
+    mod_mgr.load_mods();
 
-    REQUIRE_NOTHROW(mod_mgr.load_mod_from_script("my_mod", ""));
+    REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script("my_mod", ""));
 
     REQUIRE_NOTHROW(
         mod_mgr.run_in_mod("my_mod", R"(assert(_MOD_ID == "my_mod"))"));
@@ -32,9 +32,9 @@ TEST_CASE("Test that globals cannot be overwritten", "[Lua: Mods]")
 {
     elona::lua::LuaEnv lua;
     auto& mod_mgr = lua.get_mod_manager();
-    mod_mgr.load_mods(filesystem::dirs::mod());
+    mod_mgr.load_mods();
 
-    REQUIRE_NOTHROW(mod_mgr.load_mod_from_script("my_mod", "", true));
+    REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script("my_mod", "", true));
 
     REQUIRE_THROWS(mod_mgr.run_in_mod("my_mod", R"(_MOD_ID = "dood")"));
     REQUIRE_THROWS(mod_mgr.run_in_mod("my_mod", R"(dood = "dood")"));
@@ -50,9 +50,9 @@ TEST_CASE("Test that sandboxing removes unsafe functions", "[Lua: Mods]")
 {
     elona::lua::LuaEnv lua;
     auto& mod_mgr = lua.get_mod_manager();
-    mod_mgr.load_mods(filesystem::dirs::mod());
+    mod_mgr.load_mods();
 
-    REQUIRE_NOTHROW(mod_mgr.load_mod_from_script("my_mod", ""));
+    REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script("my_mod", ""));
 
     REQUIRE_THROWS(
         mod_mgr.run_in_mod("my_mod", R"(rawset(_G, "assert", nil))"));
@@ -86,9 +86,9 @@ TEST_CASE("Test no access to os/io", "[Lua: Mods]")
 {
     elona::lua::LuaEnv lua;
     auto& mod_mgr = lua.get_mod_manager();
-    mod_mgr.load_mods(filesystem::dirs::mod());
+    mod_mgr.load_mods();
 
-    REQUIRE_NOTHROW(mod_mgr.load_mod_from_script("my_mod", ""));
+    REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script("my_mod", ""));
 
     REQUIRE_NOTHROW(mod_mgr.run_in_mod("my_mod", R"(assert(os == nil))"));
     REQUIRE_NOTHROW(mod_mgr.run_in_mod("my_mod", R"(assert(io == nil))"));
@@ -98,10 +98,10 @@ TEST_CASE("Test usage of store in mod", "[Lua: Mods]")
 {
     elona::lua::LuaEnv lua;
     auto& mod_mgr = lua.get_mod_manager();
-    mod_mgr.load_mods(filesystem::dirs::mod());
+    mod_mgr.load_mods();
 
-    REQUIRE_NOTHROW(
-        mod_mgr.load_mod_from_script("test", "mod.store.global.thing = 1"));
+    REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script(
+        "test", "mod.store.global.thing = 1"));
 
     REQUIRE_NOTHROW(
         mod_mgr.run_in_mod("test", "assert(mod.store.global.thing == 1)"));
@@ -114,10 +114,10 @@ TEST_CASE("Test invalid usage of store in main state", "[Lua: Mods]")
 {
     elona::lua::LuaEnv lua;
     auto& mod_mgr = lua.get_mod_manager();
-    mod_mgr.load_mods(filesystem::dirs::mod());
+    mod_mgr.load_mods();
 
-    REQUIRE_NOTHROW(
-        mod_mgr.load_mod_from_script("test", "mod.store.global.thing = 1"));
+    REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script(
+        "test", "mod.store.global.thing = 1"));
 
     // Accessed from main state, not the mod's environment
     sol::object obj = (*lua.get_state())["mod.store"];
@@ -128,9 +128,9 @@ TEST_CASE("Test modification of store inside callback", "[Lua: Mods]")
 {
     elona::lua::LuaEnv lua;
     auto& mod_mgr = lua.get_mod_manager();
-    mod_mgr.load_mods(filesystem::dirs::mod());
+    mod_mgr.load_mods();
 
-    REQUIRE_NOTHROW(mod_mgr.load_mod_from_script("test", R"(
+    REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script("test", R"(
 local Event = require("game.Event")
 
 local function my_turn_handler()
@@ -162,11 +162,11 @@ TEST_CASE("Test isolation of mod environments", "[Lua: Mods]")
 {
     elona::lua::LuaEnv lua;
     auto& mod_mgr = lua.get_mod_manager();
-    mod_mgr.load_mods(filesystem::dirs::mod());
+    mod_mgr.load_mods();
 
-    REQUIRE_NOTHROW(mod_mgr.load_mod_from_script(
+    REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script(
         "first", R"(mod.store.global.thing = 42)"));
-    REQUIRE_NOTHROW(mod_mgr.load_mod_from_script(
+    REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script(
         "second", R"(mod.store.global.thing = "dood")"));
 
     REQUIRE_NOTHROW(
@@ -189,9 +189,9 @@ TEST_CASE("Test complex nested table assignment", "[Lua: Mods]")
     elona::lua::LuaEnv lua;
     auto& mod_mgr = lua.get_mod_manager();
     ;
-    mod_mgr.load_mods(filesystem::dirs::mod());
+    mod_mgr.load_mods();
 
-    REQUIRE_NOTHROW(mod_mgr.load_mod_from_script("test", R"(
+    REQUIRE_NOTHROW(mod_mgr.load_testing_mod_from_script("test", R"(
 local Event = require("game.Event")
 
 local function my_turn_handler()
@@ -229,7 +229,6 @@ TEST_CASE("Test requiring Lua chunk multiple times", "[Lua: Mods]")
 {
     elona::lua::LuaEnv lua;
     lua.get_mod_manager().load_mods(
-        filesystem::dirs::mod(),
         {filesystem::dirs::exe() / u8"tests/data/mods/test_require_chunks"});
 
     REQUIRE_NOTHROW(lua.get_mod_manager().run_in_mod("test_require_chunks", R"(
@@ -252,7 +251,6 @@ TEST_CASE(
 {
     elona::lua::LuaEnv lua;
     lua.get_mod_manager().load_mods(
-        filesystem::dirs::mod(),
         {filesystem::dirs::exe() / u8"tests/data/mods/test_require"});
 
     // Attempts to load a file outside the mod's directory.

--- a/src/tests/lua_serialization.cpp
+++ b/src/tests/lua_serialization.cpp
@@ -18,9 +18,9 @@ using namespace elona::testing;
 TEST_CASE("Test that store can be reset", "[Lua: Serialization]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(filesystem::dirs::mod());
+    lua.get_mod_manager().load_mods();
 
-    REQUIRE_NOTHROW(lua.get_mod_manager().load_mod_from_script(
+    REQUIRE_NOTHROW(lua.get_mod_manager().load_testing_mod_from_script(
         "test", "mod.store.global.thing = 1"));
 
     lua.get_mod_manager().clear_mod_stores();
@@ -32,9 +32,10 @@ TEST_CASE("Test that store can be reset", "[Lua: Serialization]")
 TEST_CASE("Test that store can be assigned", "[Lua: Serialization]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(filesystem::dirs::mod());
+    lua.get_mod_manager().load_mods();
 
-    REQUIRE_NOTHROW(lua.get_mod_manager().load_mod_from_script("test", R"(
+    REQUIRE_NOTHROW(
+        lua.get_mod_manager().load_testing_mod_from_script("test", R"(
 mod.store.global.thing = 1
 assert(mod.store.global.thing == 1)
 )"));
@@ -51,9 +52,10 @@ assert(mod.store.global == true)
 TEST_CASE("Test that store cannot have new fields", "[Lua: Serialization]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(filesystem::dirs::mod());
+    lua.get_mod_manager().load_mods();
 
-    REQUIRE_THROWS(lua.get_mod_manager().load_mod_from_script("test", R"(
+    REQUIRE_THROWS(
+        lua.get_mod_manager().load_testing_mod_from_script("test", R"(
 mod.store.test = {}
 )"));
 }
@@ -61,11 +63,11 @@ mod.store.test = {}
 TEST_CASE("Test that store can be reset across mods", "[Lua: Serialization]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(filesystem::dirs::mod());
+    lua.get_mod_manager().load_mods();
 
-    REQUIRE_NOTHROW(lua.get_mod_manager().load_mod_from_script(
+    REQUIRE_NOTHROW(lua.get_mod_manager().load_testing_mod_from_script(
         "test1", "mod.store.global.mine = false; mod.store.global.thing = 1"));
-    REQUIRE_NOTHROW(lua.get_mod_manager().load_mod_from_script(
+    REQUIRE_NOTHROW(lua.get_mod_manager().load_testing_mod_from_script(
         "test2", "mod.store.global.theirs = true; mod.store.global.thing = 2"));
 
     lua.get_mod_manager().clear_mod_stores();
@@ -83,9 +85,10 @@ TEST_CASE("Test that store can be reset across mods", "[Lua: Serialization]")
 TEST_CASE("Test that API tables aren't reset", "[Lua: Serialization]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(filesystem::dirs::mod());
+    lua.get_mod_manager().load_mods();
 
-    REQUIRE_NOTHROW(lua.get_mod_manager().load_mod_from_script("test", ""));
+    REQUIRE_NOTHROW(
+        lua.get_mod_manager().load_testing_mod_from_script("test", ""));
     REQUIRE_NOTHROW(lua.get_mod_manager().run_in_mod(
         "test", R"(Rand = require("game.Rand"); assert(Rand ~= nil))"));
 
@@ -98,9 +101,10 @@ TEST_CASE("Test that API tables aren't reset", "[Lua: Serialization]")
 TEST_CASE("Test that globals aren't reset", "[Lua: Serialization]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(filesystem::dirs::mod());
+    lua.get_mod_manager().load_mods();
 
-    REQUIRE_NOTHROW(lua.get_mod_manager().load_mod_from_script("test", ""));
+    REQUIRE_NOTHROW(
+        lua.get_mod_manager().load_testing_mod_from_script("test", ""));
     REQUIRE_NOTHROW(lua.get_mod_manager().run_in_mod(
         "test", R"(assert(_MOD_ID == "test"))"));
 
@@ -115,9 +119,10 @@ TEST_CASE(
     "[Lua: Serialization]")
 {
     elona::lua::LuaEnv lua;
-    lua.get_mod_manager().load_mods(filesystem::dirs::mod());
+    lua.get_mod_manager().load_mods();
 
-    REQUIRE_NOTHROW(lua.get_mod_manager().load_mod_from_script("test", R"(
+    REQUIRE_NOTHROW(
+        lua.get_mod_manager().load_testing_mod_from_script("test", R"(
 local Event = require("game.Event")
 
 local function my_map_init_hook()
@@ -147,8 +152,9 @@ TEST_CASE("Test preservation of global data", "[Lua: Serialization]")
 {
     start_in_debug_map();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
-        "test_serial_global", R"(
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "test_serial_global", R"(
 mod.store.global.val = 42
 )"));
 
@@ -169,8 +175,9 @@ TEST_CASE("Test preservation of map local data", "[Lua: Serialization]")
 {
     start_in_debug_map();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
-        "test_serial_map", R"(
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "test_serial_map", R"(
 mod.store.map.val = 42
 )"));
 
@@ -191,8 +198,9 @@ TEST_CASE("Test preservation of data across reloads", "[Lua: Serialization]")
 {
     start_in_debug_map();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
-        "test_serial_reload", R"(
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "test_serial_reload", R"(
 mod.store.global.val = 42
 mod.store.map.val = "hoge"
 )"));
@@ -221,8 +229,9 @@ mod.store.map.val = ""
 
 TEST_CASE("Test preservation of handles across reloads", "[Lua: Serialization]")
 {
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
-        "test_serial_handle_reload", ""));
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "test_serial_handle_reload", ""));
 
     start_in_debug_map();
 
@@ -287,8 +296,9 @@ TEST_CASE(
     "Test preservation of handles across map changes",
     "[Lua: Serialization]")
 {
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
-        "test_serial_handle_map_change", ""));
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "test_serial_handle_map_change", ""));
 
     start_in_debug_map();
 
@@ -343,8 +353,9 @@ TEST_CASE(
     "Test preservation of map local handles across map changes",
     "[Lua: Serialization]")
 {
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
-        "test_serial_handle_map_change_local", ""));
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "test_serial_handle_map_change_local", ""));
 
     start_in_debug_map();
 
@@ -392,8 +403,9 @@ TEST_CASE("Test serialization of recursive table", "[Lua: Serialization]")
 {
     start_in_debug_map();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
-        "test_serial_recursive", R"(
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "test_serial_recursive", R"(
 local t = {}
 t[1] = t
 
@@ -421,8 +433,9 @@ TEST_CASE("Test serialization of plain value", "[Lua: Serialization]")
 {
     start_in_debug_map();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
-        "test_serial_plain", R"(
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "test_serial_plain", R"(
 mod.store.global = 42
 )"));
 
@@ -444,8 +457,9 @@ assert(mod.store.global == 42)
 
 TEST_CASE("Test serialization of single handle", "[Lua: Serialization]")
 {
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
-        "test_serial_handle", ""));
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "test_serial_handle", ""));
 
     start_in_debug_map();
 
@@ -479,8 +493,9 @@ TEST_CASE("Test that disabled mods are not serialized", "[Lua: Serialization]")
 {
     start_in_debug_map();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
-        "test_serial_disabled", R"(
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "test_serial_disabled", R"(
 mod.store.global.val = 42
 )"));
 
@@ -495,8 +510,9 @@ mod.store.global.val = 0
 
     load();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
-        "test_serial_disabled", ""));
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "test_serial_disabled", ""));
 
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_serial_disabled", R"(
@@ -509,8 +525,9 @@ TEST_CASE("Test private fields are not serialized", "[Lua: Serialization]")
 {
     start_in_debug_map();
 
-    REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().load_mod_from_script(
-        "test_serial_private", R"(
+    REQUIRE_NOTHROW(
+        elona::lua::lua->get_mod_manager().load_testing_mod_from_script(
+            "test_serial_private", R"(
 mod.store.global.public = true
 mod.store.global.public2 = {
    public = true,

--- a/src/tests/lua_serialization.cpp
+++ b/src/tests/lua_serialization.cpp
@@ -240,9 +240,9 @@ mod.store.map.item = Item.create(4, 8, "core.putitoro", 0)
     auto mod = elona::lua::lua->get_mod_manager().get_enabled_mod(
         "test_serial_handle_reload");
     auto global =
-        mod->get_store(elona::lua::ModInfo::StoreType::global).as<sol::table>();
+        mod->get_store(elona::lua::ModEnv::StoreType::global).as<sol::table>();
     auto map =
-        mod->get_store(elona::lua::ModInfo::StoreType::map).as<sol::table>();
+        mod->get_store(elona::lua::ModEnv::StoreType::map).as<sol::table>();
     std::string uuid_chara_global = global["chara"]["__uuid"];
     std::string uuid_item_global = global["item"]["__uuid"];
     std::string uuid_chara_map = map["chara"]["__uuid"];
@@ -306,7 +306,7 @@ mod.store.global.it = 0
     auto mod = elona::lua::lua->get_mod_manager().get_enabled_mod(
         "test_serial_handle_map_change");
     auto store =
-        mod->get_store(elona::lua::ModInfo::StoreType::global).as<sol::table>();
+        mod->get_store(elona::lua::ModEnv::StoreType::global).as<sol::table>();
     std::string uuid_chara = store["chara"]["__uuid"];
     std::string uuid_chara_local = store["chara_local"]["__uuid"];
 
@@ -360,7 +360,7 @@ mod.store.map.item = Item.create(4, 8, "core.putitoro", 0)
     auto mod = elona::lua::lua->get_mod_manager().get_enabled_mod(
         "test_serial_handle_map_change_local");
     auto store =
-        mod->get_store(elona::lua::ModInfo::StoreType::map).as<sol::table>();
+        mod->get_store(elona::lua::ModEnv::StoreType::map).as<sol::table>();
     std::string uuid_chara = store["chara"]["__uuid"];
     std::string uuid_item = store["item"]["__uuid"];
 

--- a/src/tests/util.cpp
+++ b/src/tests/util.cpp
@@ -112,7 +112,7 @@ void register_lua_function(
     std::string callback_signature,
     std::string callback_body)
 {
-    lua.get_mod_manager().load_mods();
+    lua.load_mods();
 
     REQUIRE_NOTHROW(lua.get_mod_manager().load_testing_mod_from_script(
         mod_id,

--- a/src/tests/util.cpp
+++ b/src/tests/util.cpp
@@ -112,9 +112,9 @@ void register_lua_function(
     std::string callback_signature,
     std::string callback_body)
 {
-    lua.get_mod_manager().load_mods(filesystem::dirs::mod());
+    lua.get_mod_manager().load_mods();
 
-    REQUIRE_NOTHROW(lua.get_mod_manager().load_mod_from_script(
+    REQUIRE_NOTHROW(lua.get_mod_manager().load_testing_mod_from_script(
         mod_id,
         "\
 local exports = {}\

--- a/src/thirdparty/json5/detail/parser.hpp
+++ b/src/thirdparty/json5/detail/parser.hpp
@@ -48,7 +48,7 @@ private:
         case token_type::integer: return value{tok.get_integer()};
         case token_type::number: return value{tok.get_number()};
         case token_type::string: return value{tok.get_string()};
-        default: throw parse_error{tok, "any JSON5 value"};
+        default: throw parse_error(tok, "any JSON5 value");
         }
     }
 
@@ -62,8 +62,8 @@ private:
         {
             if (_ts.peek().type() == token_type::eof)
             {
-                throw parse_error{token{token_type::eof},
-                                  "any JSON5 value or ']'"};
+                throw parse_error(
+                    token{token_type::eof}, "any JSON5 value or ']'");
             }
             else if (_ts.peek().type() == token_type::bracket_right)
             {
@@ -80,7 +80,7 @@ private:
             }
             else if (delimiter.type() != token_type::comma)
             {
-                throw parse_error{delimiter, "']' or ','"};
+                throw parse_error(delimiter, "']' or ','");
             }
         }
         return array;
@@ -96,8 +96,8 @@ private:
         {
             if (_ts.peek().type() == token_type::eof)
             {
-                throw parse_error{token{token_type::eof},
-                                  "any JSON5 value or '}'"};
+                throw parse_error(
+                    token{token_type::eof}, "any JSON5 value or '}'");
             }
             else if (_ts.peek().type() == token_type::brace_right)
             {
@@ -109,7 +109,7 @@ private:
             const auto kv_separator = _ts.get();
             if (kv_separator.type() != token_type::colon)
             {
-                throw parse_error{kv_separator, "':'"};
+                throw parse_error(kv_separator, "':'");
             }
             const auto v = parse_value();
             object.emplace(k, v);
@@ -121,7 +121,7 @@ private:
             }
             else if (delimiter.type() != token_type::comma)
             {
-                throw parse_error{delimiter, "'}' or ','"};
+                throw parse_error(delimiter, "'}' or ','");
             }
         }
         return object;
@@ -141,8 +141,18 @@ private:
         case token_type::nan: return "NaN";
         case token_type::string:
         case token_type::identifier: return tok.get_string();
-        default: throw parse_error{tok, "string or identifier"};
+        default: throw parse_error(tok, "string or identifier");
         }
+    }
+
+
+
+    syntax_error parse_error(
+        const detail::token& actual_token,
+        const char* expected_token)
+    {
+        return syntax_error{std::string{"expect "} + expected_token +
+                            ", but actually " + actual_token.to_string()};
     }
 };
 

--- a/src/thirdparty/json5/exceptions.hpp
+++ b/src/thirdparty/json5/exceptions.hpp
@@ -52,48 +52,6 @@ private:
 
 
 
-struct parse_error : public std::runtime_error
-{
-    parse_error(const detail::token& actual_token, const char* expected_token)
-        : std::runtime_error(build_error_message(actual_token, expected_token))
-        , _actual_token(actual_token)
-        , _expected_token(expected_token)
-    {
-    }
-
-
-
-    const detail::token& actual_token() const noexcept
-    {
-        return _actual_token;
-    }
-
-
-
-    const char* expected_token() const noexcept
-    {
-        return _expected_token;
-    }
-
-
-
-private:
-    const detail::token& _actual_token;
-    const char* _expected_token;
-
-
-
-    static std::string build_error_message(
-        const detail::token& actual_token,
-        const char* expected_token)
-    {
-        return std::string{"expect "} + expected_token + ", but actually " +
-            actual_token.to_string();
-    }
-};
-
-
-
 struct syntax_error : public std::runtime_error
 {
     syntax_error(const char* error_message)


### PR DESCRIPTION
# Summary

Implement "mod list" feature. You can enable/disable mods by editing `profile/<current profile>/mods.json`.


# Problems

- You cannot enable/disable mods. All mods are always loaded.
- Mod folders don't have version identifiers, so that it's impossible to have multiple versions.
- `lua::ModManager` does too many things.
- Mod dependency resolution is incomplete.


# Details


- Refactor `ModManager`'s methods for testing.
    - All mod environment, now, are immutable regardless of whether the mod is for testing or not. You need to call `rawset()` to ignore the barrier.

- Rename `ModInfo` to `ModEnv` and move the definition from `mod_manager.hpp` to `mod_env.hpp`.
    - Because "info" is a too general word.

- Refactor loading preinit config options.
    - Reduce use of global states and make it easy to test the routine. Also add several tests for preinit config options.

- Add version identifiers to each mod folder in `mod`.
    - Built-in mods under `runtime/mod` are copied to `bin/mod` with version identifier.
    - Example: mod `core` v0.2.6 in `runtime/mod` is copied to `bin/mod/core-0.2.6`.

- Support mod list file to enable/disable mods.
    - Now, you can enable/disable mods by listing mod IDs and versions in `<path to elona>/profile/<current profile>/mods.json`.


## Format of `mods.json`

```json5
{
  mods: {
    // List pairs of mod ID and version requirement.
    core: "0.2.6",
    lomias: "*",
    larnneire: "> 2.5, < 3",
  }
}
```