### PR TITLE
Define enum class ItemCategory 

### DIFF
--- a/src/elona/adventurer.cpp
+++ b/src/elona/adventurer.cpp
@@ -365,7 +365,7 @@ int adventurer_discover_equipment()
         item->identify_state = IdentifyState::completely;
         if (item->quality >= Quality::miracle)
         {
-            if (the_item_db[itemid2int(item->id)]->category < 50000)
+            if (is_equipment(the_item_db[itemid2int(item->id)]->category))
             {
                 addnews(1, rc, 0, itemname(item->index));
             }

--- a/src/elona/ai.cpp
+++ b/src/elona/ai.cpp
@@ -326,7 +326,7 @@ void _ally_sells_item(Character& chara)
         {
             continue;
         }
-        if (the_item_db[itemid2int(item.id)]->category == 77000)
+        if (the_item_db[itemid2int(item.id)]->category == ItemCategory::ore)
         {
             sold_item_count += item.number();
             const auto total_value = item.value * item.number();

--- a/src/elona/autopick.cpp
+++ b/src/elona/autopick.cpp
@@ -52,7 +52,8 @@ std::vector<ModifierMatcher> _modifier_matchers = {
     {"rotten", [](const Item& item) { return item.param3 < 0; }},
     {"empty",
      [](const Item& item) {
-         return the_item_db[itemid2int(item.id)]->category == 72000 &&
+         return the_item_db[itemid2int(item.id)]->category ==
+             ItemCategory::chest &&
              item.param1 == 0;
      }},
     {"bad",
@@ -170,40 +171,40 @@ bool _check_category(const std::string& text, const Item& item)
             word_separator + i18n::s.get("core.autopick.category.equipment") +
                 word_separator))
     {
-        return category < 50000;
+        return is_equipment(category);
     }
 
-    ELONA_AUTOPICK_CATEGORY(melee_weapon, 10000)
-    ELONA_AUTOPICK_CATEGORY(helm, 12000)
-    ELONA_AUTOPICK_CATEGORY(shield, 14000)
-    ELONA_AUTOPICK_CATEGORY(armor, 16000)
-    ELONA_AUTOPICK_CATEGORY(boots, 18000)
-    ELONA_AUTOPICK_CATEGORY(belt, 19000)
-    ELONA_AUTOPICK_CATEGORY(cloak, 20000)
-    ELONA_AUTOPICK_CATEGORY(gloves, 22000)
-    ELONA_AUTOPICK_CATEGORY(ranged_weapon, 24000)
-    ELONA_AUTOPICK_CATEGORY(ammo, 25000)
-    ELONA_AUTOPICK_CATEGORY(ring, 32000)
-    ELONA_AUTOPICK_CATEGORY(necklace, 34000)
-    ELONA_AUTOPICK_CATEGORY(potion, 52000)
-    ELONA_AUTOPICK_CATEGORY(scroll, 53000)
-    ELONA_AUTOPICK_CATEGORY(spellbook, 54000)
-    ELONA_AUTOPICK_CATEGORY(book, 55000)
-    ELONA_AUTOPICK_CATEGORY(rod, 56000)
-    ELONA_AUTOPICK_CATEGORY(foods, 57000)
-    ELONA_AUTOPICK_CATEGORY(tool, 59000)
-    ELONA_AUTOPICK_CATEGORY(furniture, 60000)
-    ELONA_AUTOPICK_CATEGORY(well, 60001)
-    ELONA_AUTOPICK_CATEGORY(altar, 60002)
-    ELONA_AUTOPICK_CATEGORY(bodyparts, 62000)
-    ELONA_AUTOPICK_CATEGORY(junk, 64000)
-    ELONA_AUTOPICK_CATEGORY(gold_piece, 68000)
-    ELONA_AUTOPICK_CATEGORY(platinum_coin, 69000)
-    ELONA_AUTOPICK_CATEGORY(chest, 72000)
-    ELONA_AUTOPICK_CATEGORY(ore, 77000)
-    ELONA_AUTOPICK_CATEGORY(tree, 80000)
-    ELONA_AUTOPICK_CATEGORY(travelers_food, 91000)
-    ELONA_AUTOPICK_CATEGORY(cargo, 92000)
+    ELONA_AUTOPICK_CATEGORY(melee_weapon, ItemCategory::melee_weapon)
+    ELONA_AUTOPICK_CATEGORY(helm, ItemCategory::helm)
+    ELONA_AUTOPICK_CATEGORY(shield, ItemCategory::shield)
+    ELONA_AUTOPICK_CATEGORY(armor, ItemCategory::armor)
+    ELONA_AUTOPICK_CATEGORY(boots, ItemCategory::boots)
+    ELONA_AUTOPICK_CATEGORY(belt, ItemCategory::belt)
+    ELONA_AUTOPICK_CATEGORY(cloak, ItemCategory::cloak)
+    ELONA_AUTOPICK_CATEGORY(gloves, ItemCategory::gloves)
+    ELONA_AUTOPICK_CATEGORY(ranged_weapon, ItemCategory::ranged_weapon)
+    ELONA_AUTOPICK_CATEGORY(ammo, ItemCategory::ammo)
+    ELONA_AUTOPICK_CATEGORY(ring, ItemCategory::ring)
+    ELONA_AUTOPICK_CATEGORY(necklace, ItemCategory::necklace)
+    ELONA_AUTOPICK_CATEGORY(potion, ItemCategory::potion)
+    ELONA_AUTOPICK_CATEGORY(scroll, ItemCategory::scroll)
+    ELONA_AUTOPICK_CATEGORY(spellbook, ItemCategory::spellbook)
+    ELONA_AUTOPICK_CATEGORY(book, ItemCategory::book)
+    ELONA_AUTOPICK_CATEGORY(rod, ItemCategory::rod)
+    ELONA_AUTOPICK_CATEGORY(food, ItemCategory::food)
+    ELONA_AUTOPICK_CATEGORY(tool, ItemCategory::tool)
+    ELONA_AUTOPICK_CATEGORY(furniture, ItemCategory::furniture)
+    ELONA_AUTOPICK_CATEGORY(well, ItemCategory::well)
+    ELONA_AUTOPICK_CATEGORY(altar, ItemCategory::altar)
+    ELONA_AUTOPICK_CATEGORY(bodyparts, ItemCategory::bodyparts)
+    ELONA_AUTOPICK_CATEGORY(junk, ItemCategory::junk)
+    ELONA_AUTOPICK_CATEGORY(gold_piece, ItemCategory::gold_piece)
+    ELONA_AUTOPICK_CATEGORY(platinum_coin, ItemCategory::platinum_coin)
+    ELONA_AUTOPICK_CATEGORY(chest, ItemCategory::chest)
+    ELONA_AUTOPICK_CATEGORY(ore, ItemCategory::ore)
+    ELONA_AUTOPICK_CATEGORY(tree, ItemCategory::tree)
+    ELONA_AUTOPICK_CATEGORY(travelers_food, ItemCategory::travelers_food)
+    ELONA_AUTOPICK_CATEGORY(cargo, ItemCategory::cargo)
 
 #undef ELONA_AUTOPICK_CATEGORY
     return false;

--- a/src/elona/blending.cpp
+++ b/src/elona/blending.cpp
@@ -1365,7 +1365,8 @@ int blendcheckmat(int recipe_id)
                     }
                     continue;
                 }
-                if (the_item_db[itemid2int(item.id)]->category == id_at_m181)
+                if (the_item_db[itemid2int(item.id)]->category ==
+                    (ItemCategory)id_at_m181)
                 {
                     f_at_m181 = 1;
                     break;
@@ -1451,7 +1452,8 @@ int blendmatnum(int matcher, int step)
                 }
                 continue;
             }
