### PR TITLE
Run clang-format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,10 +8,6 @@ jobs:
       - checkout
 
       - run:
-          name: clang-format
-          command: make format
-
-      - run:
           name: doc
           command: |
             source ~/.cargo/env && make docgen

--- a/src/elona/autopick.cpp
+++ b/src/elona/autopick.cpp
@@ -231,9 +231,10 @@ void Autopick::load(const std::string& player_id)
     _clear();
 
     // Priority: save/xxx/autopick > save/autopick > /autopick
-    for (const auto directory : {filesystem::dirs::save(player_id),
-                                 filesystem::dirs::save(),
-                                 filesystem::dirs::exe()})
+    for (const auto directory :
+         {filesystem::dirs::save(player_id),
+          filesystem::dirs::save(),
+          filesystem::dirs::exe()})
     {
         for (const auto filename :
              {u8"autopick", u8"autopick.txt", u8"autopick.txt.txt"})

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -113,95 +113,110 @@ calc_skill_damage(const Character& chara, int skill, int power)
         return SkillDamage{
             1 + x / 20, chara.piety_point / 140 + 1 + 1, 0, 0, 0};
     case 414:
-        return SkillDamage{power / 125 + 2 + x / 50,
-                           power / 60 + 9 + 1,
-                           0,
-                           60,
-                           100 + power / 4};
+        return SkillDamage{
+            power / 125 + 2 + x / 50,
+            power / 60 + 9 + 1,
+            0,
+            60,
+            100 + power / 4};
     case 459:
-        return SkillDamage{power / 100 + 3 + x / 25,
-                           power / 40 + 12 + 1,
-                           0,
-                           60,
-                           100 + power / 4};
+        return SkillDamage{
+            power / 100 + 3 + x / 25,
+            power / 40 + 12 + 1,
+            0,
+            60,
+            100 + power / 4};
     case 418:
-        return SkillDamage{power / 80 + 1 + x / 18,
-                           power / 25 + 8 + 1,
-                           0,
-                           53,
-                           200 + power / 3};
+        return SkillDamage{
+            power / 80 + 1 + x / 18,
+            power / 25 + 8 + 1,
+            0,
+            53,
+            200 + power / 3};
     case 415:
-        return SkillDamage{power / 70 + 1 + x / 18,
-                           power / 25 + 8 + 1,
-                           0,
-                           56,
-                           200 + power / 3};
+        return SkillDamage{
+            power / 70 + 1 + x / 18,
+            power / 25 + 8 + 1,
+            0,
+            56,
+            200 + power / 3};
     case 417:
-        return SkillDamage{power / 70 + 1 + x / 18,
-                           power / 25 + 8 + 1,
-                           0,
-                           59,
-                           200 + power / 3};
+        return SkillDamage{
+            power / 70 + 1 + x / 18,
+            power / 25 + 8 + 1,
+            0,
+            59,
+            200 + power / 3};
     case 416:
-        return SkillDamage{power / 70 + 1 + x / 18,
-                           power / 25 + 8 + 1,
-                           0,
-                           58,
-                           200 + power / 3};
+        return SkillDamage{
+            power / 70 + 1 + x / 18,
+            power / 25 + 8 + 1,
+            0,
+            58,
+            200 + power / 3};
     case 419:
-        return SkillDamage{power / 50 + 1 + x / 20,
-                           power / 26 + 4 + 1,
-                           0,
-                           51,
-                           180 + power / 4};
+        return SkillDamage{
+            power / 50 + 1 + x / 20,
+            power / 26 + 4 + 1,
+            0,
+            51,
+            180 + power / 4};
     case 420:
-        return SkillDamage{power / 50 + 1 + x / 20,
-                           power / 26 + 4 + 1,
-                           0,
-                           50,
-                           180 + power / 4};
+        return SkillDamage{
+            power / 50 + 1 + x / 20,
+            power / 26 + 4 + 1,
+            0,
+            50,
+            180 + power / 4};
     case 421:
-        return SkillDamage{power / 50 + 1 + x / 20,
-                           power / 26 + 4 + 1,
-                           0,
-                           52,
-                           180 + power / 4};
+        return SkillDamage{
+            power / 50 + 1 + x / 20,
+            power / 26 + 4 + 1,
+            0,
+            52,
+            180 + power / 4};
     case 422:
-        return SkillDamage{power / 50 + 1 + x / 20,
-                           power / 25 + 4 + 1,
-                           0,
-                           53,
-                           180 + power / 4};
+        return SkillDamage{
+            power / 50 + 1 + x / 20,
+            power / 25 + 4 + 1,
+            0,
+            53,
+            180 + power / 4};
     case 423:
-        return SkillDamage{power / 50 + 1 + x / 20,
-                           power / 25 + 4 + 1,
-                           0,
-                           54,
-                           180 + power / 4};
+        return SkillDamage{
+            power / 50 + 1 + x / 20,
+            power / 25 + 4 + 1,
+            0,
+            54,
+            180 + power / 4};
     case 431:
-        return SkillDamage{power / 100 + 1 + x / 20,
-                           power / 15 + 2 + 1,
-                           0,
-                           51,
-                           150 + power / 5};
+        return SkillDamage{
+            power / 100 + 1 + x / 20,
+            power / 15 + 2 + 1,
+            0,
+            51,
+            150 + power / 5};
     case 432:
-        return SkillDamage{power / 100 + 1 + x / 20,
-                           power / 15 + 2 + 1,
-                           0,
-                           50,
-                           150 + power / 5};
+        return SkillDamage{
+            power / 100 + 1 + x / 20,
+            power / 15 + 2 + 1,
+            0,
+            50,
+            150 + power / 5};
     case 433:
-        return SkillDamage{power / 80 + 1 + x / 20,
-                           power / 12 + 2 + 1,
-                           0,
-                           59,
-                           150 + power / 5};
+        return SkillDamage{
+            power / 80 + 1 + x / 20,
+            power / 12 + 2 + 1,
+            0,
+            59,
+            150 + power / 5};
     case 434:
-        return SkillDamage{power / 80 + 1 + x / 20,
-                           power / 12 + 2 + 1,
-                           0,
-                           57,
-                           150 + power / 5};
+        return SkillDamage{
+            power / 80 + 1 + x / 20,
+            power / 12 + 2 + 1,
+            0,
+            57,
+            150 + power / 5};
     case 460:
         return SkillDamage{
             power / 100 + 1 + x / 25, power / 18 + 2 + 1, 0, 60, 100};

--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -217,8 +217,8 @@ bool is_in_map(const Position& position)
 
 Position get_random_position(const Position& base_position, int n)
 {
-    return {base_position.x - rnd(n) + rnd(n),
-            base_position.y - rnd(n) + rnd(n)};
+    return {
+        base_position.x - rnd(n) + rnd(n), base_position.y - rnd(n) + rnd(n)};
 }
 
 

--- a/src/elona/data/base_database.hpp
+++ b/src/elona/data/base_database.hpp
@@ -134,8 +134,9 @@ public:
 
         if (!data)
         {
-            throw sol::error{"No data entry with ID \"" + id.get() +
-                             "\" of type \"" + Traits::type_id + "\" exists."};
+            throw sol::error{
+                "No data entry with ID \"" + id.get() + "\" of type \"" +
+                Traits::type_id + "\" exists."};
         }
 
         return *data;
@@ -297,9 +298,9 @@ public:
 
         if (!id)
         {
-            throw sol::error{"No data entry with legacy ID \"" +
-                             std::to_string(legacy_id) + "\" of type \"" +
-                             Traits::type_id + "\" exists."};
+            throw sol::error{
+                "No data entry with legacy ID \"" + std::to_string(legacy_id) +
+                "\" of type \"" + Traits::type_id + "\" exists."};
         }
 
         return this->ensure(*id);

--- a/src/elona/data/types/type_map.cpp
+++ b/src/elona/data/types/type_map.cpp
@@ -49,8 +49,8 @@ MapDefData MapDefDB::convert(
     DATA_OPT_FUNC(generator);
     DATA_OPT_FUNC(chara_filter);
 
-    Position outer_map_position_{outer_map_position.get<int>("x"),
-                                 outer_map_position.get<int>("y")};
+    Position outer_map_position_{
+        outer_map_position.get<int>("x"), outer_map_position.get<int>("y")};
 
     optional<data::InstanceId> deed_ = none;
     if (deed)

--- a/src/elona/death.cpp
+++ b/src/elona/death.cpp
@@ -43,8 +43,8 @@ std::vector<Bone> parse_bone_file(const fs::path& filepath)
     if (!in)
         return {};
 
-    const std::string content{std::istreambuf_iterator<char>{in},
-                              std::istreambuf_iterator<char>{}};
+    const std::string content{
+        std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>{}};
 
     try
     {

--- a/src/elona/enchantment.cpp
+++ b/src/elona/enchantment.cpp
@@ -686,7 +686,7 @@ bool enchantment_add(
             sampler.add(cnt, encprocref(2, cnt));
         }
         i_at_m48 = sampler.get().value_or(0);
-        if(i_at_m48 == 0)
+        if (i_at_m48 == 0)
         {
             return false;
         }

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -117,8 +117,9 @@ InventorySlice Inventory::for_chara(const Character& chara)
     }
     else
     {
-        return {std::begin(storage) + 200 + 20 * (chara.index - 1),
-                std::begin(storage) + 200 + 20 * (chara.index - 1) + 20};
+        return {
+            std::begin(storage) + 200 + 20 * (chara.index - 1),
+            std::begin(storage) + 200 + 20 * (chara.index - 1) + 20};
     }
 }
 

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -282,15 +282,17 @@ struct Inventory
 
     InventorySlice ground()
     {
-        return {std::begin(storage) + ELONA_ITEM_ON_GROUND_INDEX,
-                std::begin(storage) + ELONA_ITEM_ON_GROUND_INDEX + 400};
+        return {
+            std::begin(storage) + ELONA_ITEM_ON_GROUND_INDEX,
+            std::begin(storage) + ELONA_ITEM_ON_GROUND_INDEX + 400};
     }
 
 
     InventorySlice map_local()
     {
-        return {std::begin(storage) + ELONA_OTHER_INVENTORIES_INDEX,
-                std::end(storage)};
+        return {
+            std::begin(storage) + ELONA_OTHER_INVENTORIES_INDEX,
+            std::end(storage)};
     }
 
 

--- a/src/elona/keybind/keybind_deserializer.cpp
+++ b/src/elona/keybind/keybind_deserializer.cpp
@@ -62,8 +62,8 @@ optional<snail::Key> _deserialize_key(
 
 void KeybindDeserializer::load(std::istream& in)
 {
-    std::string file_content{std::istreambuf_iterator<char>{in},
-                             std::istreambuf_iterator<char>{}};
+    std::string file_content{
+        std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>{}};
     const auto value = json5::parse(file_content);
 
     visit_object(value.get_object().find("core")->second.get_object());

--- a/src/elona/lua_env/api_manager.cpp
+++ b/src/elona/lua_env/api_manager.cpp
@@ -70,8 +70,8 @@ void APIManager::load_prelude()
     if (!result.valid())
     {
         sol::error err = result;
-        throw std::runtime_error{"Failed to load prelude library: "s +
-                                 err.what()};
+        throw std::runtime_error{
+            "Failed to load prelude library: "s + err.what()};
     }
 
     sol::table prelude = result;

--- a/src/elona/lua_env/config_manager.cpp
+++ b/src/elona/lua_env/config_manager.cpp
@@ -28,8 +28,8 @@ void ConfigManager::load_schema(
     const std::string& filename,
     SharedId mod_id)
 {
-    std::string s{std::istreambuf_iterator<char>{in},
-                  std::istreambuf_iterator<char>{}};
+    std::string s{
+        std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>{}};
     _impl["load_schema"](s, filename, mod_id.get());
 }
 
@@ -37,8 +37,8 @@ void ConfigManager::load_schema(
 
 void ConfigManager::load_options(std::istream& in, const std::string& filename)
 {
-    std::string s{std::istreambuf_iterator<char>{in},
-                  std::istreambuf_iterator<char>{}};
+    std::string s{
+        std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>{}};
     _impl["load_options"](s, filename);
 }
 

--- a/src/elona/lua_env/lua_api/lua_api_map.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_map.cpp
@@ -188,8 +188,8 @@ bool LuaApiMap::is_blocked_xy(int x, int y)
  */
 Position LuaApiMap::random_pos()
 {
-    return Position{elona::rnd(map_data.width - 1),
-                    elona::rnd(map_data.height - 1)};
+    return Position{
+        elona::rnd(map_data.width - 1), elona::rnd(map_data.height - 1)};
 }
 
 /**

--- a/src/elona/lua_env/mod_manager.cpp
+++ b/src/elona/lua_env/mod_manager.cpp
@@ -426,8 +426,8 @@ fs::path ModManager::resolve_path_for_mod(const std::string& path)
         }
         else
         {
-            throw std::runtime_error{"Mod '" + mod_id +
-                                     "' is disabled: " + path};
+            throw std::runtime_error{
+                "Mod '" + mod_id + "' is disabled: " + path};
         }
     }
 }

--- a/src/elona/lua_env/mod_manifest.cpp
+++ b/src/elona/lua_env/mod_manifest.cpp
@@ -124,8 +124,8 @@ ModManifest ModManifest::load(const fs::path& path)
 {
     // TODO loading error handling.
     std::ifstream in{path.native()};
-    std::string source{std::istreambuf_iterator<char>{in},
-                       std::istreambuf_iterator<char>{}};
+    std::string source{
+        std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>{}};
     const auto value = json5::parse(source);
     const auto& obj = value.get_object();
 
@@ -185,8 +185,9 @@ void ModManifest::save() const
     std::ofstream out{manifest_filepath.native()};
     if (!out)
     {
-        throw std::runtime_error{"failed to open mod manifest file to write: " +
-                                 filepathutil::to_utf8_path(manifest_filepath)};
+        throw std::runtime_error{
+            "failed to open mod manifest file to write: " +
+            filepathutil::to_utf8_path(manifest_filepath)};
     }
     out << json5::stringify(root_obj, opts) << std::endl;
 }

--- a/src/elona/lua_env/mod_version_resolver.cpp
+++ b/src/elona/lua_env/mod_version_resolver.cpp
@@ -164,8 +164,9 @@ void ModList::save(const fs::path& path)
     std::ofstream out{path.native()};
     if (!out)
     {
-        throw std::runtime_error{"failed to open mod list file to write: " +
-                                 filepathutil::to_utf8_path(path)};
+        throw std::runtime_error{
+            "failed to open mod list file to write: " +
+            filepathutil::to_utf8_path(path)};
     }
     out << json5::stringify(root_obj, opts) << std::endl;
 }

--- a/src/elona/main_menu.cpp
+++ b/src/elona/main_menu.cpp
@@ -305,8 +305,9 @@ MainMenuResult main_title_menu()
                     ripples.push_back(std::make_tuple(
                         0,
                         rnd(rnd(3) + 1),
-                        Position{s.second.x - rnd(256) + rnd(256),
-                                 s.second.y - rnd(256) + rnd(256)}));
+                        Position{
+                            s.second.x - rnd(256) + rnd(256),
+                            s.second.y - rnd(256) + rnd(256)}));
                 }
                 ++s.first;
             }

--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -349,10 +349,11 @@ void show_ex_help(int id)
     notesel(buff);
     {
         buff(0).clear();
-        std::ifstream in{lua::resolve_path_for_mod(
-                             "<core>/locale/<LANGUAGE>/lazy/exhelp.txt")
-                             .native(),
-                         std::ios::binary};
+        std::ifstream in{
+            lua::resolve_path_for_mod(
+                "<core>/locale/<LANGUAGE>/lazy/exhelp.txt")
+                .native(),
+            std::ios::binary};
         std::string tmp;
         while (std::getline(in, tmp))
         {

--- a/src/elona/message.cpp
+++ b/src/elona/message.cpp
@@ -462,10 +462,11 @@ void Message::txtef(ColorIndex color)
 {
     const auto color_int =
         static_cast<int>(static_cast<ColorIndex>(color)) % 21;
-    text_color = {static_cast<uint8_t>(255 - c_col(0, color_int)),
-                  static_cast<uint8_t>(255 - c_col(1, color_int)),
-                  static_cast<uint8_t>(255 - c_col(2, color_int)),
-                  255};
+    text_color = {
+        static_cast<uint8_t>(255 - c_col(0, color_int)),
+        static_cast<uint8_t>(255 - c_col(1, color_int)),
+        static_cast<uint8_t>(255 - c_col(2, color_int)),
+        255};
     fix_text_color = color_int == 5;
 }
 

--- a/src/elona/net.cpp
+++ b/src/elona/net.cpp
@@ -59,11 +59,13 @@ int last_received_chat_id = -1;
 
 
 
-Headers common_headers_get{{"Connection", "close"},
-                           {"User-Agent", latest_version.user_agent()}};
-Headers common_headers_post{{"Connection", "close"},
-                            {"User-Agent", latest_version.user_agent()},
-                            {"Content-Type", "application/json"}};
+Headers common_headers_get{
+    {"Connection", "close"},
+    {"User-Agent", latest_version.user_agent()}};
+Headers common_headers_post{
+    {"Connection", "close"},
+    {"User-Agent", latest_version.user_agent()},
+    {"Content-Type", "application/json"}};
 
 
 
@@ -104,10 +106,11 @@ void send_chat(ChatKind kind, const std::string& message)
     payload["kind"] = static_cast<json5::integer_type>(kind);
     payload["message"] = replace_f_word(message);
 
-    Request req{Verb::POST,
-                chat_url,
-                common_headers_post,
-                Body{json5::stringify(payload)}};
+    Request req{
+        Verb::POST,
+        chat_url,
+        common_headers_post,
+        Body{json5::stringify(payload)}};
     req.send(
         [](const auto& response) {
             if (response.status / 100 != 2)
@@ -460,10 +463,11 @@ void net_register_your_name()
     json5::value::object_type payload;
     payload["name"] = get_pc_alias() + i18n::space_if_needed() + get_pc_name();
 
-    Request req{Verb::POST,
-                poll_url,
-                common_headers_post,
-                Body{json5::stringify(payload)}};
+    Request req{
+        Verb::POST,
+        poll_url,
+        common_headers_post,
+        Body{json5::stringify(payload)}};
     req.send(
         [](const auto& response) {
             if (response.status / 100 != 2)
@@ -496,10 +500,11 @@ void net_send_vote(int poll_id)
     json5::value::object_type payload;
     payload["poll"] = static_cast<json5::integer_type>(poll_id);
 
-    Request req{Verb::POST,
-                vote_url,
-                common_headers_post,
-                Body{json5::stringify(payload)}};
+    Request req{
+        Verb::POST,
+        vote_url,
+        common_headers_post,
+        Body{json5::stringify(payload)}};
     req.send(
         [](const auto& response) {
             if (response.status / 100 != 2)

--- a/src/elona/save.cpp
+++ b/src/elona/save.cpp
@@ -91,8 +91,8 @@ void load_save_data()
         int minor;
         int patch;
         {
-            std::ifstream in{(save_dir / "foobar_data.s1").native(),
-                             std::ios::binary};
+            std::ifstream in{
+                (save_dir / "foobar_data.s1").native(), std::ios::binary};
             serialization::binary::IArchive ar{in};
             ar(major);
             ar(minor);

--- a/src/elona/scene.cpp
+++ b/src/elona/scene.cpp
@@ -84,10 +84,11 @@ void do_play_scene()
             notesel(buff);
             {
                 buff(0).clear();
-                std::ifstream in{lua::resolve_path_for_mod(
-                                     "<core>/locale/<LANGUAGE>/lazy/scene.hsp")
-                                     .native(),
-                                 std::ios::binary};
+                std::ifstream in{
+                    lua::resolve_path_for_mod(
+                        "<core>/locale/<LANGUAGE>/lazy/scene.hsp")
+                        .native(),
+                    std::ios::binary};
                 std::string tmp;
                 while (std::getline(in, tmp))
                 {

--- a/src/elona/semver.hpp
+++ b/src/elona/semver.hpp
@@ -440,8 +440,8 @@ public:
      */
     static VersionRequirement from_version(const Version& version)
     {
-        OneVersionRequirement req{OneVersionRequirement::Operator::equal,
-                                  version};
+        OneVersionRequirement req{
+            OneVersionRequirement::Operator::equal, version};
         return VersionRequirement{{req}};
     }
 

--- a/src/elona/set_item_info.cpp
+++ b/src/elona/set_item_info.cpp
@@ -7,11 +7,8 @@
 namespace elona
 {
 
-const std::set<std::string> randomizables = {"potion",
-                                             "spellbook",
-                                             "scroll",
-                                             "rod",
-                                             "ring"};
+const std::set<std::string> randomizables =
+    {"potion", "spellbook", "scroll", "rod", "ring"};
 
 bool is_randomizable(const std::string& original_name_ref)
 {

--- a/src/elona/status_ailment.cpp
+++ b/src/elona/status_ailment.cpp
@@ -319,8 +319,8 @@ void status_ailment_damage(
         }
         return;
     default:
-        throw std::runtime_error{u8"Unknown status ailment: "s +
-                                 int(status_ailment)};
+        throw std::runtime_error{
+            u8"Unknown status ailment: "s + int(status_ailment)};
     }
 }
 
@@ -582,8 +582,8 @@ void status_ailment_heal(
         }
         break;
     default:
-        throw std::runtime_error{u8"Unknown status ailment: "s +
-                                 int(status_ailment)};
+        throw std::runtime_error{
+            u8"Unknown status ailment: "s + int(status_ailment)};
     }
 }
 

--- a/src/elona/ui.cpp
+++ b/src/elona/ui.cpp
@@ -1043,9 +1043,10 @@ void render_status_ailments()
             return i18n::s.get_enum("core.status_ailment.name.burden", state);
         },
         [](auto state) {
-            return snail::Color{0,
-                                static_cast<uint8_t>(state * 40),
-                                static_cast<uint8_t>(state * 40)};
+            return snail::Color{
+                0,
+                static_cast<uint8_t>(state * 40),
+                static_cast<uint8_t>(state * 40)};
         });
 
     y = render_one_status_ailment(
@@ -1694,8 +1695,9 @@ void update_slight()
     slight.clear();
     ++msync;
 
-    const Position center{cdata.player().position.x - (fov_max + 2) / 2,
-                          (fov_max + 2) / 2 - cdata.player().position.y};
+    const Position center{
+        cdata.player().position.x - (fov_max + 2) / 2,
+        (fov_max + 2) / 2 - cdata.player().position.y};
     sy(2) = cdata.player().position.y - fov_max / 2;
     sy(3) = cdata.player().position.y + fov_max / 2;
 

--- a/src/elona/ui/ui_menu_keybindings.cpp
+++ b/src/elona/ui/ui_menu_keybindings.cpp
@@ -471,8 +471,9 @@ protected:
             {
                 if (keybind_is_bindable_key(key))
                 {
-                    return KeyPromptResult{KeyPromptResult::Type::bind,
-                                           Keybind{key, _last_modifiers}};
+                    return KeyPromptResult{
+                        KeyPromptResult::Type::bind,
+                        Keybind{key, _last_modifiers}};
                 }
             }
         }

