### PR TITLE
Improve i18n for data instances

### DIFF
--- a/runtime/mod/core/locale/en/ability.lua
+++ b/runtime/mod/core/locale/en/ability.lua
@@ -1,5 +1,6 @@
-ELONA.i18n:add {
-   ability = {
+ELONA.i18n:add_data_text(
+   "core.ability",
+   {
       attribute_life = {
          name = "Life",
       },
@@ -786,5 +787,5 @@ ELONA.i18n:add {
          name = "Drop Mine",
          description = "Set Mine",
       },
-   },
-}
+   }
+)

--- a/runtime/mod/core/locale/en/chara.lua
+++ b/runtime/mod/core/locale/en/chara.lua
@@ -117,8 +117,9 @@ ELONA.i18n:add {
 
 
 
-ELONA.i18n:add {
-   chara = {
+ELONA.i18n:add_data_text(
+   "core.chara",
+   {
       bug = {
          name = "bug",
       },
@@ -1383,5 +1384,5 @@ ELONA.i18n:add {
       alien = {
          name = "alien",
       },
-   },
-}
+   }
+)

--- a/runtime/mod/core/locale/en/class.lua
+++ b/runtime/mod/core/locale/en/class.lua
@@ -6,8 +6,9 @@ ELONA.i18n:add {
 
 
 
-ELONA.i18n:add {
-   class = {
+ELONA.i18n:add_data_text(
+   "core.class",
+   {
       warrior = {
          name = "Warrior",
          description = "The Warrior. With working knowledge of all things stabby, bashy, choppy, and shooty, anything in a Warrior's hands is bad news for their enemies. No mere thug, they have knowledge of tactics to bring even the strongest down, and are trained early on to be comfortable in all kinds of armor and shields. Warriors are personifications of the adage \"If violence isn't working, you are obviously not using enough of it.\"",
@@ -59,5 +60,5 @@ ELONA.i18n:add {
          name = "Debugger",
          description = "For debug",
       },
-   },
-}
+   }
+)

--- a/runtime/mod/core/locale/en/fish.lua
+++ b/runtime/mod/core/locale/en/fish.lua
@@ -1,5 +1,6 @@
-ELONA.i18n:add {
-   fish = {
+ELONA.i18n:add_data_text(
+   "core.fish",
+   {
       bug = {
          name = "bug",
       },
@@ -111,5 +112,5 @@ ELONA.i18n:add {
       broken_cell_phone = {
          name = "broken cell phone",
       },
-   },
-}
+   }
+)

--- a/runtime/mod/core/locale/en/god.lua
+++ b/runtime/mod/core/locale/en/god.lua
@@ -113,8 +113,9 @@ ELONA.i18n:add {
 
 
 
-ELONA.i18n:add {
-   god = {
+ELONA.i18n:add_data_text(
+   "core.god",
+   {
       eyth = {
          name = "Eyth of Infidel",
       },
@@ -284,5 +285,5 @@ ELONA.i18n:add {
             "NOTE it is machine-translated: Together foreaver...right? I will not let you go...until you die.",
          },
       },
-   },
-}
+   }
+)

--- a/runtime/mod/core/locale/en/item_material.lua
+++ b/runtime/mod/core/locale/en/item_material.lua
@@ -1,5 +1,6 @@
-ELONA.i18n:add {
-   item_material = {
+ELONA.i18n:add_data_text(
+   "core.item_material",
+   {
       vegetable_seed = {
          name = "vegetable",
          alias = "",
@@ -172,5 +173,5 @@ ELONA.i18n:add {
          name = "griffon scale",
          alias = "fallen",
       },
-   },
-}
+   }
+)

--- a/runtime/mod/core/locale/en/race.lua
+++ b/runtime/mod/core/locale/en/race.lua
@@ -1,5 +1,6 @@
-ELONA.i18n:add {
-   race = {
+ELONA.i18n:add_data_text(
+   "core.race",
+   {
       kobold = {
          name = "Kobold",
       },
@@ -244,5 +245,5 @@ ELONA.i18n:add {
          name = "Slug",
          description = "For debug",
       },
-   },
-}
+   }
+)

--- a/runtime/mod/core/locale/jp/ability.lua
+++ b/runtime/mod/core/locale/jp/ability.lua
@@ -1,5 +1,6 @@
-ELONA.i18n:add {
-   ability = {
+ELONA.i18n:add_data_text(
+   "core.ability",
+   {
       attribute_life = {
          name = "生命力",
       },
@@ -817,5 +818,5 @@ ELONA.i18n:add {
          name = "地雷投下",
          description = "足元に地雷設置",
       },
-   },
-}
+   }
+)

--- a/runtime/mod/core/locale/jp/chara.lua
+++ b/runtime/mod/core/locale/jp/chara.lua
@@ -117,8 +117,9 @@ ELONA.i18n:add {
 
 
 
-ELONA.i18n:add {
-   chara = {
+ELONA.i18n:add_data_text(
+   "core.chara",
+   {
       bug = {
          name = "バグ",
       },
@@ -1645,5 +1646,5 @@ ELONA.i18n:add {
       alien = {
          name = "エイリアン",
       },
-   },
-}
+   }
+)

--- a/runtime/mod/core/locale/jp/class.lua
+++ b/runtime/mod/core/locale/jp/class.lua
@@ -6,8 +6,9 @@ ELONA.i18n:add {
 
 
 
-ELONA.i18n:add {
-   class = {
+ELONA.i18n:add_data_text(
+   "core.class",
+   {
       warrior = {
          name = "戦士",
          description = "戦士は己の肉体を武器に、立ちはだかるものを破壊し突き進みます。魔法の扱いには向いていませんが、その高い戦闘能力には目を見張るものがあります。",
@@ -59,5 +60,5 @@ ELONA.i18n:add {
          name = "デバッガー",
          description = "デバッグ用",
       },
-   },
-}
+   }
+)

--- a/runtime/mod/core/locale/jp/fish.lua
+++ b/runtime/mod/core/locale/jp/fish.lua
@@ -1,5 +1,6 @@
-ELONA.i18n:add {
-   fish = {
+ELONA.i18n:add_data_text(
+   "core.fish",
+   {
       bug = {
          name = "バグ",
       },
@@ -111,5 +112,5 @@ ELONA.i18n:add {
       broken_cell_phone = {
          name = "壊れた携帯",
       },
-   },
-}
+   }
+)

--- a/runtime/mod/core/locale/jp/god.lua
+++ b/runtime/mod/core/locale/jp/god.lua
@@ -111,8 +111,9 @@ ELONA.i18n:add {
 
 
 
-ELONA.i18n:add {
-   god = {
+ELONA.i18n:add_data_text(
+   "core.god",
+   {
       eyth = {
          name = "無のエイス",
       },
@@ -277,5 +278,5 @@ ELONA.i18n:add {
          ready_to_receive_gift = "「君は…大切なしもべだ…」",
          ready_to_receive_gift2 = "「ずっと一緒…だよね？…もう離さない…君が死ぬまで」",
       },
-   },
-}
+   }
+)

--- a/runtime/mod/core/locale/jp/item_material.lua
+++ b/runtime/mod/core/locale/jp/item_material.lua
@@ -1,5 +1,6 @@
-ELONA.i18n:add {
-   item_material = {
+ELONA.i18n:add_data_text(
+   "core.item_material",
+   {
       vegetable_seed = {
          name = "野菜",
          alias = "",
@@ -172,5 +173,5 @@ ELONA.i18n:add {
          name = "翼鳥鱗",
          alias = "翼を折られし",
       },
-   },
-}
+   }
+)

--- a/runtime/mod/core/locale/jp/race.lua
+++ b/runtime/mod/core/locale/jp/race.lua
@@ -1,5 +1,6 @@
-ELONA.i18n:add {
-   race = {
+ELONA.i18n:add_data_text(
+   "core.race",
+   {
       kobold = {
          name = "コボルト",
       },
@@ -244,5 +245,5 @@ ELONA.i18n:add {
          name = "ナメクジ",
          description = "デバッグ用",
       },
-   },
-}
+   }
+)

--- a/src/elona/ability.cpp
+++ b/src/elona/ability.cpp
@@ -200,7 +200,7 @@ void gain_special_action()
             spact(29) = 1;
             txt(i18n::s.get(
                     "core.skill.gained",
-                    i18n::s.get_m("ability", "core.draw_charge", "name")),
+                    the_ability_db.get_text("core.draw_charge", "name")),
                 Message::color{ColorIndex::orange});
         }
         if (spact(30) == 0)
@@ -208,7 +208,7 @@ void gain_special_action()
             spact(30) = 1;
             txt(i18n::s.get(
                     "core.skill.gained",
-                    i18n::s.get_m("ability", "core.fill_charge", "name")),
+                    the_ability_db.get_text("core.fill_charge", "name")),
                 Message::color{ColorIndex::orange});
         }
     }
@@ -219,7 +219,7 @@ void gain_special_action()
             spact(31) = 1;
             txt(i18n::s.get(
                     "core.skill.gained",
-                    i18n::s.get_m("ability", "core.swarm", "name")),
+                    the_ability_db.get_text("core.swarm", "name")),
                 Message::color{ColorIndex::orange});
         }
     }

--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -701,11 +701,7 @@ void activity_others_start(Character& doer, optional_ref<Item> activity_item)
         {
             txt(i18n::s.get(
                 "core.activity.study.start.studying",
-                i18n::s.get_m(
-                    "ability",
-                    the_ability_db.get_id_from_legacy(activity_item->param1)
-                        ->get(),
-                    "name")));
+                the_ability_db.get_text(activity_item->param1, "name")));
         }
         else
         {
@@ -1112,10 +1108,7 @@ void activity_others_end_study(const Item& item)
     {
         txt(i18n::s.get(
             "core.activity.study.finish.studying",
-            i18n::s.get_m(
-                "ability",
-                the_ability_db.get_id_from_legacy(item.param1)->get(),
-                "name")));
+            the_ability_db.get_text(item.param1, "name")));
     }
     else
     {

--- a/src/elona/blending.cpp
+++ b/src/elona/blending.cpp
@@ -185,12 +185,7 @@ void window_recipe(optional_ref<Item> item, int x, int y, int width, int height)
                 : snail::Color{0, 120, 0};
             mes(dx_ + cnt % 2 * 140,
                 dy_ + cnt / 2 * 17,
-                i18n::s.get_m(
-                    "ability",
-                    the_ability_db
-                        .get_id_from_legacy(rpdata(10 + cnt * 2, rpid))
-                        ->get(),
-                    "name") +
+                the_ability_db.get_text(rpdata(10 + cnt * 2, rpid), "name") +
                     u8"  "s + rpdata((11 + cnt * 2), rpid) + u8"("s +
                     sdata(rpdata((10 + cnt * 2), rpid), 0) + u8")"s,
                 text_color);

--- a/src/elona/chara_db.cpp
+++ b/src/elona/chara_db.cpp
@@ -42,7 +42,7 @@ void chara_db_set_stats(Character& chara, CharaId chara_id)
     chara.special_actions = data->special_actions;
     creaturepack = data->creaturepack;
     chara.can_talk = data->can_talk;
-    cdatan(0, chara.index) = i18n::s.get_m("chara", data->id.get(), "name");
+    cdatan(0, chara.index) = the_character_db.get_text(data->id, "name");
     if (data->has_random_name)
     {
         cdatan(0, chara.index) = i18n::s.get(
@@ -154,7 +154,7 @@ std::string chara_db_get_name(CharaId chara_id)
 {
     if (const auto data = the_character_db[charaid2int(chara_id)])
     {
-        return i18n::s.get_m("chara", data->id.get(), "name");
+        return the_character_db.get_text(data->id, "name");
     }
     else
     {
@@ -348,11 +348,9 @@ void chara_db_get_talk(CharaId chara_id, int talk_type)
     default: break;
     }
 
-    const auto chara_id_str =
-        the_character_db.get_id_from_legacy(charaid2int(chara_id))->get();
     const auto dialog_id = "text_" + std::to_string(talk_type);
-    if (const auto text =
-            i18n::s.get_m_optional("chara", chara_id_str, dialog_id))
+    if (const auto text = the_character_db.get_text_optional(
+            charaid2int(chara_id), dialog_id))
     {
         txt(*text, Message::color{ColorIndex::cyan});
     }

--- a/src/elona/character_making.cpp
+++ b/src/elona/character_making.cpp
@@ -513,11 +513,7 @@ void draw_race_or_class_info(const std::string& description)
             mes(cnt * 150 + tx + 32,
                 ty,
                 strutil::take_by_width(
-                    i18n::s.get_m(
-                        "ability",
-                        the_ability_db.get_id_from_legacy(r)->get(),
-                        "name"),
-                    jp ? 6 : 3) +
+                    the_ability_db.get_text(r, "name"), jp ? 6 : 3) +
                     u8": "s + s(p),
                 text_color);
         }
@@ -542,10 +538,7 @@ void draw_race_or_class_info(const std::string& description)
             {
                 s += u8","s;
             }
-            s += i18n::s.get_m(
-                "ability",
-                the_ability_db.get_id_from_legacy(cnt)->get(),
-                "name");
+            s += the_ability_db.get_text(cnt, "name");
             ++r;
         }
     }
@@ -560,10 +553,7 @@ void draw_race_or_class_info(const std::string& description)
     {
         if (sdata.get(cnt, 0).original_level != 0)
         {
-            s = i18n::s.get_m(
-                "ability",
-                the_ability_db.get_id_from_legacy(cnt)->get(),
-                "name");
+            s = the_ability_db.get_text(cnt, "name");
             if (jp)
             {
                 lenfix(s, 12);
@@ -581,11 +571,7 @@ void draw_race_or_class_info(const std::string& description)
                 inf_tiles,
                 tx + 13,
                 ty + 6);
-            s(1) = i18n::s
-                       .get_m_optional(
-                           "ability",
-                           the_ability_db.get_id_from_legacy(cnt)->get(),
-                           "description")
+            s(1) = the_ability_db.get_text_optional(cnt, "description")
                        .value_or("");
             if (en)
             {

--- a/src/elona/class.cpp
+++ b/src/elona/class.cpp
@@ -46,7 +46,7 @@ std::string class_get_name(data::InstanceId class_id)
     }
     else
     {
-        return i18n::s.get_m("class", class_id.get(), "name");
+        return the_class_db.get_text(class_id, "name");
     }
 }
 

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -475,11 +475,7 @@ optional<TurnResult> use_gene_machine()
                 txt(i18n::s.get(
                         "core.action.use.gene_machine.gains.ability",
                         cdata[original_character],
-                        i18n::s.get_m(
-                            "ability",
-                            the_ability_db.get_id_from_legacy(rtval(cnt))
-                                ->get(),
-                            "name")),
+                        the_ability_db.get_text(rtval(cnt), "name")),
                     Message::color{ColorIndex::green});
             }
         }
