### PR TITLE
Fix not being able to steal items / change inventory menu UI a bit

### DIFF
--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -1254,8 +1254,8 @@ void show_money(optional_ref<Character> inventory_owner)
 {
     if (show_inventory_owners_money(invctrl(0)))
     {
-        assert(inventory_owner);
-        if (g_show_additional_item_info == AdditionalItemInfo::none)
+        if (inventory_owner &&
+            g_show_additional_item_info == AdditionalItemInfo::none)
         {
             font(13 - en * 2);
             gmode(2);

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -458,7 +458,11 @@ bool _magic_300(Character& subject, Character& target)
     invctrl(0) = 27;
     invctrl(1) = 0;
     snd("core.inv");
-    ctrl_inventory(target);
+    // In Pickpocket spact, target == player means that you attempts to steal
+    // items on the ground, not in someone's inventory.
+    ctrl_inventory(
+        target.index == 0 ? optional_ref<Character>{}
+                          : optional_ref<Character>{target});
     return true;
 }
 


### PR DESCRIPTION
# Related Issues

Close #1611


# Summary

- Fix not being able to steal items
  - In Pickpocket spact, target == player means that you attempts to steal items on the ground, not in someone's inventory.
- Change steal inventory menu UI
  - When you try to steal items on the ground, not in someone's inventory, hide money in inventory menu UI. In vanilla, it was player's money, but it was useless information. When you try to steal items from someone, the character's money is displayed in the menu as before.