### PR TITLE
Refactor: remove no-effect statements

### DIFF
--- a/src/elona/talk.cpp
+++ b/src/elona/talk.cpp
@@ -165,7 +165,6 @@ void talk_to_npc(Character &chara)
 TalkResult talk_more()
 {
     listmax = 0;
-    tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;
@@ -186,7 +185,6 @@ TalkResult talk_sleeping()
 {
     listmax = 0;
     buff = u8"("s + i18n::s.get("core.talk.is_sleeping", cdata[tc]) + u8")"s;
-    tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.bye");
     ++listmax;
@@ -206,7 +204,6 @@ TalkResult talk_busy()
 {
     listmax = 0;
     buff = u8"("s + i18n::s.get("core.talk.is_busy", cdata[tc]) + u8")"s;
-    tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.bye");
     ++listmax;
@@ -226,7 +223,6 @@ TalkResult talk_ignored()
 {
     listmax = 0;
     buff = i18n::s.get("core.talk.ignores_you", cdata[tc]);
-    tc = tc * 1 + 0;
     ELONA_APPEND_RESPONSE(0, i18n::s.get("core.ui.bye"));
     chatesc = 1;
     ELONA_TALK_SCENE_CUT();
@@ -396,7 +392,6 @@ TalkResult talk_game_begin()
     }
     listmax = 0;
     buff = i18n::s.get_enum("core.talk.unique.lomias.begin", 1);
-    tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;
@@ -411,7 +406,6 @@ TalkResult talk_game_begin()
     }
     listmax = 0;
     buff = i18n::s.get_enum("core.talk.unique.lomias.begin", 2);
-    tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;

--- a/src/elona/talk.cpp
+++ b/src/elona/talk.cpp
@@ -238,8 +238,10 @@ TalkResult talk_game_begin()
         cdata.player().blind = 100;
         listmax = 0;
         buff = i18n::s.get_enum("core.talk.unique.lomias.begin.easter_egg", 0);
-        tc = tc * (chara_find("core.larnneire") == 0) +
-            (chara_find("core.larnneire") != 0) * chara_find("core.larnneire");
+        if (const auto larnneire_chara_index = chara_find("core.larnneire"))
+        {
+            tc = larnneire_chara_index;
+        }
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.ui.more");
         ++listmax;
@@ -254,8 +256,10 @@ TalkResult talk_game_begin()
         }
         listmax = 0;
         buff = i18n::s.get_enum("core.talk.unique.lomias.begin.easter_egg", 1);
-        tc = tc * (chara_find("core.lomias") == 0) +
-            (chara_find("core.lomias") != 0) * chara_find("core.lomias");
+        if (const auto lomias_chara_index = chara_find("core.lomias"))
+        {
+            tc = lomias_chara_index;
+        }
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.ui.more");
         ++listmax;
@@ -284,8 +288,10 @@ TalkResult talk_game_begin()
         await(500);
         listmax = 0;
         buff = i18n::s.get_enum("core.talk.unique.lomias.begin.easter_egg", 2);
-        tc = tc * (chara_find("core.larnneire") == 0) +
-            (chara_find("core.larnneire") != 0) * chara_find("core.larnneire");
+        if (const auto larnneire_chara_index = chara_find("core.larnneire"))
+        {
+            tc = larnneire_chara_index;
+        }
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.ui.more");
         ++listmax;
@@ -300,8 +306,10 @@ TalkResult talk_game_begin()
         }
         listmax = 0;
         buff = i18n::s.get_enum("core.talk.unique.lomias.begin.easter_egg", 3);
-        tc = tc * (chara_find("core.lomias") == 0) +
-            (chara_find("core.lomias") != 0) * chara_find("core.lomias");
+        if (const auto lomias_chara_index = chara_find("core.lomias"))
+        {
+            tc = lomias_chara_index;
+        }
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.ui.more");
         ++listmax;
@@ -316,8 +324,10 @@ TalkResult talk_game_begin()
         }
         listmax = 0;
         buff = i18n::s.get_enum("core.talk.unique.lomias.begin.easter_egg", 4);