@@ -4533,10 +4529,7 @@ int do_cast_magic_attempt(Character& caster, int& enemy_index)
             txt(i18n::s.get(
                 "core.action.cast.self",
                 caster,
-                i18n::s.get_m(
-                    "ability",
-                    the_ability_db.get_id_from_legacy(efid)->get(),
-                    "name"),
+                the_ability_db.get_text(efid, "name"),
                 i18n::s.get_enum(
                     "core.ui.cast_style", caster.special_attack_type)));
         }

--- a/src/elona/data/base_database.hpp
+++ b/src/elona/data/base_database.hpp
@@ -10,6 +10,7 @@
 #include "../../util/map_value_iterator.hpp"
 #include "../../util/noncopyable.hpp"
 #include "../filesystem.hpp"
+#include "../i18n.hpp"
 #include "../log.hpp"
 #include "../lua_env/config_table.hpp"
 #include "../lua_env/data_table.hpp"
@@ -138,6 +139,34 @@ public:
         }
 
         return *data;
+    }
+
+
+
+    template <typename... Args>
+    std::string
+    get_text(const IdType& id, const I18NKey& property_name, Args&&... args)
+    {
+        return i18n::s.get_data_text(
+            PrototypeId{Traits::type_id},
+            id,
+            property_name,
+            std::forward<Args>(args)...);
+    }
+
+
+
+    template <typename... Args>
+    optional<std::string> get_text_optional(
+        const IdType& id,
+        const I18NKey& property_name,
+        Args&&... args)
+    {
+        return i18n::s.get_data_text_optional(
+            PrototypeId{Traits::type_id},
+            id,
+            property_name,
+            std::forward<Args>(args)...);
     }
 
 
