### PR TITLE
No inv[] project: refactor various functions

### DIFF
--- a/runtime/mod/core/locale/en/building.lua
+++ b/runtime/mod/core/locale/en/building.lua
@@ -96,15 +96,14 @@ ELONA.i18n:add {
       },
 
       shop = {
-         info = "Shop",
          extend = "You extend your shop! You can display max of {$1} items now!",
          current_shopkeeper = "Current shopkeeper is {basename($1)}.",
          no_assigned_shopkeeper = "You haven't assigned a shopkeeper yet.",
 
          log = {
-            no_shopkeeper = "Your shop doesn't have a shopkeeper.",
-            could_not_sell = "{$1} customers visited your shop but {basename($2)} couldn't sell any item.",
-            sold_items = "{$1} customers visited your shop and {basename($2)} sold {$3} items. {basename($2)} put {$4} in the shop strong box.",
+            no_shopkeeper = "[Shop] Your shop doesn't have a shopkeeper.",
+            could_not_sell = "[Shop] {$1} customers visited your shop but {basename($2)} couldn't sell any item.",
+            sold_items = "[Shop] {$1} customers visited your shop and {basename($2)} sold {$3} items. {basename($2)} put {$4} in the shop strong box.",
             gold = "{$1} gold pieces",
             and_items = " and {$1} items",
          },

--- a/runtime/mod/core/locale/jp/building.lua
+++ b/runtime/mod/core/locale/jp/building.lua
@@ -96,15 +96,14 @@ ELONA.i18n:add {
       },
 
       shop = {
-         info = "店",
          extend = "店を拡張した！これからは{$1}個のアイテムを陳列できる。",
          current_shopkeeper = "現在の店主は{basename($1)}だ。",
          no_assigned_shopkeeper = "現在店主はいない。",
 
          log = {
-            no_shopkeeper = "店には店番がいない。",
-            could_not_sell = "{$1}人が来客したが、{basename($2)}はアイテムを一つも売れなかった。",
-            sold_items = "{$1}人の来客があり、{basename($2)}は{$3}個のアイテムを売却した。{$4}が売り上げとして金庫に保管された。",
+            no_shopkeeper = "[店] 店には店番がいない。",
+            could_not_sell = "[店] {$1}人が来客したが、{basename($2)}はアイテムを一つも売れなかった。",
+            sold_items = "[店] {$1}人の来客があり、{basename($2)}は{$3}個のアイテムを売却した。{$4}が売り上げとして金庫に保管された。",
             gold = "{$1}gold",
             and_items = "と{$1}個のアイテム",
          },

--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -1033,7 +1033,7 @@ void activity_others_end_steal(Item& steal_target)
         chara_refresh(tc);
     }
     auto& stolen_item = inv[slot];
-    item_copy(steal_target.index, stolen_item.index);
+    item_copy(steal_target, stolen_item);
     stolen_item.set_number(in);
     stolen_item.is_stolen() = true;
     stolen_item.own_state = 0;

--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -1013,8 +1013,8 @@ void activity_others_end_steal(Item& steal_target)
     {
         in = steal_target.number();
     }
-    const auto slot = inv_getfreeid(0);
-    if (slot == -1)
+    const auto slot = inv_get_free_slot(0);
+    if (!slot)
     {
         txt(i18n::s.get("core.action.pick_up.your_inventory_is_full"));
         return;
@@ -1032,7 +1032,7 @@ void activity_others_end_steal(Item& steal_target)
         steal_target.body_part = 0;
         chara_refresh(tc);
     }
-    auto& stolen_item = inv[slot];
+    auto& stolen_item = *slot;
     item_copy(steal_target, stolen_item);
     stolen_item.set_number(in);
     stolen_item.is_stolen() = true;

--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -823,7 +823,7 @@ void activity_others_doing(Character& doer, optional_ref<Item> activity_item)
         }
         f = 0;
         f2 = 0;
-        tg = inv_getowner(activity_item->index);
+        tg = inv_getowner(*activity_item);
         if (tg != -1)
         {
             if (cdata[tg].original_relationship == -3)
@@ -913,7 +913,7 @@ void activity_others_doing(Character& doer, optional_ref<Item> activity_item)
         {
             txt(i18n::s.get("core.activity.steal.notice.you_are_found"));
             modify_karma(cdata.player(), -5);
-            p = inv_getowner(activity_item->index);
+            p = inv_getowner(*activity_item);
             if (tg != -1)
             {
                 if (cdata[p].id != CharaId::ebon)
@@ -1001,7 +1001,7 @@ void activity_others_doing(Character& doer, optional_ref<Item> activity_item)
 
 void activity_others_end_steal(Item& steal_target)
 {
-    tg = inv_getowner(steal_target.index);
+    tg = inv_getowner(steal_target);
     if ((tg != -1 && cdata[tg].state() != Character::State::alive) ||
         steal_target.number() <= 0)
     {
@@ -1022,7 +1022,7 @@ void activity_others_end_steal(Item& steal_target)
     steal_target.is_quest_target() = false;
     if (steal_target.body_part != 0)
     {
-        tc = inv_getowner(steal_target.index);
+        tc = inv_getowner(steal_target);
         if (tc != -1)
         {
             p = steal_target.body_part;

--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -1559,9 +1559,9 @@ void activity_eating_finish(Character& eater, Item& food)
     }
     else
     {
-        if (food.index == eater.item_which_will_be_used)
+        if (food.index == eater.ai_item)
         {
-            eater.item_which_will_be_used = 0;
+            eater.ai_item = 0;
         }
         if (eater.was_passed_item_by_you_just_now())
         {

--- a/src/elona/adventurer.cpp
+++ b/src/elona/adventurer.cpp
@@ -338,9 +338,9 @@ int adventurer_discover_equipment()
         }
         if (item.number() != 0)
         {
-            if (cdata[rc].item_which_will_be_used == item.index)
+            if (cdata[rc].ai_item == item.index)
             {
-                cdata[rc].item_which_will_be_used = 0;
+                cdata[rc].ai_item = 0;
             }
             item.remove();
             f = 1;

--- a/src/elona/ai.cpp
+++ b/src/elona/ai.cpp
@@ -568,7 +568,7 @@ void _proc_hungry(Character& chara)
                 }
                 else
                 {
-                    chara.item_which_will_be_used = item->index;
+                    chara.ai_item = item->index;
                     _change_nutrition(chara);
                 }
             }
@@ -949,7 +949,7 @@ TurnResult ai_proc_misc_map_events(Character& chara)
         }
     }
 
-    if (chara.item_which_will_be_used == 0 && chara.relationship != 10)
+    if (chara.ai_item == 0 && chara.relationship != 10)
     {
         if (game_data.current_map == mdata_t::MapId::quest &&
             game_data.executing_immediate_quest_type == 1009)
@@ -971,7 +971,7 @@ TurnResult ai_proc_misc_map_events(Character& chara)
                 }
                 if (const auto item = itemcreate_chara_inv(chara.index, 0, 0))
                 {
-                    chara.item_which_will_be_used = item->index;
+                    chara.ai_item = item->index;
                 }
             }
         }

--- a/src/elona/attack.cpp
+++ b/src/elona/attack.cpp
@@ -523,7 +523,7 @@ bool do_physical_attack_internal(
                         {
                             if (rnd(5) == 0)
                             {
-                                item_acid(cdata[cc], weapon->index);
+                                item_acid(cdata[cc], *weapon);
                             }
                         }
                     }

--- a/src/elona/blending.cpp
+++ b/src/elona/blending.cpp
@@ -1937,7 +1937,7 @@ void blending_proc_on_success_events()
     {
         create_pcpic(cdata.player());
     }
-    if (inv_getowner(item1.index) == -1)
+    if (inv_getowner(item1) == -1)
     {
         cell_refresh(item1.position.x, item1.position.y);
     }

--- a/src/elona/blending.cpp
+++ b/src/elona/blending.cpp
@@ -1846,7 +1846,7 @@ void blending_proc_on_success_events_natural_potion(Item& well, Item&)
         txt(i18n::s.get("core.action.dip.result.natural_potion_drop"));
         return;
     }
-    if (inv_getfreeid(0) == -1)
+    if (!inv_get_free_slot(0))
     {
         txt(i18n::s.get("core.ui.inv.common.inventory_is_full"));
         return;

--- a/src/elona/blending.cpp
+++ b/src/elona/blending.cpp
@@ -1888,7 +1888,7 @@ void blending_proc_on_success_events()
     const auto item2_index = rpref(12);
     if (rpdata(2, rpid) == 2)
     {
-        item_separate(item1_index);
+        item_separate(inv[item1_index]);
     }
     else if (inv[item1_index].number() <= 1)
     {
@@ -1896,7 +1896,7 @@ void blending_proc_on_success_events()
     }
     else
     {
-        int stat = item_separate(item1_index);
+        int stat = item_separate(inv[item1_index]).index;
         if (rpref(10) == stat)
         {
             rpref(10) = -2;

--- a/src/elona/building.cpp
+++ b/src/elona/building.cpp
@@ -98,6 +98,128 @@ bool _livestock_will_breed(const Character& breeder, int livestock_count)
         (L == 0 && rnd(30) == 0);
 }
 
+
+
+int calc_num_of_shop_customers(int shop_level, const Character& shopkeeper)
+{
+    int ret = 0;
+    for (int _i = 0; _i < 3; ++_i)
+    {
+        ret += rnd(shop_level / 3 + 5);
+    }
+    ret = ret * (80 + sdata(17, shopkeeper.index) * 3 / 2) / 100;
+    if (ret < 1)
+    {
+        ret = 1;
+    }
+    return ret;
+}
+
+
+
+struct ItemForSale
+{
+    Item& item;
+    ItemCategory category;
+
+
+    ItemForSale(Item& item, ItemCategory category)
+        : item(item)
+        , category(category)
+    {
+    }
+};
+
+
+
+std::vector<ItemForSale> list_items_for_sale()
+{
+    std::vector<ItemForSale> ret;
+
+    for (auto&& item : inv.ground())
+    {
+        if (item.number() <= 0)
+        {
+            continue;
+        }
+        if (item.id == ItemId::shop_strongbox)
+        {
+            continue;
+        }
+        if (item.id == ItemId::register_)
+        {
+            continue;
+        }
+        if (item.id == ItemId::book_b)
+        {
+            continue;
+        }
+        if (item.id == ItemId::gold_piece)
+        {
+            continue;
+        }
+        if (item.id == ItemId::shelter)
+        {
+            continue;
+        }
+        if (item.id == ItemId::deed)
+        {
+            continue;
+        }
+        if (item.weight < 0)
+        {
+            continue;
+        }
+        if (item.quality >= Quality::special)
+        {
+            continue;
+        }
+        if (item.value < 50)
+        {
+            continue;
+        }
+
+        const auto category = the_item_db[itemid2int(item.id)]->category;
+        if (category == ItemCategory::furniture)
+        {
+            continue;
+        }
+
+        ret.emplace_back(item, category);
+    }
+
+    return ret;
+}
+
+
+
+int calc_item_price_per_one(Item& item, const Character& shopkeeper)
+{
+    const auto V = calcitemvalue(item, 2);
+    const auto I = sdata(156, shopkeeper.index);
+
+    return V * static_cast<int>(10 + std::sqrt(I * 200)) / 100;
+}
+
+
+
+struct SoldItem
+{
+    int level;
+    Quality quality;
+    ItemCategory category;
+    int total_price;
+
+
+    SoldItem(int level, Quality quality, ItemCategory category, int total_price)
+        : level(level)
+        , quality(quality)
+        , category(category)
+        , total_price(total_price)
+    {
+    }
+};
+
 } // namespace
 
 
@@ -107,7 +229,6 @@ elona_vector1<int> fsetplantartifact;
 elona_vector1<int> fsetplantunknown;
 
 
-int sold = 0;
 int rankorg = 0;
 int rankcur = 0;
 
@@ -832,155 +953,101 @@ void update_shop_and_report()
     }
 }
 
