### PR TITLE
Implement config validation

### DIFF
--- a/doc/api/json5.luadoc
+++ b/doc/api/json5.luadoc
@@ -3,6 +3,11 @@
 module "JSON5"
 
 --- Parses JSON5 text.
+--
+--  @tparam string source JSON5 text
+--  @treturn[1] any Parsed object
+--  @treturn[2] nil If failed
+--  @treturn[2] string Error message
 --  @function parse
 function parse(source, state) end
 

--- a/src/elona/lua_env/lua_api/lua_api_json5.hpp
+++ b/src/elona/lua_env/lua_api/lua_api_json5.hpp
@@ -17,7 +17,9 @@ namespace lua
 namespace LuaApiJSON5
 {
 
-sol::object parse(const std::string& source, sol::this_state state);
+std::pair<sol::object, sol::optional<std::string>> parse(
+    const std::string& source,
+    sol::this_state state);
 std::string stringify(sol::object value, sol::table opts);
 
 void bind(sol::table&);

--- a/src/tests/lua/config.lua
+++ b/src/tests/lua/config.lua
@@ -34,9 +34,9 @@ lrun("test Config.set", function()
 
    Config.set("core.not_found", 1)
 
-   -- invalid type
+   -- Setting an invalid type should be ignored without raising an error.
    local ok = pcall(function() Config.set("core.font.quality", 1) end)
-   lequal(ok, false)
+   lequal(ok, true)
 
    -- Setting nil does nothing.
    Config.set("core.message.transparency", nil)


### PR DESCRIPTION
# Related Issues

Close #1393


# Summary

- [x] No config file
  - Use default values.
- [x] Syntax error
  - Use default values.
- [x] Validation error (type, upper/lower boundaries, etc)
  - Use default values.
- [x] Unknown options
  - Just ignore them.

Supported schema:

- `type`: The type of the option value
    - `string`
    - `integer`
    - `float`

- `enum`: The valid values of the option

- `min`: The minimum value of the option value
    - Only for integer/float options

- `max`: The maximum value of the option value
    - Only for integer/float options

If you set invalid values, foobar uses default values.


# Lua API `JSON5`

`JSON5.parse()`, now, returns a pair of nil and error message on failure instead of raising error.
This change enables the config loading routine, which internally calls the function, to handle not found/invalid format error correctly.