### PR TITLE
Lua: Fix expressions containing '/', division for float

### DIFF
--- a/runtime/mod/core/data/dialog/unique/abyss.lua
+++ b/runtime/mod/core/data/dialog/unique/abyss.lua
@@ -38,9 +38,9 @@ end
 
 local function receive_reward()
    World.data.thieves_guild_quota_recurring = false
-   Item.create(Chara.player().position, {objlv = 51 - World.data.ranks[8] / 200, flttypemajor = 60000})
+   Item.create(Chara.player().position, {objlv = 51 - World.data.ranks[8] // 200, flttypemajor = 60000})
    Item.create(Chara.player().position, "core.gold_piece", 10000 - World.data.ranks[8] + 1000)
-   Item.create(Chara.player().position, "core.platinum_coin", Math.clamp(3 - World.data.ranks[8] / 3000, 1, 3))
+   Item.create(Chara.player().position, "core.platinum_coin", Math.clamp(3 - World.data.ranks[8] // 3000, 1, 3))
 
    common.quest_completed()
 

--- a/runtime/mod/core/data/dialog/unique/doria.lua
+++ b/runtime/mod/core/data/dialog/unique/doria.lua
@@ -45,9 +45,9 @@ end
 
 local function receive_reward()
    World.data.fighters_guild_quota_recurring = false
-   Item.create(Chara.player().position, {objlv = 51 - World.data.ranks[8] / 200, quality = "Good", flttypemajor = 10000})
+   Item.create(Chara.player().position, {objlv = 51 - World.data.ranks[8] // 200, quality = "Good", flttypemajor = 10000})
    Item.create(Chara.player().position, "core.gold_piece", 10000 - World.data.ranks[8] + 1000)
-   Item.create(Chara.player().position, "core.platinum_coin", Math.clamp(4 - World.data.ranks[8] / 2500, 1, 4))
+   Item.create(Chara.player().position, "core.platinum_coin", Math.clamp(4 - World.data.ranks[8] // 2500, 1, 4))
 
    common.quest_completed()
 

--- a/runtime/mod/core/data/dialog/unique/lexus.lua
+++ b/runtime/mod/core/data/dialog/unique/lexus.lua
@@ -33,15 +33,15 @@ end
 
 local function update_quota()
    World.data.mages_guild_quota_recurring = true
-   World.data.mages_guild_quota = 75 - World.data.ranks[8] / 200
+   World.data.mages_guild_quota = 75 - World.data.ranks[8] // 200
    GUI.show_journal_update_message()
 end
 
 local function receive_reward()
    World.data.mages_guild_quota_recurring = false
-   Item.create(Chara.player().position, {objlv = 51 - World.data.ranks[8] / 200, flttypemajor = 54000})
+   Item.create(Chara.player().position, {objlv = 51 - World.data.ranks[8] // 200, flttypemajor = 54000})
    Item.create(Chara.player().position, "core.gold_piece", 10000 - World.data.ranks[8] + 1000)
-   Item.create(Chara.player().position, "core.platinum_coin", Math.clamp(4 - World.data.ranks[8] / 2500, 1, 4))
+   Item.create(Chara.player().position, "core.platinum_coin", Math.clamp(4 - World.data.ranks[8] // 2500, 1, 4))
 
    common.quest_completed()
 

--- a/runtime/mod/core/data/dialog/unique/miral.lua
+++ b/runtime/mod/core/data/dialog/unique/miral.lua
@@ -7,7 +7,7 @@ local World = Elona.game.World
 local table = Elona.game.table
 
 local function upgrade_cart_cost()
-   return (World.data.current_cart_limit - World.data.initial_cart_limit) / 10000 + 1
+   return (World.data.current_cart_limit - World.data.initial_cart_limit) // 10000 + 1
 end
 
 local function upgrade_cart_amount()

--- a/runtime/mod/core/data/dialog/unique/rogue_boss.lua
+++ b/runtime/mod/core/data/dialog/unique/rogue_boss.lua
@@ -8,7 +8,7 @@ local World = Elona.game.World
 local common = require("data/dialog/common")
 
 local function surrender_cost()
-   return Chara.player().gold / 5
+   return Chara.player().gold // 5
 end
 
 local function surrender()

--- a/runtime/mod/core/data/shop_inventory.lua
+++ b/runtime/mod/core/data/shop_inventory.lua
@@ -183,7 +183,7 @@ data:add_multi(
             }
          },
          item_base_value = function(args)
-            return args.item.value * 3 / 2
+            return args.item.value * 3 // 2
          end
       },
       {
@@ -254,7 +254,7 @@ data:add_multi(
             { one_in = 10, fixlv = "Miracle" },
          },
          item_number = function(args)
-            return 6 + args.shopkeeper.shop_rank / 10
+            return 6 + args.shopkeeper.shop_rank // 10
          end,
          item_base_value = function(args)
             if World.belongs_to_guild("thieves") then
@@ -276,12 +276,12 @@ data:add_multi(
       },
       {
          id = "visiting_merchant",
-         -- NOTE: the only shop ID for which (id / 1000) != 1.
+         -- NOTE: the only shop ID for which (id // 1000) != 1.
          legacy_id = 2003,
          rules = merchant_rules,
          item_number = merchant_item_number,
          item_base_value = function(args)
-            return args.item.value * 4 / 5
+            return args.item.value * 4 // 5
          end,
          is_temporary = true -- Uses shop ID 1.
       },
@@ -383,7 +383,7 @@ data:add_multi(
          rules = {
             { fltn = "spshop" },
          },
-         item_number = function(args) return args.item_number / 2 end,
+         item_number = function(args) return args.item_number // 2 end,
          item_base_value = function(args)
             local price = Math.clamp(args.item.value, 1, 1000000) * 50
             if args.item.id == "core.gift" then

--- a/runtime/mod/core/exports/impl/shop_inventory.lua
+++ b/runtime/mod/core/exports/impl/shop_inventory.lua
@@ -7,7 +7,7 @@ local Rand = Elona.game.Rand
 local shop_inventory = {}
 
 function shop_inventory.default_item_number(args)
-   return Math.min(80, 20 + args.shopkeeper.shop_rank / 2)
+   return Math.min(80, 20 + args.shopkeeper.shop_rank // 2)
 end
 
 function shop_inventory.test_rule_predicate(rule, index, shopkeeper)
@@ -181,14 +181,14 @@ end
 -- difficult to find in shops. More than one modifier can be applied
 -- if multiple value thresholds are reached.
 shop_inventory.cargo_amount_rates = {
-   { threshold = 70,  type = "lt", amount = function(n) return n * 200 / 100 end                    },
-   { threshold = 50,  type = "lt", amount = function(n) return n * 200 / 100 end                    },
-   { threshold = 80,  type = "gt", amount = function(n) return n / 2 + 1     end, remove_chance = 2 },
-   { threshold = 100, type = "gt", amount = function(n) return n / 2 + 1     end, remove_chance = 3 },
+   { threshold = 70,  type = "lt", amount = function(n) return n * 200 // 100 end                    },
+   { threshold = 50,  type = "lt", amount = function(n) return n * 200 // 100 end                    },
+   { threshold = 80,  type = "gt", amount = function(n) return n // 2 + 1     end, remove_chance = 2 },
+   { threshold = 100, type = "gt", amount = function(n) return n // 2 + 1     end, remove_chance = 3 },
 }
 
 function shop_inventory.cargo_amount_modifier(amount)
-   return amount * (100 + Chara.player():get_skill("core.negotiation").current_level * 10) / 100 + 1
+   return amount * (100 + Chara.player():get_skill("core.negotiation").current_level * 10) // 100 + 1
 end
 
 -- Calculate adjusted amount of cargo items to be sold based on the


### PR DESCRIPTION
# Summary

With the change of #1521, a floating point number is not treated as
a kind of integer. It is necessary to explicitly use '//', division for
integer.
