### PR TITLE
Add missing Japanese double quotation in scene file [ci skip]

### DIFF
--- a/runtime/mod/core/locale/jp/lazy/scene.hsp
+++ b/runtime/mod/core/locale/jp/lazy/scene.hsp
@@ -227,7 +227,7 @@
 {actor_1}	"パルミア王『ジャビ』,core.xabi"
 {actor_2}	"風を聴く者『ラーネイレ』,core.larnneire"
 {actor_3}	"青い髪の『ヴァリウス』,core.barius"
-{actor_4}	"ザナンの皇子サイモア,core.saimore"
+{actor_4}	"ザナンの皇子『サイモア』,core.saimore"
 
 {mc}	"core.mcTown4"
 {pic}	"bg5"


### PR DESCRIPTION
`ザナンの皇子サイモア` → `ザナンの皇子『サイモア』`