### PR TITLE
Fix/mod template

### DIFF
--- a/src/elona/lua_env/mod_manager.cpp
+++ b/src/elona/lua_env/mod_manager.cpp
@@ -361,11 +361,12 @@ std::vector<ModManifest> ModManager::get_templates()
 
 void ModManager::create_mod_from_template(
     const std::string& new_mod_id,
-    const std::string& template_mod_id)
+    const std::string& template_mod_id,
+    const semver::Version& template_mod_version)
 {
-    const auto template_mod_version = *get_enabled_version(template_mod_id);
     const auto new_mod_version = semver::Version{0, 1, 0};
 
+    // Copy all files from the template mod to the new mod.
     const auto from =
         filesystem::dirs::for_mod(template_mod_id, template_mod_version);
     const auto to = filesystem::dirs::for_mod(new_mod_id, new_mod_version);

--- a/src/elona/lua_env/mod_manager.cpp
+++ b/src/elona/lua_env/mod_manager.cpp
@@ -371,6 +371,13 @@ void ModManager::create_mod_from_template(
         filesystem::dirs::for_mod(template_mod_id, template_mod_version);
     const auto to = filesystem::dirs::for_mod(new_mod_id, new_mod_version);
     filesystem::copy_recursively(from, to);
+
+    // Edit the new mod's manifest file.
+    auto new_mod_manifest = ModManifest::load(to / "mod.json");
+    new_mod_manifest.id = new_mod_id;
+    new_mod_manifest.version = new_mod_version;
+    new_mod_manifest.name = new_mod_id;
+    new_mod_manifest.save();
 }
 
 

--- a/src/elona/lua_env/mod_manager.hpp
+++ b/src/elona/lua_env/mod_manager.hpp
@@ -161,7 +161,8 @@ public:
 
     void create_mod_from_template(
         const std::string& new_mod_id,
-        const std::string& template_mod_id);
+        const std::string& template_mod_id,
+        const semver::Version& template_mod_version);
 
     bool exists(const std::string& mod_id);
 

--- a/src/elona/lua_env/mod_manifest.hpp
+++ b/src/elona/lua_env/mod_manifest.hpp
@@ -22,6 +22,12 @@ struct ModManifest
      */
     static ModManifest load(const fs::path& path);
 
+    /**
+     * Save itself to `path`.
+     * If you call it against the mod whose `path` is none, throws exception.
+     */
+    void save() const;
+
     std::string id;
     std::string name;
     std::string author;

--- a/src/elona/main_menu.cpp
+++ b/src/elona/main_menu.cpp
@@ -1481,12 +1481,13 @@ MainMenuResult main_menu_mods_develop()
     pagesize = 16;
     keyrange = 0;
 
+    std::vector<std::pair<std::string, semver::Version>> mod_id_and_versions;
     for (const auto& tmpl : lua::lua->get_mod_manager().get_templates())
     {
         list(0, template_count) = template_count;
         listn(0, template_count) = tmpl.id + " v" + tmpl.version.to_string();
         listn(1, template_count) = tmpl.name;
-        listn(2, template_count) = tmpl.id;
+        mod_id_and_versions.emplace_back(tmpl.id, tmpl.version);
         key_list(template_count) = key_select(template_count);
         ++template_count;
     }
@@ -1593,7 +1594,9 @@ MainMenuResult main_menu_mods_develop()
                 else
                 {
                     lua::lua->get_mod_manager().create_mod_from_template(
-                        new_mod_id, listn(2, p));
+                        new_mod_id,
+                        mod_id_and_versions.at(p).first,
+                        mod_id_and_versions.at(p).second);
                     snd("core.write1");
                 }
                 init = true;


### PR DESCRIPTION
# Summary

- Fix crash when creating a new mod from a template.
  - As template mods are never enabled, `ModManifest::get_enabled_version()` always returns `none` against template mods. To avoid this, template mod's version must be passed to the mod creation routine.
- Fix the manifest file of the mod created from a template.
  - The manifest file of the mod created from a template was just a copy of the template mod's, i.e., fields `id`, `version` and `name` are `template_blank`, `0.1.0`, `Template blank`. Now, the manifest file is edited after copying with the name you input.