### PR TITLE
Adjust text spacing in ally's Wear menu

### DIFF
--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -1125,7 +1125,7 @@ void draw_window(bool dropcontinue)
                 ? snail::Color{50, 50, 200}
                 : snail::Color{100, 100, 100};
             mes(x, y, body_part_desc, text_color);
-            x += (body_part_desc.size() + 1) * 6;
+            x += (strlen_u(body_part_desc) + 1) * 6;
         }
     }
 }


### PR DESCRIPTION
# Summary

Old:

![image](https://user-images.githubusercontent.com/36858341/78987627-887e9100-7b69-11ea-8090-25effcc53dcc.png)

New:

![image](https://user-images.githubusercontent.com/36858341/78987636-8caaae80-7b69-11ea-8199-4e3361a2e6e1.png)

cf. vanilla:

![image](https://user-images.githubusercontent.com/36858341/78987645-90d6cc00-7b69-11ea-961a-41d7568be5dc.png)