+
+
 void show_shop_log()
 {
-    int shoplv = 0;
-    int customer = 0;
-    int dblistmax = 0;
     const auto worker = getworker(area);
-    std::string shop_mark =
-        u8"["s + i18n::s.get("core.building.shop.info") + u8"]"s;
     if (worker == -1)
     {
-        txt(shop_mark + i18n::s.get("core.building.shop.log.no_shopkeeper"));
+        txt(i18n::s.get("core.building.shop.log.no_shopkeeper"));
         return;
     }
-    sold = 0;
-    income(0) = 0;
-    income(1) = 0;
-    listmax = 0;
-    shoplv = 100 - game_data.ranks.at(5) / 100;
-    customer = 0;
-    for (int cnt = 0; cnt < 3; ++cnt)
-    {
-        customer += rnd(shoplv / 3 + 5);
-    }
-    customer = customer * (80 + sdata(17, worker) * 3 / 2) / 100;
-    if (customer < 1)
-    {
-        customer = 1;
-    }
+
     if (game_data.current_map != area)
     {
         ctrl_file(FileOperation2::map_items_write, u8"shoptmp.s2");
         ctrl_file(FileOperation2::map_items_read, u8"inv_"s + mid + u8".s2");
     }
     mode = 6;
-    dblistmax = 0;
-    for (const auto& item : inv.ground())
+
+    const auto shop_level = 100 - game_data.ranks.at(5) / 100;
+    const auto num_of_customers =
+        calc_num_of_shop_customers(shop_level, cdata[worker]);
+
+    const auto items_for_sale = list_items_for_sale();
+
+    int total_profit = 0;
+    int total_sold_items = 0;
+
+    std::vector<SoldItem> sold_items;
+
+    for (int _i = 0; _i < num_of_customers; ++_i)
     {
-        if (item.number() <= 0)
-        {
-            continue;
-        }
-        if (item.id == ItemId::shop_strongbox)
-        {
-            continue;
-        }
-        if (item.id == ItemId::register_)
-        {
-            continue;
-        }
-        if (item.id == ItemId::book_b)
-        {
-            continue;
-        }
-        if (item.id == ItemId::gold_piece)
-        {
-            continue;
-        }
-        if (item.id == ItemId::shelter)
-        {
-            continue;
-        }
-        if (item.id == ItemId::deed)
-        {
-            continue;
-        }
-        if (item.weight < 0)
-        {
-            continue;
-        }
-        if (item.quality >= Quality::special)
-        {
-            continue;
-        }
-        if (item.value < 50)
-        {
-            continue;
-        }
-        auto category = the_item_db[itemid2int(item.id)]->category;
-        if (category == ItemCategory::furniture)
-        {
-            continue;
-        }
-        dblist(0, dblistmax) = item.index;
-        dblist(1, dblistmax) = (int)category;
-        ++dblistmax;
-    }
-    for (int cnt = 0, cnt_end = (customer); cnt < cnt_end; ++cnt)
-    {
-        if (dblistmax == 0)
+        if (items_for_sale.empty())
         {
             break;
         }
-        p = rnd(dblistmax);
-        const auto item_index = dblist(0, p);
-        int category = dblist(1, p);
-        int val0 = calcitemvalue(inv[item_index], 2);
-        val0 = val0 * int((10 + std::sqrt(sdata(156, worker) * 200))) / 100;
-        if (val0 <= 1)
+
+        const auto& item_for_sale = choice(items_for_sale);
+
+        const auto price_per_one =
+            calc_item_price_per_one(item_for_sale.item, cdata[worker]);
+        if (price_per_one <= 1)
         {
-            continue;
+            continue; // too cheep
         }
-        if (rnd_capped(val0) > shoplv * 100 + 500)
+        if (rnd_capped(price_per_one) > shop_level * 100 + 500)
         {
-            continue;
+            continue; // too expensive
         }
-        if (inv[item_index].number() <= 0)
+        if (item_for_sale.item.number() <= 0)
         {
-            continue;
+            continue; // sold out
         }
         if (rnd(8))
         {
             continue;
         }
-        in = rnd_capped(inv[item_index].number()) + 1;
-        inv[item_index].modify_number((-in));
-        sold += in;
-        val0 = val0 * in;
+
+        const auto num = rnd_capped(item_for_sale.item.number()) + 1;
+        item_for_sale.item.modify_number(-num);
+        total_sold_items += num;
+        const auto total_price = price_per_one * num;
+
         if (rnd(4) == 0)
         {
-            list(0, listmax) =
-                the_item_db[itemid2int(inv[item_index].id)]->level;
-            list(1, listmax) = static_cast<int>(inv[item_index].quality);
-            listn(0, listmax) = std::to_string(category);
-            listn(1, listmax) = std::to_string(val0);
-            ++listmax;
+            sold_items.emplace_back(
+                the_item_db[itemid2int(item_for_sale.item.id)]->level,
+                item_for_sale.item.quality,
+                item_for_sale.category,
+                total_price);
         }
         else
         {
-            income += val0;
+            total_profit += total_price;
         }
+
         if (area == game_data.current_map)
         {
-            for (auto&& cnt : cdata.all())
+            for (auto&& chara : cdata.all())
             {
-                if (cnt.state() != Character::State::alive)
+                if (chara.state() != Character::State::alive)
                 {
                     continue;
                 }
-                if (!cnt.activity || cnt.activity.turn == 0)
+                if (!chara.activity || chara.activity.turn == 0)
                 {
                     continue;
                 }
-                if (cnt.activity.item == item_index)
+                if (chara.activity.item == item_for_sale.item.index)
                 {
-                    cdata[cnt.index].activity.finish();
+                    chara.activity.finish();
                 }
             }
         }
     }
+
     mode = 0;
     if (game_data.current_map != area)
     {
@@ -990,6 +1057,7 @@ void show_shop_log()
     {
         ctrl_file(FileOperation2::map_items_write, u8"shoptmp.s2");
     }
+
     tmpload(filepathutil::u8path(u8"shop5.s2"));
     if (fs::exists(filesystem::dirs::tmp() / u8"shop5.s2"))
     {
@@ -1003,98 +1071,98 @@ void show_shop_log()
         }
     }
     mode = 6;
-    if (income != 0)
+
+    if (total_profit != 0)
     {
         flt();
-        itemcreate_extra_inv(54, -1, -1, income);
+        itemcreate_extra_inv(54, -1, -1, total_profit);
     }
-    for (int cnt = 0, cnt_end = (listmax); cnt < cnt_end; ++cnt)
+
+    int num_of_exchanged_items = 0;
+
+    for (const auto& sold_item : sold_items)
     {
-        int cnt2 = cnt;
-        for (int cnt = 0; cnt < 4; ++cnt)
+        bool generated = false;
+        for (int i = 0; i < 4; ++i)
         {
-            flt(list(0, cnt2), static_cast<Quality>(list(1, cnt2)));
-            flttypemajor = elona::stoi(listn(0, cnt2));
+            flt(sold_item.level, sold_item.quality);
+            flttypemajor = static_cast<int>(sold_item.category);
             nostack = 1;
             if (const auto item = itemcreate_extra_inv(0, -1, -1, 0))
             {
-                if (item->value > elona::stoi(listn(1, cnt2)) * 2)
+                if (item->value > sold_item.total_price * 2)
                 {
                     item_stack(-1, *item);
-                    f = 1;
+                    generated = true;
                     break;
                 }
                 else
                 {
                     item->remove();
-                    if (cnt == 3)
-                    {
-                        f = 0;
-                        break;
-                    }
-                    else
-                    {
-                        continue;
-                    }
                 }
             }
             else
             {
-                f = 0;
                 break;
             }
         }
-        if (f == 0)
+        if (generated)
         {
-            itemcreate_extra_inv(54, -1, -1, elona::stoi(listn(1, cnt)));
-            income += elona::stoi(listn(1, cnt));
+            ++num_of_exchanged_items;
         }
         else
         {
-            ++income(1);
+            itemcreate_extra_inv(54, -1, -1, sold_item.total_price);
+            total_profit += sold_item.total_price;
         }
     }
-    if (sold == 0)
+
+    if (total_sold_items == 0)
     {
         if (!g_config.hide_shop_updates())
         {
-            txt(shop_mark +
-                i18n::s.get(
-                    "core.building.shop.log.could_not_sell",
-                    customer,
-                    cdata[worker]));
+            txt(i18n::s.get(
+                "core.building.shop.log.could_not_sell",
+                num_of_customers,
+                cdata[worker]));
         }
     }
     else
     {
         if (!g_config.hide_shop_updates())
         {
-            s = i18n::s.get("core.building.shop.log.gold", income(0));
-            if (income(1) != 0)
+            auto s = i18n::s.get("core.building.shop.log.gold", total_profit);
+            if (num_of_exchanged_items != 0)
             {
-                s += i18n::s.get("core.building.shop.log.and_items", income(1));
+                s += i18n::s.get(
+                    "core.building.shop.log.and_items", num_of_exchanged_items);
             }
             snd("core.ding2");
-            txt(shop_mark +
-                    i18n::s.get(
-                        "core.building.shop.log.sold_items",
-                        customer,
-                        cdata[worker],
-                        sold,
-                        s(0)),
+            txt(i18n::s.get(
+                    "core.building.shop.log.sold_items",
+                    num_of_customers,
+                    cdata[worker],
+                    total_sold_items,
+                    s),
                 Message::color{ColorIndex::orange});
         }
         chara_gain_skill_exp(
-            cdata[worker], 156, clamp(int(std::sqrt(income(0))) * 6, 25, 1000));
+            cdata[worker],
+            156,
+            clamp(int(std::sqrt(total_profit)) * 6, 25, 1000));
     }
-    if (sold > (110 - game_data.ranks.at(5) / 100) / 10)
+
+    if (total_sold_items > (110 - game_data.ranks.at(5) / 100) / 10)
     {
         modrank(5, 30, 2);
     }
+
     mode = 0;
     ctrl_file(FileOperation2::map_items_write, u8"shop5.s2");
     ctrl_file(FileOperation2::map_items_read, u8"shoptmp.s2");
 }
