### PR TITLE
Make legacy_id optional (default: -1) for mod-defined data

### DIFF
--- a/src/elona/data/base_database.hpp
+++ b/src/elona/data/base_database.hpp
@@ -329,6 +329,8 @@ private:
         DataTypeName convert(const lua::ConfigTable&, const std::string&); \
     };
 
+#define DATA_LEGACY_ID() \
+    const auto legacy_id = data.optional_or<int>("legacy_id", -1);
 #define DATA_REQ(name, type) type name = data.required<type>(#name);
 #define DATA_REQ_FUNC(name) \
     sol::protected_function name##_ = \

--- a/src/elona/data/types/type_ability.cpp
+++ b/src/elona/data/types/type_ability.cpp
@@ -14,7 +14,7 @@ AbilityData AbilityDB::convert(
     const lua::ConfigTable& data,
     const std::string& id)
 {
-    auto legacy_id = data.required<int>("legacy_id");
+    DATA_LEGACY_ID();
     DATA_OPT_OR(related_basic_attribute, int, 0);
     DATA_OPT_OR(ability_type, int, 0);
     DATA_OPT_OR(cost, int, 0);

--- a/src/elona/data/types/type_buff.cpp
+++ b/src/elona/data/types/type_buff.cpp
@@ -12,7 +12,7 @@ const constexpr char* data::DatabaseTraits<BuffDB>::type_id;
 
 BuffData BuffDB::convert(const lua::ConfigTable& data, const std::string& id)
 {
-    auto legacy_id = data.required<int>("legacy_id");
+    DATA_LEGACY_ID();
     DATA_ENUM(buff_type, BuffType, BuffTypeTable, BuffType::buff);
     DATA_REQ(duration, sol::protected_function);
     DATA_REQ(on_refresh, sol::protected_function);

--- a/src/elona/data/types/type_chara_chip.cpp
+++ b/src/elona/data/types/type_chara_chip.cpp
@@ -16,7 +16,7 @@ CharaChipData CharaChipDB::convert(
     const lua::ConfigTable& data,
     const std::string& id)
 {
-    auto legacy_id = data.required<int>("legacy_id");
+    DATA_LEGACY_ID();
     DATA_OPT_OR(tall, bool, false);
     DATA_OPT_OR(offset_y, int, 16);
 

--- a/src/elona/data/types/type_character.cpp
+++ b/src/elona/data/types/type_character.cpp
@@ -37,7 +37,7 @@ CharacterData CharacterDB::convert(
     const lua::ConfigTable& data,
     const std::string& id)
 {
-    auto legacy_id = data.required<int>("legacy_id");
+    DATA_LEGACY_ID();
     DATA_OPT_OR(ai_act_sub_freq, int, 0);
     DATA_OPT_OR(ai_calm, int, 0);
     DATA_OPT_OR(ai_dist, int, 0);

--- a/src/elona/data/types/type_fish.cpp
+++ b/src/elona/data/types/type_fish.cpp
@@ -12,7 +12,7 @@ const constexpr char* data::DatabaseTraits<FishDB>::type_id;
 
 FishData FishDB::convert(const lua::ConfigTable& data, const std::string& id)
 {
-    auto legacy_id = data.required<int>("legacy_id");
+    DATA_LEGACY_ID();
     DATA_OPT_OR(no_generate, bool, false);
     DATA_OPT_OR(rank, int, 0);
     DATA_OPT_OR(rarity, int, 0);

--- a/src/elona/data/types/type_god.cpp
+++ b/src/elona/data/types/type_god.cpp
@@ -12,7 +12,7 @@ const constexpr char* data::DatabaseTraits<GodDB>::type_id;
 
 GodData GodDB::convert(const lua::ConfigTable& data, const std::string& id)
 {
-    auto legacy_id = data.required<int>("legacy_id");
+    DATA_LEGACY_ID();
 
     return GodData{
         data::InstanceId{id},

--- a/src/elona/data/types/type_item.cpp
+++ b/src/elona/data/types/type_item.cpp
@@ -16,7 +16,7 @@ const constexpr char* data::DatabaseTraits<ItemDB>::type_id;
 
 ItemData ItemDB::convert(const lua::ConfigTable& data, const std::string& id)
 {
-    auto legacy_id = data.required<int>("legacy_id");
+    DATA_LEGACY_ID();
     DATA_OPT_OR(image, int, 0);
     DATA_OPT_OR(value, int, 0);
     DATA_OPT_OR(weight, int, 0);

--- a/src/elona/data/types/type_item_chip.cpp
+++ b/src/elona/data/types/type_item_chip.cpp
@@ -17,7 +17,7 @@ ItemChipData ItemChipDB::convert(
     const std::string& id)
 
 {
-    DATA_REQ(legacy_id, int);
+    DATA_LEGACY_ID();
     DATA_OPT_OR(tall, bool, false);
     DATA_OPT_OR(offset_y, int, 0);
     DATA_OPT_OR(stack_height, int, 8);

--- a/src/elona/data/types/type_item_material.cpp
+++ b/src/elona/data/types/type_item_material.cpp
@@ -14,7 +14,7 @@ ItemMaterialData ItemMaterialDB::convert(
     const lua::ConfigTable& data,
     const std::string& id)
 {
-    auto legacy_id = data.required<int>("legacy_id");
+    DATA_LEGACY_ID();
     DATA_OPT_OR(weight, int, 0);
     DATA_OPT_OR(value, int, 0);
     DATA_OPT_OR(hit_bonus, int, 0);

--- a/src/elona/data/types/type_map.cpp
+++ b/src/elona/data/types/type_map.cpp
@@ -14,7 +14,7 @@ MapDefData MapDefDB::convert(
     const lua::ConfigTable& data,
     const std::string& id)
 {
-    auto legacy_id = data.required<int>("legacy_id");
+    DATA_LEGACY_ID();
     DATA_REQ(appearance, int);
     DATA_ENUM(
         map_type, mdata_t::MapType, MapTypeTable, mdata_t::MapType::world_map);

--- a/src/elona/data/types/type_map_chip.cpp
+++ b/src/elona/data/types/type_map_chip.cpp
@@ -14,7 +14,7 @@ const constexpr char* data::DatabaseTraits<MapChipDB>::type_id;
 
 MapChip MapChipDB::convert(const lua::ConfigTable& data, const std::string& id)
 {
-    auto legacy_id = data.required<int>("legacy_id");
+    DATA_LEGACY_ID();
     DATA_REQ(atlas, int);
     DATA_OPT_OR(is_feat, bool, false);
     DATA_OPT_OR(kind, int, 0);

--- a/src/elona/data/types/type_music.cpp
+++ b/src/elona/data/types/type_music.cpp
@@ -12,7 +12,7 @@ const constexpr char* data::DatabaseTraits<MusicDB>::type_id;
 
 MusicData MusicDB::convert(const lua::ConfigTable& data, const std::string& id)
 {
-    auto legacy_id = data.required<int>("legacy_id");
+    DATA_LEGACY_ID();
     DATA_REQ(file, std::string);
 
     const fs::path music_file = lua::resolve_path_for_mod(file);

--- a/src/elona/data/types/type_sound.cpp
+++ b/src/elona/data/types/type_sound.cpp
@@ -12,7 +12,7 @@ const constexpr char* data::DatabaseTraits<SoundDB>::type_id;
 
 SoundData SoundDB::convert(const lua::ConfigTable& data, const std::string& id)
 {
-    auto legacy_id = data.required<int>("legacy_id");
+    DATA_LEGACY_ID();
     DATA_REQ(file, std::string);
 
     const fs::path sound_file = lua::resolve_path_for_mod(file);

--- a/src/elona/data/types/type_trait.cpp
+++ b/src/elona/data/types/type_trait.cpp
@@ -14,7 +14,7 @@ const constexpr char* data::DatabaseTraits<TraitDB>::type_id;
 
 TraitData TraitDB::convert(const lua::ConfigTable& data, const std::string& id)
 {
-    auto legacy_id = data.required<int>("legacy_id");
+    DATA_LEGACY_ID();
     DATA_ENUM(trait_type, int, TraitTypeTable, 0 /* feat */);
     DATA_REQ(min, int);
     DATA_REQ(max, int);

--- a/src/tests/data/registry/data_no_legacy_id/data.lua
+++ b/src/tests/data/registry/data_no_legacy_id/data.lua
@@ -1,0 +1,13 @@
+ELONA.data:add(
+   "core.chara",
+   {
+      foo = {},
+   }
+)
+
+ELONA.data:add(
+   "core.item",
+   {
+      foo = {},
+   }
+)

--- a/src/tests/data/registry/data_no_legacy_id/mod.json
+++ b/src/tests/data/registry/data_no_legacy_id/mod.json
@@ -1,0 +1,9 @@
+{
+  id: "data_no_legacy_id",
+  name: "data no legacy id",
+  author: "KI",
+  version: "0.1.0",
+  license: "MIT",
+  description: "Test mod.",
+  dependencies: { core: "*" },
+}


### PR DESCRIPTION
# Summary

In vanilla, each data is identified by its integer ID. In foobar, all data have unique string IDs, and the data which exist in vanilla have the corresponding integer IDs as well for integration with vanilla (they will be used for save data conversion in the future). However, data which don't exist in vanilla (i.e., mod-defined data) do not have vanilla IDs. In such case, the field `legacy_id` cannot be set. This PR makes `legacy_id` optional, and set `-1` by default to mod-defined data.