-        tc = tc * (chara_find("core.larnneire") == 0) +
-            (chara_find("core.larnneire") != 0) * chara_find("core.larnneire");
+        if (const auto larnneire_chara_index = chara_find("core.larnneire"))
+        {
+            tc = larnneire_chara_index;
+        }
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.ui.more");
         ++listmax;
@@ -332,8 +342,10 @@ TalkResult talk_game_begin()
         }
         listmax = 0;
         buff = i18n::s.get_enum("core.talk.unique.lomias.begin.easter_egg", 5);
-        tc = tc * (chara_find("core.lomias") == 0) +
-            (chara_find("core.lomias") != 0) * chara_find("core.lomias");
+        if (const auto lomias_chara_index = chara_find("core.lomias"))
+        {
+            tc = lomias_chara_index;
+        }
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.ui.more");
         ++listmax;
@@ -348,8 +360,10 @@ TalkResult talk_game_begin()
         }
         listmax = 0;
         buff = i18n::s.get_enum("core.talk.unique.lomias.begin.easter_egg", 6);
-        tc = tc * (chara_find("core.larnneire") == 0) +
-            (chara_find("core.larnneire") != 0) * chara_find("core.larnneire");
+        if (const auto larnneire_chara_index = chara_find("core.larnneire"))
+        {
+            tc = larnneire_chara_index;
+        }
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.ui.more");
         ++listmax;
@@ -376,8 +390,10 @@ TalkResult talk_game_begin()
     txt(i18n::s.get("core.talk.unique.lomias.begin.regain_consciousness"));
     listmax = 0;
     buff = i18n::s.get_enum("core.talk.unique.lomias.begin", 0);
-    tc = tc * (chara_find("core.lomias") == 0) +
-        (chara_find("core.lomias") != 0) * chara_find("core.lomias");
+    if (const auto lomias_chara_index = chara_find("core.lomias"))
+    {
+        tc = lomias_chara_index;
+    }
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;
@@ -420,8 +436,10 @@ TalkResult talk_game_begin()
     }
     listmax = 0;
     buff = i18n::s.get_enum("core.talk.unique.lomias.begin", 3);
-    tc = tc * (chara_find("core.larnneire") == 0) +
-        (chara_find("core.larnneire") != 0) * chara_find("core.larnneire");
+    if (const auto larnneire_chara_index = chara_find("core.larnneire"))
+    {
+        tc = larnneire_chara_index;
+    }
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;
@@ -436,8 +454,10 @@ TalkResult talk_game_begin()
     }
     listmax = 0;
     buff = i18n::s.get_enum("core.talk.unique.lomias.begin", 4, cdatan(0, 0));
-    tc = tc * (chara_find("core.lomias") == 0) +
-        (chara_find("core.lomias") != 0) * chara_find("core.lomias");
+    if (const auto lomias_chara_index = chara_find("core.lomias"))
+    {
+        tc = lomias_chara_index;
+    }
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;

--- a/src/elona/talk_house_visitor.cpp
+++ b/src/elona/talk_house_visitor.cpp
@@ -33,7 +33,6 @@ TalkResult _talk_hv_visitor()
 {
     listmax = 0;
     buff = i18n::s.get("core.talk.visitor.wanted_to_say_hi", cdata[tc]);
-    tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;
@@ -66,7 +65,6 @@ TalkResult _talk_hv_adventurer_new_year()
     listmax = 0;
     buff = i18n::s.get(
         "core.talk.visitor.adventurer.new_year.happy_new_year", cdata[tc]);
-    tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;
@@ -81,7 +79,6 @@ TalkResult _talk_hv_adventurer_new_year()
     }
     listmax = 0;
     buff = i18n::s.get("core.talk.visitor.adventurer.new_year.gift", cdata[tc]);
