### PR TITLE
Unite `cdata` and `cdatan`

### DIFF
--- a/doc/api/classes/LuaCharacter.luadoc
+++ b/doc/api/classes/LuaCharacter.luadoc
@@ -285,8 +285,8 @@ function get_ailment(ailment) end
 --- [R] The name of the character without article and title.
 --  @tfield string basename
 
---- [R] The title of the character.
---  @tfield string title
+--- [R] The alias of the character.
+--  @tfield string alias
 
 --- [RW] The sex of the character.
 --  @tfield Gender sex

--- a/src/elona/adventurer.cpp
+++ b/src/elona/adventurer.cpp
@@ -50,8 +50,8 @@ void create_adventurer(Character& adv)
     adv._156 = 100;
     adv.set_state(Character::State::adventurer_in_other_map);
     adv.image = rnd(33) * 2 + 1 + adv.sex;
-    cdatan(0, adv.index) = random_name();
-    cdatan(1, adv.index) = random_title(RandomTitleType::character);
+    adv.name = random_name();
+    adv.alias = random_title(RandomTitleType::character);
     adv.role = Role::adventurer;
     p = rnd(450);
     if (area_data[p].id == mdata_t::MapId::none ||
@@ -147,8 +147,8 @@ void addnews(int news_type, int adventurer, int fame, const std::string& valn)
         addnews2(
             i18n::s.get(
                 "core.news.discovery.text",
-                cdatan(1, adventurer),
-                cdatan(0, adventurer),
+                cdata[adventurer].alias,
+                cdata[adventurer].name,
                 valn,
                 mapname(cdata[adventurer].current_map)),
             1);
@@ -158,8 +158,8 @@ void addnews(int news_type, int adventurer, int fame, const std::string& valn)
         addnews2(
             i18n::s.get(
                 "core.news.growth.text",
-                cdatan(1, adventurer),
-                cdatan(0, adventurer),
+                cdata[adventurer].alias,
+                cdata[adventurer].name,
                 cdata[adventurer].level),
             1);
         break;
@@ -168,8 +168,8 @@ void addnews(int news_type, int adventurer, int fame, const std::string& valn)
         addnews2(
             i18n::s.get(
                 "core.news.recovery.text",
-                cdatan(1, adventurer),
-                cdatan(0, adventurer)),
+                cdata[adventurer].alias,
+                cdata[adventurer].name),
             1);
         break;
     case 4:
@@ -177,8 +177,8 @@ void addnews(int news_type, int adventurer, int fame, const std::string& valn)
         addnews2(
             i18n::s.get(
                 "core.news.accomplishment.text",
-                cdatan(1, adventurer),
-                cdatan(0, adventurer),
+                cdata[adventurer].alias,
+                cdata[adventurer].name,
                 fame),
             1);
         break;
@@ -187,8 +187,8 @@ void addnews(int news_type, int adventurer, int fame, const std::string& valn)
         addnews2(
             i18n::s.get(
                 "core.news.retirement.text",
-                cdatan(1, adventurer),
-                cdatan(0, adventurer)),
+                cdata[adventurer].alias,
+                cdata[adventurer].name),
             1);
         break;
     }

--- a/src/elona/ai.cpp
+++ b/src/elona/ai.cpp
@@ -399,13 +399,6 @@ bool _will_crush_wall(const Character& chara, int x, int y)
 
 
 
-const std::string& _chara_get_race(const Character& chara)
-{
-    return cdatan(2, chara.index);
-}
-
-
-
 // Handle 『恋のマイアヒ』
 void _proc_drunk_cat(Character& chara)
 {
@@ -938,8 +931,7 @@ TurnResult ai_proc_misc_map_events(Character& chara, int& enemy_index)
         return TurnResult::turn_end;
     }
 
-    if (chara.drunk != 0 && _chara_get_race(chara) == "core.cat" &&
-        is_in_fov(chara))
+    if (chara.drunk != 0 && chara.race == "core.cat" && is_in_fov(chara))
     {
         _proc_drunk_cat(chara);
     }
@@ -1021,7 +1013,7 @@ TurnResult ai_proc_misc_map_events(Character& chara, int& enemy_index)
                 distance = dist_helper(cdata[enemy_index], chara);
                 if (distance < 8)
                 {
-                    if (_chara_get_race(cdata.player()) == "core.snail")
+                    if (cdata.player().race == "core.snail")
                     {
                         tlocx = cdata.player().position.x;
                         tlocy = cdata.player().position.y;

--- a/src/elona/building.cpp
+++ b/src/elona/building.cpp
@@ -649,37 +649,37 @@ void prompt_hiring()
             if (p == 0)
             {
                 servant->role = Role::blacksmith;
-                cdatan(0, servant->index) =
+                servant->name =
                     i18n::s.get("core.building.guests.armory", *servant);
             }
             if (p == 1)
             {
                 servant->role = Role::general_vendor;
-                cdatan(0, servant->index) =
+                servant->name =
                     i18n::s.get("core.building.guests.general_store", *servant);
             }
             if (p == 2)
             {
                 servant->role = Role::magic_vendor;
-                cdatan(0, servant->index) =
+                servant->name =
                     i18n::s.get("core.building.guests.magic_store", *servant);
             }
             if (p == 3)
             {
                 servant->role = Role::general_store;
-                cdatan(0, servant->index) =
+                servant->name =
                     i18n::s.get("core.building.guests.goods_store", *servant);
             }
             if (p == 4)
             {
                 servant->role = Role::blacksmith;
-                cdatan(0, servant->index) =
+                servant->name =
                     i18n::s.get("core.building.guests.armory", *servant);
             }
             if (p == 5)
             {
                 servant->role = Role::blackmarket_vendor;
-                cdatan(0, servant->index) =
+                servant->name =
                     i18n::s.get("core.building.guests.blackmarket", *servant);
             }
             randomize();
@@ -692,7 +692,7 @@ void prompt_hiring()
                 continue;
             }
             if (chara.state() != Character::State::empty &&
-                cdatan(0, chara.index) == cdatan(0, servant->index))
+                chara.name == servant->name)
             {
                 chara_vanquish(*servant);
                 break;
@@ -1408,7 +1408,7 @@ void update_ranch()
             }
             if (rnd(10) != 0)
             {
-                fltnrace = cdatan(2, worker);
+                fltnrace = cdata[worker].race.get();
             }
             if (cdata[worker].id == CharaId::little_sister)
             {
@@ -1478,7 +1478,7 @@ void update_ranch()
             case 0:
                 // Egg
                 if (rnd(60) == 0 ||
-                    (cdatan(2, chara.index) == "core.chicken" && rnd(20) == 0))
+                    (chara.race == "core.chicken" && rnd(20) == 0))
                 {
                     ++egg_or_milk_count;
                     if (const auto item = itemcreate_extra_inv(573, x, y, 0))
@@ -1493,7 +1493,7 @@ void update_ranch()
             case 1:
                 // Milk
                 if (rnd(60) == 0 ||
-                    (cdatan(2, chara.index) == "core.sheep" && rnd(20) == 0))
+                    (chara.race == "core.sheep" && rnd(20) == 0))
                 {
                     ++egg_or_milk_count;
                     if (const auto item = itemcreate_extra_inv(574, x, y, 0))

--- a/src/elona/chara_db.cpp
+++ b/src/elona/chara_db.cpp
@@ -42,11 +42,11 @@ void chara_db_set_stats(Character& chara, CharaId chara_id)
     chara.special_actions = data->special_actions;
     creaturepack = data->creaturepack;
     chara.can_talk = data->can_talk;
-    cdatan(0, chara.index) = the_character_db.get_text(data->id, "name");
+    chara.name = the_character_db.get_text(data->id, "name");
     if (data->has_random_name)
     {
-        cdatan(0, chara.index) = i18n::s.get(
-            "core.chara.job.own_name", cdatan(0, chara.index), random_name());
+        chara.name =
+            i18n::s.get("core.chara.job.own_name", chara.name, random_name());
         chara.has_own_name() = true;
     }
     chara.original_relationship = chara.relationship =

--- a/src/elona/character.hpp
+++ b/src/elona/character.hpp
@@ -397,6 +397,12 @@ public:
     int _203 = 0;
     Position target_position;
 
+    std::string name;
+    std::string alias;
+    data::InstanceId race;
+    data::InstanceId class_;
+    std::string talk;
+
 
 
     void clear();

--- a/src/elona/character_making.cpp
+++ b/src/elona/character_making.cpp
@@ -259,8 +259,8 @@ static void _reroll_character()
     chara_delete(0);
     race_init_chara(cdata.player(), cmrace);
     class_init_chara(cdata.player(), cmclass);
-    cdatan(0, 0) = u8"????"s;
-    cdatan(1, 0) = cmaka;
+    cdata.player().name = u8"????"s;
+    cdata.player().alias = cmaka;
     cdata.player().level = 1;
     for (int cnt = 10; cnt < 18; ++cnt)
     {
@@ -400,7 +400,7 @@ MainMenuResult character_making_final_phase()
     }
 
     snd("core.skill");
-    cdatan(0, 0) = cmname;
+    cdata.player().name = cmname;
     cdata.player().gold = 400 + rnd(200);
 
     if (geneuse != ""s)

--- a/src/elona/character_status.cpp
+++ b/src/elona/character_status.cpp
@@ -525,8 +525,7 @@ void gain_level(Character& chara)
     }
     chara.skill_bonus += p;
     chara.total_skill_bonus += p;
