### PR TITLE
Enable/disable mods via Mod List menu

### DIFF
--- a/runtime/locale/en/main_menu.hcl
+++ b/runtime/locale/en/main_menu.hcl
@@ -72,6 +72,10 @@ locale {
                 download = "[Switch To Download]"
                 installed = "[Switch To Installed]"
             }
+
+            toggle {
+                cannot_disable = "This mod cannot be disabled."
+            }
         }
 
         mod_develop {

--- a/runtime/locale/jp/main_menu.hcl
+++ b/runtime/locale/jp/main_menu.hcl
@@ -63,7 +63,7 @@ locale {
             }
 
             download {
-                failed = "MODリストのダウンロードに失敗しました。"
+                failed = "MODリストのダウンロードに失敗しました"
             }
 
             hint {
@@ -71,6 +71,10 @@ locale {
                 info = "[MODの情報]"
                 download = "[ダウンロード]"
                 installed = "[インストール済み]"
+            }
+
+            toggle {
+                cannot_disable = "このMODは無効にできません"
             }
         }
 

--- a/src/elona/lua_env/mod_manager.cpp
+++ b/src/elona/lua_env/mod_manager.cpp
@@ -207,6 +207,37 @@ std::vector<ModManifest> ModManager::installed_mods() const
 
 
 
+void ModManager::toggle_mod(
+    const std::string& id,
+    const semver::Version& version)
+{
+    auto mod_list = ModList::from_file(filesystem::files::mod_list());
+
+    if (const auto current_version = get_enabled_version(id))
+    {
+        // Disable
+        assert(can_disable_mod(id));
+        assert(*current_version == version);
+        ELONA_LOG("lua.mod")
+            << "Disable mod " << id << "-" << version.to_string();
+
+        mod_list.mods().erase(id);
+    }
+    else
+    {
+        // Enable
+        ELONA_LOG("lua.mod")
+            << "Enable mod " << id << "-" << version.to_string();
+
+        mod_list.mods().emplace(
+            id, semver::VersionRequirement::from_version(version));
+    }
+
+    mod_list.save(filesystem::files::mod_list());
+}
+
+
+
 void ModManager::load_mods(const ResolvedModList& resolved_mod_list)
 {
     _mod_versions = resolved_mod_list.mod_versions();

--- a/src/elona/lua_env/mod_manager.cpp
+++ b/src/elona/lua_env/mod_manager.cpp
@@ -165,6 +165,48 @@ ModManager::ModManager(LuaEnv& lua)
 
 
 
+std::vector<ModManifest> ModManager::installed_mods() const
+{
+    // Traverse `mod` directory, and gather the latest versions.
+    std::unordered_map<std::string, std::pair<semver::Version, fs::path>>
+        mod_dirs;
+    for (const auto& dir : normal_mod_dirs(filesystem::dirs::mod()))
+    {
+        // Get mod ID and version from folder name.
+        const auto dir_name = filepathutil::to_utf8_path(dir.filename());
+        std::string id;
+        std::string version_str;
+        std::tie(id, version_str) = strutil::split_on_string(dir_name, "-");
+        const auto version = semver::Version::parse(version_str).right();
+
+        const auto itr = mod_dirs.find(id);
+        if (itr == std::end(mod_dirs))
+        {
+            mod_dirs[id] = std::make_pair(version, dir);
+        }
+        else
+        {
+            // Update the table only if it is the latest one.
+            if (itr->second.first < version)
+            {
+                mod_dirs[id] = std::make_pair(version, dir);
+            }
+        }
+    }
+
+    // Load each manifest.
+    std::vector<ModManifest> ret;
+    for (const auto& pair : mod_dirs)
+    {
+        const auto& dir = pair.second.second;
+        ModManifest manifest = ModManifest::load(dir / "mod.json");
+        ret.emplace_back(manifest);
+    }
+    return ret;
+}
+
+
+
 void ModManager::load_mods(const ResolvedModList& resolved_mod_list)
 {
     _mod_versions = resolved_mod_list.mod_versions();

--- a/src/elona/lua_env/mod_manager.hpp
+++ b/src/elona/lua_env/mod_manager.hpp
@@ -110,6 +110,21 @@ public:
     }
 
 
+    bool can_disable_mod(const std::string& id) const noexcept
+    {
+        // `core` mod cannot be disabled!
+        return id != "core";
+    }
+
+
+    /**
+     * Enable/disable mod. When disabling, @a version must be the same as the
+     * currently enabled version. This function, so far, only edits the mod list
+     * file. You need to re-launch foobar to apply the changes.
+     */
+    void toggle_mod(const std::string& id, const semver::Version& version);
+
+
     void load_mods(const ResolvedModList& resolved_mod_list);
 
 

--- a/src/elona/lua_env/mod_manager.hpp
+++ b/src/elona/lua_env/mod_manager.hpp
@@ -36,6 +36,14 @@ public:
 
 
     /**
+     * Gets list of the installed mods.
+     * "Installed" means that the mod is unpacked under `mod` folder.
+     * This returns only latest versions.
+     */
+    std::vector<ModManifest> installed_mods() const;
+
+
+    /**
      * Finds the mod that is currently loaded.
      */
     optional_ref<const ModEnv> get_mod(const std::string& id) const noexcept
@@ -93,6 +101,12 @@ public:
         {
             return itr->second;
         }
+    }
+
+
+    bool is_enabled(const std::string& id) const noexcept
+    {
+        return static_cast<bool>(get_enabled_version(id));
     }
 
 

--- a/src/elona/lua_env/mod_version_resolver.cpp
+++ b/src/elona/lua_env/mod_version_resolver.cpp
@@ -144,6 +144,33 @@ ModList ModList::from_stream(std::istream& in, const std::string& filepath)
 
 
 
+void ModList::save(const fs::path& path)
+{
+    json5::value::object_type root_obj;
+    json5::value::object_type requirements;
+    for (const auto& pair : _mods)
+    {
+        requirements[pair.first] = pair.second.to_string();
+    }
+    root_obj["mods"] = requirements;
+
+    json5::stringify_options opts;
+    opts.prettify = true;
+    opts.insert_trailing_comma = true;
+    opts.unquote_key = true;
+    opts.sort_by_key = true;
+
+    std::ofstream out{path.native()};
+    if (!out)
+    {
+        throw std::runtime_error{"failed to open mod list file to write: " +
+                                 filepathutil::to_utf8_path(path)};
+    }
+    out << json5::stringify(root_obj, opts) << std::endl;
+}
+
+
+
 ModIndex ModIndex::traverse(const fs::path& mod_root_dir)
 {
     std::unordered_map<std::string, std::vector<IndexEntry>> mods;

--- a/src/elona/lua_env/mod_version_resolver.hpp
+++ b/src/elona/lua_env/mod_version_resolver.hpp
@@ -26,6 +26,17 @@ public:
     static ModList from_stream(std::istream& in, const std::string& filepath);
 
 
+    // Save the mod list to `path`.
+    void save(const fs::path& path);
+
+
+
+    RequirementList& mods() noexcept
+    {
+        return _mods;
+    }
+
+
     const RequirementList& mods() const noexcept
     {
         return _mods;

--- a/src/elona/semver.hpp
+++ b/src/elona/semver.hpp
@@ -394,19 +394,14 @@ private:
                 return false;
             return lhs.patch < rhs.patch;
         }
+
+
+        friend VersionRequirement;
     };
 
 
 
 public:
-    explicit VersionRequirement(
-        const std::vector<OneVersionRequirement>& requirements)
-        : _requirements(requirements)
-    {
-    }
-
-
-
     static either::either<std::string, VersionRequirement> parse(
         const std::string& str)
     {
@@ -426,6 +421,19 @@ public:
         }
 
         return Result::right_of(VersionRequirement{requirements});
+    }
+
+
+
+    /**
+     * Create a version requirement which exactly matching @a version.
+     * The result is the same as `parse("= " + version.to_string()).right()`.
+     */
+    static VersionRequirement from_version(const Version& version)
+    {
+        OneVersionRequirement req{OneVersionRequirement::Operator::equal,
+                                  version};
+        return VersionRequirement{{req}};
     }
 
 
