### PR TITLE
Fix player's targeting algorithm when core.auto_target option is on

### DIFF
--- a/src/elona/turn_sequence_pc_actions.cpp
+++ b/src/elona/turn_sequence_pc_actions.cpp
@@ -610,6 +610,7 @@ optional<TurnResult> handle_pc_action(std::string& action)
     }
     if (action == "target")
     {
+        cdata.player().enemy_id = 0;
         findlocmode = 1;
         target_position();
         findlocmode = 0;
@@ -649,6 +650,7 @@ optional<TurnResult> handle_pc_action(std::string& action)
     }
     if (action == "look")
     {
+        cdata.player().enemy_id = 0;
         if (map_data.type != mdata_t::MapType::world_map)
         {
             return do_look_command();


### PR DESCRIPTION
# Summary

Function `target_position()` assumes that `cdata.player().enemy_id` is zero, but `core.auto_target` option breaks the assumption. To fix the bug, set 0 to `cdata.player().enemy_id` before calling `target_position()`.