### PR TITLE
No inv[] project: remove "cw" and "ammo"

### DIFF
--- a/src/elona/ai.cpp
+++ b/src/elona/ai.cpp
@@ -302,7 +302,7 @@ bool _try_do_melee_attack(const Character& attacker, const Character& target)
         return false; // Cannot do ranged attack.
     }
 
-    do_ranged_attack(result.cw, result.ammo);
+    do_ranged_attack(result.weapon, result.ammo);
     return true;
 }
 

--- a/src/elona/ai.cpp
+++ b/src/elona/ai.cpp
@@ -302,7 +302,7 @@ bool _try_do_melee_attack(const Character& attacker, const Character& target)
         return false; // Cannot do ranged attack.
     }
 
-    do_ranged_attack(result.ammo);
+    do_ranged_attack(result.cw, result.ammo);
     return true;
 }
 

--- a/src/elona/ai.cpp
+++ b/src/elona/ai.cpp
@@ -285,16 +285,6 @@ bool _try_generate_special_throwing_item(const Character& chara, int action_id)
 
 
 
-// Helper function: normalize the return value of `can_do_ranged_attack()` to
-// boolean.
-bool can_do_ranged_attack_helper()
-{
-    int stat = can_do_ranged_attack();
-    return stat == 1;
-}
-
-
-
 bool _try_do_melee_attack(const Character& attacker, const Character& target)
 {
     if (distance >= 6)
@@ -305,12 +295,14 @@ bool _try_do_melee_attack(const Character& attacker, const Character& target)
     {
         return false; // Cannot see the target.
     }
-    if (!can_do_ranged_attack_helper())
+
+    const auto result = can_do_ranged_attack();
+    if (result.type != 1)
     {
         return false; // Cannot do ranged attack.
     }
 
-    do_ranged_attack();
+    do_ranged_attack(result.ammo);
     return true;
 }
 

--- a/src/elona/attack.cpp
+++ b/src/elona/attack.cpp
@@ -32,7 +32,6 @@ namespace elona
 namespace
 {
 
-int attackitem = 0;
 int extraattack = 0;
 
 } // namespace
