### PR TITLE
Fix displayed damage scale in character sheet

### DIFF
--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -1190,7 +1190,7 @@ void show_weapon_dice(
     int tohit = calc_accuracy(weapon, ammo, false);
     dmg = calcattackdmg(weapon, ammo, AttackDamageCalculationMode::raw_damage);
     font(14 - en * 2);
-    s(2) = ""s + dmgmulti;
+    s(2) = std::to_string(dmgmulti);
     s = ""s + tohit + u8"%"s;
     if (val0 == 0)
     {


### PR DESCRIPTION

# Related Issues

Close #1587.


# Summary

![image](https://user-images.githubusercontent.com/36858341/79002000-7f51ec00-7b8a-11ea-9a49-aa93230fe1f7.png)


It should be shown as decimal, not integer.
