### PR TITLE
Add GitHub Actions workflow: clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -53,11 +53,15 @@ IncludeCategories:
   # 2: C++ standard libraries
   # 3: Third party libraries
   # 4: Others
+  - Regex: '^<charconv>'
+    Priority: 2
   - Regex: '^<chrono>'
     Priority: 2
-  - Regex: '^<codecvt>'
+  - Regex: '^<compare>'
     Priority: 2
   - Regex: '^<complex>'
+    Priority: 2
+  - Regex: '^<concepts>'
     Priority: 2
   - Regex: '^<condition_variable>'
     Priority: 2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,3 +92,21 @@ jobs:
       run: |
         make clean
         make tests VERBOSE=1
+
+  clang-format:
+    name: Run clang-format
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Install Dependencies
+      run: |
+        brew update
+        brew install -f \
+          clang-format
+
+    - name: Run clang-format
+      run: |
+        clang-format --version
+        make format

--- a/src/bench/ai.cpp
+++ b/src/bench/ai.cpp
@@ -1,12 +1,12 @@
-#include "../thirdparty/hayai/hayai.hpp"
-
 #include <cassert>
+
 #include "../elona/ability.hpp"
 #include "../elona/character.hpp"
 #include "../elona/debug.hpp"
 #include "../elona/event.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/hayai/hayai.hpp"
 #include "util.hpp"
 
 using namespace elona;

--- a/src/bench/generate.cpp
+++ b/src/bench/generate.cpp
@@ -1,11 +1,11 @@
-#include "../thirdparty/hayai/hayai.hpp"
-
 #include <cassert>
+
 #include "../elona/ability.hpp"
 #include "../elona/character.hpp"
 #include "../elona/debug.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/hayai/hayai.hpp"
 #include "util.hpp"
 
 class GenerateCharacterFixture : public ::hayai::Fixture

--- a/src/bench/i18n.cpp
+++ b/src/bench/i18n.cpp
@@ -1,7 +1,8 @@
-#include "../thirdparty/hayai/hayai.hpp"
+#include "../elona/i18n.hpp"
 
 #include <cassert>
-#include "../elona/i18n.hpp"
+
+#include "../thirdparty/hayai/hayai.hpp"
 #include "util.hpp"
 
 using namespace elona;

--- a/src/bench/lua_callbacks.cpp
+++ b/src/bench/lua_callbacks.cpp
@@ -1,6 +1,5 @@
-#include "../thirdparty/hayai/hayai.hpp"
-
 #include <cassert>
+
 #include "../elona/ability.hpp"
 #include "../elona/character.hpp"
 #include "../elona/debug.hpp"
@@ -9,6 +8,7 @@
 #include "../elona/message.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/hayai/hayai.hpp"
 #include "util.hpp"
 
 class LuaCallbacksWanderFixture : public ::hayai::Fixture

--- a/src/bench/magic.cpp
+++ b/src/bench/magic.cpp
@@ -1,11 +1,11 @@
-#include "../thirdparty/hayai/hayai.hpp"
-
 #include <cassert>
+
 #include "../elona/ability.hpp"
 #include "../elona/character.hpp"
 #include "../elona/debug.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/hayai/hayai.hpp"
 #include "util.hpp"
 
 using namespace elona;

--- a/src/bench/serialization.cpp
+++ b/src/bench/serialization.cpp
@@ -1,9 +1,9 @@
-#include "../thirdparty/hayai/hayai.hpp"
-
 #include <memory>
 #include <sstream>
+
 #include "../elona/character.hpp"
 #include "../elona/putit.hpp"
+#include "../thirdparty/hayai/hayai.hpp"
 
 using namespace elona;
 

--- a/src/elona/ability.cpp
+++ b/src/elona/ability.cpp
@@ -1,4 +1,5 @@
 #include "ability.hpp"
+
 #include "../util/range.hpp"
 #include "audio.hpp"
 #include "calc.hpp"

--- a/src/elona/ability.hpp
+++ b/src/elona/ability.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <cassert>
+
 #include <vector>
+
 #include "data/types/type_ability.hpp"
 
 

--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -1,4 +1,5 @@
 #include "activity.hpp"
+
 #include "ability.hpp"
 #include "animation.hpp"
 #include "audio.hpp"
@@ -756,8 +757,7 @@ void activity_others_doing(Character& doer)
                 Message::color{ColorIndex::cyan});
         }
         break;