-    tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;
@@ -151,7 +148,6 @@ TalkResult _talk_hv_adventurer_hate()
 {
     listmax = 0;
     buff = i18n::s.get("core.talk.visitor.adventurer.hate.dialog", cdata[tc]);
-    tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;
@@ -185,7 +181,6 @@ void _talk_hv_adventurer_best_friend()
 {
     listmax = 0;
     buff = i18n::s.get("core.talk.visitor.adventurer.like.dialog", cdata[tc]);
-    tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;
@@ -285,7 +280,6 @@ TalkResult _talk_hv_adventurer_train()
         listmax = 0;
         buff =
             i18n::s.get("core.talk.visitor.adventurer.train.pass", cdata[tc]);
-        tc = tc * 1 + 0;
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.ui.more");
         ++listmax;
@@ -308,7 +302,6 @@ TalkResult _talk_hv_adventurer_train()
         listmax = 0;
         buff = i18n::s.get(
             "core.talk.visitor.adventurer.train.learn.after", cdata[tc]);
-        tc = tc * 1 + 0;
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.ui.more");
         ++listmax;
@@ -329,7 +322,6 @@ TalkResult _talk_hv_adventurer_train()
         listmax = 0;
         buff = i18n::s.get(
             "core.talk.visitor.adventurer.train.train.after", cdata[tc]);
-        tc = tc * 1 + 0;
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.ui.more");
         ++listmax;
@@ -378,7 +370,6 @@ TalkResult _talk_hv_adventurer_friendship()
     listmax = 0;
     buff = i18n::s.get(
         "core.talk.visitor.adventurer.friendship.dialog", cdata[tc]);
-    tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;
@@ -425,7 +416,6 @@ TalkResult _talk_hv_adventurer_souvenir()
     listmax = 0;
     buff =
         i18n::s.get("core.talk.visitor.adventurer.souvenir.dialog", cdata[tc]);
-    tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;
@@ -459,7 +449,6 @@ TalkResult _talk_hv_adventurer_materials()
     listmax = 0;
     buff =
         i18n::s.get("core.talk.visitor.adventurer.materials.dialog", cdata[tc]);
-    tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;
@@ -490,7 +479,6 @@ TalkResult _talk_hv_adventurer_favorite_skill()
             the_ability_db.get_id_from_legacy(skill_id)->get(),
             "name"),
         cdata[tc]);
-    tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;
@@ -517,7 +505,6 @@ TalkResult _talk_hv_adventurer_favorite_stat()
             the_ability_db.get_id_from_legacy(skill_id)->get(),
             "name"),
         cdata[tc]);
-    tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;
@@ -547,7 +534,6 @@ TalkResult _talk_hv_adventurer_conversation()
         "core.talk.visitor.adventurer.conversation.dialog",
         cdata.player(),
         cdata[tc]);
-    tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;
@@ -581,7 +567,6 @@ TalkResult _talk_hv_adventurer_drink()
 {
     listmax = 0;
     buff = i18n::s.get("core.talk.visitor.adventurer.drink.dialog", cdata[tc]);
-    tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;
@@ -723,7 +708,6 @@ TalkResult _talk_hv_trainer()
         listmax = 0;
         buff = i18n::s.get(
             "core.talk.visitor.trainer.no_more_this_month", cdata[tc]);
-        tc = tc * 1 + 0;
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.ui.more");
         ++listmax;
@@ -769,7 +753,6 @@ TalkResult _talk_hv_trainer()
     {
         listmax = 0;
         buff = i18n::s.get("core.talk.visitor.trainer.regret", cdata[tc]);
-        tc = tc * 1 + 0;
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.ui.more");
         ++listmax;
@@ -789,7 +772,6 @@ TalkResult _talk_hv_trainer()
 
     listmax = 0;
     buff = i18n::s.get("core.talk.visitor.trainer.after", cdata[tc]);
-    tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;
@@ -834,7 +816,6 @@ TalkResult _talk_hv_beggar()
 
         listmax = 0;
         buff = i18n::s.get("core.talk.visitor.beggar.after", cdata[tc]);
-        tc = tc * 1 + 0;
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.ui.more");
         ++listmax;
@@ -851,7 +832,6 @@ TalkResult _talk_hv_beggar()
     }
     listmax = 0;
     buff = i18n::s.get("core.talk.visitor.beggar.cheap");
-    tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;
@@ -881,7 +861,6 @@ TalkResult _talk_hv_punk()
     {
         listmax = 0;
         buff = i18n::s.get("core.talk.npc.common.sex.start", cdata[tc]);
-        tc = tc * 1 + 0;
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.talk.npc.common.sex.response");
         ++listmax;
@@ -901,7 +880,6 @@ TalkResult _talk_hv_punk()
     }
     listmax = 0;
     buff = i18n::s.get("core.talk.visitor.punk.hump");
-    tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;
@@ -934,7 +912,6 @@ TalkResult _talk_hv_mysterious_producer()
         listmax = 0;
         buff = i18n::s.get(
             "core.talk.visitor.mysterious_producer.no_turning_back", cdata[tc]);
-        tc = tc * 1 + 0;
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.talk.npc.common.sex.response");
         ++listmax;
@@ -954,7 +931,6 @@ TalkResult _talk_hv_mysterious_producer()
     }
     listmax = 0;
     buff = i18n::s.get("core.talk.visitor.punk.hump");
