### PR TITLE
Refactor `Character::equipment_type` with `struct CombatStyle`

### DIFF
--- a/src/elona/attack.cpp
+++ b/src/elona/attack.cpp
@@ -419,11 +419,11 @@ bool do_physical_attack_internal()
             if (attackrange == 0)
             {
                 chara_gain_skill_exp(cdata[cc], 152, 20 / expmodifer, 0, 4);
-                if (cdata[cc].equipment_type & 2)
+                if (cdata[cc].combat_style.two_hand())
                 {
                     chara_gain_skill_exp(cdata[cc], 167, 20 / expmodifer, 0, 4);
                 }
-                if (cdata[cc].equipment_type & 4)
+                if (cdata[cc].combat_style.dual_wield())
                 {
                     chara_gain_skill_exp(cdata[cc], 166, 20 / expmodifer, 0, 4);
                 }
@@ -453,7 +453,7 @@ bool do_physical_attack_internal()
                         expmodifer,
                     0,
                     5);
-                if (cdata[tc].equipment_type & 1)
+                if (cdata[tc].combat_style.shield())
                 {
                     chara_gain_skill_exp(cdata[tc], 168, 40 / expmodifer, 0, 4);
                 }
@@ -819,7 +819,7 @@ void try_to_melee_attack()
     attackskill = 106;
     ammo = -1;
     ele = 0;