-            if (the_item_db[itemid2int(item.id)]->category == matcher)
+            if (the_item_db[itemid2int(item.id)]->category ==
+                (ItemCategory)matcher)
             {
                 m_at_m182 += item.number();
                 continue;
@@ -1506,7 +1508,7 @@ int blendlist(elona_vector2<int>& result_array, int step)
                     continue;
                 }
             }
-            reftype_at_m183 = the_item_db[itemid2int(item.id)]->category;
+            reftype_at_m183 = (int)the_item_db[itemid2int(item.id)]->category;
             if (rpdata(40 + step, rpid))
             {
                 int stat = blendcheckext(item.index, step);

--- a/src/elona/building.cpp
+++ b/src/elona/building.cpp
@@ -42,9 +42,9 @@ int calc_heirloom_value(const Item& heirloom)
     auto value = heirloom.value;
     switch (category)
     {
-    case 60000: return value / 20;
-    case 80000: return value / 10;
-    case 77000: return value / 10;
+    case ItemCategory::furniture: return value / 20;
+    case ItemCategory::tree: return value / 10;
+    case ItemCategory::ore: return value / 10;
     default: return value / 1000;
     }
 }
@@ -59,7 +59,7 @@ void add_heirloom_if_valuable_enough(
     const Item& heirloom)
 {
     const auto category = the_item_db[itemid2int(heirloom.id)]->category;
-    if (category == 60000)
+    if (category == ItemCategory::furniture)
     {
         game_data.total_deco_value += clamp(heirloom.value / 50, 50, 500);
     }
@@ -318,7 +318,8 @@ TurnResult show_house_board()
         ++p(2);
         if (item.number() != 0)
         {
-            if (the_item_db[itemid2int(item.id)]->category != 60000)
+            if (the_item_db[itemid2int(item.id)]->category !=
+                ItemCategory::furniture)
             {
                 ++p;
             }
@@ -896,13 +897,13 @@ void show_shop_log()
         {
             continue;
         }
-        int category = the_item_db[itemid2int(item.id)]->category;
-        if (category == 60000)
+        auto category = the_item_db[itemid2int(item.id)]->category;
+        if (category == ItemCategory::furniture)
         {
             continue;
         }
         dblist(0, dblistmax) = item.index;
-        dblist(1, dblistmax) = category;
+        dblist(1, dblistmax) = (int)category;
         ++dblistmax;
     }
     for (int cnt = 0, cnt_end = (customer); cnt < cnt_end; ++cnt)

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -847,7 +847,7 @@ int calcmedalvalue(const Item& item)
 
 int calcitemvalue(const Item& item, int calc_mode)
 {
-    int category = the_item_db[itemid2int(item.id)]->category;
+    const auto category = the_item_db[itemid2int(item.id)]->category;
     int ret = 0;
     if (item.identify_state == IdentifyState::unidentified)
     {
@@ -864,7 +864,7 @@ int calcitemvalue(const Item& item, int calc_mode)
                 10;
         }
     }
-    else if (category >= 50000)
+    else if (!is_equipment(category))
     {
         ret = item.value;
     }
@@ -888,7 +888,7 @@ int calcitemvalue(const Item& item, int calc_mode)
         case CurseState::blessed: ret = ret * 120 / 100; break;
         }
     }