-    if (cdatan(2, chara.index) == u8"core.mutant"s ||
-        (chara.index == 0 && trait(0) == 1))
+    if (chara.race == "core.mutant" || (chara.index == 0 && trait(0) == 1))
     {
         if (chara.level < 37)
         {

--- a/src/elona/class.cpp
+++ b/src/elona/class.cpp
@@ -20,7 +20,7 @@ void class_init_chara(Character& chara, data::InstanceId class_id)
     if (!data)
         return;
 
-    cdatan(3, chara.index) = class_id.get();
+    chara.class_ = class_id;
     for (const auto& pair : data->skills)
     {
         if (const auto ability_data = the_ability_db[pair.first])

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -743,13 +743,12 @@ TurnResult do_interact_command()
         cdata[target_index].has_custom_talk() = false;
         if (inputlog == ""s)
         {
-            cdatan(4, target_index) = "";
+            cdata[target_index].talk = "";
         }
         else
         {
-            cdatan(4, target_index) = inputlog;
-            txt(""s + cdatan(4, target_index),
-                Message::color{ColorIndex::cyan});
+            cdata[target_index].talk = inputlog;
+            txt(cdata[target_index].talk, Message::color{ColorIndex::cyan});
         }
         update_screen();
         return TurnResult::pc_turn_user_error;
@@ -799,7 +798,7 @@ TurnResult call_npc(Character& chara)
     }
     else
     {
-        cdatan(0, chara.index) = ""s + inputlog;
+        chara.name = inputlog;
         chara.has_own_name() = true;
         txt(i18n::s.get("core.action.interact.name.you_named", chara));
     }

--- a/src/elona/ctrl_file.cpp
+++ b/src/elona/ctrl_file.cpp
@@ -29,8 +29,6 @@ namespace elona
 namespace
 {
 
-elona_vector2<std::string> cdatan2;
-int elona_export;
 std::set<fs::path> loaded_files;
 
 
@@ -66,52 +64,47 @@ void arrayfile_read(const std::string& fmode_str, const fs::path& filepath)
     }
     else if (fmode_str == u8"cdatan1"s)
     {
-        if (lines.size() <= 57 * 10 / 2)
-            lines.resize(57 * 10 / 2);
-        else
-            lines.resize(57 * 10);
+        lines.resize(57 * 10);
         auto itr = std::begin(lines);
         for (int i = 0; i < 57; ++i)
         {
-            for (int j = 0; j < 10; ++j)
-            {
-                if (lines.size() <= 57 * 10 / 2 && j >= 10 / 2)
-                    break;
-                cdatan(j, i) = *itr;
-                ++itr;
-            }
+            cdata[i].name = *itr;
+            ++itr;
+            cdata[i].alias = *itr;
+            ++itr;
+            cdata[i].race = data::InstanceId{*itr};
+            ++itr;
+            cdata[i].class_ = data::InstanceId{*itr};
+            ++itr;
+            cdata[i].talk = *itr;
+            ++itr;
+            ++itr;
+            ++itr;
+            ++itr;
+            ++itr;
+            ++itr;
         }
     }
     else if (fmode_str == u8"cdatan2"s)
     {
-        if (lines.size() <= 188 * 10 / 2)
-            lines.resize(188 * 10 / 2);
-        else
-            lines.resize(188 * 10);
+        lines.resize(188 * 10);
         auto itr = std::begin(lines);
         for (int i = ELONA_MAX_PARTY_CHARACTERS; i < ELONA_MAX_CHARACTERS; ++i)
         {
-            for (int j = 0; j < 10; ++j)
-            {
-                if (lines.size() <= 188 * 10 / 2 && j >= 10 / 2)
-                    break;
-                cdatan(j, i) = *itr;
-                ++itr;
-            }
-        }
-    }
-    else if (fmode_str == u8"cdatan3"s)
-    {
-        if (lines.size() <= 10 / 2)
-            lines.resize(10 / 2);
-        else
-            lines.resize(10);
-        auto itr = std::begin(lines);
-        for (int j = 0; j < 10; ++j)
-        {
-            if (lines.size() < 10 / 2 && j >= 10 / 2)
-                break;
-            cdatan(j, tg) = *itr;
+            cdata[i].name = *itr;
+            ++itr;
+            cdata[i].alias = *itr;
+            ++itr;
+            cdata[i].race = data::InstanceId{*itr};
+            ++itr;
+            cdata[i].class_ = data::InstanceId{*itr};
+            ++itr;
+            cdata[i].talk = *itr;
+            ++itr;
+            ++itr;
+            ++itr;
+            ++itr;
+            ++itr;
             ++itr;
         }
     }
@@ -147,35 +140,37 @@ void arrayfile_write(const std::string& fmode_str, const fs::path& filepath)
     {
         for (int i = 0; i < 57; ++i)
         {
-            for (int j = 0; j < 10; ++j)
-            {
-                out << cdatan(j, i) << std::endl;
-            }
+            out << cdata[i].name << std::endl;
+            out << cdata[i].alias << std::endl;
+            out << cdata[i].race.get() << std::endl;
+            out << cdata[i].class_.get() << std::endl;
+            out << cdata[i].talk << std::endl;
+            out << std::endl;
+            out << std::endl;
+            out << std::endl;
+            out << std::endl;
+            out << std::endl;
         }
     }
     else if (fmode_str == u8"cdatan2"s)
     {
         for (int i = ELONA_MAX_PARTY_CHARACTERS; i < ELONA_MAX_CHARACTERS; ++i)
         {
-            for (int j = 0; j < 10; ++j)
-            {
-                out << cdatan(j, i) << std::endl;
-            }
-        }
-    }
-    else if (fmode_str == u8"cdatan3"s)
-    {
-        for (int j = 0; j < 10; ++j)
-        {
-            out << cdatan(j, tg) << std::endl;
+            out << cdata[i].name << std::endl;
+            out << cdata[i].alias << std::endl;
+            out << cdata[i].race.get() << std::endl;
+            out << cdata[i].class_.get() << std::endl;
+            out << cdata[i].talk << std::endl;
+            out << std::endl;
+            out << std::endl;
+            out << std::endl;
+            out << std::endl;
+            out << std::endl;
         }
     }
 
     writeloadedbuff(filepath.filename());
-    if (elona_export == 0)
-    {
-        Save::instance().add(filepath.filename());
-    }
+    Save::instance().add(filepath.filename());
 }
 
 
@@ -194,8 +189,6 @@ void arrayfile(
         tmpload(filepath.filename());
         arrayfile_read(fmode_str, filepath);
     }
-
-    elona_export = 0;
 }
 
 
@@ -425,8 +418,8 @@ void fmode_7_8(bool read, const fs::path& dir)
 
     if (!read)
     {
-        playerheader =
-            cdatan(0, 0) + u8" Lv:" + cdata.player().level + u8" " + mdatan(0);
+        playerheader = cdata.player().name + u8" Lv:" + cdata.player().level +
+            u8" " + mdatan(0);
         bsave(dir / u8"header.txt", playerheader);
     }
 
