### PR TITLE
Enable SOL_CHECK_ARGUMENTS in debug build for detecting potential bugs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,6 +290,7 @@ else() # GCC or Clang
     "g"
     "O0"
     "DDEBUG"
+    "DSOL_CHECK_ARGUMENTS"
     )
   if(ELONA_BUILD_TARGET STREQUAL "BENCH")
     list(APPEND GENERAL_OPTIONS "g1")

--- a/runtime/data/script/kernel/config.lua
+++ b/runtime/data/script/kernel/config.lua
@@ -143,7 +143,7 @@ local function load_default_values_if_unset()
          -- Almost all of options have thier own default values, but there are some exceptions:
          -- * Sections
          -- * Option "core.screen.display_mode" in headless mode
-         if schema.default then
+         if schema.default ~= nil then
             Config.set(option_key, schema.default)
          end
       end

--- a/runtime/mod/core/exports/eating_effect.lua
+++ b/runtime/mod/core/exports/eating_effect.lua
@@ -205,7 +205,7 @@ function eating_effect.quickling(eater)
    eat_message(eater, "quickling", Enums.Color.Green)
 
    local current = eater:get_skill("core.attribute_speed").current_level
-   local amount = Math.clamp(2500 - current * current / 10, 20, 2500)
+   local amount = Math.clamp(2500 - current * current // 10, 20, 2500)
    eater:gain_skill_exp("core.attribute_speed", amount);
 end
 

--- a/src/elona/data/types/type_item_material.cpp
+++ b/src/elona/data/types/type_item_material.cpp
@@ -9,22 +9,6 @@ ItemMaterialDB the_item_material_db;
 const constexpr char* data::LuaLazyCacheTraits<ItemMaterialDB>::type_id;
 
 
-namespace
-{
-
-std::unordered_map<int, int> _convert_enchantments(const lua::ConfigTable& data)
-{
-    DATA_TABLE(enchantments, std::string, int);
-    std::unordered_map<int, int> ret;
-    for (const auto& pair : enchantments)
-    {
-        ret.emplace(std::stoi(pair.first), pair.second);
-    }
-    return ret;
-}
-
-} // namespace
-
 
 ItemMaterialData ItemMaterialDB::convert(
     const lua::ConfigTable& data,
@@ -39,7 +23,7 @@ ItemMaterialData ItemMaterialDB::convert(
     DATA_OPT_OR(pv, int, 0);
     DATA_OPT_OR(dice_y, int, 0);
     DATA_OPT_OR(color, int, 0);
-    const auto enchantments = _convert_enchantments(data);
+    DATA_TABLE(enchantments, int, int);
     DATA_OPT_OR(fireproof, bool, false);
     DATA_OPT_OR(acidproof, bool, false);
 

--- a/src/elona/lua_env/api_manager.cpp
+++ b/src/elona/lua_env/api_manager.cpp
@@ -34,8 +34,8 @@ APIManager::APIManager(LuaEnv& lua)
 
 bool APIManager::is_loaded()
 {
-    bool loaded = env()["_LOADED"];
-    return loaded;
+    sol::optional<bool> loaded = env()["_LOADED"];
+    return loaded && *loaded;
 }
 
 


### PR DESCRIPTION
# Summary

Enable `SOL_CHECK_ARGUMENTS` in debug build for detecting potential bugs. Also fixed some potential bugs. They *work* as intended so far, but potentially cause wield things.