--- a/src/elona/ui/ui_menu_mods.cpp
+++ b/src/elona/ui/ui_menu_mods.cpp
@@ -97,8 +97,8 @@ void UIMenuMods::_load_mods()
             if (lua::is_reserved_mod_id(id))
                 continue;
 
-            ModDescription desc{manifest,
-                                lua::lua->get_mod_manager().is_enabled(id)};
+            ModDescription desc{
+                manifest, lua::lua->get_mod_manager().is_enabled(id)};
             _mod_descriptions.emplace_back(desc);
             listmax++;
         }

--- a/src/launcher_main.cpp
+++ b/src/launcher_main.cpp
@@ -167,9 +167,10 @@ int main(int argc, char** argv)
     app.set_call_redraw(false);
 
     app.get_renderer().enable_blended_text_rendering();
-    snail::Font font{filesystem::path("font") / "Bitstream Sans Vera Mono" /
-                         "Bitstream Sans Vera Mono.ttf",
-                     16};
+    snail::Font font{
+        filesystem::path("font") / "Bitstream Sans Vera Mono" /
+            "Bitstream Sans Vera Mono.ttf",
+        16};
     app.get_renderer().set_font(font);
 
     while (true)

--- a/src/snail/backends/sdl/filedialog.cpp
+++ b/src/snail/backends/sdl/filedialog.cpp
@@ -38,8 +38,9 @@ FileDialogResult OpenFileDialog::show()
     });
 
     // TODO: throws exception if result type is error?
