### PR TITLE
Fix OpenSSL on Windows

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -1,15 +1,10 @@
 # Change this variable to point to your Boost installation.
-BOOST_DIR = E:\build\SDK\boost_1_69_0
+BOOST_ROOT = E:\build\SDK\boost_1_69_0
 
 BIN_DIR = bin
 
-BOOST_ROOT = $(BOOST_DIR)
-BOOST_INCLUDEDIR = $(BOOST_DIR)
-BOOST_LIBRARYDIR = $(BOOST_INCLUDEDIR)\lib64-msvc-14.1
 CMAKE_ARGS = \
         -DBOOST_ROOT="$(BOOST_ROOT)" \
-        -DBOOST_INCLUDEDIR="$(BOOST_INCLUDEDIR)" \
-        -DBOOST_LIBRARYDIR="$(BOOST_LIBRARYDIR)" \
         -G "Visual Studio 15 2017 Win64" \
         $(CMAKE_ARGS)
 

--- a/Makefile.win
+++ b/Makefile.win
@@ -1,10 +1,13 @@
 # Change this variable to point to your Boost installation.
 BOOST_ROOT = E:\build\SDK\boost_1_69_0
+# Change this variable to point to your OpenSSL installation.
+OPENSSL_ROOT_DIR = E:\build\SDK\OpenSSL-v111-Win64
 
 BIN_DIR = bin
 
 CMAKE_ARGS = \
         -DBOOST_ROOT="$(BOOST_ROOT)" \
+        -DOPENSSL_ROOT_DIR="$(OPENSSL_ROOT_DIR)" \
         -G "Visual Studio 15 2017 Win64" \
         $(CMAKE_ARGS)
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 * Boost 1.69
 * Lua 5.3
 * SDL2, SDL2_image, SDL2_ttf and SDL2_mixer
+* OpenSSL 1.1.x
 * `clang-format`, `find` and `xargs` (Optional)
 
 ### Additional requirements for Windows

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
     BOOST_VERSION: 1.69.0
     BOOST_ROOT: C:\Libraries\boost_1_69_0
     PREFIX: C:\SDK
-    OPENSSL_ROOT_DIR: C:\SDK
+    OPENSSL_ROOT_DIR: C:\OpenSSL-v111-Win64
     ZLIB_ROOT: C:\SDK
 
 build:
@@ -49,11 +49,6 @@ before_build:
     %NEEDDEPENDS% cd %PREFIX%
     %NEEDDEPENDS% git clone --depth=1 https://github.com/elonafoobar/windows_deps windows
     %NEEDDEPENDS% call .\install.bat
-    rem Debug versions are the same as optimized, but they are necessary to override system-provided ones.
-    %NEEDDEPENDS% cp .\lib\VC\libcrypto.dll .\lib\VC\libcryptod.dll
-    %NEEDDEPENDS% cp .\lib\VC\libcrypto.lib .\lib\VC\libcryptod.lib
-    %NEEDDEPENDS% cp .\lib\VC\libssl.dll .\lib\VC\libssld.dll
-    %NEEDDEPENDS% cp .\lib\VC\libssl.lib .\lib\VC\libssld.lib
 
 build_script:
   - chcp 65001
@@ -65,14 +60,14 @@ build_script:
   - cd %APPVEYOR_BUILD_FOLDER%
   - if not exist bin mkdir bin
   - cd bin
-  - cmake -DCMAKE_PREFIX_PATH=%PREFIX% -DELONA_BUILD_TARGET=TESTS %CMAKE_ARGS% -DCMAKE_BUILD_TYPE=%CONFIGURATION% ..
+  - cmake -DCMAKE_PREFIX_PATH=%PREFIX% -DELONA_BUILD_TARGET=TESTS %CMAKE_ARGS% -DOPENSSL_ROOT_DIR=%OPENSSL_ROOT_DIR% -DCMAKE_BUILD_TYPE=%CONFIGURATION% ..
   - cmake --build . --config %CONFIGURATION%
   - cd %CONFIGURATION%
   - Elona_foobar.exe --durations=yes
   - cd %APPVEYOR_BUILD_FOLDER%\bin