@@ -460,7 +459,7 @@ bool do_physical_attack_internal(optional_ref<Item> cw, optional_ref<Item> ammo)
         }
         if (attackskill != 106)
         {
-            proc_weapon_enchantments();
+            proc_weapon_enchantments(*cw);
         }
         if (cdata[tc].cut_counterattack > 0)
         {
@@ -613,17 +612,16 @@ bool do_physical_attack_internal(optional_ref<Item> cw, optional_ref<Item> ammo)
     {
         if (cdata[tc].state() != Character::State::alive)
         {
-            auto& cw = inv[attackitem];
-            if (cw.is_alive())
+            if (cw->is_alive())
             {
-                if (cw.param2 < calcexpalive(cw.param1))
+                if (cw->param2 < calcexpalive(cw->param1))
                 {
-                    cw.param2 += rnd_capped(cdata[tc].level / cw.param1 + 1);
-                    if (cw.param2 >= calcexpalive(cw.param1))
+                    cw->param2 += rnd_capped(cdata[tc].level / cw->param1 + 1);
+                    if (cw->param2 >= calcexpalive(cw->param1))
                     {
                         snd("core.ding3");
                         txt(i18n::s.get(
-                                "core.misc.living_weapon_taste_blood", cw),
+                                "core.misc.living_weapon_taste_blood", *cw),
                             Message::color{ColorIndex::green});
                     }
                 }
@@ -673,7 +671,6 @@ void do_ranged_attack(optional_ref<Item> cw, optional_ref<Item> ammo)
     ammoprocbk = -1;
     ammox = cdata[tc].position.x;
     ammoy = cdata[tc].position.y;
-    attackitem = cw ? cw->index : -1;
     if (ammo)
     {
         if (ammo->count != -1)
@@ -855,7 +852,6 @@ void try_to_melee_attack()
             continue;
         }
         auto& cw = inv[cdata[cc].body_parts[cnt] % 10000 - 1];
-        attackitem = cw.index;
         if (cw.dice_x > 0)
         {
             attackskill = cw.skill;
@@ -873,11 +869,10 @@ void try_to_melee_attack()
 
 
 
-void proc_weapon_enchantments()
+void proc_weapon_enchantments(const Item& cw)
 {
     for (int cnt = 0; cnt < 15; ++cnt)
     {
-        auto& cw = inv[attackitem];
         if (cw.enchantments[cnt].id == 0)
         {
             break;

--- a/src/elona/attack.cpp
+++ b/src/elona/attack.cpp
@@ -156,7 +156,7 @@ void build_target_list()
 CanDoRangedAttackResult can_do_ranged_attack()
 {
     int cw = -1;
-    int ammo = -1;
+    optional_ref<Item> ammo;
     for (int cnt = 0; cnt < 30; ++cnt)
     {
         body = 100 + cnt;
@@ -170,27 +170,27 @@ CanDoRangedAttackResult can_do_ranged_attack()
         }
         if (cdata[cc].body_parts[cnt] / 10000 == 11)
         {
-            ammo = cdata[cc].body_parts[cnt] % 10000 - 1;
+            ammo = inv[cdata[cc].body_parts[cnt] % 10000 - 1];
         }
     }
     if (cw == -1)
     {
         cw = 0;
-        return {-1, cw, ammo};
+        return {-1, cw, none};
     }
-    if (ammo == -1)
+    if (!ammo)
     {
         if (inv[cw].skill != 111)
         {
             cw = 0;
-            return {-2, cw, ammo};
+            return {-2, cw, none};
         }
     }
-    if (ammo != -1)
+    if (ammo)
     {
-        if (inv[cw].skill != inv[ammo].skill)
+        if (inv[cw].skill != ammo->skill)
         {
-            return {-3, cw, ammo};
+            return {-3, cw, none};
         }
     }
     attackskill = inv[cw].skill;
@@ -199,7 +199,7 @@ CanDoRangedAttackResult can_do_ranged_attack()
 
 
 
-bool do_physical_attack_internal(int cw, int ammo)
+bool do_physical_attack_internal(int cw, optional_ref<Item> ammo)
 {
     int attackdmg;
 
@@ -657,7 +657,7 @@ bool do_physical_attack_internal(int cw, int ammo)
 
 
 
-void do_physical_attack(int cw, int ammo)
+void do_physical_attack(int cw, optional_ref<Item> ammo)
 {
     while (do_physical_attack_internal(cw, ammo))
         ;
@@ -665,7 +665,7 @@ void do_physical_attack(int cw, int ammo)
 
 
 
-void do_ranged_attack(int cw, int ammo)
+void do_ranged_attack(int cw, optional_ref<Item> ammo)
 {
     int ammox = 0;
     int ammoy = 0;
@@ -677,18 +677,18 @@ void do_ranged_attack(int cw, int ammo)
     ammox = cdata[tc].position.x;
     ammoy = cdata[tc].position.y;
     attackitem = cw;
-    if (ammo != -1)
+    if (ammo)
     {
-        if (inv[ammo].count != -1)
+        if (ammo->count != -1)
         {
-            if (inv[ammo].enchantments[inv[ammo].count].power % 1000 <= 0)
+            if (ammo->enchantments[ammo->count].power % 1000 <= 0)
             {
                 txt(i18n::s.get("core.action.ranged.load_normal_ammo"));
-                inv[ammo].count = -1;
+                ammo->count = -1;
             }
             else
             {
-                ammoproc = inv[ammo].enchantments[inv[ammo].count].id % 10000;
+                ammoproc = ammo->enchantments[ammo->count].id % 10000;
                 if (cc == 0)
                 {
                     if (cdata.player().sp < 50)
@@ -705,7 +705,7 @@ void do_ranged_attack(int cw, int ammo)
                     }
                     damage_sp(cdata.player(), rnd(encammoref(2, ammoproc) + 1));
                 }
-                --inv[ammo].enchantments[inv[ammo].count].power;
+                --ammo->enchantments[ammo->count].power;
             }
         }
     }
@@ -864,13 +864,13 @@ void try_to_melee_attack()
             attackskill = inv[cw].skill;
             ++attacknum;
             extraattack = 0;
-            do_physical_attack(cw, -1);
+            do_physical_attack(cw, none);
         }
     }
     if (attackskill == 106)
     {
         extraattack = 0;
-        do_physical_attack(-1, -1);
+        do_physical_attack(-1, none);
     }
 }
 

--- a/src/elona/attack.hpp
+++ b/src/elona/attack.hpp
@@ -11,12 +11,13 @@ int find_enemy_target(bool silent = false);
 struct CanDoRangedAttackResult
 {
     int type;
+    int cw;
     int ammo;
 };
 CanDoRangedAttackResult can_do_ranged_attack();
 
-void do_physical_attack(int ammo);
-void do_ranged_attack(int ammo);
+void do_physical_attack(int cw, int ammo);
+void do_ranged_attack(int cw, int ammo);
 int prompt_really_attack();
 void try_to_melee_attack();
 int target_position(bool target_chara = true);

--- a/src/elona/attack.hpp
+++ b/src/elona/attack.hpp
@@ -27,6 +27,6 @@ void do_ranged_attack(optional_ref<Item> cw, optional_ref<Item> ammo);
 int prompt_really_attack();
 void try_to_melee_attack();
 int target_position(bool target_chara = true);
-void proc_weapon_enchantments();
+void proc_weapon_enchantments(const Item& cw);
 
 } // namespace elona

--- a/src/elona/attack.hpp
+++ b/src/elona/attack.hpp
@@ -1,9 +1,15 @@
 #pragma once
 
+#include "optional.hpp"
+
 
 
 namespace elona
 {
+
+struct Item;
+
+
 
 void build_target_list();
 int find_enemy_target(bool silent = false);
@@ -12,12 +18,12 @@ struct CanDoRangedAttackResult
 {
     int type;
     int cw;
-    int ammo;
+    optional_ref<Item> ammo;
 };
 CanDoRangedAttackResult can_do_ranged_attack();
 
-void do_physical_attack(int cw, int ammo);
-void do_ranged_attack(int cw, int ammo);
+void do_physical_attack(int cw, optional_ref<Item> ammo);
+void do_ranged_attack(int cw, optional_ref<Item> ammo);
 int prompt_really_attack();
 void try_to_melee_attack();
 int target_position(bool target_chara = true);

--- a/src/elona/attack.hpp
+++ b/src/elona/attack.hpp
@@ -17,16 +17,16 @@ int find_enemy_target(bool silent = false);
 struct CanDoRangedAttackResult
 {
     int type;
-    optional_ref<Item> cw;
+    optional_ref<Item> weapon;
     optional_ref<Item> ammo;
 };
 CanDoRangedAttackResult can_do_ranged_attack();
 
-void do_physical_attack(optional_ref<Item> cw, optional_ref<Item> ammo);
-void do_ranged_attack(optional_ref<Item> cw, optional_ref<Item> ammo);
+void do_physical_attack(optional_ref<Item> weapon, optional_ref<Item> ammo);
+void do_ranged_attack(optional_ref<Item> weapon, optional_ref<Item> ammo);
 int prompt_really_attack();
 void try_to_melee_attack();
 int target_position(bool target_chara = true);
-void proc_weapon_enchantments(const Item& cw);
+void proc_weapon_enchantments(const Item& weapon);
 
 } // namespace elona

--- a/src/elona/attack.hpp
+++ b/src/elona/attack.hpp
@@ -7,9 +7,16 @@ namespace elona
 
 void build_target_list();
 int find_enemy_target(bool silent = false);
-int can_do_ranged_attack();
-void do_physical_attack();
-void do_ranged_attack();
+
+struct CanDoRangedAttackResult
+{
+    int type;
+    int ammo;
+};
+CanDoRangedAttackResult can_do_ranged_attack();
+
+void do_physical_attack(int ammo);
+void do_ranged_attack(int ammo);
 int prompt_really_attack();
 void try_to_melee_attack();
 int target_position(bool target_chara = true);

--- a/src/elona/attack.hpp
+++ b/src/elona/attack.hpp
@@ -17,13 +17,13 @@ int find_enemy_target(bool silent = false);
 struct CanDoRangedAttackResult
 {
     int type;
-    int cw;
+    optional_ref<Item> cw;
     optional_ref<Item> ammo;
 };
 CanDoRangedAttackResult can_do_ranged_attack();
 
-void do_physical_attack(int cw, optional_ref<Item> ammo);
-void do_ranged_attack(int cw, optional_ref<Item> ammo);
+void do_physical_attack(optional_ref<Item> cw, optional_ref<Item> ammo);
+void do_ranged_attack(optional_ref<Item> cw, optional_ref<Item> ammo);
 int prompt_really_attack();
 void try_to_melee_attack();
 int target_position(bool target_chara = true);

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -400,7 +400,7 @@ int calc_evasion(int cc)
 
 
 int calc_accuracy(
-    optional_ref<Item> cw,
+    optional_ref<Item> weapon,
     optional_ref<Item> ammo,
     bool consider_distance)
 {
@@ -420,9 +420,9 @@ int calc_accuracy(
     }
     else
     {
-        accuracy = sdata(12, cc) / 4 + sdata(cw->skill, cc) / 3 +
+        accuracy = sdata(12, cc) / 4 + sdata(weapon->skill, cc) / 3 +
             sdata(attackskill, cc) + 50;
-        accuracy += cdata[cc].hit_bonus + cw->hit_bonus;
+        accuracy += cdata[cc].hit_bonus + weapon->hit_bonus;
         if (ammo)
         {
             accuracy += ammo->hit_bonus;
@@ -445,7 +445,7 @@ int calc_accuracy(
                     0,
                     9);
                 const auto effective_range =
-                    calc_effective_range(itemid2int(cw->id));
+                    calc_effective_range(itemid2int(weapon->id));
                 accuracy = accuracy * effective_range[rangedist] / 100;
             }
         }
@@ -454,7 +454,7 @@ int calc_accuracy(
             if (cdata[cc].combat_style.two_hand())
             {
                 accuracy += 25;
-                if (cw->weight >= 4000)
+                if (weapon->weight >= 4000)
                 {
                     accuracy += sdata(167, cc);
                 }
@@ -463,16 +463,16 @@ int calc_accuracy(
             {
                 if (attacknum == 1)
                 {
-                    if (cw->weight >= 4000)
+                    if (weapon->weight >= 4000)
                     {
-                        accuracy -= (cw->weight - 4000 + 400) /
+                        accuracy -= (weapon->weight - 4000 + 400) /
                             (10 + sdata(166, cc) / 5);
                     }
                 }
-                else if (cw->weight > 1500)
+                else if (weapon->weight > 1500)
                 {
-                    accuracy -=
-                        (cw->weight - 1500 + 100) / (10 + sdata(166, cc) / 5);
+                    accuracy -= (weapon->weight - 1500 + 100) /
+                        (10 + sdata(166, cc) / 5);
                 }
             }
         }
@@ -484,20 +484,22 @@ int calc_accuracy(
         {
             accuracy =
                 accuracy * 100 / clamp((150 - sdata(301, cc) / 2), 115, 150);
-            if (attackskill != 106 && attackrange == 0 && cw->weight >= 4000)
+            if (attackskill != 106 && attackrange == 0 &&
+                weapon->weight >= 4000)
             {
                 accuracy -=
-                    (cw->weight - 4000 + 400) / (10 + sdata(301, cc) / 5);
+                    (weapon->weight - 4000 + 400) / (10 + sdata(301, cc) / 5);
             }
         }
         if (cc == game_data.mount)
         {
             accuracy =
                 accuracy * 100 / clamp((150 - sdata(10, cc) / 2), 115, 150);
-            if (attackskill != 106 && attackrange == 0 && cw->weight >= 4000)
+            if (attackskill != 106 && attackrange == 0 &&
+                weapon->weight >= 4000)
             {
                 accuracy -=
-                    (cw->weight - 4000 + 400) / (10 + sdata(10, cc) / 10);
+                    (weapon->weight - 4000 + 400) / (10 + sdata(10, cc) / 10);
             }
         }
     }
@@ -517,9 +519,9 @@ int calc_accuracy(
 
 
 
-int calcattackhit(optional_ref<Item> cw, optional_ref<Item> ammo)
+int calcattackhit(optional_ref<Item> weapon, optional_ref<Item> ammo)
 {
-    int tohit = calc_accuracy(cw, ammo, true);
+    int tohit = calc_accuracy(weapon, ammo, true);
     int evasion = calc_evasion(tc);
 
     if (cdata[tc].dimmed != 0)
@@ -618,7 +620,7 @@ int calcattackhit(optional_ref<Item> cw, optional_ref<Item> ammo)
 
 
 int calcattackdmg(
-    optional_ref<Item> cw,
+    optional_ref<Item> weapon,
     optional_ref<Item> ammo,
     AttackDamageCalculationMode mode)
 {
@@ -642,16 +644,16 @@ int calcattackdmg(
     }
     else
     {
-        dmgfix = cdata[cc].damage_bonus + cw->damage_bonus + cw->enhancement +
-            (cw->curse_state == CurseState::blessed);
-        dice1 = cw->dice_x;
-        dice2 = cw->dice_y;
+        dmgfix = cdata[cc].damage_bonus + weapon->damage_bonus +
+            weapon->enhancement + (weapon->curse_state == CurseState::blessed);
+        dice1 = weapon->dice_x;
+        dice2 = weapon->dice_y;
         if (ammo)
         {
             dmgfix += ammo->damage_bonus + ammo->dice_x * ammo->dice_y / 2;
             dmgmulti = 0.5 +
                 double(
-                    (sdata(13, cc) + sdata(cw->skill, cc) / 5 +
+                    (sdata(13, cc) + sdata(weapon->skill, cc) / 5 +
                      sdata(attackskill, cc) / 5 + sdata(189, cc) * 3 / 2)) /
                     40;
         }
@@ -659,24 +661,24 @@ int calcattackdmg(
         {
             dmgmulti = 0.6 +
                 double(
-                    (sdata(10, cc) + sdata(cw->skill, cc) / 5 +
+                    (sdata(10, cc) + sdata(weapon->skill, cc) / 5 +
                      sdata(attackskill, cc) / 5 + sdata(152, cc) * 2)) /
                     45;
         }
-        pierce = calc_rate_to_pierce(itemid2int(cw->id));
+        pierce = calc_rate_to_pierce(itemid2int(weapon->id));
     }
     if (attackrange)
     {
         if (mode == AttackDamageCalculationMode::actual_damage)
         {
             const auto effective_range =
-                calc_effective_range(itemid2int(cw->id));
+                calc_effective_range(itemid2int(weapon->id));
             dmgmulti = dmgmulti * effective_range[rangedist] / 100;
         }
     }
     else if (cdata[cc].combat_style.two_hand())
     {
-        if (cw->weight >= 4000)
+        if (weapon->weight >= 4000)
         {
             dmgmulti *= 1.5;
         }
@@ -742,7 +744,8 @@ int calcattackdmg(
         }
         else
         {
-            dmgmulti = dmgmulti * clamp(cw->weight / 200 + 100, 100, 150) / 100;
+            dmgmulti =
+                dmgmulti * clamp(weapon->weight / 200 + 100, 100, 150) / 100;
         }
     }
     damage = damage * dmgmulti / 100;

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -399,7 +399,10 @@ int calc_evasion(int cc)
 
 
 
-int calc_accuracy(int cw, optional_ref<Item> ammo, bool consider_distance)
+int calc_accuracy(
+    optional_ref<Item> cw,
+    optional_ref<Item> ammo,
+    bool consider_distance)
 {
     critical = 0;
     int accuracy;
@@ -417,9 +420,9 @@ int calc_accuracy(int cw, optional_ref<Item> ammo, bool consider_distance)
     }
     else
     {
-        accuracy = sdata(12, cc) / 4 + sdata(inv[cw].skill, cc) / 3 +
+        accuracy = sdata(12, cc) / 4 + sdata(cw->skill, cc) / 3 +
             sdata(attackskill, cc) + 50;
-        accuracy += cdata[cc].hit_bonus + inv[cw].hit_bonus;
+        accuracy += cdata[cc].hit_bonus + cw->hit_bonus;
         if (ammo)
         {
             accuracy += ammo->hit_bonus;
@@ -442,7 +445,7 @@ int calc_accuracy(int cw, optional_ref<Item> ammo, bool consider_distance)
                     0,
                     9);
                 const auto effective_range =
-                    calc_effective_range(itemid2int(inv[cw].id));
+                    calc_effective_range(itemid2int(cw->id));
                 accuracy = accuracy * effective_range[rangedist] / 100;
             }
         }
@@ -451,7 +454,7 @@ int calc_accuracy(int cw, optional_ref<Item> ammo, bool consider_distance)
             if (cdata[cc].combat_style.two_hand())
             {
                 accuracy += 25;
-                if (inv[cw].weight >= 4000)
+                if (cw->weight >= 4000)
                 {
                     accuracy += sdata(167, cc);
                 }
@@ -460,16 +463,16 @@ int calc_accuracy(int cw, optional_ref<Item> ammo, bool consider_distance)
             {
                 if (attacknum == 1)
                 {
-                    if (inv[cw].weight >= 4000)
+                    if (cw->weight >= 4000)
                     {
-                        accuracy -= (inv[cw].weight - 4000 + 400) /
+                        accuracy -= (cw->weight - 4000 + 400) /
                             (10 + sdata(166, cc) / 5);
                     }
                 }
-                else if (inv[cw].weight > 1500)
+                else if (cw->weight > 1500)
                 {
-                    accuracy -= (inv[cw].weight - 1500 + 100) /
-                        (10 + sdata(166, cc) / 5);
+                    accuracy -=
+                        (cw->weight - 1500 + 100) / (10 + sdata(166, cc) / 5);
                 }
             }
         }
@@ -481,22 +484,20 @@ int calc_accuracy(int cw, optional_ref<Item> ammo, bool consider_distance)
         {
             accuracy =
                 accuracy * 100 / clamp((150 - sdata(301, cc) / 2), 115, 150);
-            if (attackskill != 106 && attackrange == 0 &&
-                inv[cw].weight >= 4000)
+            if (attackskill != 106 && attackrange == 0 && cw->weight >= 4000)
             {
                 accuracy -=
-                    (inv[cw].weight - 4000 + 400) / (10 + sdata(301, cc) / 5);
+                    (cw->weight - 4000 + 400) / (10 + sdata(301, cc) / 5);
             }
         }
         if (cc == game_data.mount)
         {
             accuracy =
                 accuracy * 100 / clamp((150 - sdata(10, cc) / 2), 115, 150);
-            if (attackskill != 106 && attackrange == 0 &&
-                inv[cw].weight >= 4000)
+            if (attackskill != 106 && attackrange == 0 && cw->weight >= 4000)
             {
                 accuracy -=
-                    (inv[cw].weight - 4000 + 400) / (10 + sdata(10, cc) / 10);
+                    (cw->weight - 4000 + 400) / (10 + sdata(10, cc) / 10);
             }
         }
     }
@@ -516,7 +517,7 @@ int calc_accuracy(int cw, optional_ref<Item> ammo, bool consider_distance)
 
 
 
-int calcattackhit(int cw, optional_ref<Item> ammo)
+int calcattackhit(optional_ref<Item> cw, optional_ref<Item> ammo)
 {
     int tohit = calc_accuracy(cw, ammo, true);
     int evasion = calc_evasion(tc);
@@ -617,7 +618,7 @@ int calcattackhit(int cw, optional_ref<Item> ammo)
 
 
 int calcattackdmg(
-    int cw,
+    optional_ref<Item> cw,
     optional_ref<Item> ammo,
     AttackDamageCalculationMode mode)
 {
@@ -641,16 +642,16 @@ int calcattackdmg(
     }
     else
     {
-        dmgfix = cdata[cc].damage_bonus + inv[cw].damage_bonus +
-            inv[cw].enhancement + (inv[cw].curse_state == CurseState::blessed);
-        dice1 = inv[cw].dice_x;
-        dice2 = inv[cw].dice_y;
+        dmgfix = cdata[cc].damage_bonus + cw->damage_bonus + cw->enhancement +
+            (cw->curse_state == CurseState::blessed);
+        dice1 = cw->dice_x;
+        dice2 = cw->dice_y;
         if (ammo)
         {
             dmgfix += ammo->damage_bonus + ammo->dice_x * ammo->dice_y / 2;
             dmgmulti = 0.5 +
                 double(
-                    (sdata(13, cc) + sdata(inv[cw].skill, cc) / 5 +
+                    (sdata(13, cc) + sdata(cw->skill, cc) / 5 +
                      sdata(attackskill, cc) / 5 + sdata(189, cc) * 3 / 2)) /
                     40;
         }
@@ -658,24 +659,24 @@ int calcattackdmg(
         {
             dmgmulti = 0.6 +
                 double(
-                    (sdata(10, cc) + sdata(inv[cw].skill, cc) / 5 +
+                    (sdata(10, cc) + sdata(cw->skill, cc) / 5 +
                      sdata(attackskill, cc) / 5 + sdata(152, cc) * 2)) /
                     45;
         }
-        pierce = calc_rate_to_pierce(itemid2int(inv[cw].id));
+        pierce = calc_rate_to_pierce(itemid2int(cw->id));
     }
     if (attackrange)
     {
         if (mode == AttackDamageCalculationMode::actual_damage)
         {
             const auto effective_range =
-                calc_effective_range(itemid2int(inv[cw].id));
+                calc_effective_range(itemid2int(cw->id));
             dmgmulti = dmgmulti * effective_range[rangedist] / 100;
         }
     }
     else if (cdata[cc].combat_style.two_hand())
     {
-        if (inv[cw].weight >= 4000)
+        if (cw->weight >= 4000)
         {
             dmgmulti *= 1.5;
         }
@@ -741,8 +742,7 @@ int calcattackdmg(
         }
         else
         {
-            dmgmulti =
-                dmgmulti * clamp((inv[cw].weight / 200 + 100), 100, 150) / 100;
+            dmgmulti = dmgmulti * clamp(cw->weight / 200 + 100, 100, 150) / 100;
         }
     }
     damage = damage * dmgmulti / 100;

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -398,7 +398,8 @@ int calc_evasion(int cc)
 }
 
 
-int calc_accuracy(bool consider_distance)
+
+int calc_accuracy(int ammo, bool consider_distance)
 {
     critical = 0;
     int accuracy;
@@ -515,9 +516,9 @@ int calc_accuracy(bool consider_distance)
 
 
 
-int calcattackhit()
+int calcattackhit(int ammo)
 {
-    int tohit = calc_accuracy(true);
+    int tohit = calc_accuracy(ammo, true);
     int evasion = calc_evasion(tc);
 
     if (cdata[tc].dimmed != 0)
@@ -615,7 +616,7 @@ int calcattackhit()
 
 
 
-int calcattackdmg(AttackDamageCalculationMode mode)
+int calcattackdmg(int ammo, AttackDamageCalculationMode mode)
 {
     int prot2 = 0;
     int protfix = 0;

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -399,7 +399,7 @@ int calc_evasion(int cc)
 
 
 
-int calc_accuracy(int ammo, bool consider_distance)
+int calc_accuracy(int cw, int ammo, bool consider_distance)
 {
     critical = 0;
     int accuracy;
@@ -516,9 +516,9 @@ int calc_accuracy(int ammo, bool consider_distance)
 
 
 
-int calcattackhit(int ammo)
+int calcattackhit(int cw, int ammo)
 {
-    int tohit = calc_accuracy(ammo, true);
+    int tohit = calc_accuracy(cw, ammo, true);
     int evasion = calc_evasion(tc);
 
     if (cdata[tc].dimmed != 0)
@@ -616,7 +616,7 @@ int calcattackhit(int ammo)
 
 
 
-int calcattackdmg(int ammo, AttackDamageCalculationMode mode)
+int calcattackdmg(int cw, int ammo, AttackDamageCalculationMode mode)
 {
     int prot2 = 0;
     int protfix = 0;

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -399,7 +399,7 @@ int calc_evasion(int cc)
 
 
 
-int calc_accuracy(int cw, int ammo, bool consider_distance)
+int calc_accuracy(int cw, optional_ref<Item> ammo, bool consider_distance)
 {
     critical = 0;
     int accuracy;
@@ -420,9 +420,9 @@ int calc_accuracy(int cw, int ammo, bool consider_distance)
         accuracy = sdata(12, cc) / 4 + sdata(inv[cw].skill, cc) / 3 +
             sdata(attackskill, cc) + 50;
         accuracy += cdata[cc].hit_bonus + inv[cw].hit_bonus;
-        if (ammo != -1)
+        if (ammo)
         {
-            accuracy += inv[ammo].hit_bonus;
+            accuracy += ammo->hit_bonus;
         }
     }
 
@@ -516,7 +516,7 @@ int calc_accuracy(int cw, int ammo, bool consider_distance)
 
 
 
-int calcattackhit(int cw, int ammo)
+int calcattackhit(int cw, optional_ref<Item> ammo)
 {
     int tohit = calc_accuracy(cw, ammo, true);
     int evasion = calc_evasion(tc);
@@ -616,7 +616,10 @@ int calcattackhit(int cw, int ammo)
 
 
 
-int calcattackdmg(int cw, int ammo, AttackDamageCalculationMode mode)
+int calcattackdmg(
+    int cw,
+    optional_ref<Item> ammo,
+    AttackDamageCalculationMode mode)
 {
     int prot2 = 0;
     int protfix = 0;
@@ -642,10 +645,9 @@ int calcattackdmg(int cw, int ammo, AttackDamageCalculationMode mode)
             inv[cw].enhancement + (inv[cw].curse_state == CurseState::blessed);
         dice1 = inv[cw].dice_x;
         dice2 = inv[cw].dice_y;
-        if (ammo != -1)
+        if (ammo)
         {
-            dmgfix += inv[ammo].damage_bonus +
-                inv[ammo].dice_x * inv[ammo].dice_y / 2;
+            dmgfix += ammo->damage_bonus + ammo->dice_x * ammo->dice_y / 2;
             dmgmulti = 0.5 +
                 double(
                     (sdata(13, cc) + sdata(inv[cw].skill, cc) / 5 +
@@ -732,10 +734,10 @@ int calcattackdmg(int cw, int ammo, AttackDamageCalculationMode mode)
         {
             dmgmulti *= 1.25;
         }
-        else if (ammo != -1)
+        else if (ammo)
         {
-            dmgmulti = dmgmulti *
-                clamp((inv[ammo].weight / 100 + 100), 100, 150) / 100;
+            dmgmulti =
+                dmgmulti * clamp(ammo->weight / 100 + 100, 100, 150) / 100;
         }
         else
         {

--- a/src/elona/calc.hpp
+++ b/src/elona/calc.hpp
@@ -33,8 +33,11 @@ int calc_rate_to_pierce(int);
 std::string calcage(int);
 int calcexpalive(int = 0);
 int calc_evasion(int cc);
-int calc_accuracy(int cw, optional_ref<Item> ammo, bool consider_distance);
-int calcattackhit(int cw, optional_ref<Item> ammo);
+int calc_accuracy(
+    optional_ref<Item> cw,
+    optional_ref<Item> ammo,
+    bool consider_distance);
+int calcattackhit(optional_ref<Item> cw, optional_ref<Item> ammo);
 
 
 enum class AttackDamageCalculationMode
@@ -43,7 +46,10 @@ enum class AttackDamageCalculationMode
     raw_damage,
     defense,
 };
-int calcattackdmg(int cw, optional_ref<Item> ammo, AttackDamageCalculationMode);
+int calcattackdmg(
+    optional_ref<Item> cw,
+    optional_ref<Item> ammo,
+    AttackDamageCalculationMode);
 
 int calcmedalvalue(const Item& item);
 int calcitemvalue(const Item& item, int calc_mode);

--- a/src/elona/calc.hpp
+++ b/src/elona/calc.hpp
@@ -33,8 +33,8 @@ int calc_rate_to_pierce(int);
 std::string calcage(int);
 int calcexpalive(int = 0);
 int calc_evasion(int cc);
-int calc_accuracy(int cw, int ammo, bool consider_distance);
-int calcattackhit(int cw, int ammo);
+int calc_accuracy(int cw, optional_ref<Item> ammo, bool consider_distance);
+int calcattackhit(int cw, optional_ref<Item> ammo);
 
 
 enum class AttackDamageCalculationMode
@@ -43,7 +43,7 @@ enum class AttackDamageCalculationMode
     raw_damage,
     defense,
 };
-int calcattackdmg(int cw, int ammo, AttackDamageCalculationMode);
+int calcattackdmg(int cw, optional_ref<Item> ammo, AttackDamageCalculationMode);
 
 int calcmedalvalue(const Item& item);
 int calcitemvalue(const Item& item, int calc_mode);

--- a/src/elona/calc.hpp
+++ b/src/elona/calc.hpp
@@ -33,8 +33,8 @@ int calc_rate_to_pierce(int);
 std::string calcage(int);
 int calcexpalive(int = 0);
 int calc_evasion(int cc);
-int calc_accuracy(bool consider_distance);
-int calcattackhit();
+int calc_accuracy(int ammo, bool consider_distance);
+int calcattackhit(int ammo);
 
 
 enum class AttackDamageCalculationMode
@@ -43,7 +43,7 @@ enum class AttackDamageCalculationMode
     raw_damage,
     defense,
 };
-int calcattackdmg(AttackDamageCalculationMode);
+int calcattackdmg(int ammo, AttackDamageCalculationMode);
 
 int calcmedalvalue(const Item& item);
 int calcitemvalue(const Item& item, int calc_mode);

--- a/src/elona/calc.hpp
+++ b/src/elona/calc.hpp
@@ -33,8 +33,8 @@ int calc_rate_to_pierce(int);
 std::string calcage(int);
 int calcexpalive(int = 0);
 int calc_evasion(int cc);
-int calc_accuracy(int ammo, bool consider_distance);
-int calcattackhit(int ammo);
+int calc_accuracy(int cw, int ammo, bool consider_distance);
+int calcattackhit(int cw, int ammo);
 
 
 enum class AttackDamageCalculationMode
@@ -43,7 +43,7 @@ enum class AttackDamageCalculationMode
     raw_damage,
     defense,
 };
-int calcattackdmg(int ammo, AttackDamageCalculationMode);
+int calcattackdmg(int cw, int ammo, AttackDamageCalculationMode);
 
 int calcmedalvalue(const Item& item);
 int calcitemvalue(const Item& item, int calc_mode);

--- a/src/elona/calc.hpp
+++ b/src/elona/calc.hpp
@@ -34,10 +34,10 @@ std::string calcage(int);
 int calcexpalive(int = 0);
 int calc_evasion(int cc);
 int calc_accuracy(
-    optional_ref<Item> cw,
+    optional_ref<Item> weapon,
     optional_ref<Item> ammo,
     bool consider_distance);
-int calcattackhit(optional_ref<Item> cw, optional_ref<Item> ammo);
+int calcattackhit(optional_ref<Item> weapon, optional_ref<Item> ammo);
 
 
 enum class AttackDamageCalculationMode
@@ -47,7 +47,7 @@ enum class AttackDamageCalculationMode
     defense,
 };
 int calcattackdmg(
-    optional_ref<Item> cw,
+    optional_ref<Item> weapon,
     optional_ref<Item> ammo,
     AttackDamageCalculationMode);
 

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -3428,7 +3428,7 @@ TurnResult do_fire_command()
         update_screen();
         return TurnResult::pc_turn_user_error;
     }
-    do_ranged_attack(result.cw, result.ammo);
+    do_ranged_attack(result.weapon, result.ammo);
     return TurnResult::turn_end;
 }
 

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -3428,7 +3428,7 @@ TurnResult do_fire_command()
         update_screen();
         return TurnResult::pc_turn_user_error;
     }
-    do_ranged_attack(result.ammo);
+    do_ranged_attack(result.cw, result.ammo);
     return TurnResult::turn_end;
 }
 

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -3406,31 +3406,29 @@ TurnResult do_fire_command()
             return TurnResult::pc_turn_user_error;
         }
     }
+    const auto result = can_do_ranged_attack();
+    if (result.type == -1)
     {
-        int stat = can_do_ranged_attack();
-        if (stat == -1)
-        {
-            txt(i18n::s.get("core.action.ranged.equip.need_weapon"),
-                Message::only_once{true});
-            update_screen();
-            return TurnResult::pc_turn_user_error;
-        }
-        if (stat == -2)
-        {
-            txt(i18n::s.get("core.action.ranged.equip.need_ammo"),
-                Message::only_once{true});
-            update_screen();
-            return TurnResult::pc_turn_user_error;
-        }
-        if (stat == -3)
-        {
-            txt(i18n::s.get("core.action.ranged.equip.wrong_ammo"),
-                Message::only_once{true});
-            update_screen();
-            return TurnResult::pc_turn_user_error;
-        }
+        txt(i18n::s.get("core.action.ranged.equip.need_weapon"),
+            Message::only_once{true});
+        update_screen();
+        return TurnResult::pc_turn_user_error;
     }
-    do_ranged_attack();
+    if (result.type == -2)
+    {
+        txt(i18n::s.get("core.action.ranged.equip.need_ammo"),
+            Message::only_once{true});
+        update_screen();
+        return TurnResult::pc_turn_user_error;
+    }
+    if (result.type == -3)
+    {
+        txt(i18n::s.get("core.action.ranged.equip.wrong_ammo"),
+            Message::only_once{true});
+        update_screen();
+        return TurnResult::pc_turn_user_error;
+    }
+    do_ranged_attack(result.ammo);
     return TurnResult::turn_end;
 }
 

--- a/src/elona/dump_player_info.cpp
+++ b/src/elona/dump_player_info.cpp
@@ -150,7 +150,7 @@ void dump_player_info()
     tc = 0;
     attackskill = 106;
     int evade = calc_evasion(tc);
-    prot = calcattackdmg(AttackDamageCalculationMode::defense);
+    prot = calcattackdmg(-1, AttackDamageCalculationMode::defense);
 
     ss << u8"回避    : " << evade << u8"%" << std::endl;
     ss << u8"軽減    : " << (100 - 10000 / (prot + 100)) << u8"% + "

--- a/src/elona/dump_player_info.cpp
+++ b/src/elona/dump_player_info.cpp
@@ -150,7 +150,7 @@ void dump_player_info()
     tc = 0;
     attackskill = 106;
     int evade = calc_evasion(tc);
-    prot = calcattackdmg(-1, AttackDamageCalculationMode::defense);
+    prot = calcattackdmg(-1, -1, AttackDamageCalculationMode::defense);
 
     ss << u8"回避    : " << evade << u8"%" << std::endl;
     ss << u8"軽減    : " << (100 - 10000 / (prot + 100)) << u8"% + "

--- a/src/elona/dump_player_info.cpp
+++ b/src/elona/dump_player_info.cpp
@@ -150,7 +150,7 @@ void dump_player_info()
     tc = 0;
     attackskill = 106;
     int evade = calc_evasion(tc);
-    prot = calcattackdmg(-1, -1, AttackDamageCalculationMode::defense);
+    prot = calcattackdmg(-1, none, AttackDamageCalculationMode::defense);
 
     ss << u8"回避    : " << evade << u8"%" << std::endl;
     ss << u8"軽減    : " << (100 - 10000 / (prot + 100)) << u8"% + "

--- a/src/elona/dump_player_info.cpp
+++ b/src/elona/dump_player_info.cpp
@@ -150,7 +150,7 @@ void dump_player_info()
     tc = 0;
     attackskill = 106;
     int evade = calc_evasion(tc);
-    prot = calcattackdmg(-1, none, AttackDamageCalculationMode::defense);
+    prot = calcattackdmg(none, none, AttackDamageCalculationMode::defense);
 
     ss << u8"回避    : " << evade << u8"%" << std::endl;
     ss << u8"軽減    : " << (100 - 10000 / (prot + 100)) << u8"% + "

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -2721,51 +2721,51 @@ void equip_melee_weapon()
         {
             continue;
         }
-        const int cw = cdata[cc].body_parts[cnt] % 10000 - 1;
-        if (inv[cw].dice_x == 0)
+        const auto& weapon = inv[cdata[cc].body_parts[cnt] % 10000 - 1];
+        if (weapon.dice_x == 0)
         {
             continue;
         }
         ++attacknum;
         if (cdata[cc].combat_style.two_hand())
         {
-            if (inv[cw].weight >= 4000)
+            if (weapon.weight >= 4000)
             {
                 txt(i18n::s.get(
-                    "core.action.equip.two_handed.fits_well", inv[cw]));
+                    "core.action.equip.two_handed.fits_well", weapon));
             }
             else
             {
                 txt(i18n::s.get(
-                    "core.action.equip.two_handed.too_light", inv[cw]));
+                    "core.action.equip.two_handed.too_light", weapon));
             }
         }
         if (cdata[cc].combat_style.dual_wield())
         {
             if (attacknum == 1)
             {
-                if (inv[cw].weight >= 4000)
+                if (weapon.weight >= 4000)
                 {
                     txt(i18n::s.get(
-                        "core.action.equip.two_handed.too_heavy", inv[cw]));
+                        "core.action.equip.two_handed.too_heavy", weapon));
                 }
             }
-            else if (inv[cw].weight > 1500)
+            else if (weapon.weight > 1500)
             {
                 txt(i18n::s.get(
                     "core.action.equip.two_handed.too_heavy_other_hand",
-                    inv[cw]));
+                    weapon));
             }
         }
         if (cc == 0)
         {
             if (game_data.mount != 0)
             {
-                if (inv[cw].weight >= 4000)
+                if (weapon.weight >= 4000)
                 {
                     txt(i18n::s.get(
                         "core.action.equip.two_handed.too_heavy_when_riding",
-                        inv[cw]));
+                        weapon));
                 }
             }
         }

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -2721,7 +2721,7 @@ void equip_melee_weapon()
         {
             continue;
         }
-        cw = cdata[cc].body_parts[cnt] % 10000 - 1;
+        const int cw = cdata[cc].body_parts[cnt] % 10000 - 1;
         if (inv[cw].dice_x == 0)
         {
             continue;

--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -1137,33 +1137,33 @@ void append_accuracy_info(int val0)
         {
             continue;
         }
-        cw = cdata[cc].body_parts[cnt] % 10000 - 1;
+        const auto cw = cdata[cc].body_parts[cnt] % 10000 - 1;
         if (inv[cw].dice_x > 0)
         {
             attackskill = inv[cw].skill;
             ++p(1);
             s(1) = i18n::s.get("core.ui.chara_sheet.damage.melee") + p(1);
             ++attacknum;
-            show_weapon_dice(-1, val0);
+            show_weapon_dice(cw, -1, val0);
         }
     }
     if (attackskill == 106)
     {
         s(1) = i18n::s.get("core.ui.chara_sheet.damage.unarmed");
-        show_weapon_dice(-1, val0);
+        show_weapon_dice(-1, -1, val0);
     }
     attacknum = 0;
     const auto result = can_do_ranged_attack();
     if (result.type == 1)
     {
         s(1) = i18n::s.get("core.ui.chara_sheet.damage.dist");
-        show_weapon_dice(result.ammo, val0);
+        show_weapon_dice(result.cw, result.ammo, val0);
     }
 }
 
 
 
-void show_weapon_dice(int ammo, int val0)
+void show_weapon_dice(int cw, int ammo, int val0)
 {
     tc = cc;
     font(12 + sizefix - en * 2, snail::Font::Style::bold);
@@ -1176,13 +1176,16 @@ void show_weapon_dice(int ammo, int val0)
         mes(wx + 417, wy + 281 + p(2) * 16, s(1), {20, 10, 0});
     }
     attackrange = 0;
-    if (the_item_db[itemid2int(inv[cw].id)]->category ==
-        ItemCategory::ranged_weapon) // TODO coupling
+    if (cw != -1)
     {
-        attackrange = 1;
+        if (the_item_db[itemid2int(inv[cw].id)]->category ==
+            ItemCategory::ranged_weapon) // TODO coupling
+        {
+            attackrange = 1;
+        }
     }
-    int tohit = calc_accuracy(ammo, false);
-    dmg = calcattackdmg(ammo, AttackDamageCalculationMode::raw_damage);
+    int tohit = calc_accuracy(cw, ammo, false);
+    dmg = calcattackdmg(cw, ammo, AttackDamageCalculationMode::raw_damage);
     font(14 - en * 2);
     s(2) = ""s + dmgmulti;
     s = ""s + tohit + u8"%"s;

--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -1121,7 +1121,6 @@ void append_accuracy_info(int val0)
     p(1) = 0;
     p(2) = 0;
     attackskill = 106;
-    ammo = -1;
     attacknum = 0;
     for (int cnt = 0; cnt < 30; ++cnt)
     {
@@ -1145,26 +1144,26 @@ void append_accuracy_info(int val0)
             ++p(1);
             s(1) = i18n::s.get("core.ui.chara_sheet.damage.melee") + p(1);
             ++attacknum;
-            show_weapon_dice(val0);
+            show_weapon_dice(-1, val0);
         }
     }
     if (attackskill == 106)
     {
         s(1) = i18n::s.get("core.ui.chara_sheet.damage.unarmed");
-        show_weapon_dice(val0);
+        show_weapon_dice(-1, val0);
     }
     attacknum = 0;
-    int stat = can_do_ranged_attack();
-    if (stat == 1)
+    const auto result = can_do_ranged_attack();
+    if (result.type == 1)
     {
         s(1) = i18n::s.get("core.ui.chara_sheet.damage.dist");
-        show_weapon_dice(val0);
+        show_weapon_dice(result.ammo, val0);
     }
 }
 
 
 
-void show_weapon_dice(int val0)
+void show_weapon_dice(int ammo, int val0)
 {
     tc = cc;
     font(12 + sizefix - en * 2, snail::Font::Style::bold);
@@ -1182,8 +1181,8 @@ void show_weapon_dice(int val0)
     {
         attackrange = 1;
     }
-    int tohit = calc_accuracy(false);
-    dmg = calcattackdmg(AttackDamageCalculationMode::raw_damage);
+    int tohit = calc_accuracy(ammo, false);
+    dmg = calcattackdmg(ammo, AttackDamageCalculationMode::raw_damage);
     font(14 - en * 2);
     s(2) = ""s + dmgmulti;
     s = ""s + tohit + u8"%"s;

--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -1137,10 +1137,10 @@ void append_accuracy_info(int val0)
         {
             continue;
         }
-        const auto cw = cdata[cc].body_parts[cnt] % 10000 - 1;
-        if (inv[cw].dice_x > 0)
+        auto& cw = inv[cdata[cc].body_parts[cnt] % 10000 - 1];
+        if (cw.dice_x > 0)
         {
-            attackskill = inv[cw].skill;
+            attackskill = cw.skill;
             ++p(1);
             s(1) = i18n::s.get("core.ui.chara_sheet.damage.melee") + p(1);
             ++attacknum;
@@ -1150,7 +1150,7 @@ void append_accuracy_info(int val0)
     if (attackskill == 106)
     {
         s(1) = i18n::s.get("core.ui.chara_sheet.damage.unarmed");
-        show_weapon_dice(-1, none, val0);
+        show_weapon_dice(none, none, val0);
     }
     attacknum = 0;
     const auto result = can_do_ranged_attack();
@@ -1163,7 +1163,7 @@ void append_accuracy_info(int val0)
 
 
 
-void show_weapon_dice(int cw, optional_ref<Item> ammo, int val0)
+void show_weapon_dice(optional_ref<Item> cw, optional_ref<Item> ammo, int val0)
 {
     tc = cc;
     font(12 + sizefix - en * 2, snail::Font::Style::bold);
@@ -1176,9 +1176,9 @@ void show_weapon_dice(int cw, optional_ref<Item> ammo, int val0)
         mes(wx + 417, wy + 281 + p(2) * 16, s(1), {20, 10, 0});
     }
     attackrange = 0;
-    if (cw != -1)
+    if (cw)
     {
-        if (the_item_db[itemid2int(inv[cw].id)]->category ==
+        if (the_item_db[itemid2int(cw->id)]->category ==
             ItemCategory::ranged_weapon) // TODO coupling
         {
             attackrange = 1;

--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -1144,13 +1144,13 @@ void append_accuracy_info(int val0)
             ++p(1);
             s(1) = i18n::s.get("core.ui.chara_sheet.damage.melee") + p(1);
             ++attacknum;
-            show_weapon_dice(cw, -1, val0);
+            show_weapon_dice(cw, none, val0);
         }
     }
     if (attackskill == 106)
     {
         s(1) = i18n::s.get("core.ui.chara_sheet.damage.unarmed");
-        show_weapon_dice(-1, -1, val0);
+        show_weapon_dice(-1, none, val0);
     }
     attacknum = 0;
     const auto result = can_do_ranged_attack();
@@ -1163,7 +1163,7 @@ void append_accuracy_info(int val0)
 
 
 
-void show_weapon_dice(int cw, int ammo, int val0)
+void show_weapon_dice(int cw, optional_ref<Item> ammo, int val0)
 {
     tc = cc;
     font(12 + sizefix - en * 2, snail::Font::Style::bold);

--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -1137,14 +1137,14 @@ void append_accuracy_info(int val0)
         {
             continue;
         }
-        auto& cw = inv[cdata[cc].body_parts[cnt] % 10000 - 1];
-        if (cw.dice_x > 0)
+        auto& weapon = inv[cdata[cc].body_parts[cnt] % 10000 - 1];
+        if (weapon.dice_x > 0)
         {
-            attackskill = cw.skill;
+            attackskill = weapon.skill;
             ++p(1);
             s(1) = i18n::s.get("core.ui.chara_sheet.damage.melee") + p(1);
             ++attacknum;
-            show_weapon_dice(cw, none, val0);
+            show_weapon_dice(weapon, none, val0);
         }
     }
     if (attackskill == 106)
@@ -1157,13 +1157,16 @@ void append_accuracy_info(int val0)
     if (result.type == 1)
     {
         s(1) = i18n::s.get("core.ui.chara_sheet.damage.dist");
-        show_weapon_dice(result.cw, result.ammo, val0);
+        show_weapon_dice(result.weapon, result.ammo, val0);
     }
 }
 
 
 
-void show_weapon_dice(optional_ref<Item> cw, optional_ref<Item> ammo, int val0)
+void show_weapon_dice(
+    optional_ref<Item> weapon,
+    optional_ref<Item> ammo,
+    int val0)
 {
     tc = cc;
     font(12 + sizefix - en * 2, snail::Font::Style::bold);
@@ -1176,16 +1179,16 @@ void show_weapon_dice(optional_ref<Item> cw, optional_ref<Item> ammo, int val0)
         mes(wx + 417, wy + 281 + p(2) * 16, s(1), {20, 10, 0});
     }
     attackrange = 0;
-    if (cw)
+    if (weapon)
     {
-        if (the_item_db[itemid2int(cw->id)]->category ==
+        if (the_item_db[itemid2int(weapon->id)]->category ==
             ItemCategory::ranged_weapon) // TODO coupling
         {
             attackrange = 1;
         }
     }
-    int tohit = calc_accuracy(cw, ammo, false);
-    dmg = calcattackdmg(cw, ammo, AttackDamageCalculationMode::raw_damage);
+    int tohit = calc_accuracy(weapon, ammo, false);
+    dmg = calcattackdmg(weapon, ammo, AttackDamageCalculationMode::raw_damage);
     font(14 - en * 2);
     s(2) = ""s + dmgmulti;
     s = ""s + tohit + u8"%"s;

--- a/src/elona/menu.hpp
+++ b/src/elona/menu.hpp
@@ -107,7 +107,7 @@ void menu_chat_dialog();
 void menu_voting_box();
 
 void append_accuracy_info(int);
-void show_weapon_dice(int cw, optional_ref<Item> ammo, int val0);
+void show_weapon_dice(optional_ref<Item> cw, optional_ref<Item> ammo, int val0);
 void house_board_update_screen();
 
 } // namespace elona

--- a/src/elona/menu.hpp
+++ b/src/elona/menu.hpp
@@ -107,7 +107,7 @@ void menu_chat_dialog();
 void menu_voting_box();
 
 void append_accuracy_info(int);
-void show_weapon_dice(int);
+void show_weapon_dice(int ammo, int val0);
 void house_board_update_screen();
 
 } // namespace elona

--- a/src/elona/menu.hpp
+++ b/src/elona/menu.hpp
@@ -107,7 +107,10 @@ void menu_chat_dialog();
 void menu_voting_box();
 
 void append_accuracy_info(int);
-void show_weapon_dice(optional_ref<Item> cw, optional_ref<Item> ammo, int val0);
+void show_weapon_dice(
+    optional_ref<Item> weapon,
+    optional_ref<Item> ammo,
+    int val0);
 void house_board_update_screen();
 
 } // namespace elona

--- a/src/elona/menu.hpp
+++ b/src/elona/menu.hpp
@@ -107,7 +107,7 @@ void menu_chat_dialog();
 void menu_voting_box();
 
 void append_accuracy_info(int);
-void show_weapon_dice(int cw, int ammo, int val0);
+void show_weapon_dice(int cw, optional_ref<Item> ammo, int val0);
 void house_board_update_screen();
 
 } // namespace elona

--- a/src/elona/menu.hpp
+++ b/src/elona/menu.hpp
@@ -107,7 +107,7 @@ void menu_chat_dialog();
 void menu_voting_box();
 
 void append_accuracy_info(int);
-void show_weapon_dice(int ammo, int val0);
+void show_weapon_dice(int cw, int ammo, int val0);
 void house_board_update_screen();
 
 } // namespace elona

--- a/src/elona/ui/ui_menu_character_sheet.cpp
+++ b/src/elona/ui/ui_menu_character_sheet.cpp
@@ -558,7 +558,7 @@ void UIMenuCharacterSheet::_draw_first_page_weapon_info()
         {20, 10, 0});
     attackskill = 106;
     int evade = calc_evasion(tc);