@@ -866,8 +859,8 @@ void fmode_14_15(bool read)
         read ? filesystem::dirs::save(geneuse) : filesystem::dirs::tmp();
     if (!read)
     {
-        playerheader =
-            cdatan(0, 0) + u8"(Lv" + cdata.player().level + u8")の遺伝子";
+        playerheader = cdata.player().name + u8"(Lv" + cdata.player().level +
+            u8")の遺伝子";
         const auto filepath = dir / u8"gene_header.txt";
         bsave(filepath, playerheader);
         Save::instance().add(filepath.filename());

--- a/src/elona/death.cpp
+++ b/src/elona/death.cpp
@@ -209,8 +209,8 @@ TurnResult pc_died()
 
     Bone this_death;
     this_death.score = calcscore();
-    this_death.alias = cdatan(1, 0);
-    this_death.name = cdatan(0, 0);
+    this_death.alias = cdata.player().alias;
+    this_death.name = cdata.player().name;
     this_death.last_words = last_words;
     this_death.date = i18n::s.get(
         "core.misc.death.date",

--- a/src/elona/deferred_event.cpp
+++ b/src/elona/deferred_event.cpp
@@ -189,7 +189,7 @@ void eh_lord_of_normal_nefia(const DeferredEvent&)
 
     lord->is_lord_of_dungeon() = true;
     area_data[game_data.current_map].has_been_conquered = lord->index;
-    cdatan(0, lord->index) += u8" Lv"s + lord->level;
+    lord->name += u8" Lv"s + lord->level;
     txt(i18n::s.get("core.event.reached_deepest_level"));
     txt(i18n::s.get(
             "core.event.guarded_by_lord",

--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -1616,7 +1616,7 @@ void character_drops_item(Character& victim)
         }
     }
 
-    switch (class_get_item_type(data::InstanceId{cdatan(3, victim.index)}))
+    switch (class_get_item_type(victim.class_))
     {
     case 1:
         if (rnd(20) == 0)

--- a/src/elona/draw.cpp
+++ b/src/elona/draw.cpp
@@ -377,7 +377,7 @@ void show_hp_bar(HPBarSide side, int inf_clocky)
              ally.state() == Character::State::pet_dead) &&
             ally.has_been_used_stethoscope())
         {
-            const auto name = cdatan(0, ally.index);
+            const auto name = ally.name;
             const int x = 16 + (windoww - strlen_u(name) * 7 - 16) * right;
             int y = inf_clocky + (right ? 20 : 136) + cnt * 32;
 

--- a/src/elona/dump_player_info.cpp
+++ b/src/elona/dump_player_info.cpp
@@ -50,7 +50,7 @@ void dump_player_info()
 
     ss << std::endl;
 
-    ss << "  " << fixtxt(cdatan(1, 0) + cdatan(0, 0), 34)
+    ss << "  " << fixtxt(cdata.player().alias + cdata.player().name, 34)
        << i18n::s.get_enum("core.ui.sex", cdata.player().sex) << " "
        << calc_age(cdata.player()) << u8"歳  " << cdata.player().height
        << u8"cm " << cdata.player().weight << u8"kg" << std::endl;
@@ -59,14 +59,11 @@ void dump_player_info()
 
     ss << fixtxt(
               u8"種族       : " +
-                  the_race_db.get_text(data::InstanceId{cdatan(2, 0)}, "name"),
+                  the_race_db.get_text(cdata.player().race, "name"),
               30)
        << fixtxt(u8"信仰      : " + god_name(cdata.player().god_id), 32)
        << std::endl;
-    ss << fixtxt(
-              u8"職業       : " +
-                  class_get_name(data::InstanceId{cdatan(3, 0)}),
-              30)
+    ss << fixtxt(u8"職業       : " + class_get_name(cdata.player().class_), 30)
        << fixtxt(u8"所属      : " + guildname(), 32) << std::endl;
     ss << fixtxt(u8"レベル     : " + std::to_string(cdata.player().level), 30)
        << fixtxt(u8"経過日数  : " + std::to_string(game_data.play_days), 32)
@@ -232,11 +229,9 @@ void dump_player_info()
             continue;
         }
 
-        ss << cdatan(0, ally.index) << u8" "
-           << the_race_db.get_text(
-                  data::InstanceId{cdatan(2, ally.index)}, "name")
-           << u8"の" << class_get_name(data::InstanceId{cdatan(3, ally.index)})
-           << u8" " << i18n::s.get_enum("core.ui.sex", ally.sex) << u8" "
+        ss << ally.name << u8" " << the_race_db.get_text(ally.race, "name")
+           << u8"の" << class_get_name(ally.class_) << u8" "
+           << i18n::s.get_enum("core.ui.sex", ally.sex) << u8" "
            << calc_age(ally) << u8"歳" << u8"  " << ally.height << u8"cm"
            << u8" " << ally.weight << u8"kg" << std::endl;
         ss << u8"レベル " << ally.level;

--- a/src/elona/equipment.cpp
+++ b/src/elona/equipment.cpp
@@ -462,7 +462,7 @@ void supply_initial_equipments(Character& chara)
     int fixeq = 0;
     int probeq = 0;
     int eqtwowield = 0;
-    if (cdatan(2, chara.index) == u8"core.mutant"s)
+    if (chara.race == "core.mutant")
     {
         for (int cnt = 0, cnt_end = cnt + clamp(chara.level / 3, 0, 12);
              cnt < cnt_end;
@@ -514,7 +514,7 @@ void supply_initial_equipments(Character& chara)
         fixeq = 1;
     }
 
-    switch (class_get_equipment_type(data::InstanceId{cdatan(3, chara.index)}))
+    switch (class_get_equipment_type(chara.class_))
     {
     case 0: break;
     case 1:

--- a/src/elona/god.cpp
+++ b/src/elona/god.cpp
@@ -485,7 +485,7 @@ TurnResult do_pray()
             {
                 if (ally.state() != Character::State::empty)
                 {
-                    if (cdatan(2, ally.index) == u8"core.servant"s)
+                    if (ally.race == "core.servant")
                     {
                         ++p;
                         if (p >= 2)

--- a/src/elona/init.cpp
+++ b/src/elona/init.cpp
@@ -220,7 +220,6 @@ void initialize_elona()
     DIM2(mdatatmp, 100);
     map_data.clear();
     SDIM3(mdatan, 20, 2);
-    SDIM4(cdatan, 40, 10, ELONA_MAX_CHARACTERS);
     SDIM2(s1, 1000);
     DIM2(spell, 200);
     DIM2(spact, 500);
@@ -565,8 +564,8 @@ void initialize_debug_globals()
     }
     create_all_adventurers();
     create_pcpic(cdata.player());
-    cdatan(1, 0) = random_title(RandomTitleType::character);
-    cdatan(0, 0) = random_name();
+    cdata.player().alias = random_title(RandomTitleType::character);
+    cdata.player().name = random_name();
 }
 
 

--- a/src/elona/initialize_map_types.cpp
+++ b/src/elona/initialize_map_types.cpp
@@ -346,7 +346,7 @@ static void _init_map_test_world_north_border()
     {
         chara->role = Role::general_vendor;
         chara->shop_rank = 10;
-        cdatan(0, chara->index) = sngeneral(cdatan(0, chara->index));
+        chara->name = sngeneral(chara->name);
         chara->ai_calm = 3;
     }
     flt();
@@ -354,7 +354,7 @@ static void _init_map_test_world_north_border()
     {
         chara->role = Role::trader;
         chara->shop_rank = 12;
-        cdatan(0, chara->index) = sntrade(cdatan(0, chara->index));
+        chara->name = sntrade(chara->name);
         chara->ai_calm = 3;
     }
     flt();
@@ -362,7 +362,7 @@ static void _init_map_test_world_north_border()
     {
         chara->role = Role::innkeeper;
         chara->shop_rank = 8;
-        cdatan(0, chara->index) = sninn(cdatan(0, chara->index));
+        chara->name = sninn(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 70, 17, 13))
@@ -425,7 +425,7 @@ static void _init_map_tyris_border()
     {
         chara->role = Role::general_vendor;
         chara->shop_rank = 10;
-        cdatan(0, chara->index) = sngeneral(cdatan(0, chara->index));
+        chara->name = sngeneral(chara->name);
         chara->ai_calm = 3;
     }
     flt();
@@ -433,7 +433,7 @@ static void _init_map_tyris_border()
     {
         chara->role = Role::trader;
         chara->shop_rank = 12;
-        cdatan(0, chara->index) = sntrade(cdatan(0, chara->index));
+        chara->name = sntrade(chara->name);
         chara->ai_calm = 3;
     }
     flt();
@@ -441,7 +441,7 @@ static void _init_map_tyris_border()
     {
         chara->role = Role::innkeeper;
         chara->shop_rank = 8;
-        cdatan(0, chara->index) = sninn(cdatan(0, chara->index));
+        chara->name = sninn(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 70, 17, 13))
@@ -503,7 +503,7 @@ static void _init_map_the_smoke_and_pipe()
     {
         chara->role = Role::innkeeper;
         chara->shop_rank = 8;
-        cdatan(0, chara->index) = sninn(cdatan(0, chara->index));
+        chara->name = sninn(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 351, 26, 16))
@@ -720,16 +720,15 @@ static void _init_map_larna()
     {
         chara->role = Role::dye_vendor;
         chara->shop_rank = 5;
-        cdatan(0, chara->index) =
-            i18n::s.get("core.chara.job.dye_vendor", cdatan(0, chara->index));
+        chara->name = i18n::s.get("core.chara.job.dye_vendor", chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 13, 37))
     {
         chara->role = Role::souvenir_vendor;
         chara->shop_rank = 30;
-        cdatan(0, chara->index) = i18n::s.get(
-            "core.chara.job.souvenir_vendor", cdatan(0, chara->index));
+        chara->name =
+            i18n::s.get("core.chara.job.souvenir_vendor", chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 70, 24, 48))
@@ -1029,21 +1028,21 @@ static void _init_map_your_home()
             {
                 chara->role = Role::general_vendor;
                 chara->shop_rank = 10;
-                cdatan(0, chara->index) = sngeneral(cdatan(0, chara->index));
+                chara->name = sngeneral(chara->name);
             }
             flt();
             if (const auto chara = chara_create(-1, 1, 9, 20))
             {
                 chara->role = Role::blacksmith;
                 chara->shop_rank = 12;
-                cdatan(0, chara->index) = snarmor(cdatan(0, chara->index));
+                chara->name = snarmor(chara->name);
             }
             flt();
             if (const auto chara = chara_create(-1, 1, 4, 20))
             {
                 chara->role = Role::general_store;
                 chara->shop_rank = 10;
-                cdatan(0, chara->index) = sngoods(cdatan(0, chara->index));
+                chara->name = sngoods(chara->name);
             }
             flt();
             if (const auto chara = chara_create(-1, 41, 4, 11))
@@ -1065,7 +1064,7 @@ static void _init_map_your_home()
             {
                 chara->role = Role::magic_vendor;
                 chara->shop_rank = 11;
-                cdatan(0, chara->index) = snmagic(cdatan(0, chara->index));
+                chara->name = snmagic(chara->name);
             }
         }
     }
@@ -1132,7 +1131,7 @@ static void _init_map_derphy_town()
     {
         chara->role = Role::trader;
         chara->shop_rank = 12;
-        cdatan(0, chara->index) = sntrade(cdatan(0, chara->index));
+        chara->name = sntrade(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 70, 15, 15))
@@ -1144,41 +1143,41 @@ static void _init_map_derphy_town()
     {
         chara->role = Role::general_vendor;
         chara->shop_rank = 10;
-        cdatan(0, chara->index) = sngeneral(cdatan(0, chara->index));
+        chara->name = sngeneral(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 29, 23))
     {
         chara->role = Role::innkeeper;
         chara->shop_rank = 8;
-        cdatan(0, chara->index) = sninn(cdatan(0, chara->index));
+        chara->name = sninn(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 26, 7))
     {
         chara->role = Role::general_store;
         chara->shop_rank = 10;
-        cdatan(0, chara->index) = sngoods(cdatan(0, chara->index));
+        chara->name = sngoods(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 30, 4))
     {
         chara->role = Role::blackmarket_vendor;
         chara->shop_rank = 10;
-        cdatan(0, chara->index) = snblack(cdatan(0, chara->index));
+        chara->name = snblack(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 29, 4))
     {
         chara->role = Role::slave_master;
-        cdatan(0, chara->index) = i18n::s.get("core.chara.job.slave_master");
+        chara->name = i18n::s.get("core.chara.job.slave_master");
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 10, 6))
     {
         chara->role = Role::blacksmith;
         chara->shop_rank = 12;
-        cdatan(0, chara->index) = snarmor(cdatan(0, chara->index));
+        chara->name = snarmor(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 73, 7, 15))
@@ -1189,14 +1188,13 @@ static void _init_map_derphy_town()
     if (const auto chara = chara_create(-1, 38, 9, 18))
     {
         chara->role = Role::mayer;
-        cdatan(0, chara->index) =
-            i18n::s.get("core.chara.job.of_derphy", cdatan(0, chara->index));
+        chara->name = i18n::s.get("core.chara.job.of_derphy", chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 40, 13, 18))
     {
         chara->role = Role::trainer;
-        cdatan(0, chara->index) = sntrainer(cdatan(0, chara->index));
+        chara->name = sntrainer(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 41, 5, 26))
@@ -1251,7 +1249,7 @@ static void _init_map_derphy_thieves_guild()
     if (const auto chara = chara_create(-1, 40, 3, 6))
     {
         chara->role = Role::trainer;
-        cdatan(0, chara->index) = sntrainer(cdatan(0, chara->index));
+        chara->name = sntrainer(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 41, 3, 12))
@@ -1263,22 +1261,21 @@ static void _init_map_derphy_thieves_guild()
     {
         chara->role = Role::blackmarket_vendor;
         chara->shop_rank = 10;
-        cdatan(0, chara->index) = snblack(cdatan(0, chara->index));
+        chara->name = snblack(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 27, 13))
     {
         chara->role = Role::blackmarket_vendor;
         chara->shop_rank = 10;
-        cdatan(0, chara->index) = snblack(cdatan(0, chara->index));
+        chara->name = snblack(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 21, 19))
     {
         chara->role = Role::fence;
         chara->shop_rank = 10;
-        cdatan(0, chara->index) =
-            i18n::s.get("core.chara.job.fence", cdatan(0, chara->index));
+        chara->name = i18n::s.get("core.chara.job.fence", chara->name);
     }
     for (int _i = 0; _i < 16; ++_i)
     {
@@ -1367,35 +1364,35 @@ static void _init_map_palmia()
     {
         chara->role = Role::general_vendor;
         chara->shop_rank = 10;
-        cdatan(0, chara->index) = sngeneral(cdatan(0, chara->index));
+        chara->name = sngeneral(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 30, 17))
     {
         chara->role = Role::innkeeper;
         chara->shop_rank = 8;
-        cdatan(0, chara->index) = sninn(cdatan(0, chara->index));
+        chara->name = sninn(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 48, 3))
     {
         chara->role = Role::general_store;
         chara->shop_rank = 8;
-        cdatan(0, chara->index) = sngoods(cdatan(0, chara->index));
+        chara->name = sngoods(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 42, 17))
     {
         chara->role = Role::blacksmith;
         chara->shop_rank = 12;
-        cdatan(0, chara->index) = snarmor(cdatan(0, chara->index));
+        chara->name = snarmor(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 11, 14))
     {
         chara->role = Role::bakery;
         chara->shop_rank = 9;
-        cdatan(0, chara->index) = snbakery(cdatan(0, chara->index));
+        chara->name = snbakery(chara->name);
         chara->image = 138;
     }
     flt();
@@ -1403,14 +1400,14 @@ static void _init_map_palmia()
     {
         chara->role = Role::magic_vendor;
         chara->shop_rank = 11;
-        cdatan(0, chara->index) = snmagic(cdatan(0, chara->index));
+        chara->name = snmagic(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 41, 28))
     {
         chara->role = Role::trader;
         chara->shop_rank = 12;
-        cdatan(0, chara->index) = sntrade(cdatan(0, chara->index));
+        chara->name = sntrade(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 79, 7, 2))
@@ -1428,14 +1425,13 @@ static void _init_map_palmia()
     if (const auto chara = chara_create(-1, 38, 49, 11))
     {
         chara->role = Role::mayer;
-        cdatan(0, chara->index) =
-            i18n::s.get("core.chara.job.of_palmia", cdatan(0, chara->index));
+        chara->name = i18n::s.get("core.chara.job.of_palmia", chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 40, 30, 27))
     {
         chara->role = Role::trainer;
-        cdatan(0, chara->index) = sntrainer(cdatan(0, chara->index));
+        chara->name = sntrainer(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 41, 32, 27))
@@ -1602,28 +1598,28 @@ static void _init_map_lumiest_town()
     {
         chara->role = Role::general_vendor;
         chara->shop_rank = 10;
-        cdatan(0, chara->index) = sngeneral(cdatan(0, chara->index));
+        chara->name = sngeneral(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 24, 47))
     {
         chara->role = Role::innkeeper;
         chara->shop_rank = 8;
-        cdatan(0, chara->index) = sninn(cdatan(0, chara->index));
+        chara->name = sninn(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 37, 30))
     {
         chara->role = Role::blacksmith;
         chara->shop_rank = 12;
-        cdatan(0, chara->index) = snarmor(cdatan(0, chara->index));
+        chara->name = snarmor(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 37, 12))
     {
         chara->role = Role::bakery;
         chara->shop_rank = 9;
-        cdatan(0, chara->index) = snbakery(cdatan(0, chara->index));
+        chara->name = snbakery(chara->name);
         chara->image = 138;
     }
     flt();
@@ -1631,34 +1627,33 @@ static void _init_map_lumiest_town()
     {
         chara->role = Role::magic_vendor;
         chara->shop_rank = 11;
-        cdatan(0, chara->index) = snmagic(cdatan(0, chara->index));
+        chara->name = snmagic(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 33, 43))
     {
         chara->role = Role::trader;
         chara->shop_rank = 12;
-        cdatan(0, chara->index) = sntrade(cdatan(0, chara->index));
+        chara->name = sntrade(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 47, 12))
     {
         chara->role = Role::fisher;
         chara->shop_rank = 5;
-        cdatan(0, chara->index) = snfish(cdatan(0, chara->index));
+        chara->name = snfish(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 38, 3, 38))
     {
         chara->role = Role::mayer;
-        cdatan(0, chara->index) =
-            i18n::s.get("core.chara.job.of_lumiest", cdatan(0, chara->index));
+        chara->name = i18n::s.get("core.chara.job.of_lumiest", chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 40, 21, 28))
     {
         chara->role = Role::trainer;
-        cdatan(0, chara->index) = sntrainer(cdatan(0, chara->index));
+        chara->name = sntrainer(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 41, 21, 30))
@@ -1721,15 +1716,14 @@ static void _init_map_lumiest_mages_guild()
     if (const auto chara = chara_create(-1, 41, 27, 8))
     {
         chara->role = Role::spell_writer;
-        cdatan(0, chara->index) =
-            i18n::s.get("core.chara.job.spell_writer", cdatan(0, chara->index));
+        chara->name = i18n::s.get("core.chara.job.spell_writer", chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 41, 22, 8))
     {
         chara->role = Role::magic_vendor;
         chara->shop_rank = 11;
-        cdatan(0, chara->index) = snmagic(cdatan(0, chara->index));
+        chara->name = snmagic(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 74, 3, 9))
@@ -1740,7 +1734,7 @@ static void _init_map_lumiest_mages_guild()
     if (const auto chara = chara_create(-1, 40, 12, 6))
     {
         chara->role = Role::trainer;
-        cdatan(0, chara->index) = sntrainer(cdatan(0, chara->index));
+        chara->name = sntrainer(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 41, 3, 3))
@@ -1821,35 +1815,34 @@ static void _init_map_yowyn_town()
     {
         chara->role = Role::general_vendor;
         chara->shop_rank = 10;
-        cdatan(0, chara->index) = sngeneral(cdatan(0, chara->index));
+        chara->name = sngeneral(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 25, 8))
     {
         chara->role = Role::innkeeper;
         chara->shop_rank = 8;
-        cdatan(0, chara->index) = sninn(cdatan(0, chara->index));
+        chara->name = sninn(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 7, 8))
     {
         chara->role = Role::general_store;
         chara->shop_rank = 8;
-        cdatan(0, chara->index) = sngoods(cdatan(0, chara->index));
+        chara->name = sngoods(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 14, 14))
     {
         chara->role = Role::trader;
         chara->shop_rank = 12;
-        cdatan(0, chara->index) = sntrade(cdatan(0, chara->index));
+        chara->name = sntrade(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 35, 18))
     {
         chara->role = Role::horse_master;
-        cdatan(0, chara->index) =
-            i18n::s.get("core.chara.job.horse_master", cdatan(0, chara->index));
+        chara->name = i18n::s.get("core.chara.job.horse_master", chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 267, 33, 16))
@@ -1875,14 +1868,13 @@ static void _init_map_yowyn_town()
     if (const auto chara = chara_create(-1, 38, 3, 4))
     {
         chara->role = Role::mayer;
-        cdatan(0, chara->index) =
-            i18n::s.get("core.chara.job.of_yowyn", cdatan(0, chara->index));
+        chara->name = i18n::s.get("core.chara.job.of_yowyn", chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 40, 20, 14))
     {
         chara->role = Role::trainer;
-        cdatan(0, chara->index) = sntrainer(cdatan(0, chara->index));
+        chara->name = sntrainer(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 41, 24, 16))
@@ -2079,28 +2071,28 @@ static void _init_map_noyel()
     {
         chara->role = Role::blacksmith;
         chara->shop_rank = 12;
-        cdatan(0, chara->index) = snarmor(cdatan(0, chara->index));
+        chara->name = snarmor(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 11, 31))
     {
         chara->role = Role::general_vendor;
         chara->shop_rank = 10;
-        cdatan(0, chara->index) = sngeneral(cdatan(0, chara->index));
+        chara->name = sngeneral(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 38, 34))
     {
         chara->role = Role::innkeeper;
         chara->shop_rank = 8;
-        cdatan(0, chara->index) = sninn(cdatan(0, chara->index));
+        chara->name = sninn(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 5, 27))
     {
         chara->role = Role::bakery;
         chara->shop_rank = 9;
-        cdatan(0, chara->index) = snbakery(cdatan(0, chara->index));
+        chara->name = snbakery(chara->name);
         chara->image = 138;
     }
     flt();
@@ -2108,27 +2100,26 @@ static void _init_map_noyel()
     {
         chara->role = Role::magic_vendor;
         chara->shop_rank = 11;
-        cdatan(0, chara->index) = snmagic(cdatan(0, chara->index));
+        chara->name = snmagic(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 39, 35))
     {
         chara->role = Role::trader;
         chara->shop_rank = 12;
-        cdatan(0, chara->index) = sntrade(cdatan(0, chara->index));
+        chara->name = sntrade(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 38, 5, 18))
     {
         chara->role = Role::mayer;
-        cdatan(0, chara->index) =
-            i18n::s.get("core.chara.job.of_noyel", cdatan(0, chara->index));
+        chara->name = i18n::s.get("core.chara.job.of_noyel", chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 40, 18, 20))
     {
         chara->role = Role::trainer;
-        cdatan(0, chara->index) = sntrainer(cdatan(0, chara->index));
+        chara->name = sntrainer(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 41, 4, 33))
@@ -2233,56 +2224,56 @@ static void _init_map_port_kapul_town()
     {
         chara->role = Role::trader;
         chara->shop_rank = 12;
-        cdatan(0, chara->index) = sntrade(cdatan(0, chara->index));
+        chara->name = sntrade(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 23, 7))
     {
         chara->role = Role::blacksmith;
         chara->shop_rank = 12;
-        cdatan(0, chara->index) = snarmor(cdatan(0, chara->index));
+        chara->name = snarmor(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 32, 14))
     {
         chara->role = Role::general_vendor;
         chara->shop_rank = 10;
-        cdatan(0, chara->index) = sngeneral(cdatan(0, chara->index));
+        chara->name = sngeneral(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 22, 14))
     {
         chara->role = Role::general_store;
         chara->shop_rank = 10;
-        cdatan(0, chara->index) = sngoods(cdatan(0, chara->index));
+        chara->name = sngoods(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 16, 25))
     {
         chara->role = Role::blackmarket_vendor;
         chara->shop_rank = 10;
-        cdatan(0, chara->index) = snblack(cdatan(0, chara->index));
+        chara->name = snblack(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 17, 28))
     {
         chara->role = Role::food_vendor;
         chara->shop_rank = 10;
-        cdatan(0, chara->index) = snfood(cdatan(0, chara->index));
+        chara->name = snfood(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 41, 22, 22))
     {
         chara->role = Role::magic_vendor;
         chara->shop_rank = 11;
-        cdatan(0, chara->index) = snmagic(cdatan(0, chara->index));
+        chara->name = snmagic(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 35, 3))
     {
         chara->role = Role::innkeeper;
         chara->shop_rank = 8;
-        cdatan(0, chara->index) = sninn(cdatan(0, chara->index));
+        chara->name = sninn(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 70, 15, 15))
@@ -2303,14 +2294,13 @@ static void _init_map_port_kapul_town()
     if (const auto chara = chara_create(-1, 38, 8, 12))
     {
         chara->role = Role::mayer;
-        cdatan(0, chara->index) = i18n::s.get(
-            "core.chara.job.of_port_kapul", cdatan(0, chara->index));
+        chara->name = i18n::s.get("core.chara.job.of_port_kapul", chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 40, 16, 4))
     {
         chara->role = Role::trainer;
-        cdatan(0, chara->index) = sntrainer(cdatan(0, chara->index));
+        chara->name = sntrainer(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 41, 14, 4))
@@ -2396,7 +2386,7 @@ static void _init_map_port_kapul_fighters_guild()
     if (const auto chara = chara_create(-1, 40, 15, 10))
     {
         chara->role = Role::trainer;
-        cdatan(0, chara->index) = sntrainer(cdatan(0, chara->index));
+        chara->name = sntrainer(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 41, 14, 18))
@@ -2408,7 +2398,7 @@ static void _init_map_port_kapul_fighters_guild()
     {
         chara->role = Role::blacksmith;
         chara->shop_rank = 12;
-        cdatan(0, chara->index) = snarmor(cdatan(0, chara->index));
+        chara->name = snarmor(chara->name);
     }
     for (int _i = 0; _i < 16; ++_i)
     {
@@ -2521,49 +2511,49 @@ static void _init_map_vernis_town()
     {
         chara->role = Role::fisher;
         chara->shop_rank = 5;
-        cdatan(0, chara->index) = snfish(cdatan(0, chara->index));
+        chara->name = snfish(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 14, 12))
     {
         chara->role = Role::blacksmith;
         chara->shop_rank = 12;
-        cdatan(0, chara->index) = snarmor(cdatan(0, chara->index));
+        chara->name = snarmor(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 39, 27))
     {
         chara->role = Role::trader;
         chara->shop_rank = 12;
-        cdatan(0, chara->index) = sntrade(cdatan(0, chara->index));
+        chara->name = sntrade(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 10, 15))
     {
         chara->role = Role::general_vendor;
         chara->shop_rank = 10;
-        cdatan(0, chara->index) = sngeneral(cdatan(0, chara->index));
+        chara->name = sngeneral(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 41, 7, 26))
     {
         chara->role = Role::magic_vendor;
         chara->shop_rank = 11;
-        cdatan(0, chara->index) = snmagic(cdatan(0, chara->index));
+        chara->name = snmagic(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 14, 25))
     {
         chara->role = Role::innkeeper;
         chara->shop_rank = 8;
-        cdatan(0, chara->index) = sninn(cdatan(0, chara->index));
+        chara->name = sninn(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 1, 22, 26))
     {
         chara->role = Role::bakery;
         chara->shop_rank = 9;
-        cdatan(0, chara->index) = snbakery(cdatan(0, chara->index));
+        chara->name = snbakery(chara->name);
         chara->image = 138;
     }
     flt();
@@ -2585,14 +2575,13 @@ static void _init_map_vernis_town()
     if (const auto chara = chara_create(-1, 38, 10, 7))
     {
         chara->role = Role::mayer;
-        cdatan(0, chara->index) =
-            i18n::s.get("core.chara.job.of_vernis", cdatan(0, chara->index));
+        chara->name = i18n::s.get("core.chara.job.of_vernis", chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 40, 27, 16))
     {
         chara->role = Role::trainer;
-        cdatan(0, chara->index) = sntrainer(cdatan(0, chara->index));
+        chara->name = sntrainer(chara->name);
     }
     flt();
     if (const auto chara = chara_create(-1, 69, 25, 16))
@@ -2847,7 +2836,7 @@ static void _init_map_fields_maybe_generate_encounter()
             initlv = encounterlv + rnd(10);
             if (const auto chara = chara_create(-1, 303 + rnd(3), 14, 11))
             {
-                cdatan(0, chara->index) += u8" Lv"s + chara->level;
+                chara->name += u8" Lv"s + chara->level;
             }
         }
         event_add(23);
@@ -2884,8 +2873,8 @@ static void _init_map_fields_maybe_generate_encounter()
         {
             chara->role = Role::wandering_vendor;
             chara->shop_rank = encounterlv;
-            cdatan(0, chara->index) = i18n::s.get(
-                "core.chara.job.wandering_vendor", cdatan(0, chara->index));
+            chara->name =
+                i18n::s.get("core.chara.job.wandering_vendor", chara->name);
             generatemoney(*chara);
             for (int cnt = 0, cnt_end = (encounterlv / 2 + 1); cnt < cnt_end;
                  ++cnt)
@@ -2902,7 +2891,7 @@ static void _init_map_fields_maybe_generate_encounter()
             if (const auto chara = chara_create(-1, 159 + rnd(3), 14, 11))
             {
                 chara->role = Role::shop_guard;
-                cdatan(0, chara->index) += u8" Lv"s + chara->level;
+                chara->name += u8" Lv"s + chara->level;
             }
         }
     }

--- a/src/elona/lua_env/console.cpp
+++ b/src/elona/lua_env/console.cpp
@@ -269,7 +269,7 @@ void Console::register_builtin_commands()
             return;
 
         game_data.wizard = 1;
-        cdatan(1, 0) = "*Debug*";
+        cdata.player().alias = "*Debug*";
         _term.println("Wizard mode activated.");
     });
 
