### PR TITLE
Support undo/redo in house design mode

### DIFF
--- a/src/elona/CMakeLists.txt
+++ b/src/elona/CMakeLists.txt
@@ -143,6 +143,10 @@ set(ELONA_SOURCES
   keybind/keybind_serializer.cpp
   keybind/macro_action_queue.cpp
 
+  mapeditor/command.cpp
+  mapeditor/design_mode.cpp
+  mapeditor/undo_history.cpp
+
   pic_loader/pic_loader.cpp
   pic_loader/tinted_buffers.cpp
 

--- a/src/elona/building.hpp
+++ b/src/elona/building.hpp
@@ -9,7 +9,6 @@ void initialize_home_adata();
 TurnResult build_new_building();
 TurnResult show_house_board();
 void addbuilding(int related_town_quest_id, int building_type, int x, int y);
-void start_home_map_mode();
 void show_home_value();
 void show_shop_log();
 void try_extend_shop();

--- a/src/elona/mapeditor/command.cpp
+++ b/src/elona/mapeditor/command.cpp
@@ -1,0 +1,48 @@
+#include "command.hpp"
+
+#include "../magic.hpp"
+#include "../map.hpp"
+#include "../variables.hpp"
+
+
+
+namespace elona
+{
+namespace mapeditor
+{
+
+void PutTileCommand::redo()
+{
+    cell_data.at(_x, _y).chip_id_actual = _tile_to;
+    cell_data.at(_x, _y).chip_id_memory = _tile_to;
+}
+
+
+
+void PutTileCommand::undo()
+{
+    cell_data.at(_x, _y).chip_id_actual = _tile_from;
+    cell_data.at(_x, _y).chip_id_memory = _tile_from;
+}
+
+
+
+void CreateWallCommand::redo()
+{
+    tlocx = _x;
+    tlocy = _y;
+    tile = _tile_to;
+    efid = 438;
+    magic();
+}
+
+
+
+void CreateWallCommand::undo()
+{
+    cell_data.at(_x, _y).chip_id_actual = _tile_from;
+    cell_data.at(_x, _y).chip_id_memory = _tile_from;
+}
+
+} // namespace mapeditor
+} // namespace elona

--- a/src/elona/mapeditor/command.hpp
+++ b/src/elona/mapeditor/command.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <memory>
+
+
+
+namespace elona
+{
+namespace mapeditor
+{
+
+class AbstractCommand
+{
+public:
+    virtual ~AbstractCommand() = default;
+
+    virtual void redo() = 0;
+    virtual void undo() = 0;
+};
+
+
+
+class PutTileCommand : public AbstractCommand
+{
+public:
+    PutTileCommand(int x, int y, int tile_from, int tile_to)
+        : _x(x)
+        , _y(y)
+        , _tile_from(tile_from)
+        , _tile_to(tile_to)
+    {
+    }
+
+
+    virtual ~PutTileCommand() = default;
+
+    virtual void redo() override;
+    virtual void undo() override;
+
+
+
+private:
+    int _x;
+    int _y;
+    int _tile_from;
+    int _tile_to;
+};
+
+
+
+class CreateWallCommand : public AbstractCommand
+{
+public:
+    CreateWallCommand(int x, int y, int tile_from, int tile_to)
+        : _x(x)
+        , _y(y)
+        , _tile_from(tile_from)
+        , _tile_to(tile_to)
+    {
+    }
+
+
+    virtual ~CreateWallCommand() = default;
+
+    virtual void redo() override;
+    virtual void undo() override;
+
+
+
+private:
+    int _x;
+    int _y;
+    int _tile_from;
+    int _tile_to;
+};
+
+
+
+using CommandPtr = std::unique_ptr<AbstractCommand>;
+
+
+template <typename Command, typename... Args>
+std::unique_ptr<Command> make_command(Args&&... args)
+{
+    return std::make_unique<Command>(std::forward<Args>(args)...);
+}
+
+} // namespace mapeditor
+} // namespace elona

--- a/src/elona/mapeditor/design_mode.cpp
+++ b/src/elona/mapeditor/design_mode.cpp
@@ -1,0 +1,377 @@
+#include "design_mode.hpp"
+
+#include "../audio.hpp"
+#include "../character.hpp"
+#include "../config.hpp"
+#include "../draw.hpp"
+#include "../i18n.hpp"
+#include "../input.hpp"
+#include "../map.hpp"
+#include "../text.hpp"
+#include "../ui.hpp"
+#include "../variables.hpp"
+#include "undo_history.hpp"
+
+
+
+namespace elona
+{
+
+extern int cansee;
+extern int kdx;
+extern int kdy;
+
+
+
+namespace mapeditor
+{
+
+namespace
+{
+
+void prepare_house_board_tiles()
+{
+    std::vector<int> unavailable_tiles{
+        15,  16,  24,  25,  26,  27,  28,  29,  30,  92,  93,  94,  95,  141,
+        169, 170, 171, 180, 182, 192, 244, 245, 246, 247, 248, 249, 250, 251,
+        252, 253, 254, 255, 256, 257, 258, 292, 293, 294, 309, 310, 311, 312,
+        313, 314, 315, 316, 317, 318, 319, 320, 321, 322, 323, 324, 327, 328,
+        329, 330, 331, 332, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342,
+        343, 344, 345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356,
+        372, 373, 374, 375, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409,
+        410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 422, 431, 432, 433,
+        434, 435, 436, 437, 438, 439, 440, 441, 442, 443, 444, 445, 446, 447,
+        448, 449, 450, 451, 452, 453, 454, 455};
+
+    p = 0;
+    p(1) = 0;
+
+    gsel(2);
+
+    for (int cnt = 0; cnt < 2772; ++cnt)
+    {
+        bool available{};
+        if (cnt < 231)
+        {
+            available = true;
+        }
+        if (cnt >= 396 && cnt < 429)
+        {
+            available = true;
+        }
+        if (cnt >= 462 && cnt < 495)
+        {
+            available = true;
+        }
+        if (cnt >= 561 && cnt < 726)
+        {
+            available = true;
+        }
+        if (!available)
+        {
+            continue;
+        }
+        if (chip_data[cnt].kind == 2)
+        {
+            continue;
+        }
+        if (chip_data[cnt].kind == 1)
+        {
+            continue;
+        }
+        if (chip_data[cnt].kind2 == 5)
+        {
+            continue;
+        }
+        if (chip_data[cnt].kind == 3)
+        {
+            if (game_data.home_scale <= 3)
+            {
+                continue;
+            }
+            else
+            {
+                --p(1);
+            }
+        }
+        ++p(1);
+        if (range::find(unavailable_tiles, p(1)) != std::end(unavailable_tiles))
+        {
+            continue;
+        }
+        list(0, p) = cnt;
+        ++p;
+        if (chip_data[cnt].anime_frame != 0)
+        {
+            cnt = cnt + chip_data[cnt].anime_frame - 1;
+            continue;
+        }
+    }
+
+    listmax = p;
+    gsel(0);
+}
+
+
+
+void select_house_board_tile()
+{
+    snd("core.pop2");
+
+    auto box_size = inf_tiles / 2;
+    while (1)
+    {
+        gmode(0);
+        p = 0;
+        // TODO
+        for (int y = 0; y < 20; ++y)
+        {
+            for (int x = 0; x < 33; ++x)
+            {
+                if (p < listmax)
+                {
+                    const auto& chip = chip_data[list(0, p)];
+                    draw_map_tile(
+                        list(0, p),
+                        x * box_size,
+                        y * box_size,
+                        inf_tiles,
+                        inf_tiles,
+                        box_size,
+                        box_size);
+                    if (chip.effect & 4)
+                    {
+                        boxl(
+                            x * box_size,
+                            y * box_size,
+                            box_size,
+                            box_size,
+                            {240, 230, 220});
+                    }
+                }
+                ++p;
+            }
+        }
+
+        gmode(2);
+        redraw();
+        await(g_config.general_wait());
+        const auto input = stick();
+        if (input == StickKey::mouse_left)
+        {
+            p = mousex / box_size + mousey / box_size * 33;
+            if (p >= listmax)
+            {
+                snd("core.fail1");
+                continue;
+            }
+            tile = list(0, p);
+            snd("core.ok1");
+            house_board_update_screen();
+            return;
+        }
+        if (input == StickKey::mouse_right)
+        {
+            house_board_update_screen();
+            return;
+        }
+    }
+}
+
+
+
+int target_position_homemapmode(UndoHistory& undo_history)
+{
+    tlocx = tlocinitx;
+    tlocy = tlocinity;
+
+    while (1)
+    {
+        screenupdate = -1;
+        update_screen();
+        dx = (tlocx - scx) * inf_tiles + inf_screenx;
+        dy = (tlocy - scy) * inf_tiles + inf_screeny;
+        if (dy + inf_tiles <= windowh - inf_verh)
+        {
+            snail::Application::instance().get_renderer().set_blend_mode(
+                snail::BlendMode::blend);
+            snail::Application::instance().get_renderer().set_draw_color(
+                {127, 127, 255, 50});
+            snail::Application::instance().get_renderer().fill_rect(
+                dx,
+                dy * (dy > 0),
+                inf_tiles -
+                    (dx + inf_tiles > windoww) * (dx + inf_tiles - windoww),
+                inf_tiles + (dy < 0) * inf_screeny -
+                    (dy + inf_tiles > windowh - inf_verh) *
+                        (dy + inf_tiles - windowh + inf_verh));
+        }
+        draw_map_tile(tile, windoww - 80, 20);
+        txttargetnpc(tlocx, tlocy);
+        redraw();
+        auto action = key_check();
+        if (action == "enter")
+        {
+            select_house_board_tile();
+            wait_key_released();
+            continue;
+        }
+        if (action == "switch_mode")
+        {
+            undo_history.undo();
+            continue;
+        }
+        if (action == "identify")
+        {
+            undo_history.redo();
+            continue;
+        }
+        const auto input = stick(StickKey::mouse_left | StickKey::mouse_right);
+        if (input == StickKey::mouse_left)
+        {
+            action = "enter";
+        }
+        if (input == StickKey::mouse_right)
+        {
+            if (chip_data.for_cell(tlocx, tlocy).kind == 2 ||
+                chip_data.for_cell(tlocx, tlocy).kind == 1)
+            {
+                snd("core.fail1");
+                wait_key_released();
+                continue;
+            }
+            tile = cell_data.at(tlocx, tlocy).chip_id_actual;
+            snd("core.cursor1");
+            wait_key_released();
+        }
+        tx = clamp(mousex - inf_screenx, 0, windoww) / inf_tiles;
+        ty = clamp(mousey - inf_screeny, 0, (windowh - inf_verh)) / inf_tiles;
+        int stat = key_direction(action);
+        if (stat == 1)
+        {
+            cdata.player().position.x += kdx;
+            cdata.player().position.y += kdy;
+            if (cdata.player().position.x < 0)
+            {
+                cdata.player().position.x = 0;
+            }
+            else if (cdata.player().position.x >= map_data.width)
+            {
+                cdata.player().position.x = map_data.width - 1;
+            }
+            if (cdata.player().position.y < 0)
+            {
+                cdata.player().position.y = 0;
+            }
+            else if (cdata.player().position.y >= map_data.height)
+            {
+                cdata.player().position.y = map_data.height - 1;
+            }
+        }
+        tlocx = clamp(tx + scx, 0, map_data.width - 1);
+        tlocy = clamp(ty + scy, 0, map_data.height - 1);
+        if (action == "enter")
+        {
+            tlocinitx = 0;
+            tlocinity = 0;
+            return cansee;
+        }
+        if (action == "cancel")
+        {
+            tlocinitx = 0;
+            tlocinity = 0;
+            update_screen();
+            return -1;
+        }
+    }
+}
+
+
+
+void fill_tile(int x, int y, int from, int to)
+{
+    // out of range
+    if (x < 0 || map_data.width <= x || y < 0 || map_data.height <= y)
+        return;
+
+    if (cell_data.at(x, y).chip_id_actual != from)
+        return;
+
+    if ((chip_data[to].effect & 4) != 0 &&
+        cell_data.at(x, y).chara_index_plus_one != 0)
+        return;
+
+    // Draw one tile.
+    cell_data.at(x, y).chip_id_actual = tile;
+    cell_data.at(x, y).chip_id_memory = tile;
+
+    // Draw tiles around.
+    fill_tile(x - 1, y, from, to);
+    fill_tile(x + 1, y, from, to);
+    fill_tile(x, y - 1, from, to);
+    fill_tile(x, y + 1, from, to);
+}
+
+} // namespace
+
+
+
+void start_home_map_mode()
+{
+    UndoHistory undo_history;
+
+    const auto pc_position_prev = cdata.player().position;
+    homemapmode = 1;
+
+    prepare_house_board_tiles();
+
+    Message::instance().linebreak();
+    txt(i18n::s.get("core.building.home.design.help"));
+
+    tlocinitx = cdata.player().position.x;
+    tlocinity = cdata.player().position.y;
+    tile = 0;
+    while (1)
+    {
+        await(g_config.general_wait());
+        int stat = target_position_homemapmode(undo_history);
+        if (stat == -1)
+        {
+            break;
+        }
+
+        if (getkey(snail::Key::ctrl))
+        {
+            if (cell_data.at(tlocx, tlocy).chip_id_actual != tile)
+            {
+                fill_tile(
+                    tlocx,
+                    tlocy,
+                    cell_data.at(tlocx, tlocy).chip_id_actual,
+                    tile);
+            }
+        }
+        else if (chip_data[tile].effect & 4)
+        {
+            undo_history.push_and_execute_command(
+                make_command<CreateWallCommand>(
+                    tlocx,
+                    tlocy,
+                    cell_data.at(tlocx, tlocy).chip_id_actual,
+                    tile));
+        }
+        else
+        {
+            undo_history.push_and_execute_command(make_command<PutTileCommand>(
+                tlocx, tlocy, cell_data.at(tlocx, tlocy).chip_id_actual, tile));
+        }
+        tlocinitx = tlocx;
+        tlocinity = tlocy;
+    }
+
+    homemapmode = 0;
+    cdata.player().position = pc_position_prev;
+}
+
+} // namespace mapeditor
+} // namespace elona

--- a/src/elona/mapeditor/design_mode.hpp
+++ b/src/elona/mapeditor/design_mode.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+
+
+namespace elona
+{
+namespace mapeditor
+{
+
+void start_home_map_mode();
+
+}
+} // namespace elona

--- a/src/elona/mapeditor/undo_history.cpp
+++ b/src/elona/mapeditor/undo_history.cpp
@@ -1,0 +1,62 @@
+#include "undo_history.hpp"
+
+
+
+namespace elona
+{
+namespace mapeditor
+{
+
+void UndoHistory::push_and_execute_command(CommandPtr&& command)
+{
+    // Clear future history first.
+    _commands.resize(_current);
+
+    // Push the new one.
+    command->redo();
+    _commands.emplace_back(std::move(command));
+    _current += 1;
+}
+
+
+
+bool UndoHistory::can_redo() const
+{
+    // Has any redoable commands?
+    return _current < _commands.size();
+}
+
+
+
+void UndoHistory::redo()
+{
+    if (!can_redo())
+        return;
+
+    auto&& cmd = _commands.at(_current);
+    cmd->redo();
+    _current += 1;
+}
+
+
+
+bool UndoHistory::can_undo() const
+{
+    // Has any undoable commands?
+    return 0 < _current;
+}
+
+
+
+void UndoHistory::undo()
+{
+    if (!can_undo())
+        return;
+
+    auto&& cmd = _commands.at(_current - 1);
+    cmd->undo();
+    _current -= 1;
+}
+
+} // namespace mapeditor
+} // namespace elona

--- a/src/elona/mapeditor/undo_history.hpp
+++ b/src/elona/mapeditor/undo_history.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <vector>
+
+#include "command.hpp"
+
+
+
+namespace elona
+{
+namespace mapeditor
+{
+
+class UndoHistory
+{
+public:
+    UndoHistory() = default;
+
+
+    void push_and_execute_command(CommandPtr&& command);
+    bool can_redo() const;
+    void redo();
+    bool can_undo() const;
+    void undo();
+
+
+private:
+    std::vector<CommandPtr> _commands;
+
+    // The index of the command that will be re-done.
+    size_t _current{};
+};
+
+} // namespace mapeditor
+} // namespace elona


### PR DESCRIPTION
# Summary

*It is an experimental feature!*

Support undo (<kbd>z</kbd> key) and redo (<kbd>x</kbd>) in house design mode. The undo history is not shared between housing operations (it's intended). The history has unlimited size so far.

## Limitations

- The shortcut keys cannot be changed.
- Tile filling is not supported.
- No key hint text in log window because it is still experimental.