@@ -274,6 +303,40 @@ public:
         }
 
         return this->ensure(*id);
+    }
+
+
+
+    using Super::get_text; // Don't hide overload super class has.
+
+    template <typename... Args>
+    std::string
+    get_text(int legacy_id, const I18NKey& property_name, Args&&... args)
+    {
+        const auto id = *get_id_from_legacy(legacy_id);
+        return i18n::s.get_data_text(
+            PrototypeId{Traits::type_id},
+            id,
+            property_name,
+            std::forward<Args>(args)...);
+    }
+
+
+
+    using Super::get_text_optional; // Don't hide overload super class has.
+
+    template <typename... Args>
+    optional<std::string> get_text_optional(
+        int legacy_id,
+        const I18NKey& property_name,
+        Args&&... args)
+    {
+        const auto id = *get_id_from_legacy(legacy_id);
+        return i18n::s.get_data_text_optional(
+            PrototypeId{Traits::type_id},
+            id,
+            property_name,
+            std::forward<Args>(args)...);
     }
 
 

--- a/src/elona/dump_player_info.cpp
+++ b/src/elona/dump_player_info.cpp
@@ -5,6 +5,7 @@
 #include "calc.hpp"
 #include "character.hpp"
 #include "class.hpp"
+#include "data/types/type_race.hpp"
 #include "i18n.hpp"
 #include "item.hpp"
 #include "menu.hpp"
@@ -57,7 +58,8 @@ void dump_player_info()
     ss << std::endl;
 
     ss << fixtxt(
-              u8"種族       : " + i18n::s.get_m("race", cdatan(2, 0), "name"),
+              u8"種族       : " +
+                  the_race_db.get_text(data::InstanceId{cdatan(2, 0)}, "name"),
               30)
        << fixtxt(u8"信仰      : " + god_name(cdata.player().god_id), 32)
        << std::endl;
@@ -231,9 +233,10 @@ void dump_player_info()
         }
 
         ss << cdatan(0, ally.index) << u8" "
-           << i18n::s.get_m("race", cdatan(2, ally.index), "name") << u8"の"
-           << class_get_name(data::InstanceId{cdatan(3, ally.index)}) << u8" "
-           << i18n::s.get_enum("core.ui.sex", ally.sex) << u8" "
+           << the_race_db.get_text(
+                  data::InstanceId{cdatan(2, ally.index)}, "name")
+           << u8"の" << class_get_name(data::InstanceId{cdatan(3, ally.index)})
+           << u8" " << i18n::s.get_enum("core.ui.sex", ally.sex) << u8" "
            << calc_age(ally) << u8"歳" << u8"  " << ally.height << u8"cm"
            << u8" " << ally.weight << u8"kg" << std::endl;
         ss << u8"レベル " << ally.level;