-    case 104:
-    {
+    case 104: {
         int p = 25;
         if (game_data.weather != 0 && game_data.weather != 3)
         {

--- a/src/elona/adventurer.cpp
+++ b/src/elona/adventurer.cpp
@@ -1,5 +1,7 @@
 #include "adventurer.hpp"
+
 #include <string>
+
 #include "ability.hpp"
 #include "area.hpp"
 #include "character.hpp"

--- a/src/elona/ai.cpp
+++ b/src/elona/ai.cpp
@@ -1,4 +1,5 @@
 #include "ai.hpp"
+
 #include "ability.hpp"
 #include "activity.hpp"
 #include "animation.hpp"

--- a/src/elona/animation.cpp
+++ b/src/elona/animation.cpp
@@ -1,4 +1,5 @@
 #include "animation.hpp"
+
 #include "ability.hpp"
 #include "audio.hpp"
 #include "character.hpp"

--- a/src/elona/area.cpp
+++ b/src/elona/area.cpp
@@ -1,4 +1,5 @@
 #include "area.hpp"
+
 #include "ctrl_file.hpp"
 #include "data/types/type_map.hpp"
 #include "elona.hpp"

--- a/src/elona/area.hpp
+++ b/src/elona/area.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+
 #include "optional.hpp"
 #include "position.hpp"
 

--- a/src/elona/audio.cpp
+++ b/src/elona/audio.cpp
@@ -1,7 +1,11 @@
 #include "audio.hpp"
+
 #include <cmath>
+
 #include <unordered_map>
+
 #include <boost/math/special_functions/gamma.hpp>
+
 #include "../snail/application.hpp"
 #include "../snail/audio.hpp"
 #include "area.hpp"

--- a/src/elona/autopick.cpp
+++ b/src/elona/autopick.cpp
@@ -1,4 +1,5 @@
 #include "autopick.hpp"
+
 #include "../util/fileutil.hpp"
 #include "../util/strutil.hpp"
 #include "data/types/type_item.hpp"

--- a/src/elona/autopick.hpp
+++ b/src/elona/autopick.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+
 #include "../util/noncopyable.hpp"
 #include "filesystem.hpp"
 #include "item.hpp"

--- a/src/elona/blending.cpp
+++ b/src/elona/blending.cpp
@@ -1,4 +1,5 @@
 #include "blending.hpp"
+
 #include "ability.hpp"
 #include "activity.hpp"
 #include "audio.hpp"

--- a/src/elona/blending.hpp
+++ b/src/elona/blending.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+
 #include "elona.hpp"
 #include "enums.hpp"
 

--- a/src/elona/browser.cpp
+++ b/src/elona/browser.cpp
@@ -1,6 +1,9 @@
 #include "browser.hpp"
+
 #include <cstdlib>
+
 #include <string>
+
 #include "../util/range.hpp"
 #include "config.hpp"
 

--- a/src/elona/buff.cpp
+++ b/src/elona/buff.cpp
@@ -1,4 +1,5 @@
 #include "buff.hpp"
+
 #include "../util/range.hpp"
 #include "ability.hpp"
 #include "character.hpp"

--- a/src/elona/buff.hpp
+++ b/src/elona/buff.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <unordered_map>
+
 #include "data/types/type_buff.hpp"
 #include "optional.hpp"
 

--- a/src/elona/building.cpp
+++ b/src/elona/building.cpp
@@ -1,4 +1,5 @@
 #include "building.hpp"
+
 #include "../util/range.hpp"
 #include "ability.hpp"
 #include "activity.hpp"

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -1,4 +1,5 @@
 #include "calc.hpp"
+
 #include "ability.hpp"
 #include "area.hpp"
 #include "buff.hpp"

--- a/src/elona/calc.hpp
+++ b/src/elona/calc.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+
 #include "enums.hpp"
 #include "optional.hpp"
 

--- a/src/elona/casino.cpp
+++ b/src/elona/casino.cpp
@@ -1,4 +1,5 @@
 #include "casino.hpp"
+
 #include "ability.hpp"
 #include "audio.hpp"
 #include "calc.hpp"

--- a/src/elona/casino_card.cpp
+++ b/src/elona/casino_card.cpp
@@ -1,4 +1,5 @@
 #include "casino_card.hpp"
+
 #include "audio.hpp"
 #include "draw.hpp"
 #include "random.hpp"

--- a/src/elona/chara_db.cpp
+++ b/src/elona/chara_db.cpp
@@ -265,8 +265,7 @@ void chara_db_get_talk(CharaId chara_id, int talk_type)
     switch (chara_id)
     {
     case CharaId::younger_sister:
-    case CharaId::younger_sister_of_mansion:
-    {
+    case CharaId::younger_sister_of_mansion: {
         std::string text = i18n::s.get_enum("core.ui.onii", cdata.player().sex);
 
         if (talk_type == 100)
@@ -289,8 +288,7 @@ void chara_db_get_talk(CharaId chara_id, int talk_type)
         }
         break;
     }
-    case CharaId::maid:
-    {
+    case CharaId::maid: {
         std::string text =
             i18n::s.get_enum("core.ui.syujin", cdata.player().sex);
 
@@ -323,8 +321,7 @@ void chara_db_get_talk(CharaId chara_id, int talk_type)
         }
         break;
     }
-    case CharaId::younger_cat_sister:
-    {
+    case CharaId::younger_cat_sister: {
         std::string text = i18n::s.get_enum("core.ui.onii", cdata.player().sex);
 
         if (talk_type == 100)

--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -1,6 +1,9 @@
 #include "character.hpp"
+
 #include <cassert>
+
 #include <type_traits>
+
 #include "../util/fileutil.hpp"
 #include "../util/range.hpp"
 #include "../util/strutil.hpp"

--- a/src/elona/character.hpp
+++ b/src/elona/character.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <unordered_map>
 #include <vector>
+
 #include "../util/range.hpp"
 #include "consts.hpp"
 #include "data/types/type_character.hpp"

--- a/src/elona/character_making.cpp
+++ b/src/elona/character_making.cpp
@@ -1,4 +1,5 @@
 #include "character_making.hpp"
+
 #include "ability.hpp"
 #include "audio.hpp"
 #include "character.hpp"
@@ -16,13 +17,12 @@
 #include "random.hpp"
 #include "text.hpp"
 #include "ui.hpp"
-#include "variables.hpp"
-
 #include "ui/ui_menu_charamake_alias.hpp"
 #include "ui/ui_menu_charamake_attributes.hpp"
 #include "ui/ui_menu_charamake_class.hpp"
 #include "ui/ui_menu_charamake_gender.hpp"
 #include "ui/ui_menu_charamake_race.hpp"
+#include "variables.hpp"
 
 
 namespace

--- a/src/elona/character_status.cpp
+++ b/src/elona/character_status.cpp
@@ -1,5 +1,7 @@
 #include "character_status.hpp"
+
 #include <limits>
+
 #include "ability.hpp"
 #include "adventurer.hpp"
 #include "character.hpp"

--- a/src/elona/class.cpp
+++ b/src/elona/class.cpp
@@ -1,4 +1,5 @@
 #include "class.hpp"
+
 #include "ability.hpp"
 #include "elona.hpp"
 #include "i18n.hpp"

--- a/src/elona/class.hpp
+++ b/src/elona/class.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <vector>
+
 #include "data/types/type_class.hpp"
 
 

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -1,4 +1,5 @@
 #include "command.hpp"
+
 #include "../snail/application.hpp"
 #include "ability.hpp"
 #include "activity.hpp"
@@ -1943,8 +1944,7 @@ TurnResult do_use_command()
         screenupdate = -1;
         update_screen();
         return TurnResult::show_house_board;
-    case 19:
-    {
+    case 19: {
         int chara = -1;
         // Are there any of your pets around you?
         const auto alone = !any_of_characters_around_you(
@@ -2025,8 +2025,7 @@ TurnResult do_use_command()
         }
         chara_refresh(0);
         break;
-    case 9:
-    {
+    case 9: {
         if (read_textbook(inv[ci]))
         {
             return TurnResult::turn_end;
@@ -2213,8 +2212,7 @@ TurnResult do_use_command()
             txt(i18n::s.get("core.common.it_is_impossible"));
         }
         break;
-    case 6:
-    {
+    case 6: {
         txt(i18n::s.get("core.action.use.music_disc.play", inv[ci]));
         auto music = inv[ci].param1 + 50 + 1;
         if (music > 97)

--- a/src/elona/config.cpp
+++ b/src/elona/config.cpp
@@ -1,10 +1,13 @@
 #include "config.hpp"
+
 #include <cassert>
+
 #include <fstream>
 #include <functional>
 #include <sstream>
 #include <stdexcept>
 #include <string>
+
 #include "../snail/application.hpp"
 #include "../thirdparty/json5/json5.hpp"
 #include "../util/fps_counter.hpp"

--- a/src/elona/config.hpp
+++ b/src/elona/config.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+
 #include "../snail/window.hpp"
 #include "filesystem.hpp"
 #include "shared_id.hpp"

--- a/src/elona/config_menu.cpp
+++ b/src/elona/config_menu.cpp
@@ -1,4 +1,5 @@
 #include "config_menu.hpp"
+
 #include "../util/natural_order_comparator.hpp"
 #include "../util/range.hpp"
 #include "lua_env/config_manager.hpp"

--- a/src/elona/crafting.cpp
+++ b/src/elona/crafting.cpp
@@ -1,4 +1,5 @@
 #include "crafting.hpp"
+
 #include "ability.hpp"
 #include "audio.hpp"
 #include "calc.hpp"
@@ -13,9 +14,8 @@
 #include "message.hpp"
 #include "random.hpp"
 #include "ui.hpp"
-#include "variables.hpp"
-
 #include "ui/ui_menu_crafting.hpp"
+#include "variables.hpp"
 
 namespace elona
 {

--- a/src/elona/crafting.hpp
+++ b/src/elona/crafting.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <vector>
+
 #include "optional.hpp"
 
 namespace elona

--- a/src/elona/ctrl_file.cpp
+++ b/src/elona/ctrl_file.cpp
@@ -1,5 +1,7 @@
 #include "ctrl_file.hpp"
+
 #include <set>
+
 #include "../util/fileutil.hpp"
 #include "ability.hpp"
 #include "area.hpp"

--- a/src/elona/ctrl_file.hpp
+++ b/src/elona/ctrl_file.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <unordered_map>
+
 #include "../util/noncopyable.hpp"
 #include "filesystem.hpp"
 

--- a/src/elona/data/init.cpp
+++ b/src/elona/data/init.cpp
@@ -1,5 +1,6 @@
 #include <string>
 #include <vector>
+
 #include "types.hpp"
 
 using namespace elona;

--- a/src/elona/data/lua_lazy_cache.hpp
+++ b/src/elona/data/lua_lazy_cache.hpp
@@ -3,6 +3,7 @@
 #include <type_traits>
 #include <unordered_map>
 #include <vector>
+
 #include "../../thirdparty/ordered_map/ordered_map.h"
 #include "../../thirdparty/sol2/sol.hpp"
 #include "../../util/map_key_iterator.hpp"

--- a/src/elona/data/types/type_asset.cpp
+++ b/src/elona/data/types/type_asset.cpp
@@ -1,4 +1,5 @@
 #include "type_asset.hpp"
+
 #include "../../lua_env/interface.hpp"
 
 

--- a/src/elona/data/types/type_buff.cpp
+++ b/src/elona/data/types/type_buff.cpp
@@ -1,4 +1,5 @@
 #include "type_buff.hpp"
+
 #include "../../lua_env/enums/enums.hpp"
 
 namespace elona

--- a/src/elona/data/types/type_chara_chip.cpp
+++ b/src/elona/data/types/type_chara_chip.cpp
@@ -1,4 +1,5 @@
 #include "type_chara_chip.hpp"
+
 #include "../../lua_env/interface.hpp"
 #include "../../variables.hpp"
 

--- a/src/elona/data/types/type_character.cpp
+++ b/src/elona/data/types/type_character.cpp
@@ -1,4 +1,5 @@
 #include "type_character.hpp"
+
 #include "../../lua_env/enums/enums.hpp"
 #include "../util.hpp"
 

--- a/src/elona/data/types/type_character.hpp
+++ b/src/elona/data/types/type_character.hpp
@@ -2,6 +2,7 @@
 
 #include <unordered_map>
 #include <vector>
+
 #include "../../enums.hpp"
 #include "../../optional.hpp"
 #include "../lua_lazy_cache.hpp"

--- a/src/elona/data/types/type_item.cpp
+++ b/src/elona/data/types/type_item.cpp
@@ -1,4 +1,5 @@
 #include "type_item.hpp"
+
 #include "../../lua_env/enums/enums.hpp"
 #include "../../lua_env/lua_env.hpp"
 #include "../util.hpp"

--- a/src/elona/data/types/type_item.hpp
+++ b/src/elona/data/types/type_item.hpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <unordered_map>
+
 #include "../../enums.hpp"
 #include "../../optional.hpp"
 #include "../lua_lazy_cache.hpp"

--- a/src/elona/data/types/type_item_chip.cpp
+++ b/src/elona/data/types/type_item_chip.cpp
@@ -1,4 +1,5 @@
 #include "type_item_chip.hpp"
+
 #include "../../lua_env/interface.hpp"
 #include "../../variables.hpp"
 

--- a/src/elona/data/types/type_map.cpp
+++ b/src/elona/data/types/type_map.cpp
@@ -1,4 +1,5 @@
 #include "type_map.hpp"
+
 #include "../../lua_env/enums/enums.hpp"
 
 namespace elona

--- a/src/elona/data/types/type_map_chip.cpp
+++ b/src/elona/data/types/type_map_chip.cpp
@@ -1,4 +1,5 @@
 #include "type_map_chip.hpp"
+
 #include "../../lua_env/interface.hpp"
 #include "../../variables.hpp"
 

--- a/src/elona/data/types/type_music.cpp
+++ b/src/elona/data/types/type_music.cpp
@@ -1,4 +1,5 @@
 #include "type_music.hpp"
+
 #include "../../lua_env/interface.hpp"
 
 namespace elona

--- a/src/elona/data/types/type_portrait.cpp
+++ b/src/elona/data/types/type_portrait.cpp
@@ -1,5 +1,7 @@
 #include "type_portrait.hpp"
+
 #include <iostream>
+
 #include "../../lua_env/interface.hpp"
 
 

--- a/src/elona/data/types/type_sound.cpp
+++ b/src/elona/data/types/type_sound.cpp
@@ -1,4 +1,5 @@
 #include "type_sound.hpp"
+
 #include "../../lua_env/interface.hpp"
 
 namespace elona

--- a/src/elona/data/types/type_trait.cpp
+++ b/src/elona/data/types/type_trait.cpp
@@ -1,4 +1,5 @@
 #include "type_trait.hpp"
+
 #include "../../lua_env/enums/enums.hpp"
 
 

--- a/src/elona/data/util.hpp
+++ b/src/elona/data/util.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 #include <vector>
+
 #include "../../thirdparty/sol2/sol.hpp"
 #include "../lua_env/config_table.hpp"
 #include "../optional.hpp"

--- a/src/elona/deferred_event.cpp
+++ b/src/elona/deferred_event.cpp
@@ -1,4 +1,5 @@
 #include "deferred_event.hpp"
+
 #include "ability.hpp"
 #include "animation.hpp"
 #include "area.hpp"

--- a/src/elona/dialog.cpp
+++ b/src/elona/dialog.cpp
@@ -1,4 +1,5 @@
 #include "dialog.hpp"
+
 #include "character.hpp"
 #include "lua_env/interface.hpp"
 #include "talk.hpp"

--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -1,4 +1,5 @@
 #include "dmgheal.hpp"
+
 #include "ability.hpp"
 #include "activity.hpp"
 #include "animation.hpp"

--- a/src/elona/draw.cpp
+++ b/src/elona/draw.cpp
@@ -1,5 +1,7 @@
 #include "draw.hpp"
+
 #include <cmath>
+
 #include "../snail/application.hpp"
 #include "character.hpp"
 #include "config.hpp"

--- a/src/elona/draw.hpp
+++ b/src/elona/draw.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <vector>
+
 #include "../snail/color.hpp"
 #include "optional.hpp"
 #include "pic_loader/extent.hpp"

--- a/src/elona/dump_player_info.cpp
+++ b/src/elona/dump_player_info.cpp
@@ -1,4 +1,5 @@
 #include <sstream>
+
 #include "ability.hpp"
 #include "calc.hpp"
 #include "character.hpp"

--- a/src/elona/element.cpp
+++ b/src/elona/element.cpp
@@ -1,4 +1,5 @@
 #include "element.hpp"
+
 #include "ability.hpp"
 #include "audio.hpp"
 #include "character.hpp"

--- a/src/elona/elona.hpp
+++ b/src/elona/elona.hpp
@@ -5,6 +5,7 @@
 #include <cctype>
 #include <cmath>
 #include <cstdint>
+
 #include <algorithm>
 #include <iterator>
 #include <memory>
@@ -12,6 +13,7 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+
 #include "../snail/color.hpp"
 #include "../snail/font.hpp"
 #include "../snail/input.hpp"

--- a/src/elona/enchantment.cpp
+++ b/src/elona/enchantment.cpp
@@ -1,4 +1,5 @@
 #include "enchantment.hpp"
+
 #include "../util/range.hpp"
 #include "data/types/type_ability.hpp"
 #include "data/types/type_item.hpp"

--- a/src/elona/enchantment.hpp
+++ b/src/elona/enchantment.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+
 #include "optional.hpp"
 
 

--- a/src/elona/equipment.cpp
+++ b/src/elona/equipment.cpp
@@ -1,4 +1,5 @@
 #include "equipment.hpp"
+
 #include "adventurer.hpp"
 #include "calc.hpp"
 #include "chara_db.hpp"

--- a/src/elona/filesystem.cpp
+++ b/src/elona/filesystem.cpp
@@ -1,4 +1,5 @@
 #include "filesystem.hpp"
+
 #include "../util/strutil.hpp"
 #include "config.hpp"
 #include "defines.hpp"

--- a/src/elona/filesystem.hpp
+++ b/src/elona/filesystem.hpp
@@ -2,8 +2,8 @@
 
 #include <functional>
 #include <regex>
-#include "../util/filepathutil.hpp"
 
+#include "../util/filepathutil.hpp"
 #include "defines.hpp"
 #ifdef ELONA_OS_LINUX
 #include <dirent.h>

--- a/src/elona/fish.cpp
+++ b/src/elona/fish.cpp
@@ -1,4 +1,5 @@
 #include "fish.hpp"
+
 #include "character.hpp"
 #include "i18n.hpp"
 #include "item.hpp"

--- a/src/elona/food.cpp
+++ b/src/elona/food.cpp
@@ -1,4 +1,5 @@
 #include "food.hpp"
+
 #include "../util/strutil.hpp"
 #include "ability.hpp"
 #include "audio.hpp"

--- a/src/elona/fov.cpp
+++ b/src/elona/fov.cpp
@@ -1,4 +1,5 @@
 #include "fov.hpp"
+
 #include "character.hpp"
 #include "map.hpp"
 #include "variables.hpp"

--- a/src/elona/gdata.cpp
+++ b/src/elona/gdata.cpp
@@ -1,6 +1,8 @@
 #include "gdata.hpp"
+
 #include <iomanip>
 #include <sstream>
+
 #include "variables.hpp"
 
 

--- a/src/elona/gdata.hpp
+++ b/src/elona/gdata.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+
 #include "../version.hpp"
 
 

--- a/src/elona/god.cpp
+++ b/src/elona/god.cpp
@@ -1,5 +1,7 @@
 #include "god.hpp"
+
 #include <iostream>
+
 #include "ability.hpp"
 #include "animation.hpp"
 #include "audio.hpp"

--- a/src/elona/god.hpp
+++ b/src/elona/god.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+
 #include "data/types/type_god.hpp"
 #include "enums.hpp"
 

--- a/src/elona/hcl.hpp
+++ b/src/elona/hcl.hpp
@@ -5,7 +5,6 @@
 #define MICROHCL_MAP_TYPE tsl::ordered_map
 #define MICROHCL_MAP_ACCESSOR &it.value()
 #include "../thirdparty/microhcl/hcl.hpp"
-
 #include "filesystem.hpp"
 
 using namespace std::literals::string_literals;

--- a/src/elona/i18n.cpp
+++ b/src/elona/i18n.cpp
@@ -1,13 +1,14 @@
-#include "../thirdparty/microhil/hil.hpp"
-#include "hcl.hpp"
+#include "i18n.hpp"
 
 #include <fstream>
 #include <memory>
+
+#include "../thirdparty/microhil/hil.hpp"
 #include "config.hpp"
 #include "defines.hpp"
 #include "elona.hpp"
 #include "filesystem.hpp"
-#include "i18n.hpp"
+#include "hcl.hpp"
 #include "random.hpp"
 #include "variables.hpp"
 

--- a/src/elona/i18n.hpp
+++ b/src/elona/i18n.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+
 #include "../thirdparty/microhil/hil.hpp"
 #include "../thirdparty/sol2/sol.hpp"
 #include "../util/strutil.hpp"

--- a/src/elona/initialize_map.cpp
+++ b/src/elona/initialize_map.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+
 #include "ability.hpp"
 #include "area.hpp"
 #include "audio.hpp"

--- a/src/elona/input.cpp
+++ b/src/elona/input.cpp
@@ -1,4 +1,5 @@
 #include "input.hpp"
+
 #include "../util/strutil.hpp"
 #include "audio.hpp"
 #include "blending.hpp"

--- a/src/elona/input.hpp
+++ b/src/elona/input.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+
 #include "../snail/input.hpp"
 #include "enums.hpp"
 #include "optional.hpp"

--- a/src/elona/input_prompt.cpp
+++ b/src/elona/input_prompt.cpp
@@ -1,4 +1,5 @@
 #include "input_prompt.hpp"
+
 #include "audio.hpp"
 #include "blending.hpp"
 #include "draw.hpp"

--- a/src/elona/input_prompt.hpp
+++ b/src/elona/input_prompt.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 #include <vector>
+
 #include "../snail/input.hpp"
 #include "optional.hpp"
 

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -1,6 +1,8 @@
 #include "item.hpp"
+
 #include <iostream>
 #include <type_traits>
+
 #include "../util/strutil.hpp"
 #include "ability.hpp"
 #include "activity.hpp"

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -3,6 +3,7 @@
 #include <bitset>
 #include <memory>
 #include <vector>
+
 #include "../util/range.hpp"
 #include "consts.hpp"
 #include "data/types/type_item.hpp"

--- a/src/elona/item_db.cpp
+++ b/src/elona/item_db.cpp
@@ -1,4 +1,5 @@
 #include <unordered_map>
+
 #include "character.hpp"
 #include "data/types/type_item.hpp"
 #include "elona.hpp"

--- a/src/elona/itemgen.cpp
+++ b/src/elona/itemgen.cpp
@@ -1,4 +1,5 @@
 #include "itemgen.hpp"
+
 #include "ability.hpp"
 #include "calc.hpp"
 #include "character.hpp"

--- a/src/elona/json5util.hpp
+++ b/src/elona/json5util.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <iostream>
+
 #include "../thirdparty/json5/json5.hpp"
 #include "../util/either.hpp"
 

--- a/src/elona/keybind/input_context.cpp
+++ b/src/elona/keybind/input_context.cpp
@@ -1,4 +1,5 @@
 #include "input_context.hpp"
+
 #include "../../util/range.hpp"
 #include "../audio.hpp"
 #include "../config.hpp"

--- a/src/elona/keybind/key_names.cpp
+++ b/src/elona/keybind/key_names.cpp
@@ -1,4 +1,5 @@
 #include <unordered_map>
+
 #include "../../snail/input.hpp"
 #include "../../util/strutil.hpp"
 #include "../optional.hpp"

--- a/src/elona/keybind/keybind.cpp
+++ b/src/elona/keybind/keybind.cpp
@@ -1,4 +1,5 @@
 #include "keybind.hpp"
+
 #include "../../util/strutil.hpp"
 #include "../enums.hpp"
 #include "../gdata.hpp"

--- a/src/elona/keybind/keybind.hpp
+++ b/src/elona/keybind/keybind.hpp
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
 #include "../../snail/input.hpp"
 #include "../../thirdparty/ordered_map/ordered_map.h"
 #include "../enums.hpp"

--- a/src/elona/keybind/keybind_deserializer.cpp
+++ b/src/elona/keybind/keybind_deserializer.cpp
@@ -1,6 +1,8 @@
 #include "keybind_deserializer.hpp"
+
 #include <iostream>
 #include <string>
+
 #include "keybind.hpp"
 #include "keybind_manager.hpp"
 

--- a/src/elona/keybind/keybind_deserializer.hpp
+++ b/src/elona/keybind/keybind_deserializer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <iosfwd>
+
 #include "../../snail/input.hpp"
 #include "../../thirdparty/json5/json5.hpp"
 #include "../optional.hpp"

--- a/src/elona/keybind/keybind_manager.cpp
+++ b/src/elona/keybind/keybind_manager.cpp
@@ -1,4 +1,5 @@
 #include "keybind_manager.hpp"
+
 #include "../../util/strutil.hpp"
 #include "../filesystem.hpp"
 #include "../variables.hpp"

--- a/src/elona/keybind/keybind_serializer.cpp
+++ b/src/elona/keybind/keybind_serializer.cpp
@@ -1,5 +1,7 @@
 #include "keybind_serializer.hpp"
+
 #include <iostream>
+
 #include "../../thirdparty/json5/json5.hpp"
 #include "keybind.hpp"
 #include "keybind_manager.hpp"

--- a/src/elona/keybind/keybind_serializer.hpp
+++ b/src/elona/keybind/keybind_serializer.hpp
@@ -2,6 +2,7 @@
 
 #include <iosfwd>
 #include <string>
+
 #include "../optional.hpp"
 
 

--- a/src/elona/loading_screen.cpp
+++ b/src/elona/loading_screen.cpp
@@ -1,4 +1,5 @@
 #include "loading_screen.hpp"
+
 #include "../snail/application.hpp"
 #include "variables.hpp"
 

--- a/src/elona/log.cpp
+++ b/src/elona/log.cpp
@@ -1,5 +1,7 @@
 #include "log.hpp"
+
 #include <iomanip>
+
 #include "filesystem.hpp"
 
 

--- a/src/elona/log.hpp
+++ b/src/elona/log.hpp
@@ -18,10 +18,12 @@
  */
 
 #include <cassert>
+
 #include <chrono>
 #include <fstream>
 #include <iostream>
 #include <type_traits>
+
 #include "../util/noncopyable.hpp"
 
 

--- a/src/elona/lua_env/api_manager.cpp
+++ b/src/elona/lua_env/api_manager.cpp
@@ -1,5 +1,7 @@
 #include "api_manager.hpp"
+
 #include <iterator>
+
 #include "../../util/strutil.hpp"
 #include "enums/enums.hpp"
 #include "lua_api/lua_api.hpp"

--- a/src/elona/lua_env/config_manager.cpp
+++ b/src/elona/lua_env/config_manager.cpp
@@ -1,4 +1,5 @@
 #include "config_manager.hpp"
+
 #include "../filesystem.hpp"
 #include "lua_api/lua_api_json5.hpp"
 

--- a/src/elona/lua_env/console.cpp
+++ b/src/elona/lua_env/console.cpp
@@ -2,7 +2,9 @@
 
 #include <regex>
 #include <sstream>
+
 #include <boost/algorithm/string/predicate.hpp>
+
 #include "../../snail/application.hpp"
 #include "../../snail/blend_mode.hpp"
 #include "../../snail/input.hpp"

--- a/src/elona/lua_env/console.hpp
+++ b/src/elona/lua_env/console.hpp
@@ -3,7 +3,9 @@
 #include <queue>
 #include <string>
 #include <vector>
+
 #include <boost/circular_buffer.hpp>
+
 #include "../../thirdparty/sol2/sol.hpp"
 #include "../optional.hpp"
 #include "lua_submodule.hpp"

--- a/src/elona/lua_env/data_manager.cpp
+++ b/src/elona/lua_env/data_manager.cpp
@@ -1,4 +1,5 @@
 #include "data_manager.hpp"
+
 #include "../../util/natural_order_comparator.hpp"
 #include "../log.hpp"
 #include "api_manager.hpp"

--- a/src/elona/lua_env/data_manager.hpp
+++ b/src/elona/lua_env/data_manager.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <vector>
+
 #include "../filesystem.hpp"
 #include "data_table.hpp"
 #include "lua_submodule.hpp"

--- a/src/elona/lua_env/data_table.hpp
+++ b/src/elona/lua_env/data_table.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+
 #include "../../thirdparty/sol2/sol.hpp"
 #include "../optional.hpp"
 

--- a/src/elona/lua_env/event_manager.cpp
+++ b/src/elona/lua_env/event_manager.cpp
@@ -1,4 +1,5 @@
 #include "event_manager.hpp"
+
 #include "../log.hpp"
 #include "api_manager.hpp"
 #include "data_manager.hpp"

--- a/src/elona/lua_env/event_manager.hpp
+++ b/src/elona/lua_env/event_manager.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+
 #include "config_table.hpp"
 #include "lua_submodule.hpp"
 

--- a/src/elona/lua_env/export_manager.cpp
+++ b/src/elona/lua_env/export_manager.cpp
@@ -1,4 +1,5 @@
 #include "export_manager.hpp"
+
 #include "api_manager.hpp"
 
 

--- a/src/elona/lua_env/export_manager.hpp
+++ b/src/elona/lua_env/export_manager.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+
 #include "../enums.hpp"
 #include "../filesystem.hpp"
 #include "../message.hpp"

--- a/src/elona/lua_env/handle_manager.cpp
+++ b/src/elona/lua_env/handle_manager.cpp
@@ -1,6 +1,9 @@
 #include "handle_manager.hpp"
+
 #include <cassert>
+
 #include <set>
+
 #include "../character.hpp"
 #include "../config.hpp"
 #include "../item.hpp"

--- a/src/elona/lua_env/handle_manager.hpp
+++ b/src/elona/lua_env/handle_manager.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <set>
+
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
+
 #include "../../util/noncopyable.hpp"
 #include "lua_submodule.hpp"
 

--- a/src/elona/lua_env/i18n_function_manager.cpp
+++ b/src/elona/lua_env/i18n_function_manager.cpp
@@ -1,4 +1,5 @@
 #include "i18n_function_manager.hpp"
+
 #include "../config.hpp"
 #include "lua_env.hpp"
 

--- a/src/elona/lua_env/interface.cpp
+++ b/src/elona/lua_env/interface.cpp
@@ -1,4 +1,5 @@
 #include "interface.hpp"
+
 #include "config_table.hpp"
 #include "data_manager.hpp"
 #include "mod_manager.hpp"

--- a/src/elona/lua_env/loaded_chunk_cache.hpp
+++ b/src/elona/lua_env/loaded_chunk_cache.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <unordered_map>
+
 #include "../../thirdparty/sol2/sol.hpp"
 #include "../filesystem.hpp"
 

--- a/src/elona/lua_env/lua_api/lua_api.hpp
+++ b/src/elona/lua_env/lua_api/lua_api.hpp
@@ -1,9 +1,8 @@
 #pragma once
-#include "lua_api_common.hpp"
-
 #include "lua_api_animation.hpp"
 #include "lua_api_calc.hpp"
 #include "lua_api_chara.hpp"
+#include "lua_api_common.hpp"
 #include "lua_api_config.hpp"
 #include "lua_api_console.hpp"
 #include "lua_api_data.hpp"

--- a/src/elona/lua_env/lua_api/lua_api_animation.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_animation.cpp
@@ -1,4 +1,5 @@
 #include "lua_api_animation.hpp"
+
 #include "../../animation.hpp"
 #include "../../lua_env/enums/enums.hpp"
 

--- a/src/elona/lua_env/lua_api/lua_api_calc.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_calc.cpp
@@ -1,4 +1,5 @@
 #include "lua_api_calc.hpp"
+
 #include "../../calc.hpp"
 
 

--- a/src/elona/lua_env/lua_api/lua_api_chara.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_chara.cpp
@@ -1,4 +1,5 @@
 #include "lua_api_chara.hpp"
+
 #include "../../character.hpp"
 #include "../../lua_env/enums/enums.hpp"
 #include "../../lua_env/interface.hpp"

--- a/src/elona/lua_env/lua_api/lua_api_chara.hpp
+++ b/src/elona/lua_env/lua_api/lua_api_chara.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+
 #include "lua_api_common.hpp"
 
 namespace elona

--- a/src/elona/lua_env/lua_api/lua_api_config.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_config.cpp
@@ -1,4 +1,5 @@
 #include "lua_api_config.hpp"
+
 #include "../../config.hpp"
 #include "../config_manager.hpp"
 

--- a/src/elona/lua_env/lua_api/lua_api_console.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_console.cpp
@@ -1,4 +1,5 @@
 #include "lua_api_console.hpp"
+
 #include "../console.hpp"
 #include "../lua_env.hpp"
 

--- a/src/elona/lua_env/lua_api/lua_api_data.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_data.cpp
@@ -1,4 +1,5 @@
 #include "lua_api_data.hpp"
+
 #include "../../data/types/type_character.hpp"
 #include "../../draw.hpp"
 #include "../data_manager.hpp"

--- a/src/elona/lua_env/lua_api/lua_api_debug.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_debug.cpp
@@ -1,5 +1,7 @@
 #include "lua_api_debug.hpp"
+
 #include <sstream>
+
 #include "../../character.hpp"
 #include "../../enums.hpp"
 #include "../../item.hpp"

--- a/src/elona/lua_env/lua_api/lua_api_debug.hpp
+++ b/src/elona/lua_env/lua_api/lua_api_debug.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+
 #include "lua_api_common.hpp"
 
 namespace elona

--- a/src/elona/lua_env/lua_api/lua_api_env.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_env.cpp
@@ -1,4 +1,5 @@
 #include "lua_api_env.hpp"
+
 #include "../../../version.hpp"
 
 

--- a/src/elona/lua_env/lua_api/lua_api_env.hpp
+++ b/src/elona/lua_env/lua_api/lua_api_env.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+
 #include "lua_api_common.hpp"
 
 

--- a/src/elona/lua_env/lua_api/lua_api_fov.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_fov.cpp
@@ -1,4 +1,5 @@
 #include "lua_api_fov.hpp"
+
 #include "../../fov.hpp"
 #include "../../ui.hpp"
 #include "../api_manager.hpp"

--- a/src/elona/lua_env/lua_api/lua_api_gui.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_gui.cpp
@@ -1,4 +1,5 @@
 #include "lua_api_gui.hpp"
+
 #include "../../audio.hpp"
 #include "../../lua_env/enums/enums.hpp"
 #include "../../message.hpp"

--- a/src/elona/lua_env/lua_api/lua_api_i18n.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_i18n.cpp
@@ -1,4 +1,5 @@
 #include "lua_api_i18n.hpp"
+
 #include "../../i18n.hpp"
 
 namespace elona

--- a/src/elona/lua_env/lua_api/lua_api_input.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_input.cpp
@@ -1,4 +1,5 @@
 #include "lua_api_input.hpp"
+
 #include "../../dialog.hpp"
 #include "../../i18n.hpp"
 #include "../../input.hpp"

--- a/src/elona/lua_env/lua_api/lua_api_internal.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_internal.cpp
@@ -1,4 +1,5 @@
 #include "lua_api_internal.hpp"
+
 #include "../../audio.hpp"
 #include "../../calc.hpp"
 #include "../../character.hpp"

--- a/src/elona/lua_env/lua_api/lua_api_item.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_item.cpp
@@ -1,4 +1,5 @@
 #include "lua_api_item.hpp"
+
 #include "../../calc.hpp"
 #include "../../character.hpp"
 #include "../../data/types/type_item.hpp"

--- a/src/elona/lua_env/lua_api/lua_api_json5.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_json5.cpp
@@ -1,4 +1,5 @@
 #include "lua_api_json5.hpp"
+
 #include "../../../thirdparty/json5/json5.hpp"
 
 
@@ -16,8 +17,7 @@ json5::value to_json5_value(sol::object value)
     switch (value.get_type())
     {
     case sol::type::lua_nil: return nullptr;
-    case sol::type::number:
-    {
+    case sol::type::number: {
         // TODO integer / float
         int64_t i = value.as<int64_t>();
         double f = value.as<double>();
@@ -32,8 +32,7 @@ json5::value to_json5_value(sol::object value)
     }
     case sol::type::boolean: return value.as<bool>();
     case sol::type::string: return value.as<std::string>();
-    case sol::type::table:
-    {
+    case sol::type::table: {
         sol::table t = value;
         if (t.size() == 0)
         {
@@ -74,8 +73,7 @@ sol::object to_lua_value(const json5::value& value, sol::state_view lua)
         return sol::make_object(lua, value.get_integer());
     case json5::value_type::string:
         return sol::make_object(lua, value.get_string());
-    case json5::value_type::array:
-    {
+    case json5::value_type::array: {
         sol::table t{lua, sol::create};
         for (const auto& item : value.get_array())
         {
@@ -83,8 +81,7 @@ sol::object to_lua_value(const json5::value& value, sol::state_view lua)
         }
         return t;
     }
-    case json5::value_type::object:
-    {
+    case json5::value_type::object: {
         sol::table t{lua, sol::create};
         for (const auto& kvp : value.get_object())
         {

--- a/src/elona/lua_env/lua_api/lua_api_magic.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_magic.cpp
@@ -1,4 +1,5 @@
 #include "lua_api_magic.hpp"
+
 #include "../../character.hpp"
 #include "../../magic.hpp"
 #include "../handle_manager.hpp"

--- a/src/elona/lua_env/lua_api/lua_api_map.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_map.cpp
@@ -1,4 +1,5 @@
 #include "lua_api_map.hpp"
+
 #include "../../area.hpp"
 #include "../../character.hpp"
 #include "../../data/types/type_map.hpp"

--- a/src/elona/lua_env/lua_api/lua_api_pos.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_pos.cpp
@@ -1,4 +1,5 @@
 #include "lua_api_pos.hpp"
+
 #include "../../position.hpp"
 
 namespace elona

--- a/src/elona/lua_env/lua_api/lua_api_skill.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_skill.cpp
@@ -1,4 +1,5 @@
 #include "lua_api_skill.hpp"
+
 #include "../../ability.hpp"
 #include "../../character.hpp"
 #include "../enums/enums.hpp"

--- a/src/elona/lua_env/lua_api/lua_api_trait.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_trait.cpp
@@ -1,4 +1,5 @@
 #include "lua_api_trait.hpp"
+
 #include "../../audio.hpp"
 #include "../../character.hpp"
 #include "../../message.hpp"

--- a/src/elona/lua_env/lua_api/lua_api_wish.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_wish.cpp
@@ -1,4 +1,5 @@
 #include "lua_api_wish.hpp"
+
 #include "../../wish.hpp"
 #include "../enums/enums.hpp"
 

--- a/src/elona/lua_env/lua_api/lua_api_world.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_world.cpp
@@ -1,4 +1,5 @@
 #include "lua_api_world.hpp"
+
 #include "../../deferred_event.hpp"
 #include "../../gdata.hpp"
 

--- a/src/elona/lua_env/lua_class/lua_class_ability.cpp
+++ b/src/elona/lua_env/lua_class/lua_class_ability.cpp
@@ -1,4 +1,5 @@
 #include "lua_class_ability.hpp"
+
 #include "../../ability.hpp"
 
 namespace elona

--- a/src/elona/lua_env/lua_class/lua_class_area.cpp
+++ b/src/elona/lua_env/lua_class/lua_class_area.cpp
@@ -1,4 +1,5 @@
 #include "lua_class_area.hpp"
+
 #include "../../area.hpp"
 #include "../../map.hpp"
 

--- a/src/elona/lua_env/lua_class/lua_class_character.cpp
+++ b/src/elona/lua_env/lua_class/lua_class_character.cpp
@@ -1,4 +1,5 @@
 #include "lua_class_character.hpp"
+
 #include "../../ability.hpp"
 #include "../../buff.hpp"
 #include "../../character.hpp"

--- a/src/elona/lua_env/lua_class/lua_class_date_time.cpp
+++ b/src/elona/lua_env/lua_class/lua_class_date_time.cpp
@@ -1,4 +1,5 @@
 #include "lua_class_date_time.hpp"
+
 #include "../../gdata.hpp"
 #include "../../map.hpp"
 

--- a/src/elona/lua_env/lua_class/lua_class_item.cpp
+++ b/src/elona/lua_env/lua_class/lua_class_item.cpp
@@ -1,4 +1,5 @@
 #include "lua_class_item.hpp"
+
 #include "../../data/types/type_item.hpp"
 #include "../../data/types/type_item_material.hpp"
 #include "../../item.hpp"

--- a/src/elona/lua_env/lua_class/lua_class_map_data.cpp
+++ b/src/elona/lua_env/lua_class/lua_class_map_data.cpp
@@ -1,4 +1,5 @@
 #include "lua_class_map_data.hpp"
+
 #include "../../data/types/type_music.hpp"
 #include "../../lua_env/enums/enums.hpp"
 #include "../../map.hpp"

--- a/src/elona/lua_env/lua_class/lua_class_map_generator.cpp
+++ b/src/elona/lua_env/lua_class/lua_class_map_generator.cpp
@@ -1,4 +1,5 @@
 #include "lua_class_map_generator.hpp"
+
 #include "../../area.hpp"
 #include "../../lua_env/enums/enums.hpp"
 #include "../../map.hpp"

--- a/src/elona/lua_env/lua_class/lua_class_position.cpp
+++ b/src/elona/lua_env/lua_class/lua_class_position.cpp
@@ -1,5 +1,7 @@
 #include "lua_class_position.hpp"
+
 #include <sstream>
+
 #include "../../position.hpp"
 
 

--- a/src/elona/lua_env/lua_enums.hpp
+++ b/src/elona/lua_env/lua_enums.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 #include <unordered_map>
+
 #include "../../thirdparty/sol2/sol.hpp"
 #include "../log.hpp"
 #include "../optional.hpp"

--- a/src/elona/lua_env/mod_manager.cpp
+++ b/src/elona/lua_env/mod_manager.cpp
@@ -1,8 +1,10 @@
 #include "mod_manager.hpp"
+
 #include <map>
 #include <sstream>
 #include <unordered_set>
 #include <vector>
+
 #include "../../util/range.hpp"
 #include "../character.hpp"
 #include "../config.hpp"

--- a/src/elona/lua_env/mod_manifest.cpp
+++ b/src/elona/lua_env/mod_manifest.cpp
@@ -1,4 +1,5 @@
 #include "mod_manifest.hpp"
+
 #include "../../thirdparty/json5/json5.hpp"
 
 

--- a/src/elona/lua_env/mod_manifest.hpp
+++ b/src/elona/lua_env/mod_manifest.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <unordered_map>
+
 #include "../filesystem.hpp"
 #include "../optional.hpp"
 #include "../semver.hpp"

--- a/src/elona/lua_env/mod_serializer.cpp
+++ b/src/elona/lua_env/mod_serializer.cpp
@@ -1,4 +1,5 @@
 #include "mod_serializer.hpp"
+
 #include "../character.hpp"
 #include "../item.hpp"
 

--- a/src/elona/lua_env/mod_version_resolver.cpp
+++ b/src/elona/lua_env/mod_version_resolver.cpp
@@ -1,4 +1,5 @@
 #include "mod_version_resolver.hpp"
+
 #include "../../util/topological_sorter.hpp"
 #include "../json5util.hpp"
 #include "../log.hpp"

--- a/src/elona/lua_env/mod_version_resolver.hpp
+++ b/src/elona/lua_env/mod_version_resolver.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <unordered_map>
+
 #include "../filesystem.hpp"
 #include "../semver.hpp"
 

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -1,4 +1,5 @@
 #include <stack>
+
 #include "../util/scope_guard.hpp"
 #include "ability.hpp"
 #include "activity.hpp"
@@ -3838,8 +3839,7 @@ optional<bool> _proc_general_magic()
             .play();
         try_to_melee_attack();
         return true;
-    case 1:
-    {
+    case 1: {
         int stat =
             get_route(cdata[cc].position.x, cdata[cc].position.y, tlocx, tlocy);
         if (stat == 0)

--- a/src/elona/main.cpp
+++ b/src/elona/main.cpp
@@ -1,4 +1,5 @@
 #include "main.hpp"
+
 #include "../util/tinyargparser.hpp"
 #include "config.hpp"
 #include "init.hpp"

--- a/src/elona/main_menu.cpp
+++ b/src/elona/main_menu.cpp
@@ -1,4 +1,5 @@
 #include "main_menu.hpp"
+
 #include "../util/fileutil.hpp"
 #include "../util/strutil.hpp"
 #include "../version.hpp"

--- a/src/elona/map.cpp
+++ b/src/elona/map.cpp
@@ -1,4 +1,5 @@
 #include "map.hpp"
+
 #include "area.hpp"
 #include "building.hpp"
 #include "calc.hpp"

--- a/src/elona/map.hpp
+++ b/src/elona/map.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+
 #include "data/types/type_map_chip.hpp"
 #include "pic_loader/extent.hpp"
 #include "shared_id.hpp"

--- a/src/elona/map_cell.cpp
+++ b/src/elona/map_cell.cpp
@@ -1,4 +1,5 @@
 #include "map_cell.hpp"
+
 #include "character.hpp"
 #include "elona.hpp"
 #include "item.hpp"

--- a/src/elona/mapgen.cpp
+++ b/src/elona/mapgen.cpp
@@ -1,4 +1,5 @@
 #include "mapgen.hpp"
+
 #include "area.hpp"
 #include "calc.hpp"
 #include "character.hpp"

--- a/src/elona/mef.cpp
+++ b/src/elona/mef.cpp
@@ -1,4 +1,5 @@
 #include "mef.hpp"
+
 #include "ability.hpp"
 #include "audio.hpp"
 #include "character.hpp"

--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -1,6 +1,8 @@
 #include "menu.hpp"
+
 #include <iostream>
 #include <stack>
+
 #include "ability.hpp"
 #include "audio.hpp"
 #include "buff.hpp"
@@ -31,12 +33,13 @@
 #include "random.hpp"
 #include "trait.hpp"
 #include "ui.hpp"
-#include "variables.hpp"
-
 #include "ui/ui_menu_adventurers.hpp"
 #include "ui/ui_menu_alias.hpp"
 #include "ui/ui_menu_book.hpp"
 #include "ui/ui_menu_character_sheet.hpp"
+#include "ui/ui_menu_composite_character.hpp"
+#include "ui/ui_menu_composite_message.hpp"
+#include "ui/ui_menu_composite_town.hpp"
 #include "ui/ui_menu_ctrl_ally.hpp"
 #include "ui/ui_menu_feats.hpp"
 #include "ui/ui_menu_game_help.hpp"
@@ -50,10 +53,7 @@
 #include "ui/ui_menu_spell_writer.hpp"
 #include "ui/ui_menu_spells.hpp"
 #include "ui/ui_menu_voting_box.hpp"
-
-#include "ui/ui_menu_composite_character.hpp"
-#include "ui/ui_menu_composite_message.hpp"
-#include "ui/ui_menu_composite_town.hpp"
+#include "variables.hpp"
 
 
 

--- a/src/elona/menu.hpp
+++ b/src/elona/menu.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+
 #include "optional.hpp"
 
 namespace elona

--- a/src/elona/message.cpp
+++ b/src/elona/message.cpp
@@ -1,7 +1,10 @@
 #include "message.hpp"
+
 #include <ctype.h>
+
 #include <iomanip>
 #include <sstream>
+
 #include "../util/range.hpp"
 #include "../util/strutil.hpp"
 #include "audio.hpp"

--- a/src/elona/message.hpp
+++ b/src/elona/message.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+
 #include "../snail/color.hpp"
 #include "../util/namedparam.hpp"
 

--- a/src/elona/message_log.hpp
+++ b/src/elona/message_log.hpp
@@ -3,6 +3,7 @@
 #include <deque>
 #include <string>
 #include <vector>
+
 #include "../snail/color.hpp"
 
 

--- a/src/elona/net.cpp
+++ b/src/elona/net.cpp
@@ -1,6 +1,8 @@
 #include "net.hpp"
+
 #include <chrono>
 #include <sstream>
+
 #include "../spider/http.hpp"
 #include "../thirdparty/json5/json5.hpp"
 #include "../thirdparty/xxHash/xxhashcpp.hpp"

--- a/src/elona/optional.hpp
+++ b/src/elona/optional.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+
 #include <boost/optional.hpp>
 
 

--- a/src/elona/pic_loader/pic_loader.cpp
+++ b/src/elona/pic_loader/pic_loader.cpp
@@ -1,4 +1,5 @@
 #include "pic_loader.hpp"
+
 #include "../../snail/application.hpp"
 #include "../../snail/color.hpp"
 #include "../elona.hpp"

--- a/src/elona/pic_loader/pic_loader.hpp
+++ b/src/elona/pic_loader/pic_loader.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <cassert>
 #include <climits>
+
 #include "../../snail/image.hpp"
 #include "../../thirdparty/ordered_map/ordered_map.h"
 #include "../../util/noncopyable.hpp"

--- a/src/elona/pic_loader/tinted_buffers.cpp
+++ b/src/elona/pic_loader/tinted_buffers.cpp
@@ -1,5 +1,7 @@
 #include "tinted_buffers.hpp"
+
 #include <iostream>
+
 #include "../draw.hpp"
 #include "../elona.hpp"
 #include "pic_loader.hpp"

--- a/src/elona/pic_loader/tinted_buffers.hpp
+++ b/src/elona/pic_loader/tinted_buffers.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <unordered_map>
+
 #include "../../snail/color.hpp"
 #include "../optional.hpp"
 

--- a/src/elona/profile/profile.hpp
+++ b/src/elona/profile/profile.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+
 #include "../filesystem.hpp"
 
 

--- a/src/elona/profile/profile_manager.cpp
+++ b/src/elona/profile/profile_manager.cpp
@@ -1,4 +1,5 @@
 #include "profile_manager.hpp"
+
 #include "../filesystem.hpp"
 #include "../log.hpp"
 

--- a/src/elona/quest.cpp
+++ b/src/elona/quest.cpp
@@ -1,4 +1,5 @@
 #include "quest.hpp"
+
 #include "ability.hpp"
 #include "activity.hpp"
 #include "area.hpp"

--- a/src/elona/race.cpp
+++ b/src/elona/race.cpp
@@ -1,4 +1,5 @@
 #include "race.hpp"
+
 #include "ability.hpp"
 #include "character.hpp"
 #include "elona.hpp"

--- a/src/elona/race.hpp
+++ b/src/elona/race.hpp
@@ -3,6 +3,7 @@
 #include <functional>
 #include <string>
 #include <vector>
+
 #include "data/types/type_race.hpp"
 
 

--- a/src/elona/random.cpp
+++ b/src/elona/random.cpp
@@ -1,4 +1,5 @@
 #include "random.hpp"
+
 #include "gdata.hpp"
 
 

--- a/src/elona/random.hpp
+++ b/src/elona/random.hpp
@@ -5,6 +5,7 @@
 #include <type_traits>
 #include <utility>
 #include <vector>
+
 #include "../thirdparty/xoshiro256//xoshiro256.hpp"
 #include "optional.hpp"
 

--- a/src/elona/random_event.cpp
+++ b/src/elona/random_event.cpp
@@ -1,5 +1,7 @@
 #include "random_event.hpp"
+
 #include <cassert>
+
 #include "ability.hpp"
 #include "audio.hpp"
 #include "buff.hpp"

--- a/src/elona/save.cpp
+++ b/src/elona/save.cpp
@@ -1,4 +1,5 @@
 #include "save.hpp"
+
 #include "audio.hpp"
 #include "character_status.hpp"
 #include "config.hpp"

--- a/src/elona/save_update.cpp
+++ b/src/elona/save_update.cpp
@@ -1,4 +1,5 @@
 #include "save_update.hpp"
+
 #include "../util/fileutil.hpp"
 #include "../util/strutil.hpp"
 #include "character.hpp"

--- a/src/elona/shop.cpp
+++ b/src/elona/shop.cpp
@@ -1,4 +1,5 @@
 #include "shop.hpp"
+
 #include "ability.hpp"
 #include "calc.hpp"
 #include "character.hpp"

--- a/src/elona/status_ailment.cpp
+++ b/src/elona/status_ailment.cpp
@@ -1,4 +1,5 @@
 #include "status_ailment.hpp"
+
 #include "ability.hpp"
 #include "activity.hpp"
 #include "buff.hpp"

--- a/src/elona/talk.cpp
+++ b/src/elona/talk.cpp
@@ -1,4 +1,5 @@
 #include "talk.hpp"
+
 #include "audio.hpp"
 #include "calc.hpp"
 #include "character.hpp"

--- a/src/elona/talk.hpp
+++ b/src/elona/talk.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+
 #include "optional.hpp"
 
 namespace elona

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -2251,8 +2251,7 @@ TalkResult talk_npc()
     case 54: return talk_shop_reload_ammo();
     case 55: return talk_spell_writer_reserve();
     case 56: return talk_sex();
-    case 58:
-    {
+    case 58: {
         if (game_data.left_turns_of_timestop == 0)
         {
             event_add(25);

--- a/src/elona/tcg.cpp
+++ b/src/elona/tcg.cpp
@@ -1,4 +1,5 @@
 #include "tcg.hpp"
+
 #include "audio.hpp"
 #include "config.hpp"
 #include "ctrl_file.hpp"

--- a/src/elona/text.cpp
+++ b/src/elona/text.cpp
@@ -1,4 +1,5 @@
 #include "text.hpp"
+
 #include "../util/fileutil.hpp"
 #include "../util/strutil.hpp"
 #include "area.hpp"

--- a/src/elona/trait.cpp
+++ b/src/elona/trait.cpp
@@ -1,4 +1,5 @@
 #include "trait.hpp"
+
 #include "../util/range.hpp"
 #include "ability.hpp"
 #include "character.hpp"

--- a/src/elona/turn_sequence.cpp
+++ b/src/elona/turn_sequence.cpp
@@ -1,4 +1,5 @@
 #include "turn_sequence.hpp"
+
 #include "ability.hpp"
 #include "activity.hpp"
 #include "ai.hpp"

--- a/src/elona/turn_sequence_pc_actions.cpp
+++ b/src/elona/turn_sequence_pc_actions.cpp
@@ -1,4 +1,5 @@
 #include <chrono>
+
 #include "../snail/application.hpp"
 #include "../snail/surface.hpp"
 #include "ability.hpp"

--- a/src/elona/ui.cpp
+++ b/src/elona/ui.cpp
@@ -1,4 +1,5 @@
 #include "ui.hpp"
+
 #include "../util/strutil.hpp"
 #include "ability.hpp"
 #include "audio.hpp"
@@ -616,19 +617,27 @@ void render_digital_clock()
 {
     // 24 hour digital clock, 57 pixels wide
     font(16 - en * 2);
-    bmes(""s + game_data.date.hour + u8":"s + game_data.date.minute + u8":"s + game_data.date.second,
-         8, 8);
+    bmes(
+        ""s + game_data.date.hour + u8":"s + game_data.date.minute + u8":"s +
+            game_data.date.second,
+        8,
+        8);
 
     // date, 64 pixel wide
     font(15 - en * 2);
     int datex = 8 + 57 + 18;
-    bmes(""s + game_data.date.year + u8"/"s + game_data.date.month + u8"/"s + game_data.date.day,
-         datex, 8);
+    bmes(
+        ""s + game_data.date.year + u8"/"s + game_data.date.month + u8"/"s +
+            game_data.date.day,
+        datex,
+        8);
 
     // time of day + weather
-    bmes(i18n::s.get_enum("core.ui.time", game_data.date.hour / 4) + u8" "s +
+    bmes(
+        i18n::s.get_enum("core.ui.time", game_data.date.hour / 4) + u8" "s +
             i18n::s.get_enum("core.ui.weather", game_data.weather),
-         datex + 64 + 12, 8);
+        datex + 64 + 12,
+        8);
 }
 
 

--- a/src/elona/ui.hpp
+++ b/src/elona/ui.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+
 #include "../snail/application.hpp"
 
 namespace elona

--- a/src/elona/ui/menu_cursor_history.hpp
+++ b/src/elona/ui/menu_cursor_history.hpp
@@ -2,6 +2,7 @@
 
 #include <stack>
 #include <unordered_map>
+
 #include "../optional.hpp"
 
 

--- a/src/elona/ui/simple_prompt.hpp
+++ b/src/elona/ui/simple_prompt.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+
 #include "../audio.hpp"
 #include "../input.hpp"
 #include "../variables.hpp"

--- a/src/elona/ui/ui_menu.hpp
+++ b/src/elona/ui/ui_menu.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+
 #include "../config.hpp"
 #include "../input.hpp"
 #include "../optional.hpp"

--- a/src/elona/ui/ui_menu_adventurers.cpp
+++ b/src/elona/ui/ui_menu_adventurers.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_adventurers.hpp"
+
 #include "../audio.hpp"
 #include "../character.hpp"
 #include "../draw.hpp"

--- a/src/elona/ui/ui_menu_alias.cpp
+++ b/src/elona/ui/ui_menu_alias.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_alias.hpp"
+
 #include "../audio.hpp"
 #include "../draw.hpp"
 #include "../i18n.hpp"

--- a/src/elona/ui/ui_menu_book.cpp
+++ b/src/elona/ui/ui_menu_book.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_book.hpp"
+
 #include "../audio.hpp"
 #include "../data/types/type_asset.hpp"
 #include "../draw.hpp"

--- a/src/elona/ui/ui_menu_character_sheet.cpp
+++ b/src/elona/ui/ui_menu_character_sheet.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_character_sheet.hpp"
+
 #include "../ability.hpp"
 #include "../audio.hpp"
 #include "../buff.hpp"

--- a/src/elona/ui/ui_menu_charamake_alias.cpp
+++ b/src/elona/ui/ui_menu_charamake_alias.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_charamake_alias.hpp"
+
 #include "../audio.hpp"
 #include "../character_making.hpp"
 #include "../draw.hpp"

--- a/src/elona/ui/ui_menu_charamake_attributes.cpp
+++ b/src/elona/ui/ui_menu_charamake_attributes.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_charamake_attributes.hpp"
+
 #include "../ability.hpp"
 #include "../audio.hpp"
 #include "../character_making.hpp"

--- a/src/elona/ui/ui_menu_charamake_class.cpp
+++ b/src/elona/ui/ui_menu_charamake_class.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_charamake_class.hpp"
+
 #include "../audio.hpp"
 #include "../character_making.hpp"
 #include "../class.hpp"

--- a/src/elona/ui/ui_menu_charamake_gender.cpp
+++ b/src/elona/ui/ui_menu_charamake_gender.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_charamake_gender.hpp"
+
 #include "../audio.hpp"
 #include "../character_making.hpp"
 #include "../draw.hpp"

--- a/src/elona/ui/ui_menu_charamake_race.cpp
+++ b/src/elona/ui/ui_menu_charamake_race.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_charamake_race.hpp"
+
 #include "../audio.hpp"
 #include "../character_making.hpp"
 #include "../draw.hpp"

--- a/src/elona/ui/ui_menu_chat_history.cpp
+++ b/src/elona/ui/ui_menu_chat_history.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_chat_history.hpp"
+
 #include "../audio.hpp"
 #include "../draw.hpp"
 #include "../i18n.hpp"

--- a/src/elona/ui/ui_menu_composite.hpp
+++ b/src/elona/ui/ui_menu_composite.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <vector>
+
 #include "../audio.hpp"
 #include "../draw.hpp"
 #include "../i18n.hpp"

--- a/src/elona/ui/ui_menu_composite_character.cpp
+++ b/src/elona/ui/ui_menu_composite_character.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_composite_character.hpp"
+
 #include "../menu.hpp"
 #include "ui_menu_character_sheet.hpp"
 #include "ui_menu_equipment.hpp"

--- a/src/elona/ui/ui_menu_composite_character.hpp
+++ b/src/elona/ui/ui_menu_composite_character.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <boost/variant.hpp>
 #include <boost/variant/get.hpp>
+
 #include "ui_menu_composite.hpp"
 
 namespace elona

--- a/src/elona/ui/ui_menu_composite_message.cpp
+++ b/src/elona/ui/ui_menu_composite_message.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_composite_message.hpp"
+
 #include "ui_menu_chat_history.hpp"
 #include "ui_menu_journal.hpp"
 #include "ui_menu_message_log.hpp"

--- a/src/elona/ui/ui_menu_composite_skills.cpp
+++ b/src/elona/ui/ui_menu_composite_skills.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_composite_skills.hpp"
+
 #include "ui_menu_skills.hpp"
 #include "ui_menu_spells.hpp"
 

--- a/src/elona/ui/ui_menu_composite_town.cpp
+++ b/src/elona/ui/ui_menu_composite_town.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_composite_town.hpp"
+
 #include "ui_menu_town_chart.hpp"
 #include "ui_menu_town_economy.hpp"
 #include "ui_menu_town_politics.hpp"

--- a/src/elona/ui/ui_menu_config.cpp
+++ b/src/elona/ui/ui_menu_config.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_config.hpp"
+
 #include "../audio.hpp"
 #include "../config.hpp"
 #include "../config_menu.hpp"

--- a/src/elona/ui/ui_menu_crafting.cpp
+++ b/src/elona/ui/ui_menu_crafting.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_crafting.hpp"
+
 #include "../ability.hpp"
 #include "../audio.hpp"
 #include "../crafting.hpp"

--- a/src/elona/ui/ui_menu_ctrl_ally.cpp
+++ b/src/elona/ui/ui_menu_ctrl_ally.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_ctrl_ally.hpp"
+
 #include "../ability.hpp"
 #include "../area.hpp"
 #include "../audio.hpp"

--- a/src/elona/ui/ui_menu_equipment.cpp
+++ b/src/elona/ui/ui_menu_equipment.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_equipment.hpp"
+
 #include "../character.hpp"
 #include "../equipment.hpp"
 #include "../globals.hpp"

--- a/src/elona/ui/ui_menu_feats.cpp
+++ b/src/elona/ui/ui_menu_feats.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_feats.hpp"
+
 #include "../../snail/color.hpp"
 #include "../../util/range.hpp"
 #include "../../util/strutil.hpp"

--- a/src/elona/ui/ui_menu_game_help.cpp
+++ b/src/elona/ui/ui_menu_game_help.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_game_help.hpp"
+
 #include "../../util/fileutil.hpp"
 #include "../../util/strutil.hpp"
 #include "../audio.hpp"

--- a/src/elona/ui/ui_menu_god.cpp
+++ b/src/elona/ui/ui_menu_god.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_god.hpp"
+
 #include "../audio.hpp"
 #include "../draw.hpp"
 #include "../i18n.hpp"

--- a/src/elona/ui/ui_menu_hire.cpp
+++ b/src/elona/ui/ui_menu_hire.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_hire.hpp"
+
 #include "../audio.hpp"
 #include "../calc.hpp"
 #include "../draw.hpp"

--- a/src/elona/ui/ui_menu_item_desc.cpp
+++ b/src/elona/ui/ui_menu_item_desc.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_item_desc.hpp"
+
 #include "../../snail/color.hpp"
 #include "../audio.hpp"
 #include "../draw.hpp"

--- a/src/elona/ui/ui_menu_journal.cpp
+++ b/src/elona/ui/ui_menu_journal.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_journal.hpp"
+
 #include "../audio.hpp"
 #include "../calc.hpp"
 #include "../character.hpp"

--- a/src/elona/ui/ui_menu_keybindings.cpp
+++ b/src/elona/ui/ui_menu_keybindings.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_keybindings.hpp"
+
 #include "../audio.hpp"
 #include "../data/types/type_asset.hpp"
 #include "../draw.hpp"
@@ -47,8 +48,7 @@ static std::string _get_localized_action_name(
     // core.keybind.chat_box
     switch (action_category)
     {
-    case ActionCategory::shortcut:
-    {
+    case ActionCategory::shortcut: {
         auto action_index_plus_1 = keybind_index_number(action_id) + 1;
         if (action_index_plus_1 == 10 || action_index_plus_1 == 20)
         {
@@ -58,8 +58,7 @@ static std::string _get_localized_action_name(
             std::to_string(action_index_plus_1);
         break;
     }
-    case ActionCategory::selection:
-    {
+    case ActionCategory::selection: {
         const auto action_index_plus_1 = keybind_index_number(action_id) + 1;
         localized_name = i18n::s.get(mod_id + ".keybind.select") +
             std::to_string(action_index_plus_1);

--- a/src/elona/ui/ui_menu_materials.cpp
+++ b/src/elona/ui/ui_menu_materials.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_materials.hpp"
+
 #include "../audio.hpp"
 #include "../data/types/type_asset.hpp"
 

--- a/src/elona/ui/ui_menu_message_log.cpp
+++ b/src/elona/ui/ui_menu_message_log.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_message_log.hpp"
+
 #include "../audio.hpp"
 #include "../draw.hpp"
 #include "../i18n.hpp"

--- a/src/elona/ui/ui_menu_npc_tone.cpp
+++ b/src/elona/ui/ui_menu_npc_tone.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_npc_tone.hpp"
+
 #include "../audio.hpp"
 #include "../i18n.hpp"
 

--- a/src/elona/ui/ui_menu_quest_board.cpp
+++ b/src/elona/ui/ui_menu_quest_board.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_quest_board.hpp"
+
 #include "../../snail/color.hpp"
 #include "../audio.hpp"
 #include "../draw.hpp"

--- a/src/elona/ui/ui_menu_scene.cpp
+++ b/src/elona/ui/ui_menu_scene.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_scene.hpp"
+
 #include "../audio.hpp"
 #include "../data/types/type_asset.hpp"
 #include "../draw.hpp"

--- a/src/elona/ui/ui_menu_skills.cpp
+++ b/src/elona/ui/ui_menu_skills.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_skills.hpp"
+
 #include "../ability.hpp"
 #include "../audio.hpp"
 #include "../i18n.hpp"

--- a/src/elona/ui/ui_menu_spell_writer.cpp
+++ b/src/elona/ui/ui_menu_spell_writer.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_spell_writer.hpp"
+
 #include "../audio.hpp"
 #include "../draw.hpp"
 #include "../i18n.hpp"

--- a/src/elona/ui/ui_menu_spells.cpp
+++ b/src/elona/ui/ui_menu_spells.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_spells.hpp"
+
 #include "../ability.hpp"
 #include "../audio.hpp"
 #include "../calc.hpp"

--- a/src/elona/ui/ui_menu_town_chart.cpp
+++ b/src/elona/ui/ui_menu_town_chart.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_town_chart.hpp"
+
 #include "../area.hpp"
 #include "../audio.hpp"
 #include "../draw.hpp"

--- a/src/elona/ui/ui_menu_town_economy.cpp
+++ b/src/elona/ui/ui_menu_town_economy.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_town_economy.hpp"
+
 #include "../area.hpp"
 #include "../audio.hpp"
 #include "../draw.hpp"

--- a/src/elona/ui/ui_menu_town_politics.cpp
+++ b/src/elona/ui/ui_menu_town_politics.cpp
@@ -1,4 +1,5 @@
 #include "ui_menu_town_politics.hpp"
+
 #include "../area.hpp"
 #include "../audio.hpp"
 #include "../draw.hpp"

--- a/src/elona/wish.cpp
+++ b/src/elona/wish.cpp
@@ -4,7 +4,6 @@
 
 #include "../util/range.hpp"
 #include "../util/strutil.hpp"
-
 #include "ability.hpp"
 #include "audio.hpp"
 #include "calc.hpp"

--- a/src/elona/wish.hpp
+++ b/src/elona/wish.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+
 #include "lua_env/wrapped_function.hpp"
 #include "optional.hpp"
 

--- a/src/launcher_main.cpp
+++ b/src/launcher_main.cpp
@@ -1,4 +1,5 @@
 #include <boost/process/spawn.hpp>
+
 #include "elona/filesystem.hpp"
 #include "elona/log.hpp"
 #include "elona/profile/profile_manager.hpp"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,10 @@
 #include "elona/main.hpp"
+
 #include <iostream>
 #include <stdexcept>
+
 #include <SDL.h>
+
 #include "elona/defines.hpp"
 #include "elona/log.hpp"
 #include "snail/application.hpp"

--- a/src/putit/archive/binary_archive.hpp
+++ b/src/putit/archive/binary_archive.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <cstdint>
+
 #include <deque>
 #include <iostream>
 #include <memory>
 #include <vector>
+
 #include "../../util/filepathutil.hpp"
 #include "archive_base.hpp"
 #include "detail/byte_swap.hpp"

--- a/src/putit/archive/json_archive.hpp
+++ b/src/putit/archive/json_archive.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <cstdint>
+
 #include <iostream>
 #include <memory>
 #include <vector>
+
 #include "../../thirdparty/json5/json5.hpp"
 #include "../../util/filepathutil.hpp"
 #include "archive_base.hpp"

--- a/src/snail/application.hpp
+++ b/src/snail/application.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+
 #include "../util/noncopyable.hpp"
 #include "../util/scope_guard.hpp"
 #include "detail/sdl.hpp"

--- a/src/snail/backends/headless/application.cpp
+++ b/src/snail/backends/headless/application.cpp
@@ -1,6 +1,8 @@
 #include "../../application.hpp"
+
 #include <algorithm>
 #include <map>
+
 #include "../../input.hpp"
 
 

--- a/src/snail/backends/headless/hsp.cpp
+++ b/src/snail/backends/headless/hsp.cpp
@@ -1,5 +1,7 @@
 #include "../../hsp.hpp"
+
 #include <iostream>
+
 #include "../../application.hpp"
 
 

--- a/src/snail/backends/headless/image.cpp
+++ b/src/snail/backends/headless/image.cpp
@@ -1,4 +1,5 @@
 #include "../../image.hpp"
+
 #include "../../application.hpp"
 #include "../../renderer.hpp"
 #include "../../surface.hpp"

--- a/src/snail/backends/headless/messagebox.cpp
+++ b/src/snail/backends/headless/messagebox.cpp
@@ -1,4 +1,5 @@
 #include "../../messagebox.hpp"
+
 #include <iostream>
 
 

--- a/src/snail/backends/headless/renderer.cpp
+++ b/src/snail/backends/headless/renderer.cpp
@@ -1,5 +1,7 @@
 #include "../../renderer.hpp"
+
 #include <sstream>
+
 #include "../../detail/sdl.hpp"
 #include "../../surface.hpp"
 

--- a/src/snail/backends/sdl/application.cpp
+++ b/src/snail/backends/sdl/application.cpp
@@ -1,8 +1,11 @@
 #include "../../application.hpp"
+
 #include <algorithm>
 #include <map>
 #include <sstream>
+
 #include <boost/lexical_cast.hpp>
+
 #include "../../hsp.hpp"
 #include "../../input.hpp"
 

--- a/src/snail/backends/sdl/audio.cpp
+++ b/src/snail/backends/sdl/audio.cpp
@@ -1,7 +1,7 @@
+#include <vector>
+
 #include "../../application.hpp"
 #include "../../detail/sdl.hpp"
-
-#include <vector>
 
 
 

--- a/src/snail/backends/sdl/filedialog.cpp
+++ b/src/snail/backends/sdl/filedialog.cpp
@@ -1,6 +1,9 @@
 #include "../../filedialog.hpp"
+
 #include <cstdlib>
+
 #include <type_traits>
+
 #include "../../../thirdparty/nfd/nfd.h"
 #include "../../../util/scope_guard.hpp"
 

--- a/src/snail/backends/sdl/hsp.cpp
+++ b/src/snail/backends/sdl/hsp.cpp
@@ -1,6 +1,8 @@
 #include "../../hsp.hpp"
+
 #include <iostream>
 #include <unordered_map>
+
 #include "../../../util/strutil.hpp"
 #include "../../application.hpp"
 #include "../../color.hpp"

--- a/src/snail/backends/sdl/image.cpp
+++ b/src/snail/backends/sdl/image.cpp
@@ -1,4 +1,5 @@
 #include "../../image.hpp"
+
 #include "../../application.hpp"
 #include "../../renderer.hpp"
 #include "../../surface.hpp"

--- a/src/snail/backends/sdl/messagebox.cpp
+++ b/src/snail/backends/sdl/messagebox.cpp
@@ -1,4 +1,5 @@
 #include "../../messagebox.hpp"
+
 #include "../../detail/sdl.hpp"
 
 

--- a/src/snail/backends/sdl/renderer.cpp
+++ b/src/snail/backends/sdl/renderer.cpp
@@ -1,6 +1,8 @@
 #include "../../renderer.hpp"
+
 #include <iostream>
 #include <sstream>
+
 #include "../../detail/sdl.hpp"
 #include "../../surface.hpp"
 

--- a/src/snail/backends/sdl/surface.cpp
+++ b/src/snail/backends/sdl/surface.cpp
@@ -1,4 +1,5 @@
 #include "../../surface.hpp"
+
 #include "../../../util/fileutil.hpp"
 
 

--- a/src/snail/color.hpp
+++ b/src/snail/color.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+
 #include "detail/sdl.hpp"
 
 

--- a/src/snail/detail/sdl.hpp
+++ b/src/snail/detail/sdl.hpp
@@ -3,10 +3,12 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+
 #include <SDL.h>
 #include <SDL_image.h>
 #include <SDL_mixer.h>
 #include <SDL_ttf.h>
+
 #include "../../util/noncopyable.hpp"
 
 

--- a/src/snail/filedialog.hpp
+++ b/src/snail/filedialog.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <vector>
+
 #include "filesystem.hpp"
 
 

--- a/src/snail/font.cpp
+++ b/src/snail/font.cpp
@@ -1,6 +1,8 @@
 #include "font.hpp"
+
 #include <tuple>
 #include <unordered_map>
+
 #include "../elona/filesystem.hpp"
 
 

--- a/src/snail/font.hpp
+++ b/src/snail/font.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+
 #include "../util/enumutil.hpp"
 #include "detail/sdl.hpp"
 #include "filesystem.hpp"

--- a/src/snail/hsp.hpp
+++ b/src/snail/hsp.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+
 #include "blend_mode.hpp"
 #include "color.hpp"
 #include "filesystem.hpp"

--- a/src/snail/image.hpp
+++ b/src/snail/image.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+
 #include "../elona/optional.hpp"
 #include "blend_mode.hpp"
 #include "color.hpp"

--- a/src/snail/input.cpp
+++ b/src/snail/input.cpp
@@ -1,5 +1,7 @@
 #include "input.hpp"
+
 #include <cassert>
+
 #include <algorithm>
 #include <iostream>
 #include <tuple>

--- a/src/snail/input.hpp
+++ b/src/snail/input.hpp
@@ -3,6 +3,7 @@
 #include <array>
 #include <set>
 #include <string>
+
 #include "../elona/optional.hpp"
 #include "../util/enumutil.hpp"
 #include "../util/noncopyable.hpp"

--- a/src/snail/renderer.hpp
+++ b/src/snail/renderer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+
 #include "../util/enumutil.hpp"
 #include "../util/noncopyable.hpp"
 #include "blend_mode.hpp"

--- a/src/snail/surface.hpp
+++ b/src/snail/surface.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+
 #include "../elona/optional.hpp"
 #include "blend_mode.hpp"
 #include "color.hpp"

--- a/src/snail/window.hpp
+++ b/src/snail/window.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+
 #include "../util/enumutil.hpp"
 #include "../util/noncopyable.hpp"
 #include "detail/sdl.hpp"

--- a/src/spider/http/backends/boost_asio/core.cpp
+++ b/src/spider/http/backends/boost_asio/core.cpp
@@ -1,6 +1,8 @@
 #include "../../core.hpp"
+
 #include <iostream>
 #include <thread>
+
 #include "detail.hpp"
 
 namespace asio = boost::asio;

--- a/src/spider/http/backends/boost_asio/detail.hpp
+++ b/src/spider/http/backends/boost_asio/detail.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+
 #include <boost/asio.hpp>
 #include <boost/asio/ssl.hpp>
 

--- a/src/spider/http/backends/boost_asio/request.cpp
+++ b/src/spider/http/backends/boost_asio/request.cpp
@@ -10,11 +10,14 @@
 // Official repository: https://github.com/boostorg/beast
 
 #include "../../request.hpp"
+
 #include <functional>
 #include <string>
+
 #include <boost/beast/core.hpp>
 #include <boost/beast/http.hpp>
 #include <boost/optional.hpp>
+
 #include "../../../../thirdparty/uri/include/network/uri.hpp"
 #include "../../error.hpp"
 #include "../../response.hpp"

--- a/src/spider/http/request.hpp
+++ b/src/spider/http/request.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+
 #include "types.hpp"
 
 

--- a/src/tests/config.cpp
+++ b/src/tests/config.cpp
@@ -1,6 +1,6 @@
-#include "../thirdparty/catch2/catch.hpp"
-
 #include "../elona/config.hpp"
+
+#include "../thirdparty/catch2/catch.hpp"
 
 using namespace std::literals::string_literals;
 using namespace elona;
@@ -56,11 +56,10 @@ TEST_CASE("Test loading valid config", "[Config: Loading]")
 
 // TODO don't skip these test!
 #if 0
-#include "../thirdparty/catch2/catch.hpp"
-
 #include "../elona/config/config.hpp"
 #include "../elona/config/config_def.hpp"
 #include "../elona/testing.hpp"
+#include "../thirdparty/catch2/catch.hpp"
 #include "tests.hpp"
 
 using namespace std::literals::string_literals;

--- a/src/tests/config_def.cpp
+++ b/src/tests/config_def.cpp
@@ -1,9 +1,9 @@
 // TODO don't skip these test!
 #if 0
-#include "../thirdparty/catch2/catch.hpp"
-
 #include "../elona/config/config_def.hpp"
+
 #include "../elona/testing.hpp"
+#include "../thirdparty/catch2/catch.hpp"
 #include "tests.hpp"
 
 using namespace std::literals::string_literals;

--- a/src/tests/elonacore.cpp
+++ b/src/tests/elonacore.cpp
@@ -1,7 +1,6 @@
-#include "../thirdparty/catch2/catch.hpp"
-
 #include "../elona/testing.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/catch2/catch.hpp"
 #include "tests.hpp"
 
 using namespace Catch;

--- a/src/tests/filesystem.cpp
+++ b/src/tests/filesystem.cpp
@@ -1,6 +1,6 @@
-#include "../thirdparty/catch2/catch.hpp"
-
 #include "../elona/filesystem.hpp"
+
+#include "../thirdparty/catch2/catch.hpp"
 
 using namespace elona;
 

--- a/src/tests/i18n.cpp
+++ b/src/tests/i18n.cpp
@@ -1,13 +1,14 @@
-#include "../thirdparty/catch2/catch.hpp"
+#include "../elona/i18n.hpp"
 
 #include <sstream>
+
 #include "../elona/character.hpp"
-#include "../elona/i18n.hpp"
 #include "../elona/item.hpp"
 #include "../elona/itemgen.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/ui.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/catch2/catch.hpp"
 #include "tests.hpp"
 
 using namespace std::literals::string_literals;

--- a/src/tests/i18n_builtins.cpp
+++ b/src/tests/i18n_builtins.cpp
@@ -1,6 +1,5 @@
-#include "../thirdparty/catch2/catch.hpp"
-
 #include <sstream>
+
 #include "../elona/character.hpp"
 #include "../elona/i18n.hpp"
 #include "../elona/item.hpp"
@@ -8,6 +7,7 @@
 #include "../elona/testing.hpp"
 #include "../elona/ui.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/catch2/catch.hpp"
 #include "tests.hpp"
 
 using namespace std::literals::string_literals;

--- a/src/tests/i18n_regressions.cpp
+++ b/src/tests/i18n_regressions.cpp
@@ -1,11 +1,10 @@
-#include "../thirdparty/catch2/catch.hpp"
-
 #include "../elona/i18n.hpp"
 #include "../elona/item.hpp"
 #include "../elona/itemgen.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/ui.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/catch2/catch.hpp"
 #include "tests.hpp"
 
 using namespace std::literals::string_literals;

--- a/src/tests/item.cpp
+++ b/src/tests/item.cpp
@@ -1,9 +1,9 @@
-#include "../thirdparty/catch2/catch.hpp"
-
 #include "../elona/item.hpp"
+
 #include "../elona/itemgen.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/catch2/catch.hpp"
 #include "tests.hpp"
 
 TEST_CASE("Test that index of copied item is set", "[C++: Item]")

--- a/src/tests/keybind_deserializer.cpp
+++ b/src/tests/keybind_deserializer.cpp
@@ -1,9 +1,10 @@
-#include "../thirdparty/catch2/catch.hpp"
+#include "../elona/keybind/keybind_deserializer.hpp"
 
 #include <iostream>
+
 #include "../elona/keybind/keybind.hpp"
-#include "../elona/keybind/keybind_deserializer.hpp"
 #include "../elona/keybind/keybind_manager.hpp"
+#include "../thirdparty/catch2/catch.hpp"
 
 using namespace elona;
 using namespace elona::snail;

--- a/src/tests/keybind_key_names.cpp
+++ b/src/tests/keybind_key_names.cpp
@@ -1,7 +1,7 @@
-#include "../thirdparty/catch2/catch.hpp"
-
 #include <iostream>
+
 #include "../elona/keybind/keybind.hpp"
+#include "../thirdparty/catch2/catch.hpp"
 
 using namespace elona;
 using namespace elona::snail;

--- a/src/tests/keybind_manager.cpp
+++ b/src/tests/keybind_manager.cpp
@@ -1,7 +1,7 @@
-#include "../thirdparty/catch2/catch.hpp"
+#include "../elona/keybind/keybind_manager.hpp"
 
 #include "../elona/keybind/keybind.hpp"
-#include "../elona/keybind/keybind_manager.hpp"
+#include "../thirdparty/catch2/catch.hpp"
 
 using namespace elona;
 using namespace elona::snail;

--- a/src/tests/keybind_serializer.cpp
+++ b/src/tests/keybind_serializer.cpp
@@ -1,9 +1,10 @@
-#include "../thirdparty/catch2/catch.hpp"
+#include "../elona/keybind/keybind_serializer.hpp"
 
 #include <iostream>
+
 #include "../elona/keybind/keybind.hpp"
 #include "../elona/keybind/keybind_manager.hpp"
-#include "../elona/keybind/keybind_serializer.hpp"
+#include "../thirdparty/catch2/catch.hpp"
 
 using namespace elona;
 using namespace elona::snail;

--- a/src/tests/lua_api.cpp
+++ b/src/tests/lua_api.cpp
@@ -1,11 +1,10 @@
-#include "../thirdparty/catch2/catch.hpp"
-
 #include "../elona/filesystem.hpp"
 #include "../elona/lua_env/api_manager.hpp"
 #include "../elona/lua_env/lua_env.hpp"
 #include "../elona/lua_env/mod_manager.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/catch2/catch.hpp"
 #include "util.hpp"
 
 using namespace std::literals::string_literals;

--- a/src/tests/lua_data.cpp
+++ b/src/tests/lua_data.cpp
@@ -1,5 +1,3 @@
-#include "../thirdparty/catch2/catch.hpp"
-
 #include "../elona/filesystem.hpp"
 #include "../elona/lua_env/data_manager.hpp"
 #include "../elona/lua_env/export_manager.hpp"
@@ -7,6 +5,7 @@
 #include "../elona/lua_env/mod_manager.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/catch2/catch.hpp"
 #include "tests.hpp"
 
 TEST_CASE("test reading invalid HCL file", "[Lua: Data]")

--- a/src/tests/lua_data_character.cpp
+++ b/src/tests/lua_data_character.cpp
@@ -1,5 +1,3 @@
-#include "../thirdparty/catch2/catch.hpp"
-
 #include "../elona/character.hpp"
 #include "../elona/enums.hpp"
 #include "../elona/filesystem.hpp"
@@ -8,6 +6,7 @@
 #include "../elona/lua_env/mod_manager.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/catch2/catch.hpp"
 #include "tests.hpp"
 
 static lua::DataTable load(elona::lua::LuaEnv& lua, const std::string& name)

--- a/src/tests/lua_data_item.cpp
+++ b/src/tests/lua_data_item.cpp
@@ -1,5 +1,3 @@
-#include "../thirdparty/catch2/catch.hpp"
-
 #include "../elona/data/types/type_item.hpp"
 #include "../elona/filesystem.hpp"
 #include "../elona/item.hpp"
@@ -8,6 +6,7 @@
 #include "../elona/lua_env/mod_manager.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/catch2/catch.hpp"
 #include "tests.hpp"
 
 static lua::DataTable load(elona::lua::LuaEnv& lua, const std::string& name)

--- a/src/tests/lua_events.cpp
+++ b/src/tests/lua_events.cpp
@@ -1,6 +1,3 @@
-#include "../thirdparty/catch2/catch.hpp"
-#include "../thirdparty/sol2/sol.hpp"
-
 #include "../elona/character.hpp"
 #include "../elona/dmgheal.hpp"
 #include "../elona/filesystem.hpp"
@@ -12,6 +9,8 @@
 #include "../elona/lua_env/mod_manager.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/catch2/catch.hpp"
+#include "../thirdparty/sol2/sol.hpp"
 #include "tests.hpp"
 
 using namespace elona::testing;

--- a/src/tests/lua_mod_resolve.cpp
+++ b/src/tests/lua_mod_resolve.cpp
@@ -1,6 +1,5 @@
-#include "../thirdparty/catch2/catch.hpp"
-
 #include "../elona/lua_env/mod_version_resolver.hpp"
+#include "../thirdparty/catch2/catch.hpp"
 
 using namespace elona::lua;
 using namespace elona::semver;

--- a/src/tests/semver.cpp
+++ b/src/tests/semver.cpp
@@ -1,7 +1,6 @@
-#include "../thirdparty/catch2/catch.hpp"
-
 #include "../elona/semver.hpp"
 
+#include "../thirdparty/catch2/catch.hpp"
 #include "tests.hpp"
 
 using SemVer = elona::semver::Version;

--- a/src/tests/serialization.cpp
+++ b/src/tests/serialization.cpp
@@ -1,5 +1,3 @@
-#include "../thirdparty/catch2/catch.hpp"
-
 #include "../elona/ability.hpp"
 #include "../elona/character.hpp"
 #include "../elona/enums.hpp"
@@ -10,6 +8,7 @@
 #include "../elona/itemgen.hpp"
 #include "../elona/testing.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/catch2/catch.hpp"
 #include "tests.hpp"
 
 using namespace Catch;

--- a/src/tests/util.cpp
+++ b/src/tests/util.cpp
@@ -1,5 +1,3 @@
-#include "../thirdparty/catch2/catch.hpp"
-
 #include "../elona/config.hpp"
 #include "../elona/enums.hpp"
 #include "../elona/i18n.hpp"
@@ -9,6 +7,7 @@
 #include "../elona/lua_env/export_manager.hpp"
 #include "../elona/lua_env/mod_manager.hpp"
 #include "../elona/variables.hpp"
+#include "../thirdparty/catch2/catch.hpp"
 #include "tests.hpp"
 
 namespace elona

--- a/src/util/backtrace.cpp
+++ b/src/util/backtrace.cpp
@@ -1,8 +1,10 @@
 #include <boost/predef.h>
+
 #include "filepathutil.hpp"
 
 #if BOOST_OS_LINUX || BOOST_OS_MACOS
 #include <cxxabi.h>
+
 #include <dlfcn.h>
 #include <execinfo.h>
 #include <signal.h>

--- a/src/util/filepathutil.cpp
+++ b/src/util/filepathutil.cpp
@@ -1,10 +1,13 @@
 #include "filepathutil.hpp"
+
 #include <algorithm>
+
 #include <boost/predef.h>
 
 // For get_executable_path()
 #if BOOST_OS_WINDOWS
 #include <windows.h> // GetModuleFileName
+
 #include "unicode_utf16.hpp"
 #elif BOOST_OS_MACOS
 #include <limits.h> // PATH_MAX

--- a/src/util/fileutil.hpp
+++ b/src/util/fileutil.hpp
@@ -2,6 +2,7 @@
 
 #include <fstream>
 #include <iterator>
+
 #include "filepathutil.hpp"
 
 

--- a/src/util/natural_order_comparator.hpp
+++ b/src/util/natural_order_comparator.hpp
@@ -44,6 +44,7 @@
 
 #include <cassert>
 #include <cctype>
+
 #include <algorithm>
 #include <string>
 

--- a/src/util/strutil.hpp
+++ b/src/util/strutil.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cctype>
+
 #include <algorithm>
 #include <iterator>
 #include <sstream>


### PR DESCRIPTION
# Summary

- Fix `.clang-format` for newly added C++ `std` headers in C++17/20
- Update `clang-format` version to 9.0 and re-format all sources
- Add GitHub Actions' workflow: Run clang-format