### PR TITLE
Remove 'toggle_console' action

### DIFF
--- a/runtime/mod/core/locale/en/keybindings.lua
+++ b/runtime/mod/core/locale/en/keybindings.lua
@@ -105,7 +105,6 @@ Enter to unbind, Escape to cancel.
       dump_player_info = "Dump Player Info",
       reload_autopick = "Reload Autopick",
       screenshot = "Take Screenshot",
-      toggle_console = "Toggle Console",
       open_console = "Open Console",
 
       wizard_mewmewmew = "Mewmewmew!",

--- a/runtime/mod/core/locale/jp/keybindings.lua
+++ b/runtime/mod/core/locale/jp/keybindings.lua
@@ -105,7 +105,6 @@ ELONA.i18n:add {
       dump_player_info = "プレイヤー情報出力",
       reload_autopick = "Autopickの再読み込み",
       screenshot = "スクリーンショット",
-      toggle_console = "コンソールを切り替える",
       open_console = "コンソールを開く",
 
       wizard_mewmewmew = "うみみゃぁ！",

--- a/src/elona/keybind/keybind_actions.cpp
+++ b/src/elona/keybind/keybind_actions.cpp
@@ -158,8 +158,7 @@ void initialize_keybind_actions(ActionMap& actions)
     BIND(dump_player_info,  K(f11)         );
     BIND(reload_autopick,   SHIFT_K(backspace) );
     BIND(screenshot,        K(printscreen) );
-    BIND(toggle_console,    K(f12)         );
-    BIND(open_console,      SHIFT_K(f12)   );
+    BIND(open_console,      K(f12)         );
 
 #undef CATEGORY
 #define CATEGORY wizard

--- a/src/elona/lua_env/console.cpp
+++ b/src/elona/lua_env/console.cpp
@@ -144,13 +144,7 @@ void Console::grab_input()
 {
     using namespace snail;
 
-    bool reenable = false;
-
-    if (!_enabled)
-    {
-        _enabled = true;
-        reenable = true;
-    }
+    _enabled = true;
 
     _input = "";
     mesbox(_input, true);
@@ -224,10 +218,7 @@ void Console::grab_input()
 
     onkey_0();
 
-    if (reenable)
-    {
-        _enabled = false;
-    }
+    _enabled = false;
 }
 
 

--- a/src/elona/lua_env/console.hpp
+++ b/src/elona/lua_env/console.hpp
@@ -41,11 +41,6 @@ public:
     void init_constants();
     void init_environment();
 
-    void toggle()
-    {
-        _enabled = !_enabled;
-    }
-
     void draw();
     void print(const std::string&);
     void grab_input();

--- a/src/elona/turn_sequence_pc_actions.cpp
+++ b/src/elona/turn_sequence_pc_actions.cpp
@@ -838,11 +838,6 @@ optional<TurnResult> handle_pc_action(std::string& action)
         lua::lua->get_console().grab_input();
         return none;
     }
-    if (action == "toggle_console")
-    {
-        lua::lua->get_console().toggle();
-        return none;
-    }
     if (action != ""s && action != "cancel" /* && key != key_alter */)
     {
         txt(i18n::s.get("core.action.hit_key_for_help"),


### PR DESCRIPTION
# Summary

Remove 'toggle_console' action, which shows or hides the in-game console window. The action was bound to F12 key, but the key now triggers 'open_console' action. Toggle Console feature was less frequently used and confused users (#1625).