--- a/src/elona/enchantment.cpp
+++ b/src/elona/enchantment.cpp
@@ -215,10 +215,7 @@ void get_enchantment_description(
             if (power / 50 + 1 < 0)
             {
                 rtval = static_cast<int>(ItemDescriptionType::negative_effect);
-                const auto skill_name = i18n::s.get_m(
-                    "ability",
-                    the_ability_db.get_id_from_legacy(sid)->get(),
-                    "name");
+                const auto skill_name = the_ability_db.get_text(sid, "name");
                 if (category == ItemCategory::food)
                 {
                     s = i18n::s.get(
@@ -236,10 +233,7 @@ void get_enchantment_description(
             }
             else
             {
-                const auto skill_name = i18n::s.get_m(
-                    "ability",
-                    the_ability_db.get_id_from_legacy(sid)->get(),
-                    "name");
+                const auto skill_name = the_ability_db.get_text(sid, "name");
                 if (category == ItemCategory::food)
                 {
                     s = i18n::s.get(
@@ -263,27 +257,18 @@ void get_enchantment_description(
                 rtval = static_cast<int>(ItemDescriptionType::negative_effect);
                 s = i18n::s.get(
                     "core.enchantment.with_parameters.resistance.decreases",
-                    i18n::s.get_m(
-                        "ability",
-                        the_ability_db.get_id_from_legacy(sid)->get(),
-                        "name"));
+                    the_ability_db.get_text(sid, "name"));
             }
             else
             {
-                s = i18n::s
-                        .get_m_optional(
-                            "ability",
-                            the_ability_db.get_id_from_legacy(sid)->get(),
-                            "enchantment_description")
+                s = the_ability_db
+                        .get_text_optional(sid, "enchantment_description")
                         .value_or("");
                 if (s == ""s)
                 {
                     s = i18n::s.get(
                         "core.enchantment.with_parameters.resistance.increases",
-                        i18n::s.get_m(
-                            "ability",
-                            the_ability_db.get_id_from_legacy(sid)->get(),
-                            "name"));
+                        the_ability_db.get_text(sid, "name"));
                 }
             }
             s += enchantment_level_string(power / 100);
@@ -295,27 +280,18 @@ void get_enchantment_description(
                 rtval = static_cast<int>(ItemDescriptionType::negative_effect);
                 s = i18n::s.get(
                     "core.enchantment.with_parameters.skill.decreases",
-                    i18n::s.get_m(
-                        "ability",
-                        the_ability_db.get_id_from_legacy(sid)->get(),
-                        "name"));
+                    the_ability_db.get_text(sid, "name"));
             }
             else
             {
-                s = i18n::s
-                        .get_m_optional(
-                            "ability",
-                            the_ability_db.get_id_from_legacy(sid)->get(),
-                            "enchantment_description")
+                s = the_ability_db
+                        .get_text_optional(sid, "enchantment_description")
                         .value_or("");
                 if (s == ""s)
                 {
                     s = i18n::s.get(
                         "core.enchantment.with_parameters.skill.increases",
-                        i18n::s.get_m(
-                            "ability",
-                            the_ability_db.get_id_from_legacy(sid)->get(),
-                            "name"));
+                        the_ability_db.get_text(sid, "name"));
                 }
             }
             s += enchantment_level_string((power / 50 + 1) / 5);
@@ -326,38 +302,25 @@ void get_enchantment_description(
             {
                 s = i18n::s.get(
                     "core.enchantment.with_parameters.skill_maintenance.in_food",
-                    i18n::s.get_m(
-                        "ability",
-                        the_ability_db.get_id_from_legacy(sid)->get(),
-                        "name"));
+                    the_ability_db.get_text(sid, "name"));
                 s += enchantment_level_string(power / 50);
             }
             else
             {
                 s = i18n::s.get(
                     "core.enchantment.with_parameters.skill_maintenance.other",
-                    i18n::s.get_m(
-                        "ability",
-                        the_ability_db.get_id_from_legacy(sid)->get(),
-                        "name"));
+                    the_ability_db.get_text(sid, "name"));
             }
             break;
         case 7:
             rtval = static_cast<int>(ItemDescriptionType::enchantment);
-            s = i18n::s
-                    .get_m_optional(
-                        "ability",
-                        the_ability_db.get_id_from_legacy(sid)->get(),
-                        "enchantment_description")
+            s = the_ability_db.get_text_optional(sid, "enchantment_description")
                     .value_or("");
             if (s == ""s)
             {
                 s = i18n::s.get(
                     "core.enchantment.with_parameters.extra_damage",
-                    i18n::s.get_m(
-                        "ability",
-                        the_ability_db.get_id_from_legacy(sid)->get(),
-                        "name"));
+                    the_ability_db.get_text(sid, "name"));
             }
             s += enchantment_level_string(power / 100);
             break;
@@ -366,10 +329,7 @@ void get_enchantment_description(
             sid = encprocref(0, sid);
             s = i18n::s.get(
                 "core.enchantment.with_parameters.invokes",
-                i18n::s.get_m(
-                    "ability",
-                    the_ability_db.get_id_from_legacy(sid)->get(),
-                    "name"));
+                the_ability_db.get_text(sid, "name"));
             s += enchantment_level_string(power / 50);
             break;
         case 9:

--- a/src/elona/food.cpp
+++ b/src/elona/food.cpp
@@ -1386,20 +1386,14 @@ void apply_general_eating_effect(Character& eater, Item& food)
                         txt(i18n::s.get(
                             "core.food.effect.ability.develops",
                             eater,
-                            i18n::s.get_m(
-                                "ability",
-                                the_ability_db.get_id_from_legacy(enc)->get(),
-                                "name")));
+                            the_ability_db.get_text(enc, "name")));
                     }
                     else
                     {
                         txt(i18n::s.get(
                             "core.food.effect.ability.deteriorates",
                             eater,
-                            i18n::s.get_m(
-                                "ability",
-                                the_ability_db.get_id_from_legacy(enc)->get(),
-                                "name")));
+                            the_ability_db.get_text(enc, "name")));
                     }
                 }
                 chara_gain_skill_exp(

--- a/src/elona/get_card_info.cpp
+++ b/src/elona/get_card_info.cpp
@@ -17,7 +17,7 @@ int get_card_info(int card_id, CardInfo& card_info)
     }
     else if (const auto chara_id = the_character_db.get_id_from_legacy(card_id))
     {
-        card_name = i18n::s.get_m("chara", chara_id->get(), "name");
+        card_name = the_character_db.get_text(*chara_id, "name");
     }
     else
     {

--- a/src/elona/god.cpp
+++ b/src/elona/god.cpp
@@ -34,43 +34,59 @@ void txtgod(const GodId& id, int type)
     switch (type)
     {
     case 12:
-        message = i18n::s.get_m_optional("god", id, "random").value_or("");
+        message = the_god_db.get_text_optional(data::InstanceId{id}, "random")
+                      .value_or("");
         break;
     case 9:
-        message = i18n::s.get_m_optional("god", id, "kill").value_or("");
+        message = the_god_db.get_text_optional(data::InstanceId{id}, "kill")
+                      .value_or("");
         break;
     case 10:
-        message = i18n::s.get_m_optional("god", id, "night").value_or("");
+        message = the_god_db.get_text_optional(data::InstanceId{id}, "night")
+                      .value_or("");
         break;
     case 11:
-        message = i18n::s.get_m_optional("god", id, "welcome").value_or("");
+        message = the_god_db.get_text_optional(data::InstanceId{id}, "welcome")
+                      .value_or("");
         break;
     case 5:
-        message = i18n::s.get_m_optional("god", id, "believe").value_or("");
+        message = the_god_db.get_text_optional(data::InstanceId{id}, "believe")
+                      .value_or("");
         break;
     case 1:
-        message = i18n::s.get_m_optional("god", id, "betray").value_or("");
+        message = the_god_db.get_text_optional(data::InstanceId{id}, "betray")
+                      .value_or("");
         break;
     case 2:
-        message = i18n::s.get_m_optional("god", id, "take_over").value_or("");
+        message =
+            the_god_db.get_text_optional(data::InstanceId{id}, "take_over")
+                .value_or("");
         break;
     case 3:
         message =
-            i18n::s.get_m_optional("god", id, "fail_to_take_over").value_or("");
+            the_god_db
+                .get_text_optional(data::InstanceId{id}, "fail_to_take_over")
+                .value_or("");
         break;
     case 4:
-        message = i18n::s.get_m_optional("god", id, "offer").value_or("");
+        message = the_god_db.get_text_optional(data::InstanceId{id}, "offer")
+                      .value_or("");
         break;
     case 6:
         message =
-            i18n::s.get_m_optional("god", id, "receive_gift").value_or("");
+            the_god_db.get_text_optional(data::InstanceId{id}, "receive_gift")
+                .value_or("");
         break;
     case 7:
-        message = i18n::s.get_m_optional("god", id, "ready_to_receive_gift")
+        message = the_god_db
+                      .get_text_optional(
+                          data::InstanceId{id}, "ready_to_receive_gift")
                       .value_or("");
         break;
     case 8:
-        message = i18n::s.get_m_optional("god", id, "ready_to_receive_gift2")
+        message = the_god_db
+                      .get_text_optional(
+                          data::InstanceId{id}, "ready_to_receive_gift2")
                       .value_or("");
         break;
     default: assert(0);
@@ -656,11 +672,11 @@ std::string god_name(const GodId& id)
 {
     if (id == core_god::eyth)
     {
-        return i18n::s.get_m("god", "core.eyth", "name");
+        return the_god_db.get_text("core.eyth", "name");
     }
     else
     {
-        return i18n::s.get_m("god", id, "name");
+        return the_god_db.get_text(data::InstanceId{id}, "name");
     }
 }
 

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -720,18 +720,10 @@ void itemname_additional_info(Item& item)
         if (item.id == ItemId::textbook)
         {
             s_ += lang(
-                u8"《"s +
-                    i18n::s.get_m(
-                        "ability",
-                        the_ability_db.get_id_from_legacy(item.param1)->get(),
-                        "name") +
+                u8"《"s + the_ability_db.get_text(item.param1, "name") +
                     u8"》という題名の"s,
                 u8" titled <Art of "s +
-                    i18n::s.get_m(
-                        "ability",
-                        the_ability_db.get_id_from_legacy(item.param1)->get(),
-                        "name") +
-                    u8">"s);
+                    the_ability_db.get_text(item.param1, "name") + u8">"s);
         }
         else if (item.id == ItemId::book_of_rachel)
         {
@@ -766,11 +758,7 @@ void itemname_additional_info(Item& item)
                     s_ = s_ +
                         foodname(
                              item.param1 / 1000,
-                             i18n::s.get_m(
-                                 "fish",
-                                 the_fish_db.get_id_from_legacy(item.subname)
-                                     ->get(),
-                                 "name"),
+                             the_fish_db.get_text(item.subname, "name"),
                              item.param2,
                              item.subname);
                 }
@@ -802,10 +790,7 @@ void itemname_additional_info(Item& item)
                 s_ += u8"/bugged/"s;
                 return;
             }
