### PR TITLE
Fix relocation of item handle (#1631)

### DIFF
--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -1552,8 +1552,7 @@ void chara_relocate(
     int p = invhead;
     for (auto&& item : inv.for_chara(destination))
     {
-        Item::copy(inv[p], item);
-        inv[p].clear();
+        item_copy(inv[p], item);
         item.body_part = 0;
         ++p;
         if (p >= invhead + invrange)

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -484,27 +484,13 @@ void item_exchange(Item& a, Item& b)
 
 void Item::remove()
 {
-    number_ = 0;
-}
-
-
-
-void item_delete(Item& item)
-{
-    const auto index = item.index;
-    item.remove();
-    item.clear();
-    item.index = index; // Restore "index".
+    set_number(0);
 }
 
 
 
 void item_refresh(Item& i)
 {
-    if (i.number() <= 0)
-    {
-        i.remove();
-    }
     if (i.index >= ELONA_ITEM_ON_GROUND_INDEX && mode != 6)
     {
         // Refresh the cell the item is on if it's on the ground.

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -171,8 +171,6 @@ public:
 
 
 private:
-    static void refresh();
-
     Item(const Item&) = default;
     Item(Item&&) = default;
     Item& operator=(const Item&) = default;
@@ -327,7 +325,6 @@ Item& inv_compress(int owner);
 void item_copy(Item& src, Item& dst);
 
 void item_acid(const Character& owner, optional_ref<Item> item = none);
-void item_delete(Item& item);
 
 /**
  * Swap the content of @a a and @a b. If they points to the same object, does

--- a/src/elona/itemgen.cpp
+++ b/src/elona/itemgen.cpp
@@ -153,7 +153,7 @@ optional_ref<Item> do_create_item(int item_id, int slot, int x, int y)
 
     auto&& item = *empty_slot;
 
-    item_delete(item);
+    item.clear();
 
     if (slot == -1 && mode != 6 && mode != 9)
     {

--- a/src/tests/util.cpp
+++ b/src/tests/util.cpp
@@ -61,7 +61,8 @@ std::string test_itemname(int id, int number, bool prefix)
     REQUIRE_SOME(item);
     normalize_item(*item);
     std::string name = itemname(*item, number, prefix);
-    item_delete(*item);
+    item->remove();
+    item->clear();
     return name;
 }
 
@@ -89,7 +90,8 @@ void invalidate_item(Item& item)
     int old_y = item.position.y;
 
     // Delete the item and create new ones until the index is taken again.
-    item_delete(inv[old_index]);
+    inv[old_index].remove();
+    inv[old_index].clear();
     while (true)
     {
         const auto new_item = itemcreate_extra_inv(old_id, old_x, old_y, 3);


### PR DESCRIPTION
# Summary

* Remove item handles when calling `Item::remove()`.
* Remove and create item handles when calling `Item::copy()`.
    * TODO: These handles should be "relocated" instead of creating new handles.