@@ -283,7 +283,7 @@ void Console::register_builtin_commands()
             _term.println("Wizard mode activated.");
         }
         debug::voldemort = true;
-        cdatan(1, 0) = "*You-Know-Who*";
+        cdata.player().alias = "*You-Know-Who*";
         _term.println("I AM LORD VOLDEMORT.");
     });
 
@@ -293,7 +293,7 @@ void Console::register_builtin_commands()
 
         debug::voldemort = false;
         game_data.wizard = 0;
-        cdatan(1, 0) = random_title(RandomTitleType::character);
+        cdata.player().alias = random_title(RandomTitleType::character);
         _term.println("Wizard mode inactivated.");
     });
 

--- a/src/elona/lua_env/lua_class/lua_class_character.cpp
+++ b/src/elona/lua_env/lua_class/lua_class_character.cpp
@@ -789,19 +789,16 @@ void LuaCharacter::bind(sol::state& lua)
     LuaCharacter.set(
         "basename",
         sol::property(
-            [](Character& c) { return elona::cdatan(0, c.index); },
-            [](Character& c, const std::string& s) {
-                elona::cdatan(0, c.index) = s;
-            }));
+            [](Character& c) { return c.name; },
+            [](Character& c, const std::string& s) { c.name = s; }));
 
     /**
-     * @luadoc title field string
+     * @luadoc alias field string
      *
-     * [R] The title of the character.
+     * [R] The alias of the character.
      */