+
+
 
 void update_shop()
 {

--- a/src/elona/building.hpp
+++ b/src/elona/building.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <functional>
+#include <vector>
+
 
 
 namespace elona
@@ -27,7 +30,14 @@ void update_shop();
 void calc_collection_value(bool);
 void update_museum();
 void calc_hairloom_value(int);
-void calc_home_rank();
+
+struct HomeRankHeirloom
+{
+    std::reference_wrapper<Item> item;
+    int value;
+};
+std::vector<HomeRankHeirloom> building_update_home_rank();
+
 void update_ranch();
 
 int calcincome(int = 0);

--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -1580,7 +1580,7 @@ void chara_relocate(
     }
 
     // Clear some fields which should not be copied.
-    source.item_which_will_be_used = 0;
+    source.ai_item = 0;
     source.is_livestock() = false;
 
     // Copy from `source` to `destination` and clear `source`
@@ -1692,13 +1692,13 @@ void chara_relocate(
 
 
 
-void chara_set_item_which_will_be_used(Character& chara, const Item& item)
+void chara_set_ai_item(Character& chara, const Item& item)
 {
     const auto category = the_item_db[itemid2int(item.id)]->category;
     if (category == ItemCategory::food || category == ItemCategory::potion ||
         category == ItemCategory::scroll)
     {
-        chara.item_which_will_be_used = item.index;
+        chara.ai_item = item.index;
     }
 }
 
@@ -2219,7 +2219,7 @@ void chara_clear_status_effects()
     cdata[rc].drunk = 0;
     cdata[rc].bleeding = 0;
     cdata[rc].gravity = 0;
-    cdata[rc].item_which_will_be_used = 0;
+    cdata[rc].ai_item = 0;
     cdata[rc].hate = 0;
     cdata[rc].enemy_id = 0;
     cdata[rc].sick = 0;

--- a/src/elona/character.hpp
+++ b/src/elona/character.hpp
@@ -236,7 +236,7 @@ public:
     int relationship = 0;
     int turn_cost = 0;
     int current_speed = 0;
-    int item_which_will_be_used = 0;
+    int ai_item = 0;
     std::string portrait;
     int interest = 0;
     int time_interest_revive = 0;
@@ -438,7 +438,7 @@ public:
         ELONA_SERIALIZATION_STRUCT_FIELD(*this, relationship);
         ELONA_SERIALIZATION_STRUCT_FIELD(*this, turn_cost);
         ELONA_SERIALIZATION_STRUCT_FIELD(*this, current_speed);
-        ELONA_SERIALIZATION_STRUCT_FIELD(*this, item_which_will_be_used);
+        ELONA_SERIALIZATION_STRUCT_FIELD(*this, ai_item);
         ELONA_SERIALIZATION_STRUCT_FIELD(*this, portrait);
         ELONA_SERIALIZATION_STRUCT_FIELD(*this, interest);
         ELONA_SERIALIZATION_STRUCT_FIELD(*this, time_interest_revive);
@@ -705,7 +705,7 @@ bool chara_unequip(Item& item);
 int chara_custom_talk(int = 0, int = 0);
 int chara_impression_level(int = 0);
 void chara_modify_impression(Character& cc, int delta);
-void chara_set_item_which_will_be_used(Character& chara, const Item& item);
+void chara_set_ai_item(Character& chara, const Item& item);
 int chara_armor_class(const Character& cc);
 int chara_breed_power(const Character&);
 

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -1182,7 +1182,7 @@ TurnResult do_offer_command(Item& offering)
         return TurnResult::turn_end;
     }
     rowact_item(offering);
-    item_separate(offering.index);
+    item_separate(offering);
     txt(i18n::s.get(
         "core.action.offer.execute",
         offering,
@@ -1485,7 +1485,7 @@ TurnResult do_dip_command(Item& mix_item, Item& mix_target)
 {
     if (mix_item.id == ItemId::bait)
     {
-        item_separate(mix_target.index);
+        item_separate(mix_target);
         mix_item.modify_number(-1);
         snd("core.equip1");
         txt(i18n::s.get(
@@ -1506,7 +1506,7 @@ TurnResult do_dip_command(Item& mix_item, Item& mix_target)
     {
         if (the_item_db[itemid2int(mix_target.id)]->subcategory == 60001)
         {
-            item_separate(mix_target.index);
+            item_separate(mix_target);
             mix_item.modify_number(-1);
             if (mix_item.id != ItemId::empty_bottle)
             {
@@ -1588,7 +1588,7 @@ TurnResult do_dip_command(Item& mix_item, Item& mix_target)
             ItemCategory::food)
         {
             mix_item.modify_number(-1);
-            item_separate(mix_target.index);
+            item_separate(mix_target);
             txt(i18n::s.get(
                     "core.action.dip.result.love_food.made",
                     mix_target,
@@ -1608,7 +1608,7 @@ TurnResult do_dip_command(Item& mix_item, Item& mix_target)
             ItemCategory::food)
         {
             mix_item.modify_number(-1);
-            item_separate(mix_target.index);
+            item_separate(mix_target);
             txt(i18n::s.get(
                     "core.action.dip.result.love_food.made",
                     mix_target,
@@ -1631,7 +1631,7 @@ TurnResult do_dip_command(Item& mix_item, Item& mix_target)
         else
         {
             in = 1;
-            item_separate(mix_target.index);
+            item_separate(mix_target);
         }
         mix_item.modify_number(-1);
         mix_target.color = mix_item.color;
@@ -1655,7 +1655,7 @@ TurnResult do_dip_command(Item& mix_item, Item& mix_target)
         else
         {
             in = 1;
-            item_separate(mix_target.index);
+            item_separate(mix_target);
         }
         txt(i18n::s.get("core.action.dip.result.put_on", mix_target, mix_item));
         if (is_cursed(mix_item.curse_state))
@@ -1680,7 +1680,7 @@ TurnResult do_dip_command(Item& mix_item, Item& mix_target)
         else
         {
             in = 1;
-            item_separate(mix_target.index);
+            item_separate(mix_target);
         }
         txt(i18n::s.get("core.action.dip.result.put_on", mix_target, mix_item));
         if (is_cursed(mix_item.curse_state))
@@ -1765,7 +1765,7 @@ TurnResult do_use_command(Item& use_item)
             update_screen();
             return TurnResult::pc_turn_user_error;
         }
-        item_separate(use_item.index);
+        item_separate(use_item);
         use_item.count = game_data.date.hours() + use_item.param3;
     }
     if (use_item.has_charge())
@@ -1776,7 +1776,7 @@ TurnResult do_use_command(Item& use_item)
             update_screen();
             return TurnResult::pc_turn_user_error;
         }
-        item_separate(use_item.index);
+        item_separate(use_item);
         --use_item.count;
     }
     if (item_data->subcategory == 58500)
@@ -2351,7 +2351,7 @@ TurnResult do_use_command(Item& use_item)
             update_screen();
             return TurnResult::pc_turn_user_error;
         }
-        item_separate(use_item.index);
+        item_separate(use_item);
         snd("core.paygold1");
         cdata.player().gold -= moneybox(use_item.param2);
         use_item.param1 += moneybox(use_item.param2);
@@ -2942,7 +2942,7 @@ TurnResult do_open_command(Item& box, bool play_sound)
         mode = 0;
         return TurnResult::turn_end;
     }
-    item_separate(box.index);
+    item_separate(box);
     if (box.param1 != 0)
     {
         if (box.param2 != 0)
@@ -4206,7 +4206,7 @@ int decode_book(Item& book)
         {
             txt(i18n::s.get("core.activity.read.start", cdata[cc], book));
         }
-        item_separate(book.index);
+        item_separate(book);
         return 0;
     }
     if (cdata[cc].activity.turn > 0)
@@ -4653,7 +4653,7 @@ int drink_well(Item& well)
         txt(i18n::s.get("core.action.drink.well.is_dry", valn));
         return 1;
     }
-    item_separate(well.index);
+    item_separate(well);
     snd_at("core.drink1", cdata[cc].position);
     const auto valn = itemname(well);
     txt(i18n::s.get("core.action.drink.well.draw", cdata[cc], valn));
@@ -5011,7 +5011,7 @@ int do_zap(Item& rod)
             return 1;
         }
     }
-    item_separate(rod.index);
+    item_separate(rod);
     --rod.count;
     return 1;
 }
@@ -5680,7 +5680,7 @@ TurnResult do_bash()
         {
             const auto tree_index = mapitemfind(x, y, 526);
             auto& tree = inv[tree_index];
-            item_separate(tree.index);
+            item_separate(tree);
             snd("core.bash1");
             txt(i18n::s.get("core.action.bash.tree.execute", tree));
             if (tree.own_state == 5 || tree.param1 <= 0)

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -1595,7 +1595,7 @@ TurnResult do_dip_command(Item& mix_item, Item& mix_target)
                 i18n::s.get("core.action.dip.result.love_food.grin"));
             if (is_cursed(mix_item.curse_state))
             {
-                dipcursed(mix_target.index);
+                dipcursed(mix_target);
             }
             mix_target.is_poisoned() = true;
             return TurnResult::turn_end;
@@ -1615,7 +1615,7 @@ TurnResult do_dip_command(Item& mix_item, Item& mix_target)
                 i18n::s.get("core.action.dip.result.love_food.guilty"));
             if (is_cursed(mix_item.curse_state))
             {
-                dipcursed(mix_target.index);
+                dipcursed(mix_target);
             }
             mix_target.is_aphrodisiac() = true;
             return TurnResult::turn_end;
@@ -1659,7 +1659,7 @@ TurnResult do_dip_command(Item& mix_item, Item& mix_target)
         txt(i18n::s.get("core.action.dip.result.put_on", mix_target, mix_item));
         if (is_cursed(mix_item.curse_state))
         {
-            dipcursed(mix_target.index);
+            dipcursed(mix_target);
         }
         else
         {
@@ -1684,7 +1684,7 @@ TurnResult do_dip_command(Item& mix_item, Item& mix_target)
         txt(i18n::s.get("core.action.dip.result.put_on", mix_target, mix_item));
         if (is_cursed(mix_item.curse_state))
         {
-            dipcursed(mix_target.index);
+            dipcursed(mix_target);
         }
         else if (mix_target.id == ItemId::fireproof_blanket)
         {

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -1625,7 +1625,7 @@ TurnResult do_dip_command(Item& mix_item, Item& mix_target)
         mix_item.modify_number(-1);
         mix_target.color = mix_item.color;
         txt(i18n::s.get("core.action.dip.result.dyeing", mix_target));
-        if (inv_getowner(mix_target.index) == -1)
+        if (inv_getowner(mix_target) == -1)
         {
             cell_refresh(mix_target.position.x, mix_target.position.y);
         }
@@ -1929,7 +1929,7 @@ TurnResult do_use_command(Item& use_item)
         snd("core.build1");
         break;
     case 44:
-        if (inv_getowner(use_item.index) != -1)
+        if (inv_getowner(use_item) != -1)
         {
             txt(i18n::s.get("core.action.use.chair.needs_place_on_ground"));
             update_screen();

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -5646,7 +5646,7 @@ PickUpItemResult pick_up_item(Item& item, bool play_sound)
         {
             if (mode == 0)
             {
-                calc_home_rank();
+                building_update_home_rank();
             }
         }
         refresh_burden_state();

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -2752,7 +2752,7 @@ TurnResult do_use_command(Item& use_item)
         txt(i18n::s.get("core.action.use.deck.put_away"));
         break;
     case 38:
-        if (inv_find(701, 0) == -1)
+        if (!inv_find(ItemId::deck, 0))
         {
             txt(i18n::s.get("core.action.use.deck.no_deck"));
             update_screen();

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -895,26 +895,16 @@ TurnResult do_throw_command_internal(Item& throw_item)
             {
                 if (cell_data.at(tlocx, tlocy).item_appearances_actual != 0)
                 {
-                    cell_itemlist(tlocx, tlocy);
-                    f = 0;
-                    for (int cnt = 0, cnt_end = (listmax); cnt < cnt_end; ++cnt)
+                    if (const auto snowman =
+                            mapitemfind({tlocx, tlocy}, ItemId::snow_man))
                     {
-                        p = list(0, cnt);
-                        if (inv[p].id == ItemId::snow_man)
+                        if (is_in_fov({tlocx, tlocy}))
                         {
-                            if (is_in_fov({tlocx, tlocy}))
-                            {
-                                txt(i18n::s.get(
-                                    "core.action.throw.snow.hits_snowman",
-                                    inv[p(0)]));
-                            }
-                            inv[p].modify_number(-1);
-                            f = 1;
-                            break;
+                            txt(i18n::s.get(
+                                "core.action.throw.snow.hits_snowman",
+                                *snowman));
                         }
-                    }
-                    if (f == 1)
-                    {
+                        snowman->modify_number(-1);
                         cell_refresh(tlocx, tlocy);
                         return TurnResult::turn_end;
                     }
@@ -2997,7 +2987,7 @@ TurnResult do_use_stairs_command(int val0)
     movelevelbystairs = 0;
     if (val0 == 1)
     {
-        if (mapitemfind(cdata[cc].position.x, cdata[cc].position.y, 753) != -1)
+        if (mapitemfind(cdata[cc].position, ItemId::kotatsu))
         {
             txt(i18n::s.get("core.action.use_stairs.kotatsu.prompt"));
             if (!yes_no())
@@ -3014,8 +3004,7 @@ TurnResult do_use_stairs_command(int val0)
     {
         if (val0 == 1)
         {
-            if (mapitemfind(cdata[cc].position.x, cdata[cc].position.y, 751) !=
-                -1)
+            if (mapitemfind(cdata[cc].position, ItemId::downstairs))
             {
                 if (game_data.current_dungeon_level >=
                     area_data[game_data.current_map].deepest_level)
@@ -3031,8 +3020,7 @@ TurnResult do_use_stairs_command(int val0)
         }
         if (val0 == 2)
         {
-            if (mapitemfind(cdata[cc].position.x, cdata[cc].position.y, 750) !=
-                -1)
+            if (mapitemfind(cdata[cc].position, ItemId::upstairs))
             {
                 if (game_data.current_dungeon_level <=
                     area_data[game_data.current_map].danger_level)
@@ -5677,10 +5665,9 @@ TurnResult do_bash()
 {
     if (cell_data.at(x, y).item_appearances_memory != 0)
     {
-        if (mapitemfind(x, y, 526) != -1)
+        if (const auto tree_opt = mapitemfind({x, y}, ItemId::tree_of_fruits))
         {
-            const auto tree_index = mapitemfind(x, y, 526);
-            auto& tree = inv[tree_index];
+            auto& tree = *tree_opt;
             item_separate(tree);
             snd("core.bash1");
             txt(i18n::s.get("core.action.bash.tree.execute", tree));

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -1021,20 +1021,19 @@ TurnResult do_throw_command(Item& throw_item)
 
     if (throw_item.id == ItemId::monster_ball)
     {
-        const auto slot = inv_getfreeid(-1);
-        if (slot == -1)
+        if (const auto slot = inv_get_free_slot(-1))
         {
+            item_copy(throw_item, *slot);
+            slot->position.x = tlocx;
+            slot->position.y = tlocy;
+            slot->set_number(1);
             throw_item.modify_number(-1);
-            return do_throw_command_internal(throw_item);
+            return do_throw_command_internal(*slot);
         }
         else
         {
-            item_copy(throw_item, inv[slot]);
-            inv[slot].position.x = tlocx;
-            inv[slot].position.y = tlocy;
-            inv[slot].set_number(1);
             throw_item.modify_number(-1);
-            return do_throw_command_internal(inv[slot]);
+            return do_throw_command_internal(throw_item);
         }
     }
     else
@@ -1549,7 +1548,7 @@ TurnResult do_dip_command(Item& mix_item, Item& mix_target)
                         "core.action.dip.result.natural_potion_drop"));
                     return TurnResult::turn_end;
                 }
-                if (inv_getfreeid(0) == -1)
+                if (!inv_get_free_slot(0))
                 {
                     txt(i18n::s.get("core.ui.inv.common.inventory_is_full"));
                     return TurnResult::turn_end;
@@ -5416,7 +5415,7 @@ PickUpItemResult pick_up_item(Item& item, bool play_sound)
                 return {0, none};
             }
         }
-        if (inv_getfreeid(cc) == -1)
+        if (!inv_get_free_slot(cc))
         {
             txt(i18n::s.get("core.action.pick_up.your_inventory_is_full"));
             return {0, none};
@@ -5479,8 +5478,8 @@ PickUpItemResult pick_up_item(Item& item, bool play_sound)
     }
     else
     {
-        picked_up_item_index = inv_getfreeid(cc);
-        if (picked_up_item_index == -1)
+        const auto slot = inv_get_free_slot(cc);
+        if (!slot)
         {
             item.set_number(inumbk + in);
             if (invctrl == 12)
@@ -5494,8 +5493,9 @@ PickUpItemResult pick_up_item(Item& item, bool play_sound)
             }
             return {0, none};
         }
-        item_copy(item, inv[picked_up_item_index]);
-        inv[picked_up_item_index].set_number(in);
+        item_copy(item, *slot);
+        slot->set_number(in);
+        picked_up_item_index = slot->index;
     }
     auto& picked_up_item = inv[picked_up_item_index];
 

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -1029,7 +1029,7 @@ TurnResult do_throw_command(Item& throw_item)
         }
         else
         {
-            item_copy(throw_item.index, slot);
+            item_copy(throw_item, inv[slot]);
             inv[slot].position.x = tlocx;
             inv[slot].position.y = tlocy;
             inv[slot].set_number(1);
@@ -5494,7 +5494,7 @@ PickUpItemResult pick_up_item(Item& item, bool play_sound)
             }
             return {0, none};
         }
-        item_copy(item.index, picked_up_item_index);
+        item_copy(item, inv[picked_up_item_index]);
         inv[picked_up_item_index].set_number(in);
     }
     auto& picked_up_item = inv[picked_up_item_index];

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -5645,7 +5645,8 @@ PickUpItemResult pick_up_item(Item& item, bool play_sound)
                 }
             }
         }
-        picked_up_item_index = convertartifact(picked_up_item_index);
+        picked_up_item_index =
+            item_convert_artifact(inv[picked_up_item_index]).index;
         if (area_data[game_data.current_map].id == mdata_t::MapId::museum)
         {
             if (mode == 0)

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -902,15 +902,14 @@ optional<OnEnterResult> on_shortcut(int& citrade, bool dropcontinue)
         cc = 0;
         if (f == 0)
         {
-            int stat = inv_find(invsc, 0);
-            if (stat == -1)
-            {
-                txt(i18n::s.get("core.ui.inv.common.does_not_exist"));
-            }
-            else
+            if (inv_find(int2itemid(invsc), 0))
             {
                 Message::instance().linebreak();
                 txt(i18n::s.get("core.action.cannot_do_in_global"));
+            }
+            else
+            {
+                txt(i18n::s.get("core.ui.inv.common.does_not_exist"));
             }
             invsc = 0;
             update_screen();

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -2012,7 +2012,7 @@ on_enter_trade_target(Item& selected_item, MenuResult& result, int& citrade)
     {
         supply_new_equipment();
     }
-    inv_getfreeid_force();
+    (void)inv_get_free_slot_force(tc);
     chara_refresh(tc);
     refresh_burden_state();
     invsubroutine = 0;

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -2001,7 +2001,7 @@ on_enter_trade_target(Item& selected_item, MenuResult& result, int& citrade)
         inv[citrade].body_part = 0;
     }
     item_exchange(selected_item, inv[citrade]);
-    convertartifact(selected_item.index);
+    item_convert_artifact(selected_item);
     rc = tc;
     if (cdata[rc].item_which_will_be_used == citrade)
     {
@@ -2177,9 +2177,8 @@ OnEnterResult on_enter_receive(Item& selected_item)
         item_copy(selected_item, slot);
         selected_item.modify_number((-in));
         slot.set_number(in);
-        const auto stacked_item_index =
-            item_stack(0, slot, true).stacked_item.index;
-        convertartifact(stacked_item_index);
+        auto& stacked_item = item_stack(0, slot, true).stacked_item;
+        item_convert_artifact(stacked_item);
     }
     rc = tc;
     wear_most_valuable_equipment_for_all_body_parts();
@@ -2262,9 +2261,8 @@ OnEnterResult on_enter_small_medal(Item& selected_item)
     snd("core.paygold1");
     item_copy(selected_item, slot);
     txt(i18n::s.get("core.ui.inv.trade_medals.you_receive", slot));
-    const auto stacked_item_index =
-        item_stack(0, slot, true).stacked_item.index;
-    convertartifact(stacked_item_index, 1);
+    auto& stacked_item = item_stack(0, slot, true).stacked_item;
+    item_convert_artifact(stacked_item, true);
     return OnEnterResult{1};
 }
 

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -1844,7 +1844,7 @@ OnEnterResult on_enter_give(Item& selected_item, MenuResult& result)
         slot.set_number(1);
         auto& stacked_item = item_stack(tc, slot, true).stacked_item;
         rc = tc;
-        chara_set_item_which_will_be_used(cdata[tc], stacked_item);
+        chara_set_ai_item(cdata[tc], stacked_item);
         wear_most_valuable_equipment_for_all_body_parts();
         if (tc < 16)
         {
@@ -2002,9 +2002,9 @@ on_enter_trade_target(Item& selected_item, MenuResult& result, int& citrade)
     item_exchange(selected_item, inv[citrade]);
     item_convert_artifact(selected_item);
     rc = tc;
-    if (cdata[rc].item_which_will_be_used == citrade)
+    if (cdata[rc].ai_item == citrade)
     {
-        cdata[rc].item_which_will_be_used = 0;
+        cdata[rc].ai_item = 0;
     }
     wear_most_valuable_equipment_for_all_body_parts();
     if (tc >= 16)

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -1839,7 +1839,7 @@ OnEnterResult on_enter_give(Item& selected_item, MenuResult& result)
             selected_item.modify_number(-1);
             return OnEnterResult{1};
         }
-        item_copy(selected_item.index, slot);
+        item_copy(selected_item, inv[slot]);
         selected_item.modify_number(-1);
         inv[slot].set_number(1);
         auto& stacked_item = item_stack(tc, inv[slot], true).stacked_item;
@@ -2172,7 +2172,7 @@ OnEnterResult on_enter_receive(Item& selected_item)
     }
     else
     {
-        item_copy(selected_item.index, slot);
+        item_copy(selected_item, inv[slot]);
         selected_item.modify_number((-in));
         inv[slot].set_number(in);
         const auto stacked_item_index =
@@ -2257,7 +2257,7 @@ OnEnterResult on_enter_small_medal(Item& selected_item)
     }
     inv[i].modify_number(-calcmedalvalue(selected_item));
     snd("core.paygold1");
-    item_copy(selected_item.index, slot);
+    item_copy(selected_item, inv[slot]);
     txt(i18n::s.get("core.ui.inv.trade_medals.you_receive", inv[slot]));
     const auto stacked_item_index =
         item_stack(0, inv[slot], true).stacked_item.index;

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -1999,7 +1999,7 @@ on_enter_trade_target(Item& selected_item, MenuResult& result, int& citrade)
             cdata[tc].body_parts[p - 100] / 10000 * 10000;
         inv[citrade].body_part = 0;
     }
-    item_exchange(selected_item.index, citrade);
+    item_exchange(selected_item, inv[citrade]);
     convertartifact(selected_item.index);
     rc = tc;
     if (cdata[rc].item_which_will_be_used == citrade)

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -2032,7 +2032,7 @@ OnEnterResult on_enter_target(Item& selected_item, MenuResult& result)
             return OnEnterResult{2};
         }
     }
-    item_separate(selected_item.index);
+    item_separate(selected_item);
     invsubroutine = 0;
     result.succeeded = true;
     return OnEnterResult{result, selected_item};

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -1667,19 +1667,20 @@ OnEnterResult on_enter_give(Item& selected_item, MenuResult& result)
         txt(i18n::s.get("core.ui.inv.common.set_as_no_drop"));
         return OnEnterResult{2};
     }
-    const auto slot = inv_getfreeid(tc);
     if (cdata[tc].sleep)
     {
         txt(i18n::s.get("core.ui.inv.give.is_sleeping", cdata[tc]));
         snd("core.fail1");
         return OnEnterResult{2};
     }
-    if (slot == -1)
+    const auto slot_opt = inv_get_free_slot(tc);
+    if (!slot_opt)
     {
         txt(i18n::s.get("core.ui.inv.give.inventory_is_full", cdata[tc]));
         snd("core.fail1");
         return OnEnterResult{2};
     }
+    auto& slot = *slot_opt;
     reftype = (int)the_item_db[itemid2int(selected_item.id)]->category;
     if (selected_item.id == ItemId::gift)
     {
@@ -1839,10 +1840,10 @@ OnEnterResult on_enter_give(Item& selected_item, MenuResult& result)
             selected_item.modify_number(-1);
             return OnEnterResult{1};
         }
-        item_copy(selected_item, inv[slot]);
+        item_copy(selected_item, slot);
         selected_item.modify_number(-1);
-        inv[slot].set_number(1);
-        auto& stacked_item = item_stack(tc, inv[slot], true).stacked_item;
+        slot.set_number(1);
+        auto& stacked_item = item_stack(tc, slot, true).stacked_item;
         rc = tc;
         chara_set_item_which_will_be_used(cdata[tc], stacked_item);
         wear_most_valuable_equipment_for_all_body_parts();
@@ -2113,12 +2114,13 @@ OnEnterResult on_enter_put_into(Item& selected_item)
 
 OnEnterResult on_enter_receive(Item& selected_item)
 {
-    const auto slot = inv_getfreeid(0);
-    if (slot == -1)
+    const auto slot_opt = inv_get_free_slot(0);
+    if (!slot_opt)
     {
         txt(i18n::s.get("core.ui.inv.common.inventory_is_full"));
         return OnEnterResult{2};
     }
+    auto& slot = *slot_opt;
     if (the_item_db[itemid2int(selected_item.id)]->category ==
         ItemCategory::ore)
     {
@@ -2172,11 +2174,11 @@ OnEnterResult on_enter_receive(Item& selected_item)
     }
     else
     {
-        item_copy(selected_item, inv[slot]);
+        item_copy(selected_item, slot);
         selected_item.modify_number((-in));
-        inv[slot].set_number(in);
+        slot.set_number(in);
         const auto stacked_item_index =
-            item_stack(0, inv[slot], true).stacked_item.index;
+            item_stack(0, slot, true).stacked_item.index;
         convertartifact(stacked_item_index);
     }
     rc = tc;
@@ -2232,13 +2234,14 @@ OnEnterResult on_enter_steal(Item& selected_item, MenuResult& result)
 OnEnterResult on_enter_small_medal(Item& selected_item)
 {
     Message::instance().linebreak();
-    const auto slot = inv_getfreeid(0);
-    if (slot == -1)
+    const auto slot_opt = inv_get_free_slot(0);
+    if (!slot_opt)
     {
         txt(i18n::s.get("core.ui.inv.trade_medals.inventory_full"));
         snd("core.fail1");
         return OnEnterResult{1};
     }
+    auto& slot = *slot_opt;
     if (const auto small_medals =
             item_find(622, 3, ItemFindLocation::player_inventory))
     {
@@ -2257,10 +2260,10 @@ OnEnterResult on_enter_small_medal(Item& selected_item)
     }
     inv[i].modify_number(-calcmedalvalue(selected_item));
     snd("core.paygold1");
-    item_copy(selected_item, inv[slot]);
-    txt(i18n::s.get("core.ui.inv.trade_medals.you_receive", inv[slot]));
+    item_copy(selected_item, slot);
+    txt(i18n::s.get("core.ui.inv.trade_medals.you_receive", slot));
     const auto stacked_item_index =
-        item_stack(0, inv[slot], true).stacked_item.index;
+        item_stack(0, slot, true).stacked_item.index;
     convertartifact(stacked_item_index, 1);
     return OnEnterResult{1};
 }

--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -1479,13 +1479,15 @@ void character_drops_item()
             item.position.y = cdata[rc].position.y;
             if (!item_stack(-1, item).stacked)
             {
-                const auto slot = inv_getfreeid(-1);
-                if (slot == -1)
+                if (const auto slot = inv_get_free_slot(-1))
+                {
+                    item_copy(item, *slot);
+                    slot->own_state = -2;
+                }
+                else
                 {
                     break;
                 }
-                item_copy(item, inv[slot]);
-                inv[slot].own_state = -2;
             }
             item.remove();
         }
@@ -1610,12 +1612,14 @@ void character_drops_item()
         itemturn(item);
         if (!item_stack(-1, item).stacked)
         {
-            const auto slot = inv_getfreeid(-1);
-            if (slot == -1)
+            if (const auto slot = inv_get_free_slot(-1))
+            {
+                item_copy(item, *slot);
+            }
+            else
             {
                 break;
             }
-            item_copy(item, inv[slot]);
         }
         item.remove();
     }

--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -72,11 +72,10 @@ void end_dmghp(const Character& victim)
 
 void dmgheal_death_by_backpack(Character& chara)
 {
-    int heaviest_item_index = -1;
+    optional_ref<Item> heaviest_item;
     int heaviest_weight = 0;
-    std::string heaviest_item_name;
 
-    for (const auto& item : inv.for_chara(chara))
+    for (auto&& item : inv.for_chara(chara))
     {
         if (item.number() == 0)
         {
@@ -84,19 +83,22 @@ void dmgheal_death_by_backpack(Character& chara)
         }
         if (item.weight > heaviest_weight)
         {
-            heaviest_item_index = item.index;
+            heaviest_item = item;
             heaviest_weight = item.weight;
         }
     }
-    if (heaviest_item_index == -1)
+
+    std::string heaviest_item_name;
+    if (heaviest_item)
+    {
+        heaviest_item_name = itemname(*heaviest_item);
+    }
+    else
     {
         heaviest_item_name =
             i18n::s.get_enum_property("core.death_by.other", "backpack", 6);
     }
-    else
-    {
-        heaviest_item_name = itemname(inv[heaviest_item_index]);
-    }
+
     txt(i18n::s.get_enum_property(
         "core.death_by.other", "text", 6, chara, heaviest_item_name));
     if (chara.index == 0)

--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -1482,7 +1482,7 @@ void character_drops_item()
                 {
                     break;
                 }
-                item_copy(item.index, slot);
+                item_copy(item, inv[slot]);
                 inv[slot].own_state = -2;
             }
             item.remove();
@@ -1613,7 +1613,7 @@ void character_drops_item()
             {
                 break;
             }
-            item_copy(item.index, slot);
+            item_copy(item, inv[slot]);
         }
         item.remove();
     }