-            s_ += i18n::s.get_m(
-                "fish",
-                the_fish_db.get_id_from_legacy(item.subname)->get(),
-                "name");
+            s_ += the_fish_db.get_text(item.subname, "name");
         }
         else if (
             category == ItemCategory::food ||
@@ -1130,11 +1115,7 @@ std::string itemname(Item& item, int number, bool with_article)
     }
     if (item.id == ItemId::material_kit)
     {
-        s_ += ""s +
-            i18n::s.get_m(
-                "item_material",
-                the_item_material_db.get_id_from_legacy(item.material)->get(),
-                "name") +
+        s_ += ""s + the_item_material_db.get_text(item.material, "name") +
             lang(u8"製の"s, u8" "s);
     }
     if (jp)
@@ -1145,22 +1126,12 @@ std::string itemname(Item& item, int number, bool with_article)
     {
         if (jp)
         {
-            s_ += ""s +
-                i18n::s.get_m(
-                    "item_material",
-                    the_item_material_db.get_id_from_legacy(item.material)
-                        ->get(),
-                    "name") +
+            s_ += ""s + the_item_material_db.get_text(item.material, "name") +
                 u8"細工の"s;
         }
         else
         {
-            s_ += ""s +
-                i18n::s.get_m(
-                    "item_material",
-                    the_item_material_db.get_id_from_legacy(item.material)
-                        ->get(),
-                    "name") +
+            s_ += ""s + the_item_material_db.get_text(item.material, "name") +
                 u8"work "s;
         }
     }
@@ -1203,22 +1174,14 @@ std::string itemname(Item& item, int number, bool with_article)
                 {
                     if (item.quality >= Quality::miracle)
                     {
-                        s_ += i18n::s.get_m(
-                                  "item_material",
-                                  the_item_material_db
-                                      .get_id_from_legacy(item.material)
-                                      ->get(),
-                                  "alias") +
+                        s_ += the_item_material_db.get_text(
+                                  item.material, "alias") +
                             i18n::space_if_needed();
                     }
                     else
                     {
-                        s_ += i18n::s.get_m(
-                                  "item_material",
-                                  the_item_material_db
-                                      .get_id_from_legacy(item.material)
-                                      ->get(),
-                                  "name") +
+                        s_ += the_item_material_db.get_text(
+                                  item.material, "name") +
                             i18n::space_if_needed();
                         if (jp)
                         {
@@ -1472,21 +1435,12 @@ std::string itemname(Item& item, int number, bool with_article)
         if (jp)
         {
             s_ += u8"["s +
-                i18n::s.get_m(
-                    "item_material",
-                    the_item_material_db.get_id_from_legacy(item.material)
-                        ->get(),
-                    "name") +
-                u8"製]"s;
+                the_item_material_db.get_text(item.material, "name") + u8"製]"s;
         }
         else
         {
             s_ += u8"["s +
-                cnven(i18n::s.get_m(
-                    "item_material",
-                    the_item_material_db.get_id_from_legacy(item.material)
-                        ->get(),
-                    "name")) +
+                cnven(the_item_material_db.get_text(item.material, "name")) +
                 u8"]"s;
         }
         if (item.curse_state == CurseState::cursed)

--- a/src/elona/item_load_desc.cpp
+++ b/src/elona/item_load_desc.cpp
@@ -122,10 +122,7 @@ void _load_item_stat_text(const Item& item, int& num_of_desc)
         list(0, num_of_desc) = static_cast<int>(ItemDescriptionType::text);
         listn(0, num_of_desc) = i18n::s.get(
             "core.item.desc.it_is_made_of",
-            i18n::s.get_m(
-                "item_material",
-                the_item_material_db.get_id_from_legacy(item.material)->get(),
-                "name"));
+            the_item_material_db.get_text(item.material, "name"));
         ++num_of_desc;
     }
     if (item.material == 8)

--- a/src/elona/lua_env/i18n_manager.cpp
+++ b/src/elona/lua_env/i18n_manager.cpp
@@ -50,6 +50,7 @@ I18NManager::I18NManager(LuaEnv& lua)
     {
         const auto result = safe_script(R"(
 get_optional = I18N.get_optional
+get_data_text_optional = I18N.get_data_text_optional
 get_list = I18N.get_list
 i18n = I18N.interface
 format = I18N.format

--- a/src/elona/lua_env/i18n_manager.hpp
+++ b/src/elona/lua_env/i18n_manager.hpp
@@ -44,6 +44,17 @@ public:
         return env()["get_optional"](key, lua_args);
     }
 
+    template <typename... Args>
+    sol::optional<std::string> get_data_text_optional(
+        const std::string& key,
+        Args&&... args)
+    {
+        using swallow = std::initializer_list<int>;
+        auto lua_args = lua_state()->create_table();
+        (void)swallow{(add_arg(lua_args, std::forward<Args>(args)), 0)...};
+        return env()["get_data_text_optional"](key, lua_args);
+    }
+
     std::vector<std::string> get_list(const std::string& key)
     {
         sol::optional<std::vector<std::string>> ret = env()["get_list"](key);

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -1305,10 +1305,7 @@ bool _magic_1104(Character& target)
                     txt(s +
                             i18n::s.get(
                                 "core.magic.gain_knowledge.gain",
-                                i18n::s.get_m(
-                                    "ability",
-                                    the_ability_db.get_id_from_legacy(p)->get(),
-                                    "name")),
+                                the_ability_db.get_text(p, "name")),
                         Message::color{ColorIndex::green});
                     snd("core.ding2");
                     f = 1;
@@ -1324,11 +1321,7 @@ bool _magic_1104(Character& target)
                     txt(i18n::s.get("core.magic.common.it_is_cursed"));
                     txt(i18n::s.get(
                             "core.magic.gain_knowledge.lose",
-                            i18n::s.get_m(
-                                "ability",
-                                the_ability_db.get_id_from_legacy(p + 400)
-                                    ->get(),
-                                "name")),
+                            the_ability_db.get_text(p + 400, "name")),
                         Message::color{ColorIndex::red});
                     snd("core.curse3");
                     animeload(14, cdata.player());
@@ -1425,10 +1418,7 @@ bool _magic_1105(Character& target)
                     txt(i18n::s.get(
                             "core.magic.gain_skill",
                             target,
-                            i18n::s.get_m(
-                                "ability",
-                                the_ability_db.get_id_from_legacy(p)->get(),
-                                "name")),
+                            the_ability_db.get_text(p, "name")),
                         Message::color{ColorIndex::green});
                 }
                 break;