-    return {static_cast<FileDialogResultType>(result_type),
-            filepathutil::u8path(out)};
+    return {
+        static_cast<FileDialogResultType>(result_type),
+        filepathutil::u8path(out)};
 }
 
 
@@ -94,8 +95,9 @@ FileDialogResult SaveFileDialog::show()
     });
 
     // TODO: throws exception if result type is error?
-    return {static_cast<FileDialogResultType>(result_type),
-            filepathutil::u8path(out)};
+    return {
+        static_cast<FileDialogResultType>(result_type),
+        filepathutil::u8path(out)};
 }
 
 
@@ -116,8 +118,9 @@ FileDialogResult OpenFolderDialog::show()
     });
 
     // TODO: throws exception if result type is error?
-    return {static_cast<FileDialogResultType>(result_type),
-            filepathutil::u8path(out)};
+    return {
+        static_cast<FileDialogResultType>(result_type),
+        filepathutil::u8path(out)};
 }
 
 } // namespace snail

--- a/src/snail/backends/sdl/surface.cpp
+++ b/src/snail/backends/sdl/surface.cpp
@@ -35,8 +35,8 @@ void Surface::save(const fs::path& filepath)
     }
     else
     {
-        throw std::runtime_error{"Unknown image file format: " +
-                                 filepathutil::to_utf8_path(ext)};
+        throw std::runtime_error{
+            "Unknown image file format: " + filepathutil::to_utf8_path(ext)};
     }
 }
 