--- a/src/elona/equipment.cpp
+++ b/src/elona/equipment.cpp
@@ -1342,7 +1342,7 @@ int equip_item(int cc, Item& equipment)
     {
         return 0;
     }
-    item_separate(equipment.index);
+    item_separate(equipment);
     if (cc == 0)
     {
         item_identify(equipment, IdentifyState::almost);

--- a/src/elona/food.cpp
+++ b/src/elona/food.cpp
@@ -409,7 +409,7 @@ void get_hungry(Character& cc)
 void cook(Item& cook_tool, Item& food)
 {
     snd("core.cook1");
-    item_separate(food.index);
+    item_separate(food);
 
     const auto item_name_prev = itemname(food);
 

--- a/src/elona/initialize_map.cpp
+++ b/src/elona/initialize_map.cpp
@@ -1179,7 +1179,7 @@ void _proc_map_hooks_2()
     }
     if (game_data.current_map == mdata_t::MapId::your_home)
     {
-        calc_home_rank();
+        building_update_home_rank();
     }
     if (area_data[game_data.current_map].id == mdata_t::MapId::ranch)
     {

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -162,22 +162,17 @@ int skip_ = 0;
 optional_ref<Item>
 item_find(int matcher, int matcher_type, ItemFindLocation location_type)
 {
-    int result = -1;
+    optional_ref<Item> result;
     int max_param1 = -1;
 
-    for (int location = 0; location < 2; ++location)
+    for (const auto& inventory_id : {-1, 0})
     {
-        int invhead;
-        int invrange;
-        if (location == 0)
+        if (inventory_id == -1)
         {
             if (location_type == ItemFindLocation::player_inventory)
             {
                 continue;
             }
-            const auto pair = inv_getheader(-1);
-            invhead = pair.first;
-            invrange = pair.second;
         }
         else
         {
@@ -185,19 +180,14 @@ item_find(int matcher, int matcher_type, ItemFindLocation location_type)
             {
                 continue;
             }
-            const auto pair = inv_getheader(0);
-            invhead = pair.first;
-            invrange = pair.second;
         }
-        for (int item_index = invhead; item_index < invhead + invrange;
-             ++item_index)
+        for (auto&& item : inv.by_index(inventory_id))
         {
-            const auto& item = inv[item_index];
             if (item.number() == 0)
             {
                 continue;
             }
-            if (location == 0)
+            if (inventory_id == -1)
             {
                 if (item.position != cdata.player().position)
                 {
@@ -209,7 +199,7 @@ item_find(int matcher, int matcher_type, ItemFindLocation location_type)
             case 0:
                 if ((int)the_item_db[itemid2int(item.id)]->category == matcher)
                 {
-                    result = item.index;
+                    result = item;
                 }
                 break;
             case 1:
@@ -217,7 +207,7 @@ item_find(int matcher, int matcher_type, ItemFindLocation location_type)
                 {
                     if (max_param1 < item.param1)
                     {
-                        result = item.index;
+                        result = item;
                         max_param1 = item.param1;
                     }
                 }
@@ -225,13 +215,13 @@ item_find(int matcher, int matcher_type, ItemFindLocation location_type)
             case 2:
                 if (the_item_db[itemid2int(item.id)]->subcategory == matcher)
                 {
-                    result = item.index;
+                    result = item;
                 }
                 break;
             case 3:
                 if (item.id == int2itemid(matcher))
                 {
-                    result = item.index;
+                    result = item;
                 }
                 break;
             default: assert(0); break;
@@ -239,14 +229,7 @@ item_find(int matcher, int matcher_type, ItemFindLocation location_type)
         }
     }
 
-    if (result == -1)
-    {
-        return none;
-    }
-    else
-    {
-        return inv[result];
-    }
+    return result;
 }
 
 

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -556,7 +556,7 @@ Item& item_separate(Item& stacked_item)
         return stacked_item;
     }
 
-    auto slot = inv_get_free_slot(inv_getowner(stacked_item.index));
+    auto slot = inv_get_free_slot(inv_getowner(stacked_item));
     if (!slot)
     {
         slot = inv_get_free_slot(-1);
@@ -573,17 +573,16 @@ Item& item_separate(Item& stacked_item)
     dst.set_number(stacked_item.number() - 1);
     stacked_item.set_number(1);
 
-    if (inv_getowner(dst.index) == -1 && mode != 6)
+    if (inv_getowner(dst) == -1 && mode != 6)
     {
-        if (inv_getowner(stacked_item.index) != -1)
+        if (inv_getowner(stacked_item) != -1)
         {
-            stacked_item.position =
-                cdata[inv_getowner(stacked_item.index)].position;
+            stacked_item.position = cdata[inv_getowner(stacked_item)].position;
         }
         dst.position = stacked_item.position;
         itemturn(dst);
         cell_refresh(dst.position.x, dst.position.y);
-        if (inv_getowner(stacked_item.index) != -1)
+        if (inv_getowner(stacked_item) != -1)
         {
             txt(i18n::s.get("core.item.something_falls_from_backpack"));
         }
@@ -601,7 +600,7 @@ bool chara_unequip(Item& item)
         return false;
 
     int body_part = item.body_part;
-    int owner = inv_getowner(item.index);
+    int owner = inv_getowner(item);
     if (owner == -1)
         return false;
 
@@ -1610,7 +1609,7 @@ ItemStackResult item_stack(int inventory_id, Item& base_item, bool show_message)
             item.modify_number(base_item.number());
             base_item.remove();
 
-            if (mode != 6 && inv_getowner(base_item.index) == -1)
+            if (mode != 6 && inv_getowner(base_item) == -1)
             {
                 cell_refresh(base_item.position.x, base_item.position.y);
             }
@@ -2105,17 +2104,17 @@ std::pair<int, int> inv_getheader(int owner)
 
 
 
-int inv_getowner(int inv_id)
+int inv_getowner(const Item& item)
 {
-    if (inv_id < 200)
+    if (item.index < 200)
     {
         return 0;
     }
-    if (inv_id >= ELONA_ITEM_ON_GROUND_INDEX)
+    if (item.index >= ELONA_ITEM_ON_GROUND_INDEX)
     {
         return -1;
     }
-    return (inv_id - 200) / 20 + 1;
+    return (item.index - 200) / 20 + 1;
 }
 
 
@@ -2670,9 +2669,9 @@ void dipcursed(Item& item)
     {
         --item.enhancement;
         txt(i18n::s.get("core.action.dip.rusts", item));
-        if (inv_getowner(item.index) != -1)
+        if (inv_getowner(item) != -1)
         {
-            chara_refresh(inv_getowner(item.index));
+            chara_refresh(inv_getowner(item));
         }
     }
     else

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -2161,7 +2161,9 @@ int inv_sum(int owner)
     return n;
 }
 
-int inv_compress(int owner)
+
+
+Item& inv_compress(int owner)
 {
     int number_of_deleted_items{};
     for (int i = 0; i < 100; ++i)
@@ -2195,33 +2197,27 @@ int inv_compress(int owner)
         }
     }
 
-    int slot = -1;
-    for (const auto& item : inv.by_index(owner))
+    for (auto&& item : inv.by_index(owner))
     {
         if (item.number() == 0)
         {
-            slot = item.index;
-            break;
+            return item;
         }
     }
 
-    if (slot == -1)
+    // Destroy 1 existing item forcely.
+    auto&& item = get_random_inv(owner);
+    item.remove();
+    if (mode != 6)
     {
-        // Destroy 1 existing item forcely.
-        auto&& item = get_random_inv(owner);
-        slot = item.index;
-        item.remove();
-        if (mode != 6)
+        if (item.position.x >= 0 && item.position.x < map_data.width &&
+            item.position.y >= 0 && item.position.y < map_data.height)
         {
-            if (item.position.x >= 0 && item.position.x < map_data.width &&
-                item.position.y >= 0 && item.position.y < map_data.height)
-            {
-                cell_refresh(item.position.x, item.position.y);
-            }
+            cell_refresh(item.position.x, item.position.y);
         }
     }
 
-    return slot;
+    return item;
 }
 
 
@@ -2238,7 +2234,7 @@ optional_ref<Item> inv_get_free_slot(int inventory_id)
     if (inventory_id == -1 && mode != 6)
     {
         txt(i18n::s.get("core.item.items_are_destroyed"));
-        return inv[inv_compress(inventory_id)];
+        return inv_compress(inventory_id);
     }
     return none;
 }

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -2286,26 +2286,29 @@ int inv_weight(int owner)
     return weight;
 }
 
