### PR TITLE
Fix welcome message shown on starting

### DIFF
--- a/src/elona/init.cpp
+++ b/src/elona/init.cpp
@@ -564,8 +564,7 @@ void initialize_game()
 
     mtilefilecur = -1;
     firstturn = 1;
-    Message::instance().buffered_message_begin(
-        "  Lafrontier presents Elona ver 1.22. Welcome traveler! ");
+    Message::instance().buffered_message_begin("   Welcome traveler! ");
 
     if (mode == 5)
     {


### PR DESCRIPTION
# Summary

Here is the original message (same as vanilla):
```
Lafrontier presents Elona ver 1.22. Welcome traveler!
```

This variant is neither "Elona ver 1.22" nor developed by "Lafrontier" (the author of the vanilla, a.k.a., Noa).