-    tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;
@@ -1019,7 +995,6 @@ TalkResult _talk_hv_merchant()
     }
     listmax = 0;
     buff = i18n::s.get("core.talk.visitor.merchant.regret", cdata[tc]);
-    tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -532,7 +532,6 @@ TalkResult talk_guard_return_item()
             listmax = 0;
             buff = i18n::s.get_enum(
                 "core.talk.npc.guard.lost.found_often.dialog", 0, cdata[tc]);
-            tc = tc * 1 + 0;
             ELONA_APPEND_RESPONSE(0, i18n::s.get("core.ui.more"));
             chatesc = 1;
             ELONA_TALK_SCENE_CUT();
@@ -605,7 +604,6 @@ TalkResult talk_ally_order_wait()
 {
     listmax = 0;
     buff = i18n::s.get("core.talk.npc.ally.wait_at_town", cdata[tc]);
-    tc = tc * 1 + 0;
     ELONA_APPEND_RESPONSE(0, i18n::s.get("core.ui.more"));
     chatesc = 1;
     ELONA_TALK_SCENE_CUT();
@@ -752,7 +750,6 @@ TalkResult talk_ally_marriage()
     cdata[tc].is_married() = true;
     listmax = 0;
     buff = i18n::s.get("core.talk.npc.ally.marriage.accepts");
-    tc = tc * 1 + 0;
     ELONA_APPEND_RESPONSE(0, i18n::s.get("core.ui.more"));
     chatesc = 1;
     ELONA_TALK_SCENE_CUT();
@@ -767,7 +764,6 @@ TalkResult talk_ally_gene()
     {
         listmax = 0;
         buff = i18n::s.get("core.talk.npc.ally.make_gene.refuses");
-        tc = tc * 1 + 0;
         ELONA_APPEND_RESPONSE(0, i18n::s.get("core.ui.more"));
         chatesc = 1;
         ELONA_TALK_SCENE_CUT();
@@ -775,7 +771,6 @@ TalkResult talk_ally_gene()
     }
     listmax = 0;
     buff = i18n::s.get("core.talk.npc.ally.make_gene.accepts");
-    tc = tc * 1 + 0;
     ELONA_APPEND_RESPONSE(0, i18n::s.get("core.ui.more"));
     chatesc = 1;
     ELONA_TALK_SCENE_CUT();
@@ -791,7 +786,6 @@ TalkResult talk_innkeeper_shelter()
 {
     listmax = 0;
     buff = i18n::s.get("core.talk.npc.innkeeper.go_to_shelter", cdata[tc]);
-    tc = tc * 1 + 0;
     ELONA_APPEND_RESPONSE(0, i18n::s.get("core.ui.more"));
     chatesc = 1;
     ELONA_TALK_SCENE_CUT();
@@ -982,7 +976,6 @@ TalkResult talk_adventurer_join()
     {
         listmax = 0;
         buff = i18n::s.get("core.talk.npc.adventurer.join.accept", cdata[tc]);
-        tc = tc * 1 + 0;
         ELONA_APPEND_RESPONSE(0, i18n::s.get("core.ui.more"));
         chatesc = 1;
         ELONA_TALK_SCENE_CUT();
@@ -1042,7 +1035,6 @@ TalkResult talk_wizard_return()
 {
     listmax = 0;
     buff = i18n::s.get("core.talk.npc.wizard.return", cdata[tc]);
-    tc = tc * 1 + 0;
     ELONA_APPEND_RESPONSE(0, i18n::s.get("core.ui.more"));
     chatesc = 1;
     ELONA_TALK_SCENE_CUT();
@@ -1107,7 +1099,6 @@ TalkResult talk_sex()
     }
     listmax = 0;
     buff = i18n::s.get("core.talk.npc.common.sex.start", cdata[tc]);
-    tc = tc * 1 + 0;
     ELONA_APPEND_RESPONSE(0, i18n::s.get("core.talk.npc.common.sex.response"));
     chatesc = 1;
     ELONA_TALK_SCENE_CUT();
@@ -1120,7 +1111,6 @@ TalkResult talk_result_maid_chase_out()
     --game_data.number_of_waiting_guests;
     listmax = 0;
     buff = i18n::s.get("core.talk.npc.maid.do_not_meet", cdata[tc]);
-    tc = tc * 1 + 0;
     ELONA_APPEND_RESPONSE(0, i18n::s.get("core.ui.more"));
     chatesc = 1;
     ELONA_TALK_SCENE_CUT();
@@ -1150,7 +1140,6 @@ TalkResult talk_prostitute_buy()
     earn_gold(cdata[tc], sexvalue);
     listmax = 0;
     buff = i18n::s.get("core.talk.npc.common.sex.start", cdata[tc]);
-    tc = tc * 1 + 0;
     ELONA_APPEND_RESPONSE(0, i18n::s.get("core.talk.npc.common.sex.response"));
     chatesc = 1;
     ELONA_TALK_SCENE_CUT();
@@ -1288,7 +1277,6 @@ TalkResult talk_accepted_quest()
     {
         listmax = 0;
         buff = i18n::s.get("core.talk.npc.quest_giver.accept.hunt", cdata[tc]);
-        tc = tc * 1 + 0;
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.ui.more");
         ++listmax;
@@ -1307,7 +1295,6 @@ TalkResult talk_accepted_quest()
         listmax = 0;
         buff =
             i18n::s.get("core.talk.npc.quest_giver.accept.harvest", cdata[tc]);
-        tc = tc * 1 + 0;
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.ui.more");
         ++listmax;
@@ -1325,7 +1312,6 @@ TalkResult talk_accepted_quest()
     {
         listmax = 0;
         buff = i18n::s.get("core.talk.npc.quest_giver.accept.party", cdata[tc]);
-        tc = tc * 1 + 0;
         list(0, listmax) = 0;
         listn(0, listmax) = i18n::s.get("core.ui.more");
         ++listmax;
@@ -1485,7 +1471,6 @@ TalkResult talk_finish_escort()
 {
     listmax = 0;
     buff = i18n::s.get("core.talk.npc.quest_giver.finish.escort", cdata[tc]);
-    tc = tc * 1 + 0;
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
     ++listmax;
@@ -2197,7 +2182,6 @@ TalkResult talk_npc()
                         buff = i18n::s.get(
                             "core.talk.npc.shop.criminal.sell", cdata[tc]);
                     }
-                    tc = tc * 1 + 0;
                     ELONA_APPEND_RESPONSE(0, i18n::s.get("core.ui.more"));
                     chatesc = 1;
                     ELONA_TALK_SCENE_CUT();


### PR DESCRIPTION
# Summary

Remove no-effect statements:

```cpp
tc = tc * 1 + 0;
```


Also, simplify assignment statements:

```diff
-tc = tc * (chara_find("core.larnneire") == 0) +
-    (chara_find("core.larnneire") != 0) * chara_find("core.larnneire");
+if (const auto larnneire_chara_index = chara_find("core.larnneire"))
+{
+    tc = larnneire_chara_index;
+}
```