--- a/src/tests/keybind_serializer.cpp
+++ b/src/tests/keybind_serializer.cpp
@@ -56,9 +56,10 @@ TEST_CASE(
     keybind::actions.clear();
     keybind::actions.emplace(
         "game_action1",
-        Action{ActionCategory::game,
-               {{Key::key_a, ModKey::none},
-                {Key::key_1, ModKey::ctrl | ModKey::shift}}});
+        Action{
+            ActionCategory::game,
+            {{Key::key_a, ModKey::none},
+             {Key::key_1, ModKey::ctrl | ModKey::shift}}});
     keybind::actions.emplace(
         "menu_action1",
         Action{ActionCategory::menu, {{Key::key_b, ModKey::shift}}});

--- a/src/util/unicode.hpp
+++ b/src/util/unicode.hpp
@@ -200,8 +200,8 @@ inline encoded_result<wchar_t> code_point_to_utf16(char32_t codepoint)
              unicode_detail::lead_shifted_bits);
         auto trail = unicode_detail::first_trail_surrogate +
             (normal & unicode_detail::trail_surrogate_bitmask);
-        er.code_units = std::array<wchar_t, 4>{static_cast<wchar_t>(lead),
-                                               static_cast<wchar_t>(trail)};
+        er.code_units = std::array<wchar_t, 4>{
+            static_cast<wchar_t>(lead), static_cast<wchar_t>(trail)};
         er.code_units_size = 2;
         er.error = error_code::ok;
     }


### PR DESCRIPTION
# Summary

Some CI failed with `clang-format`'s update. The indentation style for initializer list and uniform initialization seems to change.