-    prot = calcattackdmg(-1, none, AttackDamageCalculationMode::defense);
+    prot = calcattackdmg(none, none, AttackDamageCalculationMode::defense);
     font(14 - en * 2);
     mes(wx + 460 + en * 8,
         wy + 279 + p(2) * 16,

--- a/src/elona/ui/ui_menu_character_sheet.cpp
+++ b/src/elona/ui/ui_menu_character_sheet.cpp
@@ -558,7 +558,7 @@ void UIMenuCharacterSheet::_draw_first_page_weapon_info()
         {20, 10, 0});
     attackskill = 106;
     int evade = calc_evasion(tc);
-    prot = calcattackdmg(AttackDamageCalculationMode::defense);
+    prot = calcattackdmg(-1, AttackDamageCalculationMode::defense);
     font(14 - en * 2);
     mes(wx + 460 + en * 8,
         wy + 279 + p(2) * 16,

--- a/src/elona/ui/ui_menu_character_sheet.cpp
+++ b/src/elona/ui/ui_menu_character_sheet.cpp
@@ -558,7 +558,7 @@ void UIMenuCharacterSheet::_draw_first_page_weapon_info()
         {20, 10, 0});
     attackskill = 106;
     int evade = calc_evasion(tc);
-    prot = calcattackdmg(-1, AttackDamageCalculationMode::defense);
+    prot = calcattackdmg(-1, -1, AttackDamageCalculationMode::defense);
     font(14 - en * 2);
     mes(wx + 460 + en * 8,
         wy + 279 + p(2) * 16,

--- a/src/elona/ui/ui_menu_character_sheet.cpp
+++ b/src/elona/ui/ui_menu_character_sheet.cpp
@@ -558,7 +558,7 @@ void UIMenuCharacterSheet::_draw_first_page_weapon_info()
         {20, 10, 0});
     attackskill = 106;
     int evade = calc_evasion(tc);
