### PR TITLE
Fix no-kill win in arena or pet arena

### DIFF
--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -1393,7 +1393,6 @@ void chara_vanquish(Character& chara)
         }
         chara.shop_store_id = 0;
     }
-    quest_check();
     modify_crowd_density(chara.index, 1);
 }
 

--- a/src/elona/initialize_map_types.cpp
+++ b/src/elona/initialize_map_types.cpp
@@ -828,9 +828,8 @@ static void _init_map_arena()
                 chara->relationship = -3;
                 chara->original_relationship = -3;
                 chara->hate = 30;
-                chara->relationship = -3;
                 chara->is_lord_of_dungeon() = true;
-                if (chara->level > arenaop(1) || chara->relationship != -3)
+                if (chara->level > arenaop(1))
                 {
                     chara_vanquish(*chara);
                     --cnt;

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -1645,6 +1645,7 @@ bool _magic_653(Character& target)
     }
     txt(i18n::s.get("core.magic.vanish", target));
     chara_vanquish(target);
+    quest_check();
     return true;
 }
 


### PR DESCRIPTION
# Related Issues

Close #1639.

# Summary

Don't call `quest_check()` within `chara_vanquish()`, and call `quest_check()` in the caller of it if needed.