### PR TITLE
`tools/docgen` fails to generate some functions' documentation

### DIFF
--- a/doc/api/map.luadoc
+++ b/doc/api/map.luadoc
@@ -142,6 +142,10 @@ function set_feat(position, tile, param1, param2) end
 --  @function clear_feat
 function clear_feat(position) end
 
+--- Randomly sprays the map with the given tile type;
+--  @function spray_tile
+function spray_tile(tile, amount) end
+
 --- [R] The map data for the current map. This contains serialized values
 --  controlling various aspects of the current map.
 --  @tfield LuaMapData data

--- a/src/elona/lua_env/lua_api/lua_api_chara.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_chara.cpp
@@ -17,8 +17,19 @@ namespace lua
  * @tparam LuaCharacter chara (const) a character
  * @treturn bool true if the character is alive
  */
-bool LuaApiChara::is_alive(sol::optional<LuaCharacterHandle> chara)
+bool LuaApiChara::is_alive(
+// `libclang`, invoked from `tools/docgen`, fails to parse this parameter
+//  for some reason.
+#ifndef ELONA_DOCGEN
+    sol::optional<LuaCharacterHandle> chara
+#else
+    int chara
+#endif
+)
 {
+    // `libclang`, invoked from `tools/docgen`, fails to parse this function's
+    // body for some reason.
+#ifndef ELONA_DOCGEN
     if (!chara)
     {
         return false;
@@ -31,6 +42,7 @@ bool LuaApiChara::is_alive(sol::optional<LuaCharacterHandle> chara)
     }
 
     return chara_ref->state() == Character::State::alive;
+#endif
 }
 
 /**

--- a/src/elona/lua_env/lua_api/lua_api_chara.hpp
+++ b/src/elona/lua_env/lua_api/lua_api_chara.hpp
@@ -55,7 +55,7 @@ bool can_recruit_allies();
 void remove_from_party(LuaCharacterHandle);
 
 void bind(sol::table&);
-}; // namespace LuaApiChara
+} // namespace LuaApiChara
 
 } // namespace lua
 } // namespace elona

--- a/src/elona/lua_env/lua_api/lua_api_item.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_item.cpp
@@ -114,6 +114,9 @@ sol::optional<LuaItemHandle> LuaApiItem::create(
 sol::optional<LuaItemHandle>
 LuaApiItem::create_xy(int x, int y, sol::table args)
 {
+    // `libclang`, invoked from `tools/docgen`, fails to parse this function's
+    // body for some reason.
+#ifndef ELONA_DOCGEN
     int id = 0;
     int slot = -1;
     int number = 0;
@@ -202,6 +205,7 @@ LuaApiItem::create_xy(int x, int y, sol::table args)
     {
         return sol::nullopt;
     }
+#endif
 }
 
 /**

--- a/src/elona/lua_env/lua_api/lua_api_map.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_map.cpp
@@ -467,7 +467,7 @@ void LuaApiMap::clear_feat_xy(int x, int y)
 
 
 /**
- * @ luadoc
+ * @luadoc
  *
  * Randomly sprays the map with the given tile type;
  */

--- a/tools/docgen/src/main.rs
+++ b/tools/docgen/src/main.rs
@@ -13,6 +13,7 @@ const NOLUADOC: &str = "@noluadoc";
 const LUA_API: &str = "LuaApi";
 const LUA_CLASS: &str = "Lua";
 const VARARGS: &str = "sol::variadic_args";
+const EXTRA_COMPILE_OPTIONS: &[&str] = &["-DELONA_DOCGEN"];
 
 #[derive(Debug, Clone)]
 struct ModuleComment {
@@ -543,7 +544,7 @@ fn generate_doc<'a>(path: &Path, index: &Index<'a>, is_class: bool) -> Option<Do
         return None;
     }
 
-    let tu = index.parser(path).parse().unwrap();
+    let tu = index.parser(path).arguments(EXTRA_COMPILE_OPTIONS).parse().unwrap();
     let module_comment = get_module_comment(&tu, is_class);
     if !module_comment.is_some() {
         println!("{:?}: No @luadoc comment found in header, skipping.", path);

--- a/tools/docgen/src/main.rs
+++ b/tools/docgen/src/main.rs
@@ -4,7 +4,7 @@ use clang::*;
 use clap::{crate_name, crate_version, App, Arg};
 use regex::Regex;
 
-use std::fs::{self, File, read_to_string};
+use std::fs::{self, read_to_string, File};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
@@ -44,7 +44,10 @@ impl ModuleComment {
         if self.is_class {
             format!("--  @classmod {}", self.module)
         } else {
-            format!("--  @usage local {0} = Elona.game.{0}\nmodule \"{0}\"", self.module)
+            format!(
+                "--  @usage local {0} = Elona.game.{0}\nmodule \"{0}\"",
+                self.module
+            )
         }
     }
 }
@@ -403,10 +406,14 @@ fn strip_comment(text: &str) -> Option<(String, Metadata)> {
     // " >   foo" => "  foo"
     // " *>  foo" => "  foo"
     // "   > foo" => "foo"
-    let re_preserve_leading_space_in_lua_code_block =
-        Regex::new(r"^[ *]*(?:> )?(.*)").unwrap();
-    let strip_preserve_leading_space_in_lua_code_block =
-        |i| re_preserve_leading_space_in_lua_code_block.captures(i).and_then(|c| c.get(1)).unwrap().as_str();
+    let re_preserve_leading_space_in_lua_code_block = Regex::new(r"^[ *]*(?:> )?(.*)").unwrap();
+    let strip_preserve_leading_space_in_lua_code_block = |i| {
+        re_preserve_leading_space_in_lua_code_block
+            .captures(i)
+            .and_then(|c| c.get(1))
+            .unwrap()
+            .as_str()
+    };
 
     let meta: Metadata;
 
@@ -544,7 +551,11 @@ fn generate_doc<'a>(path: &Path, index: &Index<'a>, is_class: bool) -> Option<Do
         return None;
     }
 
-    let tu = index.parser(path).arguments(EXTRA_COMPILE_OPTIONS).parse().unwrap();
+    let tu = index
+        .parser(path)
+        .arguments(EXTRA_COMPILE_OPTIONS)
+        .parse()
+        .unwrap();
     let module_comment = get_module_comment(&tu, is_class);
     if !module_comment.is_some() {
         println!("{:?}: No @luadoc comment found in header, skipping.", path);


### PR DESCRIPTION
# Summary

`libclang` fails to parse these functions for some reason. As workaround, define `ELONA_DOCGEN` while `tools/docgen/` is running and enclose such code with `#ifndef ELONA_DOCGEN` and `#endif`.