-int inv_getfreeid_force()
+
+
+Item& inv_get_free_slot_force(int inventory_id)
 {
-    if (const auto slot = inv_get_free_slot(tc))
+    assert(inventory_id != -1);
+
+    if (const auto slot = inv_get_free_slot(inventory_id))
     {
-        return slot->index;
+        return *slot;
     }
-    for (int cnt = 0; cnt < 100; ++cnt)
+    while (true)
     {
-        p = rnd(invrange) + invhead;
-        if (inv[p].body_part == 0)
+        auto& item = get_random_inv(inventory_id);
+        if (item.body_part == 0)
         {
-            inv[p].remove();
-            if (cdata[tc].item_which_will_be_used == p)
+            item.remove();
+            if (cdata[inventory_id].item_which_will_be_used == item.index)
             {
-                cdata[tc].item_which_will_be_used = 0;
+                cdata[inventory_id].item_which_will_be_used = 0;
             }
-            break;
+            return item;
         }
     }
-    return p;
 }
 
 

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -456,29 +456,26 @@ void itemturn(Item& item)
 
 
 
-void item_copy(int a, int b)
+void item_copy(Item& src, Item& dst)
 {
-    if (a < 0 || b < 0)
-        return;
+    const auto was_empty = dst.number() == 0;
 
-    bool was_empty = inv[b].number() == 0;
-
-    if (was_empty && inv[a].number() > 0)
+    if (was_empty && src.number() > 0)
     {
         // Clean up any stale handles that may have been left over from an item
         // in the same index being removed.
-        lua::lua->get_handle_manager().remove_item_handle_run_callbacks(inv[b]);
+        lua::lua->get_handle_manager().remove_item_handle_run_callbacks(dst);
     }
 
-    Item::copy(inv[a], inv[b]);
+    Item::copy(src, dst);
 
-    if (was_empty && inv[b].number() != 0)
+    if (was_empty && dst.number() != 0)
     {
-        lua::lua->get_handle_manager().create_item_handle_run_callbacks(inv[b]);
+        lua::lua->get_handle_manager().create_item_handle_run_callbacks(dst);
     }
-    else if (!was_empty && inv[b].number() == 0)
+    else if (!was_empty && dst.number() == 0)
     {
-        inv[b].remove();
+        dst.remove();
     }
 }
 
@@ -581,7 +578,7 @@ int item_separate(int src)
         }
     }
 
-    item_copy(src, dst);
+    item_copy(inv[src], inv[dst]);
     inv[dst].set_number(inv[src].number() - 1);
     inv[src].set_number(1);
 
@@ -2312,7 +2309,7 @@ void item_drop(Item& item_in_inventory, int num, bool building_shelter)
     }
 
     auto& dropped_item = inv[slot];
-    item_copy(item_in_inventory.index, dropped_item.index);
+    item_copy(item_in_inventory, dropped_item);
     dropped_item.position = cdata[cc].position;
     dropped_item.set_number(num);
     itemturn(dropped_item);

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -2119,7 +2119,7 @@ int inv_getowner(const Item& item)
 
 
 
-int inv_find(int id, int owner)
+bool inv_find(ItemId id, int owner)
 {
     for (const auto& item : inv.for_chara(cdata[owner]))
     {
@@ -2127,13 +2127,15 @@ int inv_find(int id, int owner)
         {
             continue;
         }
-        if (item.id == int2itemid(id))
+        if (item.id == id)
         {
-            return item.index;
+            return true;
         }
     }
-    return -1; // Not found
+    return false; // Not found
 }
