### PR TITLE
Unidentified item's name is different from its color

### DIFF
--- a/src/elona/set_item_info.cpp
+++ b/src/elona/set_item_info.cpp
@@ -51,7 +51,7 @@ void set_item_info()
             // The choice can't be completely random - it has to be the
             // same as all other items of this type. So, base it off the
             // random seed of the current save data.
-            int p = (data.legacy_id % game_data.random_seed) % 6;
+            int p = (data.legacy_id + game_data.random_seed) % 6;
             iknownnameref(data.legacy_id) =
                 i18n::s.get_enum(
                     "core.ui.random_item." + data.originalnameref2, p) +


### PR DESCRIPTION
# Summary

For example, a red-colored potion is named "brown potion" when it is unidentified.

## Cause

The formula to calculate random name is different from that of color.

```cpp
// Random name
name = (item_id % random_seed) % 6;
// Random color
color = (item_id + random_seed) % 6;

// cf. Random name (in vanilla)
name = (item_id + random_seed) % 6;
```

The module operation between item_id and random_seed should be changed to addition like vanilla.

## Screenshots

Wrong random name

![image](https://user-images.githubusercontent.com/36858341/75883819-fc40c600-5e66-11ea-84f8-68df44deb8ff.png)

Correct random name

![image](https://user-images.githubusercontent.com/36858341/75883872-15497700-5e67-11ea-8acf-b106ff38c6b2.png)