-    if (cdata[cc].equipment_type & 1)
+    if (cdata[cc].combat_style.shield())
     {
         if (clamp(int(std::sqrt(sdata(168, cc)) - 3), 1, 5) +
                 cdata[cc].has_power_bash() * 5 >

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -407,7 +407,7 @@ int calc_accuracy(bool consider_distance)
     {
         accuracy =
             sdata(12, cc) / 5 + sdata(10, cc) / 2 + sdata(attackskill, cc) + 50;
-        if (cdata[cc].equipment_type & 1)
+        if (cdata[cc].combat_style.shield())
         {
             accuracy = accuracy * 100 / 130;
         }
@@ -447,7 +447,7 @@ int calc_accuracy(bool consider_distance)
         }
         else
         {
-            if (cdata[cc].equipment_type & 2)
+            if (cdata[cc].combat_style.two_hand())
             {
                 accuracy += 25;
                 if (inv[cw].weight >= 4000)
@@ -455,7 +455,7 @@ int calc_accuracy(bool consider_distance)
                     accuracy += sdata(167, cc);
                 }
             }
-            else if (cdata[cc].equipment_type & 4)
+            else if (cdata[cc].combat_style.dual_wield())
             {
                 if (attacknum == 1)
                 {
@@ -670,7 +670,7 @@ int calcattackdmg(AttackDamageCalculationMode mode)
             dmgmulti = dmgmulti * effective_range[rangedist] / 100;
         }
     }
-    else if (cdata[cc].equipment_type & 2)
+    else if (cdata[cc].combat_style.two_hand())
     {
         if (inv[cw].weight >= 4000)
         {
@@ -1407,11 +1407,11 @@ int calcspellfail(int id, int cc)
     {
         percentage = 100;
     }
-    if (cdata[cc].equipment_type & 4)
+    if (cdata[cc].combat_style.dual_wield())
     {
         percentage -= 6;
     }
-    if (cdata[cc].equipment_type & 1)
+    if (cdata[cc].combat_style.shield())
     {
         percentage -= 12;
     }

--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -738,7 +738,7 @@ void chara_refresh(int cc)
     cdata[cc].pv = 0;
     cdata[cc].hit_bonus = 0;
     cdata[cc].damage_bonus = 0;
-    cdata[cc].equipment_type = 0;
+    cdata[cc].combat_style.reset();
     attacknum = 0;
     cdata[cc].rate_to_pierce = 0;
     cdata[cc].rate_of_critical_hit = 0;
@@ -759,10 +759,7 @@ void chara_refresh(int cc)
         cdata[cc].sum_of_equipment_weight += inv[rp].weight;
         if (inv[rp].skill == 168)
         {
-            if (!(cdata[cc].equipment_type & 1))
-            {
-                cdata[cc].equipment_type += 1;
-            }
+            cdata[cc].combat_style.set_shield();
         }
         cdata[cc].dv += inv[rp].dv;
         cdata[cc].pv += inv[rp].pv;
@@ -1023,7 +1020,7 @@ void chara_refresh(int cc)
             }
         }
     }
-    if (cdata[cc].equipment_type & 1)
+    if (cdata[cc].combat_style.shield())
     {
         if (cdata[cc].pv > 0)
         {
@@ -1033,11 +1030,11 @@ void chara_refresh(int cc)
     }
     else if (attacknum == 1)
     {
-        cdata[cc].equipment_type += 2;
+        cdata[cc].combat_style.set_two_hand();
     }
     else if (attacknum != 0)
     {
-        cdata[cc].equipment_type += 4;
+        cdata[cc].combat_style.set_dual_wield();
     }
     cdata[cc].max_mp =
         clamp(
@@ -1097,7 +1094,7 @@ void chara_refresh(int cc)
         buff_apply(
             cdata[cc], *the_buff_db.get_id_from_legacy(buff.id), buff.power);
     }
-    if (cdata[cc].equipment_type & 4)
+    if (cdata[cc].combat_style.dual_wield())
     {
         cdata[cc].extra_attack += int(std::sqrt(sdata(166, cc))) * 3 / 2 + 4;
     }

--- a/src/elona/character.hpp
+++ b/src/elona/character.hpp
@@ -120,6 +120,79 @@ struct Activity
 
 
 
+struct CombatStyle
+{
+public:
+    bool unarmed() const noexcept
+    {
+        return _inner == 0;
+    }
+
+
+    bool shield() const noexcept
+    {
+        return _inner & 1;
+    }
+
+
+    bool two_hand() const noexcept
+    {
+        return _inner & 2;
+    }
+
+
+    bool dual_wield() const noexcept
+    {
+        return _inner & 4;
+    }
+
+
+
+    void reset() noexcept
+    {
+        _inner = 0;
+    }
+
+
+    void set_unarmed() noexcept
+    {
+        reset();
+    }
+
+
+    void set_shield() noexcept
+    {
+        _inner |= 1;
+    }
+
+
+    void set_two_hand() noexcept
+    {
+        _inner |= 2;
+    }
+
+
+    void set_dual_wield() noexcept
+    {
+        _inner |= 4;
+    }
+
+
+
+    template <typename Archive>
+    void serialize(Archive& ar)
+    {
+        ar(_inner);
+    }
+
+
+
+private:
+    int _inner{};
+};
+
+
+
 struct Character
 {
     enum class State : int
@@ -182,7 +255,7 @@ public:
     int enemy_id = 0;
     int gold = 0;
     int platinum_coin = 0;
-    int equipment_type = 0;
+    CombatStyle combat_style;
     int melee_attack_type = 0;
     int fame = 0;
     int experience = 0;
@@ -384,7 +457,7 @@ public:
         ELONA_SERIALIZATION_STRUCT_FIELD(*this, enemy_id);
         ELONA_SERIALIZATION_STRUCT_FIELD(*this, gold);
         ELONA_SERIALIZATION_STRUCT_FIELD(*this, platinum_coin);
-        ELONA_SERIALIZATION_STRUCT_FIELD(*this, equipment_type);
+        ELONA_SERIALIZATION_STRUCT_FIELD(*this, combat_style);
         ELONA_SERIALIZATION_STRUCT_FIELD(*this, melee_attack_type);
         ELONA_SERIALIZATION_STRUCT_FIELD(*this, fame);
         ELONA_SERIALIZATION_STRUCT_FIELD(*this, experience);

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -2781,7 +2781,7 @@ void equip_melee_weapon()
             continue;
         }
         ++attacknum;
-        if (cdata[cc].equipment_type & 2)
+        if (cdata[cc].combat_style.two_hand())
         {
             if (inv[cw].weight >= 4000)
             {
@@ -2794,7 +2794,7 @@ void equip_melee_weapon()
                     "core.action.equip.two_handed.too_light", inv[cw]));
             }
         }
-        if (cdata[cc].equipment_type & 4)
+        if (cdata[cc].combat_style.dual_wield())
         {
             if (attacknum == 1)
             {


### PR DESCRIPTION
# Summary

Encapsulate the bit flag operations against the member variable into `struct CombatStyle`. Since the internal representation is kept, this change does not break the existing save data.

