### PR TITLE
Fix text rendering in message log menu

### DIFF
--- a/src/elona/ui/ui_menu_message_log.cpp
+++ b/src/elona/ui/ui_menu_message_log.cpp
@@ -53,17 +53,17 @@ void _draw_single_message(size_t cnt, int message_offset)
     {
         return;
     }
-    if (static_cast<int>(n) + message_offset < static_cast<int>(cnt) + 4)
+    if (static_cast<int>(n) + message_offset < static_cast<int>(cnt) + 5)
     {
         return;
     }
 
     int message_width = 0;
     font(14 - en * 2);
-    for (const auto& span : message_log.at(n - cnt - 4 + message_offset))
+    for (const auto& span : message_log.at(n - cnt - 5 + message_offset))
     {
         mes(message_width * 7 + inf_msgx + 6,
-            inf_msgy - cnt * inf_msgspace + vfix,
+            inf_msgy - (cnt + 1) * inf_msgspace + vfix - 3,
             span.text,
             span.color);
 
@@ -75,16 +75,10 @@ void _draw_single_message(size_t cnt, int message_offset)
 
 void _draw_messages(int message_offset)
 {
-    gsel(4);
-    gmode(0);
-    boxf();
-    for (int cnt = 0; cnt < inf_maxlog - 3; ++cnt)
+    for (int cnt = 0; cnt < inf_maxlog - 4; ++cnt)
     {
         _draw_single_message(cnt, message_offset);
     }
-    gsel(0);
-    gmode(2);
-    gcopy(4, 0, 0, windoww, inf_msgy, 0, -3);
 }
 
 } // namespace


### PR DESCRIPTION
# Summary

Fix text rendering in the message log menu when config `core.font.quality` is set to `high`.


# Screenshots

## Before

![image](https://user-images.githubusercontent.com/36858341/79026113-b643f400-7bc2-11ea-97f0-5f6b8845914e.png)

![image](https://user-images.githubusercontent.com/36858341/79026116-b8a64e00-7bc2-11ea-9baa-47ce380ce654.png)


## After

![image](https://user-images.githubusercontent.com/36858341/79026125-c0fe8900-7bc2-11ea-8a9a-83d81c01745a.png)


![image](https://user-images.githubusercontent.com/36858341/79026123-be039880-7bc2-11ea-828f-7ff66238fdfb.png)
