### PR TITLE
Fix GitHub Actions' Build job on Ubuntu

### DIFF
--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -6,7 +6,7 @@
 #ifdef ELONA_OS_WINDOWS
 #include <crtdbg.h>
 
-#include <windows>
+#include <windows.h>
 // Prevent assertion dialogs from appearing on Windows, hanging CI test runs
 int WindowsCrtReportHook(int reportType, char* message, int* returnValue)
 {


### PR DESCRIPTION
# Summary

`boost::filesystem::directory_iterator` has several bugs in Linux:

https://www.boost.org/users/history/version_1_70_0.html

> Fixed possible use of uninitialized data in directory iterator
> increment operation on Linux.

I tried updating Boost to the latest, in which the bug has been fixed,
but CMake does not appear to support latest Boost.

Thus, I rewrite `elona::filesystem::glob_{entries,dirs,files}` functions
without `boost::filesystem::directory_iterator` in Linux.