@@ -1538,11 +1528,7 @@ bool _magic_1119(Character& target)
                                 i18n::s.get(
                                     "core.magic.gain_skill_potential.increases",
                                     target,
-                                    i18n::s.get_m(
-                                        "ability",
-                                        the_ability_db.get_id_from_legacy(p)
-                                            ->get(),
-                                        "name")),
+                                    the_ability_db.get_text(p, "name")),
                             Message::color{ColorIndex::green});
                     }
                 }
@@ -1552,10 +1538,7 @@ bool _magic_1119(Character& target)
                     txt(i18n::s.get(
                             "core.magic.gain_skill_potential.decreases",
                             target,
-                            i18n::s.get_m(
-                                "ability",
-                                the_ability_db.get_id_from_legacy(p)->get(),
-                                "name")),
+                            the_ability_db.get_text(p, "name")),
                         Message::color{ColorIndex::red});
                 }
                 break;
@@ -1618,8 +1601,7 @@ bool _magic_1113(Character& target)
     else
     {
         i = rnd(8) + 10;
-        const auto valn = i18n::s.get_m(
-            "ability", the_ability_db.get_id_from_legacy(i)->get(), "name");
+        const auto valn = the_ability_db.get_text(i, "name");
         if (efstatus == CurseState::none)
         {
             txt(i18n::s.get(
@@ -4119,10 +4101,7 @@ optional<bool> _proc_general_magic(Character& subject, Character& target)
                     txt(i18n::s.get(
                         "core.magic.special_attack.self",
                         subject,
-                        i18n::s.get_m(
-                            "ability",
-                            the_ability_db.get_id_from_legacy(efid)->get(),
-                            "name"),
+                        the_ability_db.get_text(efid, "name"),
                         i18n::s.get_enum(
                             "core.ui.cast_style",
                             subject.special_attack_type)));
@@ -4516,10 +4495,7 @@ optional<bool> _proc_general_magic(Character& subject, Character& target)
         {
             valn = i18n::s.get(
                 "core.magic.breath.named",
-                i18n::s.get_m(
-                    "ability",
-                    the_ability_db.get_id_from_legacy(ele)->get(),
-                    "name"));
+                the_ability_db.get_text(ele, "name"));
         }
         else
         {

--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -562,12 +562,8 @@ std::string make_spell_description(int skill_id)
         }
         result += u8" "s;
     }
-    result += i18n::s
-                  .get_m_optional(
-                      "ability",
-                      the_ability_db.get_id_from_legacy(skill_id)->get(),
-                      "description")
-                  .value_or("");
+    result +=
+        the_ability_db.get_text_optional(skill_id, "description").value_or("");
 
     return result;
 }

--- a/src/elona/talk_house_visitor.cpp
+++ b/src/elona/talk_house_visitor.cpp
@@ -255,10 +255,7 @@ TalkResult _talk_hv_adventurer_train(Character& speaker)
     {
         buff = i18n::s.get(
             "core.talk.visitor.adventurer.train.learn.dialog",
-            i18n::s.get_m(
-                "ability",
-                the_ability_db.get_id_from_legacy(skill_id)->get(),
-                "name"),
+            the_ability_db.get_text(skill_id, "name"),
             std::to_string(
                 calclearncost(skill_id, cdata.player().index, true)) +
                 i18n::s.get("core.ui.platinum"),
@@ -276,10 +273,7 @@ TalkResult _talk_hv_adventurer_train(Character& speaker)
     {
         buff = i18n::s.get(
             "core.talk.visitor.adventurer.train.train.dialog",
-            i18n::s.get_m(
-                "ability",
-                the_ability_db.get_id_from_legacy(skill_id)->get(),
-                "name"),
+            the_ability_db.get_text(skill_id, "name"),
             std::to_string(
                 calclearncost(skill_id, cdata.player().index, true)) +
                 i18n::s.get("core.ui.platinum"),
@@ -501,10 +495,7 @@ TalkResult _talk_hv_adventurer_favorite_skill(Character& speaker)
     listmax = 0;
     buff = i18n::s.get(
         "core.talk.visitor.adventurer.favorite_skill.dialog",
-        i18n::s.get_m(
-            "ability",
-            the_ability_db.get_id_from_legacy(skill_id)->get(),
-            "name"),
+        the_ability_db.get_text(skill_id, "name"),
         speaker);
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
@@ -529,10 +520,7 @@ TalkResult _talk_hv_adventurer_favorite_stat(Character& speaker)
     listmax = 0;
     buff = i18n::s.get(
         "core.talk.visitor.adventurer.favorite_stat.dialog",
-        i18n::s.get_m(
-            "ability",
-            the_ability_db.get_id_from_legacy(skill_id)->get(),
-            "name"),
+        the_ability_db.get_text(skill_id, "name"),
         speaker);
     list(0, listmax) = 0;
     listn(0, listmax) = i18n::s.get("core.ui.more");
@@ -730,10 +718,7 @@ void _trainer_do_training(int plat, int chatval_)
     txt(i18n::s.get(
             "core.talk.visitor.trainer.potential_expands",
             cdata.player(),
-            i18n::s.get_m(
-                "ability",
-                the_ability_db.get_id_from_legacy(chatval_)->get(),
-                "name")),
+            the_ability_db.get_text(chatval_, "name")),
         Message::color{ColorIndex::green});
     modify_potential(cdata.player(), chatval_, 10);
 }
@@ -782,10 +767,7 @@ TalkResult _talk_hv_trainer(Character& speaker)
             list(0, listmax) = p(cnt);
             listn(0, listmax) = i18n::s.get(
                 "core.talk.visitor.trainer.choices.improve",
-                i18n::s.get_m(
-                    "ability",
-                    the_ability_db.get_id_from_legacy(p(cnt))->get(),
-                    "name"));
+                the_ability_db.get_text(p(cnt), "name"));
             ++listmax;
         }
     }

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -1477,10 +1477,7 @@ TalkResult talk_trainer(Character& speaker, bool is_training)
     {
         buff = i18n::s.get(
             "core.talk.npc.trainer.cost.training",
-            i18n::s.get_m(
-                "ability",
-                the_ability_db.get_id_from_legacy(selected_skill)->get(),
-                "name"),
+            the_ability_db.get_text(selected_skill, "name"),
             calctraincost(selected_skill, cdata.player().index),
             speaker);
         if (cdata.player().platinum_coin >=
@@ -1496,10 +1493,7 @@ TalkResult talk_trainer(Character& speaker, bool is_training)
     {
         buff = i18n::s.get(
             "core.talk.npc.trainer.cost.learning",
-            i18n::s.get_m(
-                "ability",
-                the_ability_db.get_id_from_legacy(selected_skill)->get(),
-                "name"),
+            the_ability_db.get_text(selected_skill, "name"),
             calclearncost(selected_skill, cdata.player().index),
             speaker);
         if (cdata.player().platinum_coin >=

--- a/src/elona/text.cpp
+++ b/src/elona/text.cpp
@@ -464,20 +464,14 @@ std::string txtskillchange(const Character& chara, int id, bool increase)
             return i18n::s.get(
                 "core.skill.default.increase",
                 chara,
-                i18n::s.get_m(
-                    "ability",
-                    the_ability_db.get_id_from_legacy(id)->get(),
-                    "name"));
+                the_ability_db.get_text(id, "name"));
         }
         else
         {
             return i18n::s.get(
                 "core.skill.default.decrease",
                 chara,
-                i18n::s.get_m(
-                    "ability",
-                    the_ability_db.get_id_from_legacy(id)->get(),
-                    "name"));
+                the_ability_db.get_text(id, "name"));
         }
     }
 }
