### PR TITLE
Fix that mods except for `core` cannot be enabled in `mods.json`

### DIFF
--- a/src/elona/lua_env/interface.cpp
+++ b/src/elona/lua_env/interface.cpp
@@ -10,6 +10,32 @@ namespace elona
 namespace lua
 {
 
+namespace
+{
+
+template <typename F>
+std::vector<fs::path> mod_dirs_internal(const fs::path& base_dir, F predicate)
+{
+    std::vector<fs::path> result;
+    // E.g., lomias-1.2.3
+    for (const auto& entry : filesystem::glob_dirs(
+             base_dir, std::regex{R"([a-z][a-z0-9_]+-[0-9]\.[0-9]\.[0-9])"}))
+    {
+        if (fs::exists(entry.path() / "mod.json"))
+        {
+            if (predicate(entry.path()))
+            {
+                result.push_back(entry.path());
+            }
+        }
+    }
+    return result;
+}
+
+} // namespace
+
+
+
 optional<ConfigTable> data(const char* type, const std::string& id)
 {
     if (auto table = lua->get_data_manager().get().raw(type, id))
@@ -36,6 +62,33 @@ optional<ConfigTable> data(const char* type, int legacy_id)
 fs::path resolve_path_for_mod(const std::string& path)
 {
     return lua->get_mod_manager().resolve_path_for_mod(path);
+}
+
+
+
+std::vector<fs::path> all_mod_dirs(const fs::path& base_dir)
+{
+    return mod_dirs_internal(base_dir, [](const auto&) { return true; });
+}
+
+
+
+std::vector<fs::path> template_mod_dirs(const fs::path& base_dir)
+{
+    return mod_dirs_internal(base_dir, [](const auto& path) {
+        const auto id_and_version = filepathutil::to_utf8_path(path.filename());
+        return strutil::has_prefix(id_and_version, "template_");
+    });
+}
+
+
+
+std::vector<fs::path> normal_mod_dirs(const fs::path& base_dir)
+{
+    return mod_dirs_internal(base_dir, [](const auto& path) {
+        const auto id_and_version = filepathutil::to_utf8_path(path.filename());
+        return !strutil::has_prefix(id_and_version, "template_");
+    });
 }
 
 } // namespace lua

--- a/src/elona/lua_env/interface.hpp
+++ b/src/elona/lua_env/interface.hpp
@@ -105,5 +105,11 @@ optional<ConfigTable> data(const char* type, int legacy_id);
 
 fs::path resolve_path_for_mod(const std::string& path);
 
+
+// List mod directories under `base_dir`.
+std::vector<fs::path> all_mod_dirs(const fs::path& base_dir);
+std::vector<fs::path> template_mod_dirs(const fs::path& base_dir);
+std::vector<fs::path> normal_mod_dirs(const fs::path& base_dir);
+
 } // namespace lua
 } // namespace elona

--- a/src/elona/lua_env/lua_env.cpp
+++ b/src/elona/lua_env/lua_env.cpp
@@ -72,9 +72,7 @@ void LuaEnv::load_mods()
 {
     const auto list = ModList::from_file(filesystem::files::mod_list());
     const auto lock = ModLock{};
-    // const auto index = ModIndex::traverse(filesystem::dirs::mod());
-    const auto index = ModIndex{
-        {{"core", {ModIndex::IndexEntry{semver::Version{0, 2, 6}, {}}}}}};
+    const auto index = ModIndex::traverse(filesystem::dirs::mod());
 
     ModVersionResolver resolver;
     const auto resolve_result = resolver.resolve(list, lock, index);

--- a/src/elona/lua_env/mod_manager.cpp
+++ b/src/elona/lua_env/mod_manager.cpp
@@ -37,44 +37,6 @@ bool _is_alnum_only(const std::string& str)
 
 
 
-template <typename F>
-std::vector<fs::path> mod_dirs_internal(const fs::path& base_dir, F predicate)
-{
-    std::vector<fs::path> result;
-    // E.g., lomias-1.2.3
-    for (const auto& entry : filesystem::glob_dirs(
-             base_dir, std::regex{R"([a-z][a-z0-9_]+-[0-9]\.[0-9]\.[0-9])"}))
-    {
-        if (fs::exists(entry.path() / "mod.json"))
-        {
-            if (predicate(entry.path()))
-            {
-                result.push_back(entry.path());
-            }
-        }
-    }
-    return result;
-}
-
-
-
-std::vector<fs::path> all_mod_dirs(const fs::path& base_dir)
-{
-    return mod_dirs_internal(base_dir, [](const auto&) { return true; });
-}
-
-
-
-std::vector<fs::path> template_mod_dirs(const fs::path& base_dir)
-{
-    return mod_dirs_internal(base_dir, [](const auto& path) {
-        const auto id_and_version = filepathutil::to_utf8_path(path.filename());
-        return strutil::has_prefix(id_and_version, "template_");
-    });
-}
-
-
-
 // Callback to be called in Lua for preventing write access to unknown
 // globals.
 int deny_new_fields(

--- a/src/elona/lua_env/mod_version_resolver.hpp
+++ b/src/elona/lua_env/mod_version_resolver.hpp
@@ -67,6 +67,9 @@ public:
         either::either<std::string, std::reference_wrapper<const IndexEntry>>;
 
 
+    static ModIndex traverse(const fs::path& mod_root_dir);
+
+
     ModIndex(
         const std::unordered_map<std::string, std::vector<IndexEntry>>& mods)
         : _mods(mods)


### PR DESCRIPTION

# Summary

Implement `ModIndex::traverse()`, a function which traverses `mod`
folder to construct mod index.
