### PR TITLE
Add 'Hang' to [i]nteract menu to hang arbitrary NPCs

### DIFF
--- a/runtime/mod/core/locale/en/action.lua
+++ b/runtime/mod/core/locale/en/action.lua
@@ -91,6 +91,7 @@ ELONA.i18n:add {
             release = "Release",
             name = "Name",
             info = "Info",
+            hang = "Hang",
          },
 
          change_tone = {

--- a/runtime/mod/core/locale/jp/action.lua
+++ b/runtime/mod/core/locale/jp/action.lua
@@ -91,6 +91,7 @@ ELONA.i18n:add {
             release = "縄を解く",
             name = "名前をつける",
             info = "情報",
+            hang = "吊る",
          },
 
          change_tone = {

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -668,9 +668,13 @@ TurnResult do_interact_command()
         }
     }
     prompt.append("name", 3);
-    if (0 || game_data.wizard)
+    if (game_data.wizard)
     {
         prompt.append("info", 6);
+        if (target_index != 0 && !cdata[target_index].is_hung_on_sand_bag())
+        {
+            prompt.append("hang", 11);
+        }
     }
     {
         int stat = prompt.query(promptx, prompty, 200);
@@ -771,6 +775,15 @@ TurnResult do_interact_command()
     if (p == 10)
     {
         change_npc_tone(cdata[target_index]);
+    }
+    if (p == 11)
+    {
+        snd("core.build1");
+        cdata[target_index].is_hung_on_sand_bag() = true;
+        txt(i18n::s.get("core.action.use.sandbag.start", cdata[target_index]));
+        txt(i18n::s.get(
+            "core.action.use.leash.other.start.dialog", cdata[target_index]));
+        animeload(8, target_index);
     }
     update_screen();
     return TurnResult::pc_turn_user_error;


### PR DESCRIPTION
# Summary

Add 'Hang' to [i]nteract menu to hang arbitrary NPCs (except for that you cannot hang yourself). Of course, the choice is available only in wizard mode.