-    if (category == 57000)
+    if (category == ItemCategory::food)
     {
         if (item.param2 > 0)
         {
@@ -910,7 +910,7 @@ int calcitemvalue(const Item& item, int calc_mode)
     {
         if (mode == 6)
         {
-            if (category == 92000)
+            if (category == ItemCategory::cargo)
             {
                 ret = ret * trate(item.param1) / 100;
                 if (calc_mode == 1)
@@ -928,7 +928,7 @@ int calcitemvalue(const Item& item, int calc_mode)
         {
             ret = ret / 10;
         }
-        else if (category == 54000)
+        else if (category == ItemCategory::spellbook)
         {
             ret = ret / 5 + ret * item.count / (ichargelevel * 2 + 1);
         }
@@ -937,7 +937,7 @@ int calcitemvalue(const Item& item, int calc_mode)
             ret = ret / 2 + ret * item.count / (ichargelevel * 3 + 1);
         }
     }
-    if (category == 72000)
+    if (category == ItemCategory::chest)
     {
         if (item.param1 == 0)
         {
@@ -950,7 +950,7 @@ int calcitemvalue(const Item& item, int calc_mode)
         ret = ret * 100 / (100 + sdata(156, 0));
         if (game_data.guild.belongs_to_mages_guild != 0)
         {
-            if (category == 54000)
+            if (category == ItemCategory::spellbook)
             {
                 ret = ret * 80 / 100;
             }
@@ -968,7 +968,7 @@ int calcitemvalue(const Item& item, int calc_mode)
             max = ret / 3;
         }
         ret = ret * (100 + sdata(156, 0) * 5) / 1000;
-        if (category < 50000)
+        if (is_equipment(category))
         {
             ret /= 20;
         }
@@ -991,7 +991,7 @@ int calcitemvalue(const Item& item, int calc_mode)
     if (calc_mode == 2)
     {
         ret = ret / 5;
-        if (category < 50000)
+        if (is_equipment(category))
         {
             ret /= 3;
         }
@@ -1164,7 +1164,7 @@ int calccostreload(int owner, bool do_reload)
     {
         if (item.number() == 0)
             continue;
-        if (the_item_db[itemid2int(item.id)]->category != 25000)
+        if (the_item_db[itemid2int(item.id)]->category != ItemCategory::ammo)
             continue;
 
         for (auto&& enc : item.enchantments)

--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -1682,7 +1682,8 @@ void chara_relocate(
 void chara_set_item_which_will_be_used(Character& chara, const Item& item)
 {
     const auto category = the_item_db[itemid2int(item.id)]->category;
-    if (category == 57000 || category == 52000 || category == 53000)
+    if (category == ItemCategory::food || category == ItemCategory::potion ||
+        category == ItemCategory::scroll)
     {
         chara.item_which_will_be_used = item.index;
     }

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -1947,8 +1947,7 @@ TurnResult do_use_command()
         screenupdate = -1;
         update_screen();
         return TurnResult::show_house_board;
-    case 19:
-    {
+    case 19: {
         int chara = -1;
         // Are there any of your pets around you?
         const auto alone = !any_of_characters_around_you(
@@ -2029,8 +2028,7 @@ TurnResult do_use_command()
         }
         chara_refresh(0);
         break;
-    case 9:
-    {
+    case 9: {
         if (read_textbook(inv[ci]))
         {
             return TurnResult::turn_end;
@@ -2217,8 +2215,7 @@ TurnResult do_use_command()
             txt(i18n::s.get("core.common.it_is_impossible"));
         }
         break;
-    case 6:
-    {
+    case 6: {
         txt(i18n::s.get("core.action.use.music_disc.play", inv[ci]));
         auto music = inv[ci].param1 + 50 + 1;
         if (music > 97)

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -844,7 +844,7 @@ TurnResult do_throw_command()
         }
         return TurnResult::turn_end;
     }
-    if (the_item_db[itemid2int(inv[ci].id)]->category == 52000 ||
+    if (the_item_db[itemid2int(inv[ci].id)]->category == ItemCategory::potion ||
         inv[ci].id == ItemId::tomato)
     {
         if (inv[ci].id != ItemId::empty_bottle)
@@ -1457,7 +1457,8 @@ TurnResult do_dip_command()
         return TurnResult::turn_end;
     }
     snd("core.drink1");
-    if (the_item_db[itemid2int(inv[cidip].id)]->category == 52000)
+    if (the_item_db[itemid2int(inv[cidip].id)]->category ==
+        ItemCategory::potion)
     {
         if (the_item_db[itemid2int(inv[ci].id)]->subcategory == 60001)
         {
@@ -1533,7 +1534,7 @@ TurnResult do_dip_command()
     }
     if (inv[cidip].id == ItemId::poison)
     {
-        if (the_item_db[itemid2int(inv[ci].id)]->category == 57000)
+        if (the_item_db[itemid2int(inv[ci].id)]->category == ItemCategory::food)
         {
             inv[cidip].modify_number(-1);
             item_separate(ci);
@@ -1552,7 +1553,7 @@ TurnResult do_dip_command()
     }
     if (inv[cidip].id == ItemId::love_potion)
     {
-        if (the_item_db[itemid2int(inv[ci].id)]->category == 57000)
+        if (the_item_db[itemid2int(inv[ci].id)]->category == ItemCategory::food)
         {
             inv[cidip].modify_number(-1);
             item_separate(ci);
@@ -1779,7 +1780,7 @@ TurnResult do_use_command()
                 txt(i18n::s.get("core.action.use.living.weird"));
             }
             txt(i18n::s.get("core.action.use.living.it"));
-            reftype = item_data->category;
+            reftype = (int)item_data->category;
             listmax = 0;
 
             Prompt prompt;
@@ -1804,7 +1805,9 @@ TurnResult do_use_command()
                     list(0, listmax) = rtval;
                     list(1, listmax) = rtval(1);
                     get_enchantment_description(
-                        list(0, listmax), list(1, listmax), 0);
+                        list(0, listmax),
+                        list(1, listmax),
+                        ItemCategory::unidentified);
 
                     prompt.append(s);
 
@@ -1944,7 +1947,8 @@ TurnResult do_use_command()
         screenupdate = -1;
         update_screen();
         return TurnResult::show_house_board;
-    case 19: {
+    case 19:
+    {
         int chara = -1;
         // Are there any of your pets around you?
         const auto alone = !any_of_characters_around_you(
@@ -2025,7 +2029,8 @@ TurnResult do_use_command()
         }
         chara_refresh(0);
         break;
-    case 9: {
+    case 9:
+    {
         if (read_textbook(inv[ci]))
         {
             return TurnResult::turn_end;
@@ -2212,7 +2217,8 @@ TurnResult do_use_command()
             txt(i18n::s.get("core.common.it_is_impossible"));
         }
         break;
-    case 6: {
+    case 6:
+    {
         txt(i18n::s.get("core.action.use.music_disc.play", inv[ci]));
         auto music = inv[ci].param1 + 50 + 1;
         if (music > 97)

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -328,7 +328,7 @@ void make_item_list(int& mainweapon, int citrade)
             item_checkknown(item);
 
             // reftype使ってるとこ案外減ってる
-            reftype = the_item_db[itemid2int(item.id)]->category;
+            reftype = (int)the_item_db[itemid2int(item.id)]->category;
 
             if (item.own_state == 5)
             {
@@ -1309,7 +1309,8 @@ OnEnterResult on_enter(int& citrade, bool dropcontinue)
         {
             if (inv_sum(-1) >= map_data.max_item_count)
             {
-                if (the_item_db[itemid2int(inv[ci].id)]->category != 60000)
+                if (the_item_db[itemid2int(inv[ci].id)]->category !=
+                    ItemCategory::furniture)
                 {
                     txt(i18n::s.get("core.ui.inv.drop.cannot_anymore"));
                     snd("core.fail1");
@@ -1660,7 +1661,7 @@ OnEnterResult on_enter(int& citrade, bool dropcontinue)
             snd("core.fail1");
             return OnEnterResult{2};
         }
-        reftype = the_item_db[itemid2int(inv[ci].id)]->category;
+        reftype = (int)the_item_db[itemid2int(inv[ci].id)]->category;
         if (inv[ci].id == ItemId::gift)
         {
             txt(i18n::s.get(
@@ -2062,7 +2063,7 @@ OnEnterResult on_enter(int& citrade, bool dropcontinue)
             txt(i18n::s.get("core.ui.inv.common.inventory_is_full"));
             return OnEnterResult{2};
         }
-        if (the_item_db[itemid2int(inv[ci].id)]->category == 77000)
+        if (the_item_db[itemid2int(inv[ci].id)]->category == ItemCategory::ore)
         {
             snd("core.fail1");
             txt(i18n::s.get("core.ui.inv.take_ally.refuse_dialog", cdata[tc]),

--- a/src/elona/data/types/type_item.cpp
+++ b/src/elona/data/types/type_item.cpp
@@ -86,7 +86,7 @@ ItemData ItemDB::convert(const lua::ConfigTable& data, const std::string& id)
         expiration_date,
         level,
         fltselect,
-        category,
+        static_cast<ItemCategory>(category),
         subcategory,
         rarity,
         coefficient,

--- a/src/elona/data/types/type_item.hpp
+++ b/src/elona/data/types/type_item.hpp
@@ -40,7 +40,7 @@ struct ItemData
     int expiration_date;
     int level;
     int fltselect;
-    int category;
+    ItemCategory category;
     int subcategory;
     int rarity;
     int coefficient;

--- a/src/elona/elonacore.cpp
+++ b/src/elona/elonacore.cpp
@@ -2469,7 +2469,7 @@ int convertartifact(int item_index, int ignore_external_container)
     int f_at_m163 = 0;
     int tc_at_m163 = 0;
     std::string n_at_m163;
-    if (the_item_db[itemid2int(inv[item_index].id)]->category >= 50000)
+    if (!is_equipment(the_item_db[itemid2int(inv[item_index].id)]->category))
     {
         return item_index;
     }
@@ -3029,7 +3029,7 @@ void character_drops_item()
             continue;
         }
         if (catitem != 0 && !item.is_blessed_by_ehekatl() &&
-            the_item_db[itemid2int(item.id)]->category < 50000 &&
+            is_equipment(the_item_db[itemid2int(item.id)]->category) &&
             item.quality >= Quality::great)
         {
             if (rnd(3))
@@ -3038,7 +3038,7 @@ void character_drops_item()
                         "core.misc.black_cat_licks", cdata[catitem], item),
                     Message::color{ColorIndex::cyan});
                 item.is_blessed_by_ehekatl() = true;
-                reftype = the_item_db[itemid2int(item.id)]->category;
+                reftype = (int)the_item_db[itemid2int(item.id)]->category;
                 enchantment_add(
                     item,
                     enchantment_generate(enchantment_gen_level(rnd(4))),
@@ -3677,7 +3677,7 @@ void auto_identify()
         {
             continue;
         }
-        if (the_item_db[itemid2int(item.id)]->category >= 50000)
+        if (!is_equipment(the_item_db[itemid2int(item.id)]->category))
         {
             continue;
         }
@@ -5965,7 +5965,7 @@ void load_gene_files()
         {
             continue;
         }
-        if (the_item_db[itemid2int(item.id)]->category == 25000)
+        if (the_item_db[itemid2int(item.id)]->category == ItemCategory::ammo)
         {
             item.count = -1;
         }
@@ -6705,7 +6705,8 @@ void map_global_proc_travel_events()
             {
                 continue;
             }
-            if (the_item_db[itemid2int(item.id)]->category == 91000)
+            if (the_item_db[itemid2int(item.id)]->category ==
+                ItemCategory::travelers_food)
             {
                 f = 1;
                 ci = item.index;
@@ -8072,7 +8073,7 @@ int pick_up_item(bool play_sound)
                 }
             }
         }
-        if (the_item_db[itemid2int(inv[ci].id)]->category == 57000)
+        if (the_item_db[itemid2int(inv[ci].id)]->category == ItemCategory::food)
         {
             if (inv[ci].own_state == 4)
             {
@@ -8130,7 +8131,8 @@ int pick_up_item(bool play_sound)
     {
         if (trait(215) != 0)
         {
-            if (the_item_db[itemid2int(inv[ci].id)]->category == 56000)
+            if (the_item_db[itemid2int(inv[ci].id)]->category ==
+                ItemCategory::rod)
             {
                 if (inv[ci].count > 0)
                 {
@@ -8154,7 +8156,8 @@ int pick_up_item(bool play_sound)
         }
         if (trait(216) != 0)
         {
-            if (the_item_db[itemid2int(inv[ci].id)]->category == 52000)
+            if (the_item_db[itemid2int(inv[ci].id)]->category ==
+                ItemCategory::potion)
             {
                 if (inv[ci].id != ItemId::poison &&
                     inv[ci].id != ItemId::potion_of_cure_corruption)
@@ -8198,7 +8201,7 @@ int pick_up_item(bool play_sound)
     inv[ci].set_number(inumbk);
     if (mode == 6)
     {
-        if (the_item_db[itemid2int(inv[ti].id)]->category == 57000)
+        if (the_item_db[itemid2int(inv[ti].id)]->category == ItemCategory::food)
         {
             if (invctrl == 11 || invctrl == 22)
             {
@@ -8234,7 +8237,8 @@ int pick_up_item(bool play_sound)
             snd_("core.paygold1");
             cdata.player().gold -= sellgold;
             earn_gold(cdata[tc], sellgold);
-            if (the_item_db[itemid2int(inv[ti].id)]->category == 92000)
+            if (the_item_db[itemid2int(inv[ti].id)]->category ==
+                ItemCategory::cargo)
             {
                 inv[ti].param2 = calcitemvalue(inv[ti], 0);
             }
@@ -10496,7 +10500,8 @@ void discover_hidden_path()
 
 void dipcursed(int item_index, int)
 {
-    if (the_item_db[itemid2int(inv[item_index].id)]->category == 57000)
+    if (the_item_db[itemid2int(inv[item_index].id)]->category ==
+        ItemCategory::food)
     {
         if (inv[item_index].material == 35)
         {
@@ -10513,7 +10518,7 @@ void dipcursed(int item_index, int)
             return;
         }
     }
-    if (the_item_db[itemid2int(inv[item_index].id)]->category < 50000)
+    if (is_equipment(the_item_db[itemid2int(inv[item_index].id)]->category))
     {
         --inv[item_index].enhancement;
         txt(i18n::s.get("core.action.dip.rusts", inv[item_index]));

--- a/src/elona/enchantment.cpp
+++ b/src/elona/enchantment.cpp
@@ -191,7 +191,11 @@ std::string enchantment_level_string(int level)
 
 
 
-void get_enchantment_description(int val0, int power, int category, bool trait)
+void get_enchantment_description(
+    int val0,
+    int power,
+    ItemCategory category,
+    bool trait)
 {
     rtval(0) = static_cast<int>(ItemDescriptionType::enchantment);
     rtval(1) = 0;
@@ -215,7 +219,7 @@ void get_enchantment_description(int val0, int power, int category, bool trait)
                     "ability",
                     the_ability_db.get_id_from_legacy(sid)->get(),
                     "name");
-                if (category == 57000)
+                if (category == ItemCategory::food)
                 {
                     s = i18n::s.get(
                         "core.enchantment.with_parameters.attribute.in_food.decreases",
@@ -236,7 +240,7 @@ void get_enchantment_description(int val0, int power, int category, bool trait)
                     "ability",
                     the_ability_db.get_id_from_legacy(sid)->get(),
                     "name");
-                if (category == 57000)
+                if (category == ItemCategory::food)
                 {
                     s = i18n::s.get(
                         "core.enchantment.with_parameters.attribute.in_food.increases",
@@ -318,7 +322,7 @@ void get_enchantment_description(int val0, int power, int category, bool trait)
             break;
         case 6:
             rtval = static_cast<int>(ItemDescriptionType::maintains_skill);
-            if (category == 57000)
+            if (category == ItemCategory::food)
             {
                 s = i18n::s.get(
                     "core.enchantment.with_parameters.skill_maintenance.in_food",
@@ -653,12 +657,12 @@ bool enchantment_add(
         const auto type_ = type >= 10000 ? type / 10000 : type;
         if (encref(3, type_) != 0)
         {
-            if (!check_enchantment_filters(category, type_))
+            if (!check_enchantment_filters((int)category, type_))
             {
                 return false;
             }
         }
-        else if (category == 25000 && !not_halve)
+        else if (category == ItemCategory::ammo && !not_halve)
         {
             return false;
         }
@@ -711,13 +715,14 @@ bool enchantment_add(
         {
             if (encprocref(3, cnt) != 0)
             {
-                if (!enchantment_filter(category, encprocref(3, cnt)))
+                if (!enchantment_filter((int)category, encprocref(3, cnt)))
                 {
                     if (encprocref(4, cnt) == 0)
                     {
                         continue;
                     }
-                    else if (!enchantment_filter(category, encprocref(4, cnt)))
+                    else if (!enchantment_filter(
+                                 (int)category, encprocref(4, cnt)))
                     {
                         continue;
                     }
@@ -777,7 +782,7 @@ bool enchantment_add(
 
     if (item.enchantments[i_at_m48].id == enc)
     {
-        if (category == 25000)
+        if (category == ItemCategory::ammo)
         {
             return false;
         }

--- a/src/elona/enchantment.hpp
+++ b/src/elona/enchantment.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 
+#include "enums.hpp"
 #include "optional.hpp"
 
 
@@ -70,7 +71,7 @@ int enchantment_gen_p(int multiplier = 100);
 
 
 std::string enchantment_print_level(int level);
-void get_enchantment_description(int, int, int, bool = false);
+void get_enchantment_description(int, int, ItemCategory, bool = false);
 void add_enchantments(Item& item);
 
 void initialize_ego_data();

--- a/src/elona/enums.hpp
+++ b/src/elona/enums.hpp
@@ -135,7 +135,7 @@ enum class ItemCategory : int
 
 inline bool is_equipment(ItemCategory c)
 {
-    return c <= (ItemCategory)50000;
+    return c <= static_cast<ItemCategory>(50000);
 }
 
 /**

--- a/src/elona/enums.hpp
+++ b/src/elona/enums.hpp
@@ -96,7 +96,47 @@ enum class IdentifyState : int
     completely = 3,
 };
 
+enum class ItemCategory : int
+{
+    unidentified = 0,
+    melee_weapon = 10000,
+    helm = 12000,
+    shield = 14000,
+    armor = 16000,
+    boots = 18000,
+    belt = 19000,
+    cloak = 20000,
+    gloves = 22000,
+    ranged_weapon = 24000,
+    ammo = 25000,
+    ring = 32000,
+    necklace = 34000,
+    potion = 52000,
+    scroll = 53000,
+    spellbook = 54000,
+    book = 55000,
+    rod = 56000,
+    food = 57000,
+    tool = 59000,
+    furniture = 60000,
+    well = 60001,
+    altar = 60002,
+    bodyparts = 62000,
+    junk = 64000,
+    gold_piece = 68000,
+    platinum_coin = 69000,
+    chest = 72000,
+    ore = 77000,
+    tree = 80000,
+    travelers_food = 91000,
+    cargo = 92000,
+    bug = 99999999,
+};
 
+inline bool is_equipment(ItemCategory c)
+{
+    return c <= (ItemCategory)50000;
+}
 
 /**
  * Quality of items or characters. They are mainly used for identification.

--- a/src/elona/equipment.cpp
+++ b/src/elona/equipment.cpp
@@ -377,7 +377,7 @@ void supply_new_equipment()
                                 [itemid2int(
                                      inv[cdata[rc].body_parts[cnt] % 10000 - 1]
                                          .id)]
-                                    ->category == 10000)
+                                    ->category == ItemCategory::melee_weapon)
                         {
                             haveweapon = 1;
                         }
@@ -428,7 +428,7 @@ void supply_new_equipment()
             item->identify_state = IdentifyState::completely;
             if (item->quality >= Quality::miracle)
             {
-                if (the_item_db[itemid2int(item->id)]->category < 50000)
+                if (is_equipment(the_item_db[itemid2int(item->id)]->category))
                 {
                     if (cdata[rc].character_role == 13)
                     {

--- a/src/elona/food.cpp
+++ b/src/elona/food.cpp
@@ -658,7 +658,7 @@ void apply_general_eating_effect(Character& eater, Item& food)
         }
         nutrition = 3500;
     }
-    if (the_item_db[itemid2int(food.id)]->category == 57000)
+    if (the_item_db[itemid2int(food.id)]->category == ItemCategory::food)
     {
         nutrition = nutrition * (100 + food.param2 * 15) / 100;
     }

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -135,7 +135,6 @@ InventorySlice Inventory::by_index(int index)
 
 elona_vector1<int> p_at_m57;
 std::string s_;
-int a_ = 0;
 int skip_ = 0;
 
 
@@ -203,7 +202,7 @@ item_find(int matcher, int matcher_type, ItemFindLocation location_type)
             switch (matcher_type)
             {
             case 0:
-                if (the_item_db[itemid2int(item.id)]->category == matcher)
+                if ((int)the_item_db[itemid2int(item.id)]->category == matcher)
                 {
                     result = item.index;
                 }
@@ -623,7 +622,7 @@ bool chara_unequip(Item& item)
 IdentifyState item_identify(Item& item, IdentifyState level)
 {
     if (level == IdentifyState::almost &&
-        the_item_db[itemid2int(item.id)]->category >= 50000)
+        !is_equipment(the_item_db[itemid2int(item.id)]->category))
     {
         level = IdentifyState::completely;
     }
@@ -727,7 +726,10 @@ void itemname_additional_info(int item_index)
                 u8" of <"s + rpname(inv[item_index].subname) + u8">"s);
         }
     }
-    if (a_ == 55000)
+
+    auto category = the_item_db[itemid2int(inv[item_index].id)]->category;
+
+    if (category == ItemCategory::book)
     {
         if (inv[item_index].id == ItemId::textbook)
         {
@@ -762,7 +764,7 @@ void itemname_additional_info(int item_index)
                 u8" titled <"s + booktitle(inv[item_index].param1) + u8">"s);
         }
     }
-    if (a_ == 60002)
+    if (category == ItemCategory::altar)
     {
         if (inv[item_index].param1 != 0)
         {
@@ -771,7 +773,7 @@ void itemname_additional_info(int item_index)
                 u8" <"s + god_name(inv[item_index].param1) + u8">"s);
         }
     }
-    if (a_ == 57000)
+    if (category == ItemCategory::food)
     {
         if (inv[item_index].param1 != 0)
         {
@@ -828,7 +830,8 @@ void itemname_additional_info(int item_index)
                 "name");
         }
         else if (
-            a_ == 57000 || a_ == 62000 ||
+            category == ItemCategory::food ||
+            category == ItemCategory::bodyparts ||
             inv[item_index].id == ItemId::figurine ||
             inv[item_index].id == ItemId::card ||
             inv[item_index].id == ItemId::shit ||
@@ -849,7 +852,7 @@ void itemname_additional_info(int item_index)
                 }
             }
         }
-        if (a_ == 60000)
+        if (category == ItemCategory::furniture)
         {
             if (jp)
             {
@@ -949,17 +952,18 @@ std::string itemname(int item_index, int number, int skip_article)
     {
         num2_ = number;
     }
-    a_ = the_item_db[itemid2int(inv[item_index].id)]->category;
+    const auto category = the_item_db[itemid2int(inv[item_index].id)]->category;
     if (jp)
     {
         if (num2_ > 1)
         {
             s2_ = u8"個の"s;
-            if (a_ == 16000)
+            if (category == ItemCategory::armor)
             {
                 s2_ = u8"着の"s;
             }
-            if (a_ == 54000 || a_ == 55000)
+            if (category == ItemCategory::spellbook ||
+                category == ItemCategory::book)
             {
                 if (inv[item_index].id == ItemId::recipe)
                 {
@@ -970,23 +974,25 @@ std::string itemname(int item_index, int number, int skip_article)
                     s2_ = u8"冊の"s;
                 }
             }
-            if (a_ == 10000)
+            if (category == ItemCategory::melee_weapon)
             {
                 s2_ = u8"本の"s;
             }
-            if (a_ == 52000)
+            if (category == ItemCategory::potion)
             {
                 s2_ = u8"服の"s;
             }
-            if (a_ == 53000)
+            if (category == ItemCategory::scroll)
             {
                 s2_ = u8"巻の"s;
             }
-            if (a_ == 22000 || a_ == 18000)
+            if (category == ItemCategory::boots ||
+                category == ItemCategory::gloves)
             {
                 s2_ = u8"対の"s;
             }
-            if (a_ == 68000 || a_ == 69000 ||
+            if (category == ItemCategory::gold_piece ||
+                category == ItemCategory::platinum_coin ||
                 inv[item_index].id == ItemId::small_medal ||
                 inv[item_index].id == ItemId::music_ticket ||
                 inv[item_index].id == ItemId::token_of_friendship)
@@ -1069,12 +1075,13 @@ std::string itemname(int item_index, int number, int skip_article)
                 {
                     s2_ = u8"cargo";
                 }
-                if (a_ == 22000 || a_ == 18000)
+                if (category == ItemCategory::boots ||
+                    category == ItemCategory::gloves)
                 {
                     s2_ = u8"pair";
                 }
             }
-            if (a_ == 57000 && inv[item_index].param1 != 0 &&
+            if (category == ItemCategory::food && inv[item_index].param1 != 0 &&
                 inv[item_index].param2 != 0)
             {
                 s2_ = u8"dish";
@@ -1124,12 +1131,12 @@ std::string itemname(int item_index, int number, int skip_article)
     }
     if (en)
     {
-        if (a_ == 57000 && inv[item_index].param1 != 0 &&
+        if (category == ItemCategory::food && inv[item_index].param1 != 0 &&
             inv[item_index].param2 != 0)
         {
             skip_ = 1;
         }
-        if (inv[item_index].subname != 0 && a_ == 60000)
+        if (inv[item_index].subname != 0 && category == ItemCategory::furniture)
         {
             if (inv[item_index].subname >= 12)
             {
@@ -1168,7 +1175,7 @@ std::string itemname(int item_index, int number, int skip_article)
     {
         itemname_additional_info(item_index);
     }
-    if (a_ == 60000 && inv[item_index].material != 0)
+    if (category == ItemCategory::furniture && inv[item_index].material != 0)
     {
         if (jp)
         {
@@ -1202,7 +1209,7 @@ std::string itemname(int item_index, int number, int skip_article)
     {
         alpha_ = 0;
         if (inv[item_index].identify_state == IdentifyState::completely &&
-            a_ < 50000)
+            is_equipment(category))
         {
             if (inv[item_index].is_eternal_force())
             {
@@ -1272,7 +1279,8 @@ std::string itemname(int item_index, int number, int skip_article)
         }
         else if (inv[item_index].identify_state != IdentifyState::completely)
         {
-            if (inv[item_index].quality < Quality::miracle || a_ >= 50000)
+            if (inv[item_index].quality < Quality::miracle ||
+                !is_equipment(category))
             {
                 s_ += ioriginalnameref(itemid2int(inv[item_index].id));
             }
@@ -1309,7 +1317,8 @@ std::string itemname(int item_index, int number, int skip_article)
             {
                 s_ += ioriginalnameref(itemid2int(inv[item_index].id));
             }
-            if (en && a_ < 50000 && inv[item_index].subname >= 10000 &&
+            if (en && is_equipment(category) &&
+                inv[item_index].subname >= 10000 &&
                 inv[item_index].subname < 20000)
             {
                 s_ += u8" "s + egoname((inv[item_index].subname - 10000));
@@ -1340,7 +1349,8 @@ std::string itemname(int item_index, int number, int skip_article)
         if (skip_article == 0)
         {
             if (inv[item_index].identify_state == IdentifyState::completely &&
-                (inv[item_index].quality >= Quality::miracle && a_ < 50000))
+                (inv[item_index].quality >= Quality::miracle &&
+                 is_equipment(category)))
             {
                 s_ = u8"the "s + s_;
             }
@@ -1508,7 +1518,8 @@ std::string itemname(int item_index, int number, int skip_article)
     {
         s_ += lang(u8" Lv"s, u8" Level "s) + inv[item_index].param2;
     }
-    if (inv[item_index].identify_state == IdentifyState::almost && a_ < 50000)
+    if (inv[item_index].identify_state == IdentifyState::almost &&
+        is_equipment(category))
     {
         s_ += u8" ("s +
             cnven(i18n::s.get_enum(
@@ -1546,7 +1557,7 @@ std::string itemname(int item_index, int number, int skip_article)
             s_ += i18n::s.get("core.item.approximate_curse_state.doomed");
         }
     }
-    if (a_ == 72000)
+    if (category == ItemCategory::chest)
     {
         if (inv[item_index].id == ItemId::shopkeepers_trunk)
         {
@@ -1560,7 +1571,7 @@ std::string itemname(int item_index, int number, int skip_article)
             }
         }
     }
-    if (a_ == 92000 && inv[item_index].param2 != 0)
+    if (category == ItemCategory::cargo && inv[item_index].param2 != 0)
     {
         s_ += lang(
             u8"(仕入れ値 "s + inv[item_index].param2 + u8"g)"s,
@@ -1631,7 +1642,7 @@ void remain_make(Item& remain, const Character& chara)
 bool item_stack(int inventory_id, Item& base_item, bool show_message)
 {
     if (base_item.quality == Quality::special &&
-        the_item_db[itemid2int(base_item.id)]->category < 50000)
+        is_equipment(the_item_db[itemid2int(base_item.id)]->category))
     {
         return 0;
     }
@@ -1681,7 +1692,7 @@ bool item_stack(int inventory_id, Item& base_item, bool show_message)
 
 void item_dump_desc(const Item& i)
 {
-    reftype = the_item_db[itemid2int(i.id)]->category;
+    reftype = (int)the_item_db[itemid2int(i.id)]->category;
 
     item_db_get_charge_level(inv[ci], itemid2int(i.id));
     item_db_get_description(inv[ci], itemid2int(i.id));
@@ -1724,7 +1735,7 @@ void item_acid(const Character& owner, int ci)
         }
     }
 
-    if (the_item_db[itemid2int(inv[ci].id)]->category >= 50000)
+    if (!is_equipment(the_item_db[itemid2int(inv[ci].id)]->category))
     {
         return;
     }
@@ -1800,8 +1811,8 @@ bool item_fire(int owner, optional_ref<Item> burned_item)
             continue;
         }
 
-        int a_ = the_item_db[itemid2int(item.id)]->category;
-        if (a_ == 57000 && item.param2 == 0)
+        const auto category = the_item_db[itemid2int(item.id)]->category;
+        if (category == ItemCategory::food && item.param2 == 0)
         {
             if (owner == -1)
             {
@@ -1828,7 +1839,8 @@ bool item_fire(int owner, optional_ref<Item> burned_item)
             continue;
         }
 
-        if (a_ == 72000 || a_ == 59000 || a_ == 68000 ||
+        if (category == ItemCategory::chest || category == ItemCategory::tool ||
+            category == ItemCategory::gold_piece ||
             item.quality >= Quality::miracle)
         {
             continue;
@@ -1842,8 +1854,10 @@ bool item_fire(int owner, optional_ref<Item> burned_item)
             }
         }
 
-        if (a_ != 56000 && a_ != 80000 && a_ != 55000 && a_ != 53000 &&
-            a_ != 54000)
+        if (category != ItemCategory::rod && category != ItemCategory::tree &&
+            category != ItemCategory::book &&
+            category != ItemCategory::scroll &&
+            category != ItemCategory::spellbook)
         {
             if (rnd(4))
             {
@@ -2024,8 +2038,9 @@ bool item_cold(int owner, optional_ref<Item> destroyed_item)
             continue;
         }
 
-        int a_ = the_item_db[itemid2int(item.id)]->category;
-        if (a_ == 72000 || a_ == 59000 || a_ == 68000)
+        const auto category = the_item_db[itemid2int(item.id)]->category;
+        if (category == ItemCategory::chest || category == ItemCategory::tool ||
+            category == ItemCategory::gold_piece)
         {
             continue;
         }
@@ -2033,7 +2048,7 @@ bool item_cold(int owner, optional_ref<Item> destroyed_item)
         {
             continue;
         }
-        if (a_ != 52000)
+        if (category != ItemCategory::potion)
         {
             if (rnd(30))
             {
@@ -2425,18 +2440,18 @@ int iequiploc(const Item& item)
 {
     switch (the_item_db[itemid2int(item.id)]->category)
     {
-    case 12000: return 1;
-    case 34000: return 2;
-    case 20000: return 3;
-    case 16000: return 4;
-    case 10000: return 5;
-    case 14000: return 5;
-    case 32000: return 6;
-    case 22000: return 7;
-    case 18000: return 9;
-    case 24000: return 10;
-    case 25000: return 11;
-    case 19000: return 8;
+    case ItemCategory::helm: return 1;
+    case ItemCategory::necklace: return 2;
+    case ItemCategory::cloak: return 3;
+    case ItemCategory::armor: return 4;
+    case ItemCategory::melee_weapon: return 5;
+    case ItemCategory::shield: return 5;
+    case ItemCategory::ring: return 6;
+    case ItemCategory::gloves: return 7;
+    case ItemCategory::boots: return 9;
+    case ItemCategory::ranged_weapon: return 10;
+    case ItemCategory::ammo: return 11;
+    case ItemCategory::belt: return 8;
     default: return 0;
     }
 }

--- a/src/elona/item_db.cpp
+++ b/src/elona/item_db.cpp
@@ -136,7 +136,7 @@ void item_db_get_charge_level(const Item& item, int legacy_id)
 
     const auto& info = the_item_db.ensure(legacy_id);
     ichargelevel = info.chargelevel;
-    reftype = info.category;
+    reftype = (int)info.category;
 }
 
 
@@ -153,7 +153,7 @@ void item_db_set_full_stats(Item& item, int legacy_id)
     item.difficulty_of_identification = 0; // Default value
     item.image = info.image;
     fixeditemenc(0) = 0; // Default value
-    reftype = info.category;
+    reftype = (int)info.category;
     reftypeminor = info.subcategory;
 
     switch (legacy_id)

--- a/src/elona/item_load_desc.cpp
+++ b/src/elona/item_load_desc.cpp
@@ -248,7 +248,8 @@ void _load_item_enchantment_desc(const Item& item, int& num_of_desc)
         if (enc.id == 0)
             break;
 
-        get_enchantment_description(enc.id, enc.power, reftype);
+        get_enchantment_description(
+            enc.id, enc.power, the_item_db[itemid2int(item.id)]->category);
         listn(0, num_of_desc) = i18n::s.get("core.enchantment.it") + s;
         list(0, num_of_desc) = rtval;
         list(1, num_of_desc) = rtval(1);

--- a/src/elona/itemgen.cpp
+++ b/src/elona/itemgen.cpp
@@ -25,7 +25,7 @@ int initnum;
 
 int calculate_original_value(const Item& ci)
 {
-    if (the_item_db[itemid2int(ci.id)]->category == 60000)
+    if (the_item_db[itemid2int(ci.id)]->category == ItemCategory::furniture)
     {
         return ci.value * 100 / (80 + std::max(1, ci.subname) * 20) -
             the_item_material_db[ci.material]->value * 2;
@@ -104,7 +104,7 @@ int get_random_item_id()
             continue;
         if (fltselect != data.fltselect)
             continue;
-        if (flttypemajor != 0 && flttypemajor != data.category)
+        if (flttypemajor != 0 && flttypemajor != (int)data.category)
             continue;
         if (flttypeminor != 0 && flttypeminor != data.subcategory)
             continue;
@@ -409,7 +409,9 @@ optional_ref<Item> do_create_item(int item_id, int slot, int x, int y)
         item.count = 6;
     }
 
-    if (reftype == 72000)
+    const auto category = the_item_db[itemid2int(item.id)]->category;
+
+    if (category == ItemCategory::chest)
     {
         item.param1 = game_data.current_dungeon_level *
                 (game_data.current_map != mdata_t::MapId::shelter_) +
@@ -440,7 +442,7 @@ optional_ref<Item> do_create_item(int item_id, int slot, int x, int y)
         }
     }
 
-    if (reftype == 57000 && item.param1 != 0)
+    if (category == ItemCategory::food && item.param1 != 0)
     {
         if (mode == 6)
         {
@@ -464,7 +466,7 @@ optional_ref<Item> do_create_item(int item_id, int slot, int x, int y)
     }
 
     init_item_quality_curse_state_material_and_equipments(item);
-    if (reftype == 60000)
+    if (category == ItemCategory::furniture)
     {
         if (rnd(3) == 0)
         {
@@ -480,20 +482,22 @@ optional_ref<Item> do_create_item(int item_id, int slot, int x, int y)
     {
         item.identify_state = IdentifyState::completely;
     }
-    if (reftype == 68000 || reftype == 69000 ||
+    if (category == ItemCategory::gold_piece ||
+        category == ItemCategory::platinum_coin ||
         item.id == ItemId::small_medal || item.id == ItemId::music_ticket ||
         item.id == ItemId::token_of_friendship || item.id == ItemId::bill)
     {
         item.curse_state = CurseState::none;
         item.identify_state = IdentifyState::completely;
     }
-    if (reftype == 92000)
+    if (category == ItemCategory::cargo)
     {
         item.identify_state = IdentifyState::completely;
         item.curse_state = CurseState::none;
         itemmemory(0, itemid2int(item.id)) = 1;
     }
-    if (reftype == 62000 || reftype == 64000 || reftype == 77000)
+    if (category == ItemCategory::bodyparts || category == ItemCategory::junk ||
+        category == ItemCategory::ore)
     {
         item.curse_state = CurseState::none;
     }
@@ -541,7 +545,9 @@ optional_ref<Item> do_create_item(int item_id, int slot, int x, int y)
 
 void init_item_quality_curse_state_material_and_equipments(Item& item)
 {
-    if (reftype < 60000)
+    const auto category = the_item_db[itemid2int(item.id)]->category;
+
+    if (category < ItemCategory::furniture)
     {
         if (rnd(12) == 0)
         {
@@ -550,7 +556,7 @@ void init_item_quality_curse_state_material_and_equipments(Item& item)
         if (rnd(13) == 0)
         {
             item.curse_state = CurseState::cursed;
-            if (the_item_db[itemid2int(item.id)]->category < 50000)
+            if (is_equipment(category))
             {
                 if (rnd(4) == 0)
                 {
@@ -563,9 +569,10 @@ void init_item_quality_curse_state_material_and_equipments(Item& item)
     {
         item.curse_state = CurseState::none;
     }
-    if (reftype < 50000 || (reftype == 60000 && rnd(5) == 0))
+    if (is_equipment(category) ||
+        (category == ItemCategory::furniture && rnd(5) == 0))
     {
-        if (item.material >= 1000 || reftype == 60000)
+        if (item.material >= 1000 || category == ItemCategory::furniture)
         {
             initialize_item_material(item);
         }
@@ -592,7 +599,7 @@ void init_item_quality_curse_state_material_and_equipments(Item& item)
                 1);
         }
     }
-    if (reftype < 52000)
+    if (category < ItemCategory::potion)
     {
         add_enchantments(item);
     }
@@ -606,7 +613,7 @@ void init_item_quality_curse_state_material_and_equipments(Item& item)
 
 void calc_furniture_value(Item& item)
 {
-    if (reftype == 60000)
+    if (the_item_db[itemid2int(item.id)]->category == ItemCategory::furniture)
     {
         if (item.subname != 0)
         {
@@ -679,7 +686,8 @@ void determine_item_material(Item& item)
     }
     mtlv = clamp(rnd(mtlv + 1) + objfix, 0, 4);
     objfix = 0;
-    if (reftype == 60000)
+
+    if (the_item_db[itemid2int(item.id)]->category == ItemCategory::furniture)
     {
         if (rnd(2) == 0)
         {
@@ -724,7 +732,7 @@ void change_item_material(Item& item, int material_id)
 {
     item.color = 0;
     p = item.material;
-    reftype = the_item_db[itemid2int(item.id)]->category;
+
     fixlv = item.quality;
     for (auto e : the_item_material_db[p]->enchantments)
     {
@@ -753,7 +761,8 @@ void change_item_material(Item& item, int material_id)
 
 void apply_item_material(Item& item)
 {
-    if (reftype == 60000)
+    const auto category = the_item_db[itemid2int(item.id)]->category;
+    if (category == ItemCategory::furniture)
     {
         if (item.material == 3 || item.material == 16 || item.material == 21 ||
             item.material == 2)
@@ -763,7 +772,7 @@ void apply_item_material(Item& item)
     }
     p = item.material;
     item.weight = item.weight * the_item_material_db[p]->weight / 100;
-    if (reftype == 60000)
+    if (category == ItemCategory::furniture)
     {
         item.value += the_item_material_db[p]->value * 2;
     }

--- a/src/elona/lua_env/lua_api/lua_api_item.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_item.cpp
@@ -273,7 +273,7 @@ int LuaApiItem::trade_rate(LuaItemHandle handle)
     auto& item_ref = lua::ref<Item>(handle);
 
     // Item must be in the cargo category.
-    if (the_item_db[itemid2int(item_ref.id)]->category != 92000)
+    if (the_item_db[itemid2int(item_ref.id)]->category != ItemCategory::cargo)
     {
         return 0;
     }

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -3845,8 +3845,7 @@ optional<bool> _proc_general_magic()
             .play();
         try_to_melee_attack();
         return true;
-    case 1:
-    {
+    case 1: {
         int stat =
             get_route(cdata[cc].position.x, cdata[cc].position.y, tlocx, tlocy);
         if (stat == 0)

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -2624,7 +2624,8 @@ bool _magic_630_1129()
             {
                 f = 0;
             }
-            if (the_item_db[itemid2int(inv[ci].id)]->category == 54000)
+            if (the_item_db[itemid2int(inv[ci].id)]->category ==
+                ItemCategory::spellbook)
             {
                 if (rnd(4) == 0)
                 {
@@ -2642,7 +2643,8 @@ bool _magic_630_1129()
                 {
                     p = ichargelevel - inv[ci].count + 1;
                 }
-                if (the_item_db[itemid2int(inv[ci].id)]->category == 54000)
+                if (the_item_db[itemid2int(inv[ci].id)]->category ==
+                    ItemCategory::spellbook)
                 {
                     p = 1;
                 }
@@ -2872,7 +2874,7 @@ bool _magic_1132(int& fltbk, int& valuebk)
     {
         save_set_autosave();
         animeload(8, cc);
-        fltbk = the_item_db[itemid2int(inv[ci].id)]->category;
+        fltbk = (int)the_item_db[itemid2int(inv[ci].id)]->category;
         valuebk = calcitemvalue(inv[ci], 0);
         inv[ci].remove();
         for (int cnt = 0;; ++cnt)
@@ -3334,7 +3336,8 @@ bool _magic_651()
             {
                 continue;
             }
-            if (the_item_db[itemid2int(item.id)]->category != 57000)
+            if (the_item_db[itemid2int(item.id)]->category !=
+                ItemCategory::food)
             {
                 continue;
             }
@@ -3842,7 +3845,8 @@ optional<bool> _proc_general_magic()
             .play();
         try_to_melee_attack();
         return true;
-    case 1: {
+    case 1:
+    {
         int stat =
             get_route(cdata[cc].position.x, cdata[cc].position.y, tlocx, tlocy);
         if (stat == 0)

--- a/src/elona/map.cpp
+++ b/src/elona/map.cpp
@@ -358,7 +358,8 @@ void map_reload(const std::string& map_filename)
         {
             if (item.own_state == 1)
             {
-                if (the_item_db[itemid2int(item.id)]->category == 57000)
+                if (the_item_db[itemid2int(item.id)]->category ==
+                    ItemCategory::food)
                 {
                     item.remove();
                     cell_refresh(item.position.x, item.position.y);

--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -1175,7 +1175,8 @@ void show_weapon_dice(int val0)
         mes(wx + 417, wy + 281 + p(2) * 16, s(1), {20, 10, 0});
     }
     attackrange = 0;
-    if (the_item_db[itemid2int(inv[cw].id)]->category == 24000) // TODO coupling
+    if (the_item_db[itemid2int(inv[cw].id)]->category ==
+        ItemCategory::ranged_weapon) // TODO coupling
     {
         attackrange = 1;
     }

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -2252,8 +2252,7 @@ TalkResult talk_npc()
     case 54: return talk_shop_reload_ammo();
     case 55: return talk_spell_writer_reserve();
     case 56: return talk_sex();
-    case 58:
-    {
+    case 58: {
         if (game_data.left_turns_of_timestop == 0)
         {
             event_add(25);

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -2086,7 +2086,8 @@ TalkResult talk_npc()
                 }
                 if (quest_data[rq].id == 1003)
                 {
-                    if (the_item_db[itemid2int(item.id)]->category == 57000 &&
+                    if (the_item_db[itemid2int(item.id)]->category ==
+                            ItemCategory::food &&
                         item.param1 / 1000 == quest_data[rq].extra_info_1 &&
                         item.param2 == quest_data[rq].extra_info_2)
                     {
@@ -2251,7 +2252,8 @@ TalkResult talk_npc()
     case 54: return talk_shop_reload_ammo();
     case 55: return talk_spell_writer_reserve();
     case 56: return talk_sex();
-    case 58: {
+    case 58:
+    {
         if (game_data.left_turns_of_timestop == 0)
         {
             event_add(25);

--- a/src/elona/turn_sequence.cpp
+++ b/src/elona/turn_sequence.cpp
@@ -462,18 +462,18 @@ optional<TurnResult> npc_turn_misc(Character& chara)
     }
 
     const auto category = the_item_db[itemid2int(inv[ci].id)]->category;
-    if (category == 57000)
+    if (category == ItemCategory::food)
     {
         if (chara.relationship != 10 || chara.nutrition <= 6000)
         {
             return do_eat_command();
         }
     }
-    if (category == 52000)
+    if (category == ItemCategory::potion)
     {
         return do_drink_command();
     }
-    if (category == 53000)
+    if (category == ItemCategory::scroll)
     {
         return do_read_command();
     }
@@ -521,10 +521,11 @@ TurnResult npc_turn_ai_main(Character& chara)
                     if (number == 1)
                     {
                         ci = item;
-                        p = the_item_db[itemid2int(inv[ci].id)]->category;
+                        const auto category =
+                            the_item_db[itemid2int(inv[ci].id)]->category;
                         if (chara.nutrition <= 6000)
                         {
-                            if (p == 57000)
+                            if (category == ItemCategory::food)
                             {
                                 if (inv[ci].own_state <= 0 &&
                                     !is_cursed(inv[ci].curse_state))
@@ -532,7 +533,7 @@ TurnResult npc_turn_ai_main(Character& chara)
                                     return do_eat_command();
                                 }
                             }
-                            if (p == 60001)
+                            if (category == ItemCategory::well)
                             {
                                 if (inv[ci].own_state <= 1 &&
                                     inv[ci].param1 >= -5 &&
@@ -543,7 +544,8 @@ TurnResult npc_turn_ai_main(Character& chara)
                                 }
                             }
                         }
-                        if (p == 68000 || p == 77000)
+                        if (category == ItemCategory::gold_piece ||
+                            category == ItemCategory::ore)
                         {
                             if (inv[ci].own_state <= 0 &&
                                 !inv[ci].is_precious() &&
@@ -1420,7 +1422,7 @@ optional<TurnResult> pc_turn_advance_time()
     {
         auto&& item = get_random_inv(0);
         if (item.number() > 0 &&
-            the_item_db[itemid2int(item.id)]->category == 52000)
+            the_item_db[itemid2int(item.id)]->category == ItemCategory::potion)
         {
             ci = item.index;
             item_db_on_drink(item, itemid2int(item.id));

--- a/src/elona/turn_sequence_pc_actions.cpp
+++ b/src/elona/turn_sequence_pc_actions.cpp
@@ -230,7 +230,8 @@ optional<TurnResult> handle_pc_action(std::string& action)
                 continue;
             if (item.position != cdata[cc].position)
                 continue;
-            if (the_item_db[itemid2int(item.id)]->category == 72000)
+            if (the_item_db[itemid2int(item.id)]->category ==
+                ItemCategory::chest)
             {
                 p = 1;
             }
@@ -238,7 +239,8 @@ optional<TurnResult> handle_pc_action(std::string& action)
             {
                 p = 2;
             }
-            if (the_item_db[itemid2int(item.id)]->category == 60002)
+            if (the_item_db[itemid2int(item.id)]->category ==
+                ItemCategory::altar)
             {
                 p(0) = 3;
                 p(1) = item.index;

--- a/src/elona/ui/ui_menu_feats.cpp
+++ b/src/elona/ui/ui_menu_feats.cpp
@@ -82,7 +82,8 @@ static void _load_traits_by_enchantments()
             {
                 if (enc.id == 0)
                     break;
-                get_enchantment_description(enc.id, enc.power, 0, true);
+                get_enchantment_description(
+                    enc.id, enc.power, ItemCategory::unidentified, true);
                 if (!s(0).empty())
                 {
                     traits_by_enchantments.push_back(s);

--- a/src/elona/wish.cpp
+++ b/src/elona/wish.cpp
@@ -631,8 +631,9 @@ bool wish_for_item(const std::string& input)
                 continue;
             }
         }
-        if (the_item_db[itemid2int(item->id)]->category == 52000 ||
-            the_item_db[itemid2int(item->id)]->category == 53000)
+        if (the_item_db[itemid2int(item->id)]->category ==
+                ItemCategory::potion ||
+            the_item_db[itemid2int(item->id)]->category == ItemCategory::scroll)
         {
             item->set_number(3 + rnd(2));
             if (item->value >= 20000)


### PR DESCRIPTION
<!-- Thank you for contributing! -->

<!-- Please delete unused template. -->

<!-- For new feature -->
# Related Issues

#850


# Summary
Defines enum class ItemCategory instead of hard-coded numbers. ItemCategory is derived from int so this change keeps the compatibility of save data.