@@ -2623,21 +2617,13 @@ void cnvbonus(int ability_id, int bonus)
     {
         if (bonus > 0)
         {
-            buff += u8"　　"s +
-                i18n::s.get_m(
-                    "ability",
-                    the_ability_db.get_id_from_legacy(ability_id)->get(),
-                    "name") +
+            buff += u8"　　"s + the_ability_db.get_text(ability_id, "name") +
                 u8"耐性に <green>クラス"s + bonus / 50 + u8"<col>("s + bonus +
                 u8") のボーナス\n"s;
         }
         if (bonus < 0)
         {
-            buff += u8"　　"s +
-                i18n::s.get_m(
-                    "ability",
-                    the_ability_db.get_id_from_legacy(ability_id)->get(),
-                    "name") +
+            buff += u8"　　"s + the_ability_db.get_text(ability_id, "name") +
                 u8"耐性に <red>クラス"s + bonus / 50 + u8"<col>("s + bonus +
                 u8") のマイナス修正\n"s;
         }
@@ -2646,20 +2632,12 @@ void cnvbonus(int ability_id, int bonus)
     {
         if (bonus > 0)
         {
-            buff += u8"　　"s +
-                i18n::s.get_m(
-                    "ability",
-                    the_ability_db.get_id_from_legacy(ability_id)->get(),
-                    "name") +
+            buff += u8"　　"s + the_ability_db.get_text(ability_id, "name") +
                 u8"に <green>+"s + bonus + u8"<col> のボーナス\n"s;
         }
         if (bonus < 0)
         {
-            buff += u8"　　"s +
-                i18n::s.get_m(
-                    "ability",
-                    the_ability_db.get_id_from_legacy(ability_id)->get(),
-                    "name") +
+            buff += u8"　　"s + the_ability_db.get_text(ability_id, "name") +
                 u8"に <red>"s + bonus + u8"<col> のマイナス修正\n"s;
         }
     }

--- a/src/elona/ui.cpp
+++ b/src/elona/ui.cpp
@@ -680,12 +680,7 @@ void render_skill_trackers()
             continue;
         }
         bmes(
-            strutil::take_by_width(
-                i18n::s.get_m(
-                    "ability",
-                    the_ability_db.get_id_from_legacy(skill)->get(),
-                    "name"),
-                6),
+            strutil::take_by_width(the_ability_db.get_text(skill, "name"), 6),
             16,
             inf_clocky + 107 + y * 16);
         bmes(

--- a/src/elona/ui/ui_menu_character_sheet.cpp
+++ b/src/elona/ui/ui_menu_character_sheet.cpp
@@ -9,6 +9,7 @@
 #include "../class.hpp"
 #include "../data/types/type_asset.hpp"
 #include "../data/types/type_buff.hpp"
+#include "../data/types/type_race.hpp"
 #include "../draw.hpp"
 #include "../enchantment.hpp"
 #include "../keybind/keybind.hpp"
@@ -471,7 +472,8 @@ void UIMenuCharacterSheet::_draw_first_page_text_name()
 {
     s(0) = cdatan(0, _chara.index);
     s(1) = cdatan(1, _chara.index);
-    s(2) = cnven(i18n::s.get_m("race", cdatan(2, _chara.index), "name"));
+    s(2) = cnven(the_race_db.get_text(
+        data::InstanceId{cdatan(2, _chara.index)}, "name"));
     s(4) = cnven(class_get_name(data::InstanceId{cdatan(3, _chara.index)}));
     if (_chara.sex == 0)
     {
@@ -831,8 +833,7 @@ static bool _is_resistance(int skill)
 
 void UIMenuCharacterSheet::_draw_skill_name(int cnt, int skill_id)
 {
-    std::string skill_name = i18n::s.get_m(
-        "ability", the_ability_db.get_id_from_legacy(skill_id)->get(), "name");
+    std::string skill_name = the_ability_db.get_text(skill_id, "name");
 
     if (_is_resistance(skill_id))
     {
@@ -885,12 +886,7 @@ void UIMenuCharacterSheet::_draw_skill_desc(int cnt, int skill_id)
 {
     mes(wx + 330,
         wy + 66 + cnt * 19 + 2,
-        i18n::s
-            .get_m_optional(
-                "ability",
-                the_ability_db.get_id_from_legacy(skill_id)->get(),
-                "description")
-            .value_or(""));
+        the_ability_db.get_text_optional(skill_id, "description").value_or(""));
 }
 
 void UIMenuCharacterSheet::_draw_skill_train_cost(

--- a/src/elona/ui/ui_menu_charamake_attributes.cpp
+++ b/src/elona/ui/ui_menu_charamake_attributes.cpp
@@ -58,8 +58,7 @@ static void _load_attributes_list(elona_vector1<int>& _attributes)
     for (int cnt = 10; cnt < 18; ++cnt)
     {
         list(0, listmax) = _attributes(cnt - 10);
-        listn(0, listmax) = i18n::s.get_m(
-            "ability", the_ability_db.get_id_from_legacy(cnt)->get(), "name");
+        listn(0, listmax) = the_ability_db.get_text(cnt, "name");
         ++listmax;
     }
 }

--- a/src/elona/ui/ui_menu_charamake_class.cpp
+++ b/src/elona/ui/ui_menu_charamake_class.cpp
@@ -3,6 +3,7 @@
 #include "../audio.hpp"
 #include "../character_making.hpp"
 #include "../class.hpp"
+#include "../data/types/type_race.hpp"
 #include "../draw.hpp"
 #include "../i18n.hpp"
 #include "../menu.hpp"
@@ -56,7 +57,7 @@ void UIMenuCharamakeClass::update()
 }
 
 static void _draw_class_info(
-    const std::string& class_id,
+    data::InstanceId class_id,
     int chip_male,
     int chip_female,
     const std::string& race)
@@ -89,7 +90,7 @@ static void _draw_class_info(
             race);
 
     draw_race_or_class_info(
-        i18n::s.get_m_optional("class", class_id, "description").value_or(""));
+        the_class_db.get_text_optional(class_id, "description").value_or(""));
 }
 
 void UIMenuCharamakeClass::_draw_window()
@@ -159,15 +160,15 @@ void UIMenuCharamakeClass::draw()
     _draw_window();
     _draw_choices();
 
-    const std::string& selected_class = listn(1, cs);
-    _reload_selected_class(data::InstanceId{selected_class});
+    const auto selected_class = data::InstanceId{listn(1, cs)};
+    _reload_selected_class(selected_class);
 
     const auto& race_data = the_race_db.ensure(_race_id);
     _draw_class_info(
         selected_class,
         race_data.male_image,
         race_data.female_image,
-        i18n::s.get_m("race", _race_id.get(), "name"));
+        the_race_db.get_text(_race_id, "name"));
 }
 
 optional<UIMenuCharamakeClass::ResultType> UIMenuCharamakeClass::on_key(

--- a/src/elona/ui/ui_menu_charamake_race.cpp
+++ b/src/elona/ui/ui_menu_charamake_race.cpp
@@ -32,7 +32,8 @@ static void _load_race_list()
     }
     for (int cnt = 0, cnt_end = (listmax); cnt < cnt_end; ++cnt)
     {
-        listn(0, cnt) = i18n::s.get_m("race", listn(1, cnt), "name");
+        listn(0, cnt) =
+            the_race_db.get_text(data::InstanceId{listn(1, cnt)}, "name");
         if (list(0, cnt) == 1)
         {
             listn(0, cnt) = u8"(extra)"s + listn(0, cnt);
@@ -87,8 +88,7 @@ void UIMenuCharamakeRace::_draw_race_info(data::InstanceId race_id)
 
     gmode(2);
     draw_race_or_class_info(
-        i18n::s.get_m_optional("race", race_id.get(), "description")
-            .value_or(""));
+        the_race_db.get_text_optional(race_id, "description").value_or(""));
 }
 
 