+
+
 
 bool inv_getspace(int owner)
 {

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -1642,9 +1642,9 @@ void item_dump_desc(Item& item)
 
 
 
-void item_acid(const Character& owner, int item_index)
+void item_acid(const Character& owner, optional_ref<Item> item)
 {
-    if (item_index == -1)
+    if (!item)
     {
         for (const auto& body_part : owner.body_parts)
         {
@@ -1661,31 +1661,31 @@ void item_acid(const Character& owner, int item_index)
             {
                 if (rnd(30) == 0)
                 {
-                    item_index = p;
+                    item = inv[i];
                     break;
                 }
             }
         }
-        if (item_index == -1)
+        if (!item)
         {
             return;
         }
     }
 
-    if (!is_equipment(the_item_db[itemid2int(inv[item_index].id)]->category))
+    if (!is_equipment(the_item_db[itemid2int(item->id)]->category))
     {
         return;
     }
 
-    if (inv[item_index].is_acidproof())
+    if (item->is_acidproof())
     {
-        txt(i18n::s.get("core.item.acid.immune", owner, inv[item_index]));
+        txt(i18n::s.get("core.item.acid.immune", owner, *item));
     }
     else
     {
-        txt(i18n::s.get("core.item.acid.damaged", owner, inv[item_index]),
+        txt(i18n::s.get("core.item.acid.damaged", owner, *item),
             Message::color{ColorIndex::purple});
-        --inv[item_index].enhancement;
+        --item->enhancement;
     }
 }
 

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -2652,37 +2652,35 @@ void damage_by_cursed_equipments()
 
 
 
-void dipcursed(int item_index, int)
+void dipcursed(Item& item)
 {
-    if (the_item_db[itemid2int(inv[item_index].id)]->category ==
-        ItemCategory::food)
+    if (the_item_db[itemid2int(item.id)]->category == ItemCategory::food)
     {
-        if (inv[item_index].material == 35)
+        if (item.material == 35)
         {
-            txt(i18n::s.get("core.action.dip.rots", inv[item_index]));
-            inv[item_index].param3 = -1;
-            inv[item_index].image = 336;
-            cell_refresh(
-                inv[item_index].position.x, inv[item_index].position.y);
-            return;
+            txt(i18n::s.get("core.action.dip.rots", item));
+            item.param3 = -1;
+            item.image = 336;
+            cell_refresh(item.position.x, item.position.y);
         }
         else
         {
-            txt(i18n::s.get("core.action.dip.unchanged", inv[item_index]));
-            return;
+            txt(i18n::s.get("core.action.dip.unchanged", item));
         }
     }
-    if (is_equipment(the_item_db[itemid2int(inv[item_index].id)]->category))
+    else if (is_equipment(the_item_db[itemid2int(item.id)]->category))
     {
-        --inv[item_index].enhancement;
-        txt(i18n::s.get("core.action.dip.rusts", inv[item_index]));
-        if (inv_getowner(item_index) != -1)
+        --item.enhancement;
+        txt(i18n::s.get("core.action.dip.rusts", item));
+        if (inv_getowner(item.index) != -1)
         {
-            chara_refresh(inv_getowner(item_index));
+            chara_refresh(inv_getowner(item.index));
         }
-        return;
     }
-    txt(i18n::s.get("core.common.nothing_happens"));
+    else
+    {
+        txt(i18n::s.get("core.common.nothing_happens"));
+    }
 }
 
 

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -566,44 +566,47 @@ void Item::set_number(int number_)
 
 
 
-int item_separate(int src)
+Item& item_separate(Item& stacked_item)
 {
-    if (inv[src].number() <= 1)
-        return src;
+    if (stacked_item.number() <= 1)
+    {
+        return stacked_item;
+    }
 
-    int dst = inv_getfreeid(inv_getowner(src));
+    int dst = inv_getfreeid(inv_getowner(stacked_item.index));
     if (dst == -1)
     {
         dst = inv_getfreeid(-1);
         if (dst == -1)
         {
-            inv[src].set_number(1);
+            stacked_item.set_number(1);
             txt(i18n::s.get("core.item.something_falls_and_disappears"));
-            return src;
+            return stacked_item;
         }
     }
 
-    item_copy(inv[src], inv[dst]);
-    inv[dst].set_number(inv[src].number() - 1);
-    inv[src].set_number(1);
+    item_copy(stacked_item, inv[dst]);
+    inv[dst].set_number(stacked_item.number() - 1);
+    stacked_item.set_number(1);
 
     if (inv_getowner(dst) == -1 && mode != 6)
     {
-        if (inv_getowner(src) != -1)
+        if (inv_getowner(stacked_item.index) != -1)
         {
-            inv[src].position = cdata[inv_getowner(src)].position;
+            stacked_item.position =
+                cdata[inv_getowner(stacked_item.index)].position;
         }
-        inv[dst].position = inv[src].position;
+        inv[dst].position = stacked_item.position;
         itemturn(inv[dst]);
         cell_refresh(inv[dst].position.x, inv[dst].position.y);
-        if (inv_getowner(src) != -1)
+        if (inv_getowner(stacked_item.index) != -1)
         {
             txt(i18n::s.get("core.item.something_falls_from_backpack"));
         }
         refresh_burden_state();
     }
 
-    return dst;
+    return inv[dst];
 }
 
 
@@ -1824,7 +1827,7 @@ bool item_fire(int owner, optional_ref<Item> burned_item)
 
         if (blanket)
         {
-            item_separate(blanket->index);
+            item_separate(*blanket);
             if (is_in_fov(cdata[owner]))
             {
                 txt(i18n::s.get(
@@ -2007,7 +2010,7 @@ bool item_cold(int owner, optional_ref<Item> destroyed_item)
         }
         if (blanket)
         {
-            item_separate(blanket->index);
+            item_separate(*blanket);
             if (is_in_fov(cdata[owner]))
             {
                 txt(i18n::s.get(

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -481,14 +481,19 @@ void item_copy(Item& src, Item& dst)
 
 
 
-void item_exchange(int a, int b)
+void item_exchange(Item& a, Item& b)
 {
-    Item tmp;
-    Item::copy(inv[a], tmp);
-    Item::copy(inv[b], inv[a]);
-    Item::copy(tmp, inv[b]);
+    if (a.index == b.index)
+    {
+        return;
+    }
 
-    lua::lua->get_handle_manager().swap_handles<Item>(inv[b], inv[a]);
+    Item tmp;
+    Item::copy(a, tmp);
+    Item::copy(b, a);
+    Item::copy(tmp, b);
+
+    lua::lua->get_handle_manager().swap_handles(b, a);
 }
 
 

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -2282,9 +2282,9 @@ Item& inv_get_free_slot_force(int inventory_id)
         if (item.body_part == 0)
         {
             item.remove();
-            if (cdata[inventory_id].item_which_will_be_used == item.index)
+            if (cdata[inventory_id].ai_item == item.index)
             {
-                cdata[inventory_id].item_which_will_be_used = 0;
+                cdata[inventory_id].ai_item = 0;
             }
             return item;
         }

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -311,20 +311,20 @@ optional_ref<Item> itemfind(int inventory_id, int matcher, int matcher_type)
 
 
 
-int mapitemfind(int x, int y, int id)
+optional_ref<Item> mapitemfind(const Position& pos, ItemId id)
 {
-    for (const auto& item : inv.ground())
+    for (auto&& item : inv.ground())
     {
         if (item.number() == 0)
         {
             continue;
         }
-        if (item.id == int2itemid(id) && item.position == Position{x, y})
+        if (item.id == id && item.position == pos)
         {
-            return item.index;
+            return item;
         }
     }
-    return -1; // Not found
+    return none; // Not found
 }
 
 

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -2359,7 +2359,7 @@ void item_drop(Item& item_in_inventory, int num, bool building_shelter)
     {
         if (mode == 0)
         {
-            calc_home_rank();
+            building_update_home_rank();
         }
     }
     if (stacked_item.id == ItemId::campfire)

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -379,7 +379,7 @@ Item& get_random_inv(int owner);
 
 optional_ref<Item> inv_get_free_slot(int inventory_id);
 
-int inv_getowner(int = 0);
+int inv_getowner(const Item& item);
 int inv_sum(int = 0);
 int inv_weight(int = 0);
 bool inv_getspace(int);

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -376,7 +376,9 @@ void mapitem_cold(int x, int y);
 // TODO unsure how these are separate from item
 int inv_find(int = 0, int = 0);
 Item& get_random_inv(int owner);
-int inv_getfreeid(int = 0);
+
+optional_ref<Item> inv_get_free_slot(int inventory_id);
+
 int inv_getowner(int = 0);
 int inv_sum(int = 0);
 int inv_weight(int = 0);

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -320,8 +320,6 @@ void item_copy(int = 0, int = 0);
 void item_acid(const Character& owner, int item_index = -1);
 void item_delete(Item& item);
 void item_exchange(int = 0, int = 0);
-void item_modify_num(Item&, int);
-void item_set_num(Item&, int);
 void itemturn(Item& item);
 optional_ref<Item>
 itemfind(int inventory_id, int matcher, int matcher_type = 0);

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -315,7 +315,7 @@ IdentifyState item_identify(Item& item, int power);
 std::vector<std::reference_wrapper<Item>> itemlist(int owner, int id);
 
 void item_checkknown(Item& item);
-int inv_compress(int);
+Item& inv_compress(int owner);
 
 /**
  * Copy @a src to @a dst.

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -432,7 +432,9 @@ void auto_identify();
 void begintempinv();
 void exittempinv();
 bool cargocheck(const Item& item);
-int convertartifact(int = 0, int = 0);
+Item& item_convert_artifact(
+    Item& artifact,
+    bool ignore_external_container = false);
 void damage_by_cursed_equipments();
 void dipcursed(Item& item);
 int efstatusfix(int = 0, int = 0, int = 0, int = 0);

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -324,7 +324,7 @@ int inv_compress(int);
  */
 void item_copy(Item& src, Item& dst);
 
-void item_acid(const Character& owner, int item_index = -1);
+void item_acid(const Character& owner, optional_ref<Item> item = none);
 void item_delete(Item& item);
 
 /**

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -374,7 +374,7 @@ bool item_cold(int owner, optional_ref<Item> destroyed_item = none);
 void mapitem_cold(int x, int y);
 
 // TODO unsure how these are separate from item
-int inv_find(int = 0, int = 0);
+bool inv_find(ItemId id, int owner);
 Item& get_random_inv(int owner);
 
 optional_ref<Item> inv_get_free_slot(int inventory_id);

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -383,7 +383,8 @@ int inv_getowner(int = 0);
 int inv_sum(int = 0);
 int inv_weight(int = 0);
 bool inv_getspace(int);
-int inv_getfreeid_force();
+
+Item& inv_get_free_slot_force(int inventory_id);
 
 void remain_make(Item& remain, const Character& chara);
 

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -442,7 +442,7 @@ void equip_melee_weapon();
 int gain_skills_by_geen_engineering();
 int transplant_body_parts();
 std::pair<int, int> inv_getheader(int);
-int mapitemfind(int = 0, int = 0, int = 0);
+optional_ref<Item> mapitemfind(const Position& pos, ItemId id);
 std::string itemname(Item& item, int number = 0, bool with_article = true);
 
 } // namespace elona

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -351,7 +351,11 @@ optional_ref<Item> item_find(
     int matcher_type = 0,
     ItemFindLocation = ItemFindLocation::player_inventory_and_ground);
 
-int item_separate(int);
+/**
+ * Separate @a item's stack.
+ * @param item the item to separate
+ */
+Item& item_separate(Item& stacked_item);
 
 struct ItemStackResult
 {

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -326,7 +326,15 @@ void item_copy(Item& src, Item& dst);
 
 void item_acid(const Character& owner, int item_index = -1);
 void item_delete(Item& item);
-void item_exchange(int = 0, int = 0);
+
+/**
+ * Swap the content of @a a and @a b. If they points to the same object, does
+ * nothing.
+ * @param a one item
+ * @param b another item
+ */
+void item_exchange(Item& a, Item& b);
+
 void itemturn(Item& item);
 optional_ref<Item>
 itemfind(int inventory_id, int matcher, int matcher_type = 0);

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -316,7 +316,14 @@ std::vector<std::reference_wrapper<Item>> itemlist(int owner, int id);
 
 void item_checkknown(Item& item);
 int inv_compress(int);
-void item_copy(int = 0, int = 0);
+
+/**
+ * Copy @a src to @a dst.
+ * @param src the source
+ * @param dst the destination
+ */
+void item_copy(Item& src, Item& dst);
+
 void item_acid(const Character& owner, int item_index = -1);
 void item_delete(Item& item);
 void item_exchange(int = 0, int = 0);

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -434,7 +434,7 @@ void exittempinv();
 bool cargocheck(const Item& item);
 int convertartifact(int = 0, int = 0);
 void damage_by_cursed_equipments();
-void dipcursed(int = 0, int = 0);
+void dipcursed(Item& item);
 int efstatusfix(int = 0, int = 0, int = 0, int = 0);
 void equip_melee_weapon();
 int gain_skills_by_geen_engineering();

--- a/src/elona/itemgen.cpp
+++ b/src/elona/itemgen.cpp
@@ -277,7 +277,7 @@ optional_ref<Item> do_create_item(int item_id, int slot, int x, int y)
     item.quality = static_cast<Quality>(fixlv);
     if (fixlv == Quality::special && mode != 6 && nooracle == 0)
     {
-        int owner = inv_getowner(item.index);
+        int owner = inv_getowner(item);
         if (owner != -1)
         {
             if (cdata[owner].character_role == 13)

--- a/src/elona/itemgen.cpp
+++ b/src/elona/itemgen.cpp
@@ -147,14 +147,13 @@ optional_ref<Item> do_create_item(int item_id, int slot, int x, int y)
         }
     }
 
-    const auto empty_slot = inv_getfreeid(slot);
-    if (empty_slot == -1)
+    const auto empty_slot = inv_get_free_slot(slot);
+    if (!empty_slot)
         return none;
 
-    auto&& item = inv[empty_slot];
+    auto&& item = *empty_slot;
 
     item_delete(item);
-    item.index = empty_slot; // needed?
 
     if (slot == -1 && mode != 6 && mode != 9)
     {

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -3416,8 +3416,8 @@ bool _magic_651()
     {
         txt(i18n::s.get("core.magic.scavenge.apply", cdata[cc], cdata[tc]));
     }
-    int eat_item_index = -1;
-    for (const auto& item : inv.for_chara(cdata[tc]))
+    optional_ref<Item> eat_item_opt;
+    for (auto&& item : inv.for_chara(cdata[tc]))
     {
         if (item.number() == 0)
         {
@@ -3425,13 +3425,13 @@ bool _magic_651()
         }
         if (item.id == ItemId::fish_a)
         {
-            eat_item_index = item.index;
+            eat_item_opt = item;
             break;
         }
     }
-    if (eat_item_index == -1)
+    if (!eat_item_opt)
     {
-        for (const auto& item : inv.for_chara(cdata[tc]))
+        for (auto&& item : inv.for_chara(cdata[tc]))
         {
             if (item.number() == 0)
             {
@@ -3446,15 +3446,15 @@ bool _magic_651()
             {
                 continue;
             }
-            eat_item_index = item.index;
+            eat_item_opt = item;
             break;
         }
     }
-    if (eat_item_index == -1)
+    if (!eat_item_opt)
     {
         return true;
     }
-    auto& eat_item = inv[eat_item_index];
+    auto& eat_item = *eat_item_opt;
     if (eat_item.is_aphrodisiac())
     {
         if (is_in_fov(cdata[tc]))

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -81,7 +81,7 @@ bool _magic_1136(Item& treasure_map)
     }
     if (treasure_map.param1 == 0)
     {
-        item_separate(treasure_map.index);
+        item_separate(treasure_map);
         for (int cnt = 0; cnt < 1000; ++cnt)
         {
             dx = 4 + rnd(map_data.width - 8);
@@ -743,7 +743,7 @@ bool _magic_185(Item& rod)
             rnd(the_ability_db[efid]->cost / 2 + 1) +
                 the_ability_db[efid]->cost / 2 + 1);
     }
-    item_separate(rod.index);
+    item_separate(rod);
     --rod.count;
     rowactre = 0;
     spot_fishing(rod);

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -2516,7 +2516,6 @@ bool _magic_21_1127()
     {
         assert(target_item_opt);
         auto& target_item = *target_item_opt;
-        int target_item_index = target_item.index;
         equip = target_item.body_part;
         if (target_item.quality == Quality::special)
         {
@@ -2536,7 +2535,13 @@ bool _magic_21_1127()
             const auto reconstructed_artifact =
                 itemcreate_player_inv(itemid2int(target_item.id), 0);
             assert(reconstructed_artifact);
-            target_item_index = reconstructed_artifact->index;
+            if (equip != 0)
+            {
+                cdata[cc].body_parts[equip - 100] =
+                    cdata[cc].body_parts[equip - 100] / 10000 * 10000 +
+                    reconstructed_artifact->index + 1;
+                reconstructed_artifact->body_part = equip;
+            }
         }
         else
         {
@@ -2560,13 +2565,13 @@ bool _magic_21_1127()
                 cdata[cc],
                 s(0),
                 target_item));
-        }
-        if (equip != 0)
-        {
-            cdata[cc].body_parts[equip - 100] =
-                cdata[cc].body_parts[equip - 100] / 10000 * 10000 +
-                target_item_index + 1;
-            inv[target_item_index].body_part = equip;
+            if (equip != 0)
+            {
+                cdata[cc].body_parts[equip - 100] =
+                    cdata[cc].body_parts[equip - 100] / 10000 * 10000 +
+                    target_item.index + 1;
+                target_item.body_part = equip;
+            }
         }
     }
     else

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -2253,8 +2253,7 @@ bool _magic_435()
     }
     f = 1;
     {
-        int stat = inv_find(663, cc);
-        if (stat != -1)
+        if (inv_find(ItemId::monster_heart, cc))
         {
             efp = efp * 3 / 2;
         }

--- a/src/elona/map.cpp
+++ b/src/elona/map.cpp
@@ -1543,14 +1543,12 @@ TurnResult exit_map()
         cell_featread(cdata.player().position.x, cdata.player().position.y);
         if (game_data.current_map == mdata_t::MapId::your_home)
         {
-            if (mapitemfind(cdata[cc].position.x, cdata[cc].position.y, 751) !=
-                -1)
+            if (mapitemfind(cdata[cc].position, ItemId::downstairs))
             {
                 feat(1) = 11;
                 feat(2) = 0;
             }
-            if (mapitemfind(cdata[cc].position.x, cdata[cc].position.y, 750) !=
-                -1)
+            if (mapitemfind(cdata[cc].position, ItemId::upstairs))
             {
                 feat(1) = 10;
                 feat(2) = 0;

--- a/src/elona/map.cpp
+++ b/src/elona/map.cpp
@@ -1916,7 +1916,7 @@ void prepare_charas_for_map_unload()
     for (int cnt = 0; cnt < 57; ++cnt)
     {
         cdata[cnt].activity.finish();
-        cdata[cnt].item_which_will_be_used = 0;
+        cdata[cnt].ai_item = 0;
     }
 
     // remove living adventurers from the map and set their states

--- a/src/elona/map_cell.cpp
+++ b/src/elona/map_cell.cpp
@@ -179,25 +179,6 @@ void cell_movechara(int cc, int x, int y)
 
 
 
-int cell_itemlist(int x, int y)
-{
-    listmax = 0;
-    for (const auto& item : inv.ground())
-    {
-        if (item.number() > 0)
-        {
-            if (item.position.x == x && item.position.y == y)
-            {
-                list(0, listmax) = item.index;
-                ++listmax;
-            }
-        }
-    }
-    return rtval;
-}
-
-
-
 // Returns pair of number of items and the last item on the cell.
 std::pair<int, int> cell_itemoncell(const Position& pos)
 {

--- a/src/elona/map_cell.hpp
+++ b/src/elona/map_cell.hpp
@@ -1,11 +1,15 @@
 #pragma once
 
-#include <unordered_map>
+#include <utility>
+
+
 
 namespace elona
 {
 
 struct Position;
+
+
 
 // Maps from an enumeration to an ID in the current tileset.
 enum class TileKind : int
@@ -20,7 +24,6 @@ enum class TileKind : int
 std::pair<int, int> cell_itemoncell(const Position& pos);
 void cell_featread(int x, int y);
 int cell_findspace(int = 0, int = 0, int = 0);
-int cell_itemlist(int = 0, int = 0);
 void cell_check(int = 0, int = 0);
 void cell_featclear(int = 0, int = 0);
 void cell_featset(int = 0, int = 0, int = 0, int = 0, int = 0, int = 0);

--- a/src/elona/random_event.cpp
+++ b/src/elona/random_event.cpp
@@ -98,14 +98,14 @@ optional<RandomEvent> generate_random_event_in_sleep()
     }
     if (rnd(250) == 0)
     {
-        if (inv_getfreeid(0) != -1)
+        if (inv_get_free_slot(0))
         {
             id = 19;
         }
     }
     if (rnd(10000) == 0)
     {
-        if (inv_getfreeid(0) != -1)
+        if (inv_get_free_slot(0))
         {
             id = 21;
         }

--- a/src/elona/save.cpp
+++ b/src/elona/save.cpp
@@ -222,7 +222,7 @@ void load_gene_files()
             item.count = -1;
         }
         item.body_part = 0;
-        item_copy(item.index, inv_getfreeid(-1));
+        item_copy(item, inv[inv_getfreeid(-1)]);
     }
     for (auto&& cnt : cdata.all())
     {

--- a/src/elona/save.cpp
+++ b/src/elona/save.cpp
@@ -222,7 +222,7 @@ void load_gene_files()
             item.count = -1;
         }
         item.body_part = 0;
-        item_copy(item, inv[inv_getfreeid(-1)]);
+        item_copy(item, *inv_get_free_slot(-1));
     }
     for (auto&& cnt : cdata.all())
     {

--- a/src/elona/talk_house_visitor.cpp
+++ b/src/elona/talk_house_visitor.cpp
@@ -348,7 +348,7 @@ TalkResult _talk_hv_adventurer_train()
 
 void _adventurer_receive_coin()
 {
-    if (inv_getfreeid(-1) == -1)
+    if (!inv_get_free_slot(-1))
     {
         txt(i18n::s.get(
             "core.talk.visitor.adventurer.friendship.no_empty_spot"));
@@ -401,7 +401,7 @@ TalkResult _talk_hv_adventurer_friendship()
 
 void _adventurer_receive_souvenir()
 {
-    if (inv_getfreeid(0) == -1)
+    if (!inv_get_free_slot(0))
     {
         txt(i18n::s.get(
             "core.talk.visitor.adventurer.souvenir.inventory_is_full"));
@@ -610,7 +610,7 @@ TalkResult _talk_hv_adventurer()
         return _talk_hv_adventurer_hate();
     }
     if (cdata[tc].impression >= 100 && !cdata[tc].is_best_friend() &&
-        inv_getfreeid(-1) != -1)
+        inv_get_free_slot(-1))
     {
         // NOTE: this dialog falls through.
         _talk_hv_adventurer_best_friend();

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -444,7 +444,7 @@ TalkResult talk_arena_master_score()
 TalkResult talk_quest_delivery()
 {
     const auto slot = inv_getfreeid_force();
-    item_copy(deliver(1), slot);
+    item_copy(inv[deliver(1)], inv[slot]);
     inv[slot].set_number(1);
     rc = tc;
     chara_set_item_which_will_be_used(cdata[tc], inv[slot]);
@@ -460,7 +460,7 @@ TalkResult talk_quest_delivery()
 TalkResult talk_quest_supply()
 {
     const auto slot = inv_getfreeid_force();
-    item_copy(supply, slot);
+    item_copy(inv[supply], inv[slot]);
     inv[slot].set_number(1);
     cdata[tc].was_passed_item_by_you_just_now() = true;
     rc = tc;

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -1558,7 +1558,7 @@ TalkResult talk_quest_giver()
         }
         if (quest_data[rq].id == 1002)
         {
-            if (inv_getfreeid(0) == -1)
+            if (!inv_get_free_slot(0))
             {
                 buff = i18n::s.get(
                     "core.talk.npc.quest_giver.about.backpack_full", cdata[tc]);

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -449,7 +449,7 @@ TalkResult talk_quest_delivery(Item& item_to_deliver)
     item_copy(item_to_deliver, slot);
     slot.set_number(1);
     rc = tc;
-    chara_set_item_which_will_be_used(cdata[tc], slot);
+    chara_set_ai_item(cdata[tc], slot);
     rq = deliver;
     item_to_deliver.modify_number(-1);
     txt(i18n::s.get("core.talk.npc.common.hand_over", item_to_deliver));
@@ -468,7 +468,7 @@ TalkResult talk_quest_supply(Item& item_to_supply)
     slot.set_number(1);
     cdata[tc].was_passed_item_by_you_just_now() = true;
     rc = tc;
-    chara_set_item_which_will_be_used(cdata[tc], slot);
+    chara_set_ai_item(cdata[tc], slot);
     item_to_supply.modify_number(-1);
     txt(i18n::s.get("core.talk.npc.common.hand_over", item_to_supply));
     quest_set_data(3);

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -441,37 +441,43 @@ TalkResult talk_arena_master_score()
     return TalkResult::talk_npc;
 }
 
-TalkResult talk_quest_delivery()
+
+
+TalkResult talk_quest_delivery(Item& item_to_deliver)
 {
     auto& slot = inv_get_free_slot_force(tc);
-    item_copy(inv[deliver(1)], slot);
+    item_copy(item_to_deliver, slot);
     slot.set_number(1);
     rc = tc;
     chara_set_item_which_will_be_used(cdata[tc], slot);
     rq = deliver;
-    inv[deliver(1)].modify_number(-1);
-    txt(i18n::s.get("core.talk.npc.common.hand_over", inv[deliver(1)]));
+    item_to_deliver.modify_number(-1);
+    txt(i18n::s.get("core.talk.npc.common.hand_over", item_to_deliver));
     quest_set_data(3);
     quest_complete();
     refresh_burden_state();
     return TalkResult::talk_npc;
 }
 
-TalkResult talk_quest_supply()
+
+
+TalkResult talk_quest_supply(Item& item_to_supply)
 {
     auto& slot = inv_get_free_slot_force(tc);
-    item_copy(inv[supply], slot);
+    item_copy(item_to_supply, slot);
     slot.set_number(1);
     cdata[tc].was_passed_item_by_you_just_now() = true;
     rc = tc;
     chara_set_item_which_will_be_used(cdata[tc], slot);
-    inv[supply].modify_number(-1);
-    txt(i18n::s.get("core.talk.npc.common.hand_over", inv[supply]));
+    item_to_supply.modify_number(-1);
+    txt(i18n::s.get("core.talk.npc.common.hand_over", item_to_supply));
     quest_set_data(3);
     quest_complete();
     refresh_burden_state();
     return TalkResult::talk_npc;
 }
+
+
 
 TalkResult talk_shop_attack()
 {
@@ -1704,6 +1710,9 @@ void talk_wrapper(TalkResult initial)
 
 TalkResult talk_npc()
 {
+    optional_ref<Item> item_to_deliver;
+    optional_ref<Item> item_to_supply;
+
     listmax = 0;
     if (buff == ""s)
     {
@@ -2010,8 +2019,7 @@ TalkResult talk_npc()
             61, i18n::s.get("core.talk.npc.caravan_master.choices.hire"));
     }
     f = 0;
-    deliver(0) = -1;
-    deliver(1) = -1;
+    deliver = -1;
     if (game_data.current_dungeon_level == 1)
     {
         for (int cnt = 0, cnt_end = (game_data.number_of_existing_quests);
@@ -2049,7 +2057,7 @@ TalkResult talk_npc()
                 {
                     p = quest_data[cnt].target_item_id;
                     deliver = cnt;
-                    for (const auto& item : inv.pc())
+                    for (auto&& item : inv.pc())
                     {
                         if (item.number() == 0)
                         {
@@ -2057,7 +2065,7 @@ TalkResult talk_npc()
                         }
                         if (item.id == int2itemid(p))
                         {
-                            deliver(1) = item.index;
+                            item_to_deliver = item;
                             break;
                         }
                     }
@@ -2073,8 +2081,7 @@ TalkResult talk_npc()
             quest_data[rq].client_chara_type == 3 &&
             quest_data[rq].progress == 1)
         {
-            supply = -1;
-            for (const auto& item : inv.pc())
+            for (auto&& item : inv.pc())
             {
                 if (item.number() == 0)
                 {
@@ -2091,7 +2098,7 @@ TalkResult talk_npc()
                         item.param1 / 1000 == quest_data[rq].extra_info_1 &&
                         item.param2 == quest_data[rq].extra_info_2)
                     {
-                        supply = item.index;
+                        item_to_supply = item;
                         break;
                     }
                 }
@@ -2099,18 +2106,18 @@ TalkResult talk_npc()
                 {
                     if (item.id == int2itemid(quest_data[rq].target_item_id))
                     {
-                        supply = item.index;
+                        item_to_supply = item;
                         break;
                     }
                 }
             }
-            if (supply != -1)
+            if (item_to_supply)
             {
                 ELONA_APPEND_RESPONSE(
                     26,
                     i18n::s.get(
                         "core.talk.npc.quest_giver.choices.here_is_item",
-                        inv[supply]));
+                        *item_to_supply));
             }
             else
             {
@@ -2128,7 +2135,7 @@ TalkResult talk_npc()
                     "core.talk.npc.quest_giver.choices.about_the_work"));
         }
     }
-    if (deliver != -1 && deliver(1) != -1)
+    if (deliver != -1 && item_to_deliver)
     {
         ELONA_APPEND_RESPONSE(
             25,
@@ -2226,8 +2233,10 @@ TalkResult talk_npc()
     case 42: return talk_pet_arena_master_score();
     case 23: return talk_arena_master_score();
     case 24: return TalkResult::talk_quest_giver;
-    case 25: return talk_quest_delivery();
-    case 26: return talk_quest_supply();
+    case 25:
+        assert(item_to_deliver);
+        return talk_quest_delivery(*item_to_deliver);
+    case 26: assert(item_to_supply); return talk_quest_supply(*item_to_supply);
     case 30: return talk_trainer_learn_skill();
     case 31: return talk_shop_attack();
     case 32: return talk_guard_return_item();

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -443,11 +443,11 @@ TalkResult talk_arena_master_score()
 
 TalkResult talk_quest_delivery()
 {
-    const auto slot = inv_getfreeid_force();
-    item_copy(inv[deliver(1)], inv[slot]);
-    inv[slot].set_number(1);
+    auto& slot = inv_get_free_slot_force(tc);
+    item_copy(inv[deliver(1)], slot);
+    slot.set_number(1);
     rc = tc;
-    chara_set_item_which_will_be_used(cdata[tc], inv[slot]);
+    chara_set_item_which_will_be_used(cdata[tc], slot);
     rq = deliver;
     inv[deliver(1)].modify_number(-1);
     txt(i18n::s.get("core.talk.npc.common.hand_over", inv[deliver(1)]));
@@ -459,12 +459,12 @@ TalkResult talk_quest_delivery()
 
 TalkResult talk_quest_supply()
 {
-    const auto slot = inv_getfreeid_force();
-    item_copy(inv[supply], inv[slot]);
-    inv[slot].set_number(1);
+    auto& slot = inv_get_free_slot_force(tc);
+    item_copy(inv[supply], slot);
+    slot.set_number(1);
     cdata[tc].was_passed_item_by_you_just_now() = true;
     rc = tc;
-    chara_set_item_which_will_be_used(cdata[tc], inv[slot]);
+    chara_set_item_which_will_be_used(cdata[tc], slot);
     inv[supply].modify_number(-1);
     txt(i18n::s.get("core.talk.npc.common.hand_over", inv[supply]));
     quest_set_data(3);

--- a/src/elona/turn_sequence.cpp
+++ b/src/elona/turn_sequence.cpp
@@ -453,40 +453,39 @@ optional<TurnResult> npc_turn_misc(Character& chara)
         }
     }
 
-    if (chara.item_which_will_be_used == 0)
+    if (chara.ai_item == 0)
     {
         return none;
     }
-    if (inv[chara.item_which_will_be_used].number() == 0)
+    if (inv[chara.ai_item].number() == 0)
     {
-        chara.item_which_will_be_used = 0;
+        chara.ai_item = 0;
         return none;
     }
     if (chara.relationship != 0)
     {
-        chara.item_which_will_be_used = 0;
+        chara.ai_item = 0;
     }
 
     const auto category =
-        the_item_db[itemid2int(inv[chara.item_which_will_be_used].id)]
-            ->category;
+        the_item_db[itemid2int(inv[chara.ai_item].id)]->category;
     if (category == ItemCategory::food)
     {
         if (chara.relationship != 10 || chara.nutrition <= 6000)
         {
-            return do_eat_command(inv[chara.item_which_will_be_used]);
+            return do_eat_command(inv[chara.ai_item]);
         }
     }
     if (category == ItemCategory::potion)
     {
-        return do_drink_command(inv[chara.item_which_will_be_used]);
+        return do_drink_command(inv[chara.ai_item]);
     }
     if (category == ItemCategory::scroll)
     {
-        return do_read_command(inv[chara.item_which_will_be_used]);
+        return do_read_command(inv[chara.ai_item]);
     }
 
-    chara.item_which_will_be_used = 0;
+    chara.ai_item = 0;
 
     return none;
 }

--- a/src/elona/world.cpp
+++ b/src/elona/world.cpp
@@ -83,7 +83,7 @@ void weather_changes()
     }
     if (game_data.current_map == mdata_t::MapId::your_home)
     {
-        calc_home_rank();
+        building_update_home_rank();
     }
     if (map_data.type == mdata_t::MapType::world_map)
     {

--- a/src/tests/item.cpp
+++ b/src/tests/item.cpp
@@ -16,9 +16,11 @@ TEST_CASE("Test that index of copied item is set", "[C++: Item]")
     REQUIRE_SOME(i_opt);
     Item& i = *i_opt;
 
-    int ti = elona::inv_getfreeid(-1);
-    elona::Item::copy(i, elona::inv[ti]);
+    const auto slot_opt = elona::inv_get_free_slot(-1);
+    REQUIRE_SOME(slot_opt);
+    auto& slot = *slot_opt;
+    elona::Item::copy(i, slot);
 
     REQUIRE(elona::inv[i.index].index == i.index);
-    REQUIRE(elona::inv[ti].index == ti);
+    REQUIRE(elona::inv[slot.index].index == slot.index);
 }

--- a/src/tests/lua_handles.cpp
+++ b/src/tests/lua_handles.cpp
@@ -616,8 +616,8 @@ TEST_CASE("Test copying of item handles", "[Lua: Handles]")
     int ti = elona::inv_getfreeid(-1);
     REQUIRE(handle_mgr.get_handle(elona::inv[ti]) == sol::lua_nil);
 
-    elona::item_copy(i.index, ti);
-    Item& copy = elona::inv[ti];
+    elona::item_copy(i, slot);
+    Item& copy = slot;
     sol::table handle_copy = handle_mgr.get_handle(copy);
 
     REQUIRE(handle_mgr.handle_is_valid(handle) == true);
@@ -631,7 +631,7 @@ TEST_CASE("Test copying of item handles", "[Lua: Handles]")
 
     // Assert that copying to an existing item will not try to
     // overwrite the existing handle.
-    REQUIRE_NOTHROW(elona::item_copy(i.index, ti));
+    REQUIRE_NOTHROW(elona::item_copy(i, slot));
 }
 
 TEST_CASE("Test copying of item handles after removal", "[Lua: Handles]")
@@ -655,7 +655,7 @@ TEST_CASE("Test copying of item handles after removal", "[Lua: Handles]")
     b.set_number(0);
 
     // item_copy should clean up the handle in b's slot.
-    REQUIRE_NOTHROW(elona::item_copy(a.index, b.index));
+    REQUIRE_NOTHROW(elona::item_copy(a, b));
 }
 
 TEST_CASE("Test swapping of item handles", "[Lua: Handles]")

--- a/src/tests/lua_handles.cpp
+++ b/src/tests/lua_handles.cpp
@@ -679,7 +679,7 @@ TEST_CASE("Test swapping of item handles", "[Lua: Handles]")
     std::string uuid_a = handle_a["__uuid"];
     std::string uuid_b = handle_b["__uuid"];
 
-    elona::item_exchange(item_a.index, item_b.index);
+    elona::item_exchange(item_a, item_b);
 
     // Disabled temporarily.
     // TODO: rethink how should swapping behave.

--- a/src/tests/lua_handles.cpp
+++ b/src/tests/lua_handles.cpp
@@ -588,14 +588,14 @@ TEST_CASE("Test separation of item handles", "[Lua: Handles]")
     Item& i = *i_opt;
     sol::table handle = handle_mgr.get_handle(i);
 
-    elona::item_separate(i.index);
+    elona::item_separate(i);
     Item& item_sep = i;
     sol::table handle_sep = handle_mgr.get_handle(item_sep);
 
     REQUIRE(handle_mgr.handle_is_valid(handle) == true);
     REQUIRE(handle_mgr.handle_is_valid(handle_sep) == true);
 
-    elona::item_separate(i.index);
+    elona::item_separate(i);
     REQUIRE(handle_mgr.handle_is_valid(handle) == true);
     REQUIRE(handle_mgr.handle_is_valid(handle_sep) == true);
 }

--- a/src/tests/lua_handles.cpp
+++ b/src/tests/lua_handles.cpp
@@ -613,8 +613,10 @@ TEST_CASE("Test copying of item handles", "[Lua: Handles]")
     Item& i = *i_opt;
     sol::table handle = handle_mgr.get_handle(i);
 
-    int ti = elona::inv_getfreeid(-1);
-    REQUIRE(handle_mgr.get_handle(elona::inv[ti]) == sol::lua_nil);
+    const auto slot_opt = elona::inv_get_free_slot(-1);
+    REQUIRE_SOME(slot_opt);
+    auto& slot = *slot_opt;
+    REQUIRE(handle_mgr.get_handle(slot) == sol::lua_nil);
 
     elona::item_copy(i, slot);
     Item& copy = slot;


### PR DESCRIPTION
# Summary

Refactor these functions:

* `_magic_651()` (Scavenge)
* `_magic_645_1114()` (Curse)
* `_magic_21_1127()` (Change material)
* `item_copy()`
* `dmgheal_death_by_backpack()`
* `item_exchange()`
* `item_separate()`
* `show_shop_log()`
* `inv_get_free_slot()`
* `inv_get_free_slot_force()`
* `talk_quest_delivery()` / `talk_quest_supply()`
* `item_find()`
* `item_acid()`
* `inv_compress()`
* `dipcursed()`
* `convertartifact()` (fix #1576)
* `cell_itemlist()` / `mapitemfind()`
* `inv_getowner()`
* `inv_find()`
* `calc_home_rank()` (fix #1567)
* `pick_up_item()`

