### PR TITLE
Make it possible to assign shortcut on cargo items

### DIFF
--- a/runtime/mod/core/locale/en/ctrl_inventory.lua
+++ b/runtime/mod/core/locale/en/ctrl_inventory.lua
@@ -58,10 +58,6 @@ ELONA.i18n:add {
             inventory_is_full = "Your inventory is full.",
 
             invalid = "Invalid Item Id found. Item No:{$1}, Id:{$2} has been removed from your inventory.",
-
-            shortcut = {
-               cargo = "You can't make a shortcut for cargo stuff.",
-            },
          },
 
          examine = {

--- a/runtime/mod/core/locale/jp/ctrl_inventory.lua
+++ b/runtime/mod/core/locale/jp/ctrl_inventory.lua
@@ -58,10 +58,6 @@ ELONA.i18n:add {
             inventory_is_full = "バックパックが一杯だ。",
 
             invalid = "Invalid Item Id found. Item No:{$1}, Id:{$2} has been removed from your inventory.",
-
-            shortcut = {
-               cargo = "荷車の荷物は登録できない。",
-            },
          },
 
          examine = {

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -936,6 +936,11 @@ optional<OnEnterResult> on_shortcut(int& citrade, bool dropcontinue)
                 return OnEnterResult{result};
             }
         }
+        if (!cargocheck(inv[p]))
+        {
+            result.turn_result = TurnResult::pc_turn_user_error;
+            return OnEnterResult{result};
+        }
         return on_enter(none, p(0), citrade, dropcontinue);
     }
 
@@ -2602,13 +2607,6 @@ optional<MenuResult> on_cancel(bool dropcontinue)
 
 bool on_assign_shortcut(const std::string& action, int shortcut)
 {
-    p = list(0, pagesize * page + cs);
-    if (inv[p].weight < 0)
-    {
-        snd("core.fail1");
-        txt(i18n::s.get("core.ui.inv.common.shortcut.cargo"));
-        return false;
-    }
     snd("core.ok1");
     p = itemid2int(inv[list(0, pagesize * page + cs)].id) + invctrl * 10000;
     if (game_data.skill_shortcuts.at(shortcut) == p)


### PR DESCRIPTION
# Summary

Make it possible to assign shortcut on cargo items. However, you cannot use cargo items in area where you cannot do so in vanilla. Now, you can assign any shortcut on eating traveler's food.
