### PR TITLE
Hotfix/0.6.1: Disable network feature temporarily until the bug is resolved

### DIFF
--- a/src/elona/config.cpp
+++ b/src/elona/config.cpp
@@ -373,7 +373,7 @@ void bind_setters()
     CONFIG_OPTION("language.language", std::string, language);
     CONFIG_OPTION("message.add_timestamps", bool, message_add_timestamps);
     CONFIG_OPTION("message.transparency", int, message_transparency);
-    CONFIG_OPTION("net.is_enabled", bool, net);
+    // CONFIG_OPTION("net.is_enabled", bool, net);
     CONFIG_OPTION("screen.display_mode", std::string, display_mode);
     CONFIG_OPTION("screen.heartbeat", bool, heartbeat);
     CONFIG_OPTION("screen.high_quality_shadows", bool, high_quality_shadow);
@@ -391,6 +391,14 @@ void bind_setters()
     conf.bind_setter("core.game.default_save", &setters::game_default_save);
     conf.bind_setter("core.foobar.show_fps", &setters::foobar_show_fps);
     conf.bind_setter("core.screen.fullscreen", &setters::screen_fullscreen);
+
+
+    // Always disable network feature.
+    conf.bind_setter(
+        "core.net.is_enabled", +[](const bool& value) {
+            (void)value;
+            g_config.set_net(false);
+        });
 
 #undef CONFIG_OPTION
 } // namespace


### PR DESCRIPTION
# Summary

If you enable network feature on Windows, Elona foobar will freeze. The
whole binary data is surely sent to the remote server, but neither the
success handler nor the failure handler is called. The bug is
reproducible, but the cause hasn't been found yet. Anyway, the network
features are temporarily disabled until the bug resolved.