@@ -461,6 +469,14 @@ public:
 
 private:
     std::vector<OneVersionRequirement> _requirements;
+
+
+
+    explicit VersionRequirement(
+        const std::vector<OneVersionRequirement>& requirements)
+        : _requirements(requirements)
+    {
+    }
 };
 
 } // namespace semver

--- a/src/elona/ui/ui_menu_mods.hpp
+++ b/src/elona/ui/ui_menu_mods.hpp
@@ -1,22 +1,29 @@
 #pragma once
+
 #include "../lua_env/mod_manifest.hpp"
 #include "ui_menu.hpp"
+
+
+
 namespace elona
 {
 namespace ui
 {
+
 struct ModDescription
 {
     lua::ModManifest manifest;
     bool enabled;
 };
 
+
+
 class UIMenuMods : public UIMenu<DummyResult>
 {
 public:
-    UIMenuMods()
-    {
-    }
+    UIMenuMods() = default;
+
+
 
 protected:
     virtual bool init();
@@ -30,6 +37,8 @@ protected:
     void _draw_mod_list();
     void _draw_window();
 
+
+
 private:
     std::vector<ModDescription> _mod_descriptions;
     std::vector<std::string> _description_pages;
@@ -37,5 +46,6 @@ private:
     bool _redraw;
     bool _is_download;
 };
+
 } // namespace ui
 } // namespace elona

--- a/src/elona/ui/ui_menu_mods.hpp
+++ b/src/elona/ui/ui_menu_mods.hpp
@@ -45,6 +45,9 @@ private:
 
     bool _redraw;
     bool _is_download;
+
+
+    void _try_to_toggle_mod(ModDescription& desc);
 };
 
 } // namespace ui


### PR DESCRIPTION
# Summary

- List installed mods instead of enabled ones in Mod List menu. They are sorted by their IDs in natural order.
- Make it possible to enable/disable mods via Mod List menu.