-    LuaCharacter.set("title", sol::property([](Character& c) {
-                         return elona::cdatan(1, c.index);
-                     }));
+    LuaCharacter.set(
+        "alias", sol::property([](Character& c) { return c.alias; }));
 
     /**
      * @luadoc sex field Gender

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -383,7 +383,7 @@ bool _magic_1147(Character& target)
 // Item: salt solution
 bool _magic_1142(Character& target)
 {
-    if (cdatan(2, target.index) == u8"core.snail"s)
+    if (target.race == "core.snail")
     {
         if (is_in_fov(target))
         {
@@ -1105,7 +1105,7 @@ bool _magic_461(Character& subject)
     cdata[stat].current_map = 0;
     txt(i18n::s.get(
             "core.magic.resurrection.apply",
-            cnven(cdatan(0, stat)),
+            cnven(cdata[stat].name),
             cdata[stat]),
         Message::color{ColorIndex::orange});
     txt(i18n::s.get("core.magic.resurrection.dialog"));

--- a/src/elona/map.cpp
+++ b/src/elona/map.cpp
@@ -1026,7 +1026,7 @@ void map_reload_noyel()
         {
             chara->only_christmas() = true;
             chara->is_hung_on_sand_bag() = true;
-            cdatan(0, chara->index) = i18n::s.get("core.chara.job.fanatic");
+            chara->name = i18n::s.get("core.chara.job.fanatic");
         }
         flt();
         if (const auto chara = chara_create(-1, 347, 35, 19))
@@ -1060,7 +1060,7 @@ void map_reload_noyel()
             chara->only_christmas() = true;
             chara->role = Role::food_vendor;
             chara->shop_rank = 10;
-            cdatan(0, chara->index) = snfood(cdatan(0, chara->index));
+            chara->name = snfood(chara->name);
         }
         flt();
         if (const auto chara = chara_create(-1, 239, 25, 8))
@@ -1071,9 +1071,9 @@ void map_reload_noyel()
             chara->only_christmas() = true;
             chara->role = Role::souvenir_vendor;
             chara->shop_rank = 30;
-            cdatan(0, chara->index) = random_name();
-            cdatan(0, chara->index) = i18n::s.get(
-                "core.chara.job.souvenir_vendor", cdatan(0, chara->index));
+            chara->name = random_name();
+            chara->name =
+                i18n::s.get("core.chara.job.souvenir_vendor", chara->name);
         }
         flt();
         if (const auto chara = chara_create(-1, 271, 24, 22))
@@ -1084,9 +1084,9 @@ void map_reload_noyel()
             chara->only_christmas() = true;
             chara->role = Role::souvenir_vendor;
             chara->shop_rank = 30;
-            cdatan(0, chara->index) = random_name();
-            cdatan(0, chara->index) = i18n::s.get(
-                "core.chara.job.souvenir_vendor", cdatan(0, chara->index));
+            chara->name = random_name();
+            chara->name =
+                i18n::s.get("core.chara.job.souvenir_vendor", chara->name);
         }
         flt();
         if (const auto chara = chara_create(-1, 1, 38, 12))
@@ -1094,7 +1094,7 @@ void map_reload_noyel()
             chara->ai_calm = 3;
             chara->role = Role::blackmarket_vendor;
             chara->shop_rank = 10;
-            cdatan(0, chara->index) = snblack(cdatan(0, chara->index));
+            chara->name = snblack(chara->name);
             chara->only_christmas() = true;
         }
         flt();
@@ -1106,9 +1106,9 @@ void map_reload_noyel()
             chara->only_christmas() = true;
             chara->role = Role::street_vendor;
             chara->shop_rank = 30;
-            cdatan(0, chara->index) = random_name();
-            cdatan(0, chara->index) = i18n::s.get(
-                "core.chara.job.street_vendor", cdatan(0, chara->index));
+            chara->name = random_name();
+            chara->name =
+                i18n::s.get("core.chara.job.street_vendor", chara->name);
         }
         flt();
         if (const auto chara = chara_create(-1, 271, 29, 24))
@@ -1119,9 +1119,9 @@ void map_reload_noyel()
             chara->only_christmas() = true;
             chara->role = Role::street_vendor;
             chara->shop_rank = 30;
-            cdatan(0, chara->index) = random_name();
-            cdatan(0, chara->index) = i18n::s.get(
-                "core.chara.job.street_vendor2", cdatan(0, chara->index));
+            chara->name = random_name();
+            chara->name =
+                i18n::s.get("core.chara.job.street_vendor2", chara->name);
         }
         for (int cnt = 0; cnt < 20; ++cnt)
         {

--- a/src/elona/mef.cpp
+++ b/src/elona/mef.cpp
@@ -307,7 +307,7 @@ bool mef_proc_from_movement(Character& chara)
     }
     if (mef(0, i) == 1)
     {
-        if (cdatan(2, chara.index) != u8"core.spider"s)
+        if (chara.race != "core.spider")
         {
             if (rnd_capped(mef(5, i) + 25) <
                     rnd_capped(

--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -1475,12 +1475,12 @@ int change_npc_tone(Character& chara)
     if (result.value)
     {
         chara.has_custom_talk() = true;
-        cdatan(4, chara.index) = *result.value;
+        chara.talk = *result.value;
     }
     else
     {
         chara.has_custom_talk() = false;
-        cdatan(4, chara.index) = "";
+        chara.talk = "";
     }
 
     return 1;

--- a/src/elona/net.cpp
+++ b/src/elona/net.cpp
@@ -7,6 +7,7 @@
 #include "../thirdparty/json5/json5.hpp"
 #include "../thirdparty/xxHash/xxhashcpp.hpp"
 #include "../util/scope_guard.hpp"
+#include "character.hpp"
 #include "config.hpp"
 #include "i18n.hpp"
 #include "input.hpp"
@@ -145,12 +146,12 @@ std::string get_pc_name()
 {
     if (config_get_boolean("core.net.hide_your_name"))
     {
-        const auto seed = xxhash::xxhash32(cdatan(0, 0));
+        const auto seed = xxhash::xxhash32(cdata.player().name);
         return eval_with_random_seed(seed, []() { return random_name(); });
     }
     else
     {
-        return cdatan(0, 0);
+        return cdata.player().name;
     }
 }
 
@@ -160,13 +161,13 @@ std::string get_pc_alias()
 {
     if (config_get_boolean("core.net.hide_your_alias"))
     {
-        const auto seed = xxhash::xxhash32(cdatan(1, 0));
+        const auto seed = xxhash::xxhash32(cdata.player().alias);
         return eval_with_random_seed(
             seed, []() { return random_title(RandomTitleType::character); });
     }
     else
     {
-        return cdatan(1, 0);
+        return cdata.player().alias;
     }
 }
 

--- a/src/elona/quest.cpp
+++ b/src/elona/quest.cpp
@@ -434,7 +434,7 @@ void quest_set_data(optional_ref<const Character> client, int val0)
         if (game_data.current_map == quest_data[rq].originating_map_id &&
             game_data.current_dungeon_level == 1)
         {
-            s(12) = ""s + cdatan(0, quest_data[rq].target_chara_index);
+            s(12) = cdata[quest_data[rq].target_chara_index].name;
         }
         else
         {
@@ -578,7 +578,7 @@ void quest_on_map_initialize()
         }
         quest_data[i].client_chara_index = cnt.index;
         quest_data[i].originating_map_id = game_data.current_map;
-        qname(i) = cdatan(0, cnt.index);
+        qname(i) = cnt.name;
         cnt.related_quest_id = i + 1;
         game_data.number_of_existing_quests = i + 1;
     }

--- a/src/elona/race.cpp
+++ b/src/elona/race.cpp
@@ -18,7 +18,7 @@ void race_init_chara(Character& chara, data::InstanceId race_id)
     if (!data)
         return;
 
-    cdatan(2, chara.index) = race_id.get();
+    chara.race = race_id;
 
     chara.melee_attack_type = data->melee_attack_type;
     chara.special_attack_type = data->special_attack_type;
@@ -111,50 +111,50 @@ std::vector<std::reference_wrapper<const RaceData>> race_get_available(
 
 void gain_race_feat()
 {
-    if (cdatan(2, 0) == u8"core.dwarf"s)
+    if (cdata.player().race == "core.dwarf")
     {
         trait(152) = 2;
         trait(155) = 1;
     }
-    if (cdatan(2, 0) == u8"core.elea"s)
+    if (cdata.player().race == "core.elea")
     {
         trait(168) = 1;
         trait(156) = 1;
     }
-    if (cdatan(2, 0) == u8"core.eulderna"s)
+    if (cdata.player().race == "core.eulderna")
     {
         trait(153) = 1;
     }
-    if (cdatan(2, 0) == u8"core.lich"s)
+    if (cdata.player().race == "core.lich")
     {
         trait(151) = 1;
         trait(155) = 2;
         trait(152) = 1;
     }
-    if (cdatan(2, 0) == u8"core.golem"s)
+    if (cdata.player().race == "core.golem")
     {
         trait(157) = 1;
         trait(152) = 2;
     }
-    if (cdatan(2, 0) == u8"core.yerles"s)
+    if (cdata.player().race == "core.yerles")
     {
         trait(154) = 1;
     }
-    if (cdatan(2, 0) == u8"core.juere"s)
+    if (cdata.player().race == "core.juere")
     {
         trait(158) = 1;
         trait(159) = 1;
     }
-    if (cdatan(2, 0) == u8"core.goblin"s)
+    if (cdata.player().race == "core.goblin")
     {
         trait(155) = 1;
         trait(159) = 1;
     }
-    if (cdatan(2, 0) == u8"core.mutant"s)
+    if (cdata.player().race == "core.mutant")
     {
         trait(0) = 1;
     }
-    if (cdatan(2, 0) == u8"core.fairy"s)
+    if (cdata.player().race == "core.fairy")
     {
         trait(160) = 1;
         trait(161) = 1;

--- a/src/elona/save.cpp
+++ b/src/elona/save.cpp
@@ -123,7 +123,7 @@ void load_save_data()
     }
     if (game_data.wizard == 1)
     {
-        cdatan(1, 0) = u8"*Debug*"s;
+        cdata.player().alias = u8"*Debug*"s;
     }
     refresh_speed(cdata.player());
     time_begin = timeGetTime() / 1000;

--- a/src/elona/scene.cpp
+++ b/src/elona/scene.cpp
@@ -381,8 +381,10 @@ void conquer_lesimas()
     draw_region("void", 0, 0, 0, 0, windoww, windowh);
     asset_load("g1");
     gsel(0);
-    ui_draw_caption(
-        i18n::s.get("core.win.you_acquired_codex", cdatan(1, 0), cdatan(0, 0)));
+    ui_draw_caption(i18n::s.get(
+        "core.win.you_acquired_codex",
+        cdata.player().alias,
+        cdata.player().name));
     windowshadow = 1;
     ww = 680;
     wh = 488;

--- a/src/elona/status_ailment.cpp
+++ b/src/elona/status_ailment.cpp
@@ -214,7 +214,7 @@ void status_ailment_damage(
     case StatusAilment::dimmed:
         if (chara.quality > Quality::great && rnd_capped(chara.level / 3 + 1))
             return;
-        if (cdatan(2, chara.index) == u8"core.golem"s)
+        if (chara.race == "core.golem")
             return;
         power = calc_power_decreased_by_resistance(
             chara.index, power, Element::sound);

--- a/src/elona/talk.cpp
+++ b/src/elona/talk.cpp
@@ -466,7 +466,8 @@ TalkResult talk_game_begin(Character& initial_speaker)
         }
     }
     listmax = 0;
-    buff = i18n::s.get_enum("core.talk.unique.lomias.begin", 4, cdatan(0, 0));
+    buff = i18n::s.get_enum(
+        "core.talk.unique.lomias.begin", 4, cdata.player().name);
     if (const auto lomias = chara_find("core.lomias"))
     {
         speaker = std::ref(*lomias);
@@ -510,17 +511,14 @@ std::string talk_get_speaker_name(const Character& chara)
     {
         return actor(0, current_actor_index);
     }
-    if (cdatan(1, chara.index) == ""s)
+    if (chara.alias == ""s)
     {
-        speaker_name = cdatan(0, chara.index) + u8" "s;
+        speaker_name = chara.name + u8" "s;
     }
     else
     {
-        speaker_name = i18n::s.get(
-                           "core.talk.window.of",
-                           cdatan(0, chara.index),
-                           cdatan(1, chara.index)) +
-            " ";
+        speaker_name =
+            i18n::s.get("core.talk.window.of", chara.name, chara.alias) + " ";
     }
     if (chara.sex == 0)
     {
@@ -530,7 +528,7 @@ std::string talk_get_speaker_name(const Character& chara)
     {
         speaker_name += cnven(i18n::s.get("core.ui.sex3.female"));
     }
-    if (cdatan(1, chara.index) != ""s)
+    if (chara.alias != ""s)
     {
         speaker_name += " " + i18n::s.get("core.talk.window.fame", chara.fame);
     }

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -306,7 +306,7 @@ TalkResult talk_arena_master(Character& speaker, int chatval_)
             arenaop(1) = charaid2int(chara->id);
             buff = i18n::s.get(
                 "core.talk.npc.arena_master.enter.target",
-                cdatan(0, chara->index),
+                chara->name,
                 speaker);
             break;
         }
@@ -696,7 +696,7 @@ TalkResult talk_slave_buy(Character& speaker, int chatval_)
     listmax = 0;
     buff = i18n::s.get(
         "core.talk.npc.slave_trader.buy.cost",
-        cnven(cdatan(0, 56)),
+        cnven(cdata[56].name),
         calc_slave_value(cdata.tmp()),
         speaker);
     if (cdata.player().gold >= calc_slave_value(cdata.tmp()))
@@ -713,7 +713,7 @@ TalkResult talk_slave_buy(Character& speaker, int chatval_)
     if (chatval_ == 1)
     {
         txt(i18n::s.get(
-            "core.talk.npc.slave_trader.buy.you_buy", cnven(cdatan(0, 56))));
+            "core.talk.npc.slave_trader.buy.you_buy", cnven(cdata[56].name)));
         snd("core.paygold1");
         cdata.player().gold -= calc_slave_value(cdata.tmp());
         new_ally_joins(cdata.tmp());
@@ -748,7 +748,7 @@ TalkResult talk_slave_sell(Character& speaker)
         {
             txt(i18n::s.get(
                 "core.talk.npc.slave_trader.sell.you_sell_off",
-                cnven(cdatan(0, stat))));
+                cnven(cdata[stat].name)));
             snd("core.getgold1");
             earn_gold(cdata.player(), calc_slave_value(cdata[stat]) * 2 / 3);
             if (cdata[stat].state() == Character::State::alive)

--- a/src/elona/text.cpp
+++ b/src/elona/text.cpp
@@ -805,16 +805,16 @@ std::string replace_tag(
     }
     if (source == u8"player"s)
     {
-        return cdatan(0, 0);
+        return cdata.player().name;
     }
     if (source == u8"aka"s)
     {
-        return cdatan(1, 0);
+        return cdata.player().alias;
     }
     if (source == u8"npc"s)
     {
         assert(client);
-        return cdatan(0, client->index);
+        return client->name;
     }
     if (source == u8"ある"s)
     {
@@ -2404,18 +2404,18 @@ void text_replace_tags_in_quest_text(optional_ref<const Character> client)
             }
             if (s == u8"player"s)
             {
-                s = cdatan(0, 0);
+                s = cdata.player().name;
                 break;
             }
             if (s == u8"aka"s)
             {
-                s = cdatan(1, 0);
+                s = cdata.player().alias;
                 break;
             }
             if (s == u8"npc"s)
             {
                 assert(client);
-                s = cdatan(0, client->index);
+                s = client->name;
                 break;
             }
             if (s == u8"ある"s)
@@ -2535,17 +2535,17 @@ std::string name(int chara_index)
     }
     if (en)
     {
-        const char first = cdatan(0, chara_index)[0];
+        const char first = cdata[chara_index].name[0];
         if (first == '\"' || first == '<')
         {
-            return cdatan(0, chara_index);
+            return cdata[chara_index].name;
         }
         if (cdata[chara_index].has_own_name() == 0)
         {
-            return u8"the "s + cdatan(0, chara_index);
+            return u8"the "s + cdata[chara_index].name;
         }
     }
-    return cdatan(0, chara_index);
+    return cdata[chara_index].name;
 }
 
 

--- a/src/elona/turn_sequence.cpp
+++ b/src/elona/turn_sequence.cpp
@@ -370,14 +370,13 @@ optional<TurnResult> npc_turn_misc(Character& chara, int& enemy_index)
     enemy_index = chara.enemy_id;
 
     // Talk
-    if (cdatan(4, chara.index) != ""s)
+    if (!chara.talk.empty())
     {
         if (chara.has_custom_talk() == 0)
         {
             if (rnd(30) == 0)
             {
-                txt(""s + cdatan(4, chara.index),
-                    Message::color{ColorIndex::cyan});
+                txt(chara.talk, Message::color{ColorIndex::cyan});
             }
         }
     }

--- a/src/elona/ui/ui_menu_adventurers.cpp
+++ b/src/elona/ui/ui_menu_adventurers.cpp
@@ -102,8 +102,8 @@ _draw_list_entry_pic_and_rank(int cnt, const Character& chara, int _p)
 
 void UIMenuAdventurers::_draw_list_entry_name(int cnt, const Character& chara)
 {
-    const auto name = strutil::take_by_width(
-        cdatan(1, chara.index) + u8" "s + cdatan(0, chara.index), 26);
+    const auto name =
+        strutil::take_by_width(chara.alias + u8" "s + chara.name, 26);
     cs_list(cs == cnt, name, wx + 118, wy + 66 + cnt * 19 - 1);
 }
 

--- a/src/elona/ui/ui_menu_character_sheet.cpp
+++ b/src/elona/ui/ui_menu_character_sheet.cpp
@@ -470,11 +470,10 @@ void UIMenuCharacterSheet::_draw_first_page_text_level()
 
 void UIMenuCharacterSheet::_draw_first_page_text_name()
 {
-    s(0) = cdatan(0, _chara.index);
-    s(1) = cdatan(1, _chara.index);
-    s(2) = cnven(the_race_db.get_text(
-        data::InstanceId{cdatan(2, _chara.index)}, "name"));
-    s(4) = cnven(class_get_name(data::InstanceId{cdatan(3, _chara.index)}));
+    s(0) = _chara.name;
+    s(1) = _chara.alias;
+    s(2) = cnven(the_race_db.get_text(_chara.race, "name"));
+    s(4) = cnven(class_get_name(_chara.class_));
     if (_chara.sex == 0)
     {
         s(3) = cnven(i18n::s.get("core.ui.sex3.male"));

--- a/src/elona/ui/ui_menu_ctrl_ally.cpp
+++ b/src/elona/ui/ui_menu_ctrl_ally.cpp
@@ -280,8 +280,7 @@ snail::Color UIMenuCtrlAlly::_draw_get_color(const Character& chara)
 
 std::string UIMenuCtrlAlly::_get_ally_name(const Character& chara)
 {
-    std::string ally_name =
-        ""s + cdatan(1, chara.index) + u8" "s + cdatan(0, chara.index);
+    std::string ally_name = chara.alias + u8" "s + chara.name;
 
     if (chara.current_map != 0)
     {
@@ -416,8 +415,7 @@ std::string UIMenuCtrlAlly::_modify_ally_info_gene_engineer(
 
 void UIMenuCtrlAlly::_draw_ally_list_entry_sell(int cnt, const Character& chara)
 {
-    std::string ally_name =
-        ""s + cdatan(1, chara.index) + u8" "s + cdatan(0, chara.index);
+    std::string ally_name = chara.alias + u8" "s + chara.name;
     ally_name += u8" Lv."s + chara.level;
 
     cs_list(cs == cnt, ally_name, wx + 84, wy + 66 + cnt * 19 - 1);

--- a/src/elona/ui/ui_menu_feats.cpp
+++ b/src/elona/ui/ui_menu_feats.cpp
@@ -273,7 +273,7 @@ void UIMenuFeats::_draw_acquirable_trait_number(int tc_)
     else
     {
         note = i18n::s.get(
-            "core.trait.window.your_trait", cnven(cdatan(0, _chara_index)));
+            "core.trait.window.your_trait", cnven(cdata[_chara_index].name));
     }
     display_note(note, 50);
 }

--- a/src/elona/ui/ui_menu_hire.cpp
+++ b/src/elona/ui/ui_menu_hire.cpp
@@ -159,7 +159,7 @@ void UIMenuHire::_draw_list_entry_pic(int cnt, const Character& chara)
 
 void UIMenuHire::_draw_list_entry_name(int cnt, const Character& chara)
 {
-    const auto chara_name = strutil::take_by_width(cdatan(0, chara.index), 36);
+    const auto chara_name = strutil::take_by_width(chara.name, 36);
     cs_list(cs == cnt, chara_name, wx + 84, wy + 66 + cnt * 19 - 1);
 }
 

--- a/src/elona/ui/ui_menu_quest_board.cpp
+++ b/src/elona/ui/ui_menu_quest_board.cpp
@@ -181,7 +181,7 @@ void UIMenuQuestBoard::_draw_list_entry_date(const std::string& date_text)
 
 void UIMenuQuestBoard::_draw_list_entry_giver_name(int chara_index)
 {
-    const auto name = strutil::take_by_width(cdatan(0, chara_index), 20);
+    const auto name = strutil::take_by_width(cdata[chara_index].name, 20);
     mes(wx + 392, y + 2, name);
 }
 

--- a/src/elona/variables.hpp
+++ b/src/elona/variables.hpp
@@ -293,7 +293,6 @@ ELONA_EXTERN(elona_vector2<int> picfood);
 ELONA_EXTERN(elona_vector2<int> qdata);
 ELONA_EXTERN(elona_vector2<int> slight);
 ELONA_EXTERN(elona_vector2<std::string> _melee);
-ELONA_EXTERN(elona_vector2<std::string> cdatan);
 ELONA_EXTERN(elona_vector2<std::string> listn);
 ELONA_EXTERN(elona_vector2<std::string> mapnamerd);
 ELONA_EXTERN(elona_vector3<int> bddata);

--- a/src/elona/wish.cpp
+++ b/src/elona/wish.cpp
@@ -265,7 +265,7 @@ void wish_for_character()
             cdata.player().position.x,
             cdata.player().position.y))
     {
-        txt(cdatan(0, chara->index) + " is summoned.");
+        txt(chara->name + " is summoned.");
     }
 }
 
@@ -409,7 +409,7 @@ bool grant_special_wishing(const std::string& wish)
             if (stat == 1)
             {
                 txt(i18n::s.get("core.wish.wish_alias.new_alias", cmaka));
-                cdatan(1, 0) = cmaka;
+                cdata.player().alias = cmaka;
             }
             else
             {

--- a/src/tests/i18n_builtins.cpp
+++ b/src/tests/i18n_builtins.cpp
@@ -21,7 +21,7 @@ TEST_CASE("test i18n builtin: characters", "[I18N: Builtins]")
     testing::start_in_debug_map();
 
     Character& you = elona::cdata.player();
-    elona::cdatan(0, you.index) = u8"Orville";
+    you.name = "Orville";
     you.sex = 0;
 
     Character& out_of_fov =
@@ -111,7 +111,7 @@ TEST_CASE("test i18n builtin: characters", "[I18N: Builtins]")
             i18n::s.format("something go{s($1, true)} to hell.", chara) ==
             u8"something goes to hell.");
 
-        elona::cdatan(0, chara.index) = u8"Putit the mochi vendor";
+        chara.name = "Putit the mochi vendor";
         REQUIRE(i18n::s.format("{name_nojob($1)}", chara) == u8"Putit ");
     }
 }

--- a/src/tests/serialization.cpp
+++ b/src/tests/serialization.cpp
@@ -98,7 +98,7 @@ TEST_CASE("Test character data compatibility", "[C++: Serialization]")
     int player_idx = 0;
     load_previous_savefile();
     REQUIRE(elona::cdata[player_idx].index == player_idx);
-    REQUIRE(elona::cdatan(0, player_idx) == u8"foobar_test");
+    REQUIRE(elona::cdata[player_idx].name == u8"foobar_test");
 }
 
 TEST_CASE("Test other character data compatibility", "[C++: Serialization]")
@@ -106,7 +106,7 @@ TEST_CASE("Test other character data compatibility", "[C++: Serialization]")
     int chara_idx = 57;
     load_previous_savefile();
     REQUIRE(elona::cdata[chara_idx].index == chara_idx);
-    REQUIRE(elona::cdatan(0, chara_idx) == u8"風を聴く者『ラーネイレ』");
+    REQUIRE(elona::cdata[chara_idx].name == u8"風を聴く者『ラーネイレ』");
 }
 
 TEST_CASE("Test item data compatibility (in inventory)", "[C++: Serialization]")


### PR DESCRIPTION
# Summary

Unite `cdata` and `cdatan`. This PR does not change the save data format. All saves are kept compatible.

`cdatan` is mapped to `Character`'s fields like this:

* `cdatan(0, *)` -> `Character::name`
* `cdatan(1, *)` -> `Character::alias`
* `cdatan(2, *)` -> `Character::race`
* `cdatan(3, *)` -> `Character::class_`
* `cdatan(4, *)` -> `Character::talk`
