### PR TITLE
Raise exception in libsnail headless mode

### DIFF
--- a/src/snail/CMakeLists.txt
+++ b/src/snail/CMakeLists.txt
@@ -15,7 +15,6 @@ string(TOLOWER ${SNAIL_BACKEND} SNAIL_DIR)
 # Source files
 set(SNAIL_SOURCES
   font.cpp
-  image.cpp
   input.cpp
   surface.cpp
 
@@ -24,10 +23,11 @@ set(SNAIL_SOURCES
   backends/${SNAIL_DIR}/detail.cpp
   backends/${SNAIL_DIR}/filedialog.cpp
   backends/${SNAIL_DIR}/hsp.cpp
+  backends/${SNAIL_DIR}/image.cpp
   backends/${SNAIL_DIR}/messagebox.cpp
   backends/${SNAIL_DIR}/renderer.cpp
-  backends/${SNAIL_DIR}/window.cpp
   backends/${SNAIL_DIR}/surface.cpp
+  backends/${SNAIL_DIR}/window.cpp
   )
 
 add_library(${SNAIL_LIBRARY} STATIC ${SNAIL_SOURCES})

--- a/src/snail/backends/headless/detail.cpp
+++ b/src/snail/backends/headless/detail.cpp
@@ -9,52 +9,68 @@ namespace snail
 namespace detail
 {
 
-void enforce_sdl(int)
+void enforce_sdl(int result)
 {
+    if (result != 0)
+    {
+        throw std::runtime_error{"enforce_sdl(int)"};
+    }
 }
 
 
-void enforce_ttf(int)
+void enforce_ttf(int result)
 {
+    if (result != 0)
+    {
+        throw std::runtime_error{"enforce_ttf(int)"};
+    }
 }
 
 
-void enforce_image(int)
+void enforce_image(int result)
 {
+    if (result != 0)
+    {
+        throw std::runtime_error{"enforce_img(int)"};
+    }
 }
 
 
 
-void enforce_mixer(int)
+void enforce_mixer(int result)
 {
+    if (result != 0)
+    {
+        throw std::runtime_error{"enforce_mixer(int)"};
+    }
 }
 
 
 
 void* enforce_sdl_internal(void* result)
 {
-    return result;
+    return result ? result : throw std::runtime_error{"enforce_sdl(void*)"};
 }
 
 
 
 void* enforce_ttf_internal(void* result)
 {
-    return result;
+    return result ? result : throw std::runtime_error{"enforce_ttf(void*)"};
 }
 
 
 
 void* enforce_img_internal(void* result)
 {
-    return result;
+    return result ? result : throw std::runtime_error{"enforce_img(void*)"};
 }
 
 
 
 void* enforce_mixer_internal(void* result)
 {
-    return result;
+    return result ? result : throw std::runtime_error{"enforce_mixer(void*)"};
 }
 
 

--- a/src/snail/backends/headless/image.cpp
+++ b/src/snail/backends/headless/image.cpp
@@ -1,0 +1,36 @@
+#include "../../image.hpp"
+#include "../../application.hpp"
+#include "../../renderer.hpp"
+#include "../../surface.hpp"
+
+
+
+namespace elona
+{
+namespace snail
+{
+
+Image::Image(const fs::path& filepath, optional<Color> keycolor)
+{
+    Surface surface{filepath, keycolor};
+
+    _width = surface.width();
+    _height = surface.height();
+}
+
+
+
+Image::Image(::SDL_Texture* ptr)
+{
+    _ptr.reset(ptr, ::SDL_DestroyTexture);
+}
+
+
+
+void Image::
+    _render(::SDL_Renderer*, BlendMode, int, int, int, int, int, int, int, int)
+{
+}
+
+} // namespace snail
+} // namespace elona

--- a/src/snail/backends/sdl/image.cpp
+++ b/src/snail/backends/sdl/image.cpp
@@ -1,7 +1,7 @@
-#include "image.hpp"
-#include "application.hpp"
-#include "renderer.hpp"
-#include "surface.hpp"
+#include "../../image.hpp"
+#include "../../application.hpp"
+#include "../../renderer.hpp"
+#include "../../surface.hpp"
 
 
 


### PR DESCRIPTION
# Summary

In headless mode (i.e., in testing), libsnail did't raise exceptions
even if calls of SDL functions fail. In CI test, loading image files
occasionally fails for some reason, then the program crashes because of
segfault. Generally speaking, it is very hard to determine the cause of
segfault, especially in remote environment. This commit makes libsnail
raise exceptions in headless mode so that more detailed error log is
reported.
