### PR TITLE
Change save directory's naming convention

### DIFF
--- a/runtime/mod/core/locale/en/chara_making.lua
+++ b/runtime/mod/core/locale/en/chara_making.lua
@@ -88,7 +88,6 @@ ELONA.i18n:add {
          },
 
          what_is_your_name = "Last question. What's your name?",
-         name_is_already_taken = "Sorry, but the name is already taken.",
       },
    },
 }

--- a/runtime/mod/core/locale/jp/chara_making.lua
+++ b/runtime/mod/core/locale/jp/chara_making.lua
@@ -88,7 +88,6 @@ ELONA.i18n:add {
          },
 
          what_is_your_name = "最後の質問だ。君の名前は？",
-         name_is_already_taken = "あいにく、その名前の冒険者はすでに存在する。",
       },
    },
 }


### PR DESCRIPTION
# Summary

New naming convention: `path/to/elonafoobar/profile/<profile name>/save/save_<N>` where `N` is a sequential number starting with 1

Old save folders will not be renamed. With this change, you can name your player character without worrying the name is already used.

![image](https://user-images.githubusercontent.com/36858341/83324112-e2fcb980-a29d-11ea-9294-075e53032616.png)