-  - cmake -DCMAKE_PREFIX_PATH=%PREFIX% -DELONA_BUILD_TARGET=GAME %CMAKE_ARGS% -DCMAKE_BUILD_TYPE=%CONFIGURATION% ..
+  - cmake -DCMAKE_PREFIX_PATH=%PREFIX% -DELONA_BUILD_TARGET=GAME %CMAKE_ARGS% -DOPENSSL_ROOT_DIR=%OPENSSL_ROOT_DIR% -DCMAKE_BUILD_TYPE=%CONFIGURATION% ..
   - cmake --build . --config %CONFIGURATION%
-  - cmake -DCMAKE_PREFIX_PATH=%PREFIX% -DELONA_BUILD_TARGET=LAUNCHER %CMAKE_ARGS% -DCMAKE_BUILD_TYPE=%CONFIGURATION% ..
+  - cmake -DCMAKE_PREFIX_PATH=%PREFIX% -DELONA_BUILD_TARGET=LAUNCHER %CMAKE_ARGS% -DOPENSSL_ROOT_DIR=%OPENSSL_ROOT_DIR% -DCMAKE_BUILD_TYPE=%CONFIGURATION% ..
   - cmake --build . --config %CONFIGURATION%
 
 after_build:
@@ -81,8 +76,8 @@ after_build:
   - mv CHANGELOG*.md bin\Elona_foobar
   - mv LICENSE.txt bin\Elona_foobar
   - mv CREDITS.txt bin\Elona_foobar
-  - cp %OPENSSL_ROOT_DIR%\lib\VC\libcrypto.dll bin\Elona_foobar\libcrypto-1_1-x64.dll
-  - cp %OPENSSL_ROOT_DIR%\lib\VC\libssl.dll bin\Elona_foobar\libssl.dll
+  - cp %OPENSSL_ROOT_DIR%\bin\libcrypto-1_1-x64.dll bin\Elona_foobar
+  - cp %OPENSSL_ROOT_DIR%\bin\libssl-1_1-x64.dll bin\Elona_foobar
   - del bin\Elona_foobar\*.ilk
   - del bin\Elona_foobar\*.pdb
   - rd /q /s bin\Elona_foobar\graphic

--- a/deps/install.bat
+++ b/deps/install.bat
@@ -22,7 +22,4 @@ xcopy /y /e /s .\windows\lua-5.3.4-wstring\lib\x64 .\lib
 xcopy /y /e /s .\windows\zlib-1.2.11\include .\include
 xcopy /y /e /s .\windows\zlib-1.2.11\lib\x64 .\lib
 
-xcopy /y /e /s .\windows\openssl-1.1.1c\include .\include
-xcopy /y /e /s .\windows\openssl-1.1.1c\lib .\lib
-
 echo Done.

--- a/src/elona/config.cpp
+++ b/src/elona/config.cpp
@@ -376,7 +376,7 @@ void bind_setters()
     CONFIG_OPTION("language.language", std::string, language);
     CONFIG_OPTION("message.add_timestamps", bool, message_add_timestamps);
     CONFIG_OPTION("message.transparency", int, message_transparency);
-    // CONFIG_OPTION("net.is_enabled", bool, net);
+    CONFIG_OPTION("net.is_enabled", bool, net);
     CONFIG_OPTION("screen.display_mode", std::string, display_mode);
     CONFIG_OPTION("screen.heartbeat", bool, heartbeat);
     CONFIG_OPTION("screen.high_quality_shadows", bool, high_quality_shadow);
@@ -394,14 +394,6 @@ void bind_setters()
     conf.bind_setter("core.game.default_save", &setters::game_default_save);
     conf.bind_setter("core.foobar.show_fps", &setters::foobar_show_fps);
     conf.bind_setter("core.screen.fullscreen", &setters::screen_fullscreen);
-
-
-    // Always disable network feature.
-    conf.bind_setter(
-        "core.net.is_enabled", +[](const bool& value) {
-            (void)value;
-            g_config.set_net(false);
-        });
 
 #undef CONFIG_OPTION
 } // namespace


### PR DESCRIPTION
# Related Issues

#1526


# Summary

Fix crash on Windows caused by OpenSSL's DLL loading error. Elona foobar used pre-built OpenSSL binaries in `deps/windows`, but they might be broken. Now, user-provided OpenSSL is (dynamically) linked. Note that you need to install OpenSSL manually. In Appveyor CI, pre-installed binaries are linked (in `C:\OpenSSL-v111-Win64`).