### PR TITLE
Fix GitHub Actions workflow: include 'runner.os' in cache key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: deps/elona
-        key: elona122
+        key: elona122-${{ runner.os }}
 
     - name: Download Vanilla Elona
       run: |
@@ -81,7 +81,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: deps/elona
-        key: elona122
+        key: elona122-${{ runner.os }}
 
     - name: Download Vanilla Elona
       run: |


### PR DESCRIPTION
# Summary

Fix broken GitHub Actions workflow.