### PR TITLE
Fix chara drop: rich person/noble child/tourist

### DIFF
--- a/runtime/mod/core/data/chara.lua
+++ b/runtime/mod/core/data/chara.lua
@@ -6898,6 +6898,7 @@ data:add_multi(
          category = 0,
          rarity = 20000,
          coefficient = 400,
+         drops = { "core.rich_person" },
       },
       {
          id = "noble_child",
@@ -6923,6 +6924,7 @@ data:add_multi(
          category = 0,
          rarity = 40000,
          coefficient = 400,
+         drops = { "core.noble_child" },
       },
       {
          id = "tourist",
@@ -6949,6 +6951,7 @@ data:add_multi(
          category = 0,
          rarity = 100000,
          coefficient = 400,
+         drops = { "core.tourist" },
       },
       {
          id = "festival_tourist",

--- a/runtime/mod/core/data/chara_drop.lua
+++ b/runtime/mod/core/data/chara_drop.lua
@@ -14,7 +14,7 @@ end
 
 
 local function lootrich(chara, count)
-   for _=0,count do
+   for _ = 1, count do
       Item.create(chara.position, {level = chara.level, flttypeminor = 77001});
    end
    if Rand.one_in(3) then


### PR DESCRIPTION
# Related Issues

Similar to #1538 


# Summary

Rich person / noble child / tourist don't drop gems and/or wallets. Also, the number of gems which they may drop is different from that in vanilla.