--- a/src/elona/ui/ui_menu_ctrl_ally.cpp
+++ b/src/elona/ui/ui_menu_ctrl_ally.cpp
@@ -401,18 +401,11 @@ std::string UIMenuCtrlAlly::_modify_ally_info_gene_engineer(
             }
             else
             {
-                ally_info += ""s +
-                    i18n::s.get_m(
-                        "ability",
-                        the_ability_db.get_id_from_legacy(rtval)->get(),
-                        "name");
+                ally_info += ""s + the_ability_db.get_text(rtval, "name");
                 if (rtval(1) != -1)
                 {
-                    ally_info += u8", "s +
-                        i18n::s.get_m(
-                            "ability",
-                            the_ability_db.get_id_from_legacy(rtval(1))->get(),
-                            "name");
+                    ally_info +=
+                        u8", "s + the_ability_db.get_text(rtval(1), "name");
                 }
             }
         }

--- a/src/elona/ui/ui_menu_skills.cpp
+++ b/src/elona/ui/ui_menu_skills.cpp
@@ -142,11 +142,7 @@ void UIMenuSkills::_draw_skill_name(int cnt, int skill_id)
     }
     cs_list(
         cs == cnt,
-        i18n::s.get_m(
-            "ability",
-            the_ability_db.get_id_from_legacy(skill_id)->get(),
-            "name") +
-            skill_shortcut,
+        the_ability_db.get_text(skill_id, "name") + skill_shortcut,
         wx + 84,
         wy + 66 + cnt * 19 - 1);
 }

--- a/src/elona/ui/ui_menu_spells.cpp
+++ b/src/elona/ui/ui_menu_spells.cpp
@@ -136,11 +136,7 @@ void UIMenuSpells::_draw_spell_name(int cnt, int spell_id)
     }
     cs_list(
         cs == cnt,
-        i18n::s.get_m(
-            "ability",
-            the_ability_db.get_id_from_legacy(spell_id)->get(),
-            "name") +
-            spell_shortcut,
+        the_ability_db.get_text(spell_id, "name") + spell_shortcut,
         wx + 84,
         wy + 66 + cnt * 19 - 1);
 }

--- a/src/elona/wish.cpp
+++ b/src/elona/wish.cpp
@@ -697,8 +697,7 @@ bool wish_for_skill(const std::string& input)
             continue;
         }
 
-        auto name = i18n::s.get_m(
-            "ability", the_ability_db.get_id_from_legacy(id)->get(), "name");
+        auto name = the_ability_db.get_text(id, "name");
         int similarity = 0;
         if (name == wish)
         {
@@ -727,8 +726,7 @@ bool wish_for_skill(const std::string& input)
     if (!selector.empty())
     {
         const auto id = selector.get_force();
-        const auto name = i18n::s.get_m(
-            "ability", the_ability_db.get_id_from_legacy(id)->get(), "name");
+        const auto name = the_ability_db.get_text(id, "name");
         if (!name.empty())
         {
             if (sdata.get(id, 0).original_level == 0)


### PR DESCRIPTION
# Related issues

Close #1615 

# Summary

Now that localized text associated with data instances can be retrieved through `i18n::s.get_data_text()`. It totally substitutes `i18n::s.get_m()` and its variants.

In addition, the way to define such text were changed. Use `ELONA.i18n:add_data_text()` instead of `ELONA.i18n:add()`.