-    prot = calcattackdmg(-1, -1, AttackDamageCalculationMode::defense);
+    prot = calcattackdmg(-1, none, AttackDamageCalculationMode::defense);
     font(14 - en * 2);
     mes(wx + 460 + en * 8,
         wy + 279 + p(2) * 16,

--- a/src/elona/variables.hpp
+++ b/src/elona/variables.hpp
@@ -333,7 +333,6 @@ ELONA_EXTERN(int cs);
 ELONA_EXTERN(int cs_bk2);
 ELONA_EXTERN(int cs_bk);
 ELONA_EXTERN(int cspecialeq);
-ELONA_EXTERN(int cw);
 ELONA_EXTERN(int cxinit);
 ELONA_EXTERN(int cyinit);
 ELONA_EXTERN(int damage);

--- a/src/elona/variables.hpp
+++ b/src/elona/variables.hpp
@@ -303,7 +303,6 @@ ELONA_EXTERN(elona_vector2<std::string> mapnamerd);
 ELONA_EXTERN(elona_vector3<int> bddata);
 ELONA_EXTERN(elona_vector3<int> efmap);
 ELONA_EXTERN(elona_vector3<int> map);
-ELONA_EXTERN(int ammo);
 ELONA_EXTERN(int ammoproc);
 ELONA_EXTERN(int ammoprocbk);
 ELONA_EXTERN(int animode);


### PR DESCRIPTION
# Summary

Remove two global variables: `cw` and `ammo`. `cw` maybe stands for "current weapon". They are now passed to each function as parameters, not global variables. In addition, they were changed from index of `inv` to reference of `struct Item`.