### PR TITLE
Add more information to the save selection menu

### DIFF
--- a/runtime/mod/core/locale/en/ui.lua
+++ b/runtime/mod/core/locale/en/ui.lua
@@ -889,5 +889,13 @@ ELONA.i18n:add {
          time = "{zfill($1, 2)}:{zfill($2, 2)}:{zfill($3, 2)}",
          date = "{zfill($1, 2)}/{zfill($2, 2)}/{zfill($3, 2)}",
       },
+
+      save_header = {
+         last_played_at = "Last played at {$1}/{zfill($2, 2)}/{zfill($3, 2)} {zfill($4, 2)}:{zfill($5, 2)}",
+         play_seconds = {
+            minutes = "Played in {$1} min.",
+            hours = "Played in {$1} h. and {$2} min.",
+         },
+      },
    },
 }

--- a/runtime/mod/core/locale/jp/ui.lua
+++ b/runtime/mod/core/locale/jp/ui.lua
@@ -937,5 +937,13 @@ ELONA.i18n:add {
          time = "{zfill($1, 2)}:{zfill($2, 2)}:{zfill($3, 2)}",
          date = "{zfill($1, 2)}/{zfill($2, 2)}/{zfill($3, 2)}",
       },
+
+      save_header = {
+         last_played_at = "最後にプレイした日時: {$1}/{zfill($2, 2)}/{zfill($3, 2)} {zfill($4, 2)}:{zfill($5, 2)}",
+         play_seconds = {
+            minutes = "プレイ時間: {$1}分",
+            hours = "プレイ時間: {$1}時間{$2}分",
+         },
+      },
    },
 }

--- a/src/elona/CMakeLists.txt
+++ b/src/elona/CMakeLists.txt
@@ -83,6 +83,7 @@ set(ELONA_SOURCES
   random_event.cpp
   randomgen.cpp
   save.cpp
+  save_header.cpp
   save_update.cpp
   scene.cpp
   set_item_info.cpp

--- a/src/elona/ctrl_file.cpp
+++ b/src/elona/ctrl_file.cpp
@@ -18,6 +18,7 @@
 #include "map.hpp"
 #include "mef.hpp"
 #include "quest.hpp"
+#include "save_header.hpp"
 #include "serialization/serialization.hpp"
 #include "variables.hpp"
 
@@ -418,9 +419,7 @@ void fmode_7_8(bool read, const fs::path& dir)
 
     if (!read)
     {
-        playerheader = cdata.player().name + u8" Lv:" + cdata.player().level +
-            u8" " + mdatan(0);
-        bsave(dir / u8"header.txt", playerheader);
+        SaveHeader::save(dir);
     }
 
     {

--- a/src/elona/json5util.hpp
+++ b/src/elona/json5util.hpp
@@ -7,16 +7,14 @@
 
 
 
-namespace elona
-{
-namespace json5util
+namespace elona::json5util
 {
 
 using parse_result = either::either<std::string, json5::value>;
 
 
 
-parse_result parse_stream(std::istream& in)
+inline parse_result parse_stream(std::istream& in)
 {
     if (!in)
     {
@@ -36,5 +34,4 @@ parse_result parse_stream(std::istream& in)
     }
 }
 
-} // namespace json5util
-} // namespace elona
+} // namespace elona::json5util

--- a/src/elona/main.cpp
+++ b/src/elona/main.cpp
@@ -7,6 +7,7 @@
 #include "lua_env/lua_event/base_event.hpp"
 #include "main_menu.hpp"
 #include "profile/profile_manager.hpp"
+#include "save_header.hpp"
 #include "turn_sequence.hpp"
 #include "variables.hpp"
 
@@ -55,11 +56,9 @@ void _start_elona()
     }
     else if (defload != ""s)
     {
-        if (!fs::exists(filesystem::dirs::save(defload) / u8"header.txt"))
+        if (!SaveHeader::exists(filesystem::dirs::save(defload)))
         {
-            if (fs::exists(
-                    filesystem::dirs::save(u8"sav_" + defload) /
-                    u8"header.txt"))
+            if (SaveHeader::exists(filesystem::dirs::save(u8"sav_" + defload)))
             {
                 // TODO: Delete it when v1.0.0 stable is released.
                 defload = u8"sav_"s + defload;

--- a/src/elona/save_header.cpp
+++ b/src/elona/save_header.cpp
@@ -1,0 +1,262 @@
+#include "save_header.hpp"
+
+#include <ctime>
+
+#include <chrono>
+
+#include "../version.hpp"
+#include "character.hpp"
+#include "class.hpp"
+#include "gdata.hpp"
+#include "json5util.hpp"
+#include "race.hpp"
+#include "serialization/serialization.hpp"
+#include "text.hpp"
+
+
+
+namespace elona
+{
+
+namespace
+{
+
+const fs::path vanilla_filename = filepathutil::u8path("header.txt");
+const fs::path foobar_filename = filepathutil::u8path("header.json");
+
+
+
+int64_t now_unix_time()
+{
+    using std::chrono::system_clock;
+
+    return system_clock::to_time_t(system_clock::now());
+}
+
+
+
+int64_t get_played_seconds()
+{
+    return game_data.play_time;
+}
+
+
+
+std::string last_played_at_to_string(int64_t time)
+{
+    std::time_t time_ = static_cast<std::time_t>(time);
+    const std::tm* local_time = std::localtime(&time_);
+
+    // TODO: localize
+    const auto y = local_time->tm_year + 1900;
+    const auto M = local_time->tm_mon + 1;
+    const auto d = local_time->tm_mday;
+    const auto h = local_time->tm_hour;
+    const auto m = local_time->tm_min;
+
+    return i18n::s.get("core.ui.save_header.last_played_at", y, M, d, h, m);
+}
+
+
+
+std::string play_seconds_to_string(int64_t sec)
+{
+    if (sec < 3600) // less than 1 hour
+    {
+        return i18n::s.get(
+            "core.ui.save_header.play_seconds.minutes",
+            std::max(sec / 60, int64_t{1}));
+    }
+    else
+    {
+        return i18n::s.get(
+            "core.ui.save_header.play_seconds.hours",
+            sec / 3600,
+            (sec % 3600) / 60);
+    }
+}
+
+
+
+// TODO: not implemented yet
+std::string detect_save_data_version()
+{
+    return "vanilla v1.22";
+}
+
+} // namespace
+
+
+
+std::string SaveHeader::title() const
+{
+    return save_dir_name + "   " + version + (is_wizard ? "   (wizard)" : "");
+}
+
+
+
+std::vector<std::string> SaveHeader::to_string() const
+{
+    if (format == Format::vanilla)
+    {
+        return {
+            name + "  Lv: " + std::to_string(level) + "   " + location,
+        };
+    }
+    else
+    {
+        return {
+            last_played_at_to_string(last_played_at) + "   " +
+                play_seconds_to_string(play_seconds),
+            alias + " " + name + "  Lv: " + std::to_string(level) + "   " +
+                race + " " + class_,
+            ingame_time + "   " + location,
+        };
+    }
+}
+
+
+
+SaveHeader SaveHeader::load(const fs::path& save_dir)
+{
+    assert(SaveHeader::exists(save_dir));
+
+    if (fs::exists(save_dir / foobar_filename))
+    {
+        return load_foobar(save_dir);
+    }
+    else
+    {
+        return load_vanilla(save_dir);
+    }
+}
+
+
+
+void SaveHeader::save(const fs::path& save_dir)
+{
+    auto h = SaveHeader::current_state();
+
+    {
+        // Vanilla
+        std::ofstream out{(save_dir / vanilla_filename).native()};
+        out << h.name << " Lv:" << h.level << " " << h.location << std::endl;
+    }
+    {
+        // foobar
+        serialization::json::save(save_dir / foobar_filename, h);
+    }
+}
+
+
+
+bool SaveHeader::exists(const fs::path& save_dir)
+{
+    return fs::exists(save_dir / vanilla_filename) ||
+        fs::exists(save_dir / foobar_filename);
+}
+
+
+
+SaveHeader SaveHeader::current_state()
+{
+    const auto play_seconds = get_played_seconds();
+    const auto now = now_unix_time();
+
+    SaveHeader h;
+
+    // The format of the newly-saved header is always @ref
+    // SaveHeader::Format::foobar.
+    h.format = Format::foobar;
+    // h.save_dir_name = no need to set here;
+
+    h.version = "v" + latest_version.short_string();
+    h.name = cdata.player().name;
+    h.alias = cdata.player().alias;
+    h.level = cdata.player().level;
+    h.race = the_race_db.get_text(cdata.player().race, "name");
+    h.class_ = class_get_name(cdata.player().class_);
+    h.location = mdatan(0) + maplevel();
+    h.is_wizard = game_data.wizard;
+    h.ingame_time = game_data.date.to_string(); // TODO localize
+    h.last_played_at = now;
+    h.play_seconds = play_seconds;
+
+    return h;
+}
+
+
+
+/*
+ * <NAME> Lv:<LEVEL> <LOCATION>
+ */
+SaveHeader SaveHeader::load_vanilla(const fs::path& save_dir)
+{
+    std::string name = "<unknown>";
+    int level = 1;
+    std::string location = "<unknown>";
+    {
+        // TODO: handle parsing error
+        std::string file_content;
+        std::ifstream in{(save_dir / vanilla_filename).native()};
+        std::getline(in, file_content);
+        const auto lv_pos = file_content.find(" Lv:");
+        name = file_content.substr(0, lv_pos);
+        const auto space_pos = file_content.find(' ', lv_pos + 4);
+        level = std::stoi(file_content.substr(lv_pos + 4, space_pos));
+        location = file_content.substr(space_pos + 1);
+    }
+
+    SaveHeader h;
+
+    h.format = Format::vanilla;
+    h.save_dir_name = filepathutil::to_utf8_path(save_dir.filename());
+
+    h.version = detect_save_data_version();
+    h.name = name;
+    h.alias = "<unknown>";
+    h.level = level;
+    h.race = "<unknown>";
+    h.class_ = "<unknown>";
+    h.location = location;
+    h.is_wizard = false;
+    h.ingame_time = "<unknown>";
+    h.last_played_at = -1;
+    h.play_seconds = 0;
+
+    return h;
+}
+
+
+
+SaveHeader SaveHeader::load_foobar(const fs::path& save_dir)
+{
+    json5::value::object_type obj;
+    {
+        // TODO: handle parsing error
+        std::ifstream in{(save_dir / foobar_filename).native()};
+        auto raw_json = json5util::parse_stream(in).right();
+        obj = raw_json.get_object();
+    }
+
+    SaveHeader h;
+
+    h.format = Format::foobar;
+    h.save_dir_name = filepathutil::to_utf8_path(save_dir.filename());
+
+    h.version = obj["version"].get_string();
+    h.name = obj["name"].get_string();
+    h.alias = obj["alias"].get_string();
+    h.level = obj["level"].get_integer();
+    h.race = obj["race"].get_string();
+    h.class_ = obj["class"].get_string();
+    h.location = obj["location"].get_string();
+    h.is_wizard = obj["is_wizard"].get_boolean();
+    h.ingame_time = obj["ingame_time"].get_string();
+    h.last_played_at = obj["last_played_at"].get_integer();
+    h.play_seconds = obj["play_seconds"].get_integer();
+
+    return h;
+}
+
+} // namespace elona

--- a/src/elona/save_header.hpp
+++ b/src/elona/save_header.hpp
@@ -1,0 +1,188 @@
+#pragma once
+
+#include "filesystem.hpp"
+#include "serialization/macros.hpp"
+
+
+
+namespace elona
+{
+
+/**
+ * Represents the header file which contains save data's summary. It is shown in
+ * the save selection menu.
+ */
+struct SaveHeader
+{
+    /// Represents the format of the header file.
+    enum class Format
+    {
+        /// Vanilla-compatible.
+        vanilla,
+
+        /// New format with extra properties.
+        foobar,
+    };
+
+
+
+    /// The format of the header file. This field is not serialized.
+    Format format;
+
+    /// The save directory's name. This field is not serialized.
+    std::string save_dir_name;
+
+    /// The identifier of the save version.
+    /// If the save is saved in foobar, it is just foobar's version like v1.2.3.
+    /// If not, it pair of the variant and its version.
+    /// @ref SaveHeader::Format::foobar only
+    std::string version;
+
+    /// Your name.
+    std::string name;
+
+    /// Your alias.
+    /// @ref SaveHeader::Format::foobar only
+    std::string alias;
+
+    /// Your level.
+    int64_t level;
+
+    /// Your race name. Note that it is not a race ID.
+    /// @ref SaveHeader::Format::foobar only
+    std::string race;
+
+    /// Your class name. Note that it is not a class ID.
+    /// @ref SaveHeader::Format::foobar only
+    std::string class_;
+
+    /// The location where you are. Note that it is not a map ID.
+    std::string location;
+
+    /// The flag whether Wizard mode is on.
+    /// @ref SaveHeader::Format::foobar only
+    bool is_wizard;
+
+    /// In-game current time.
+    /// @ref SaveHeader::Format::foobar only
+    std::string ingame_time;
+
+    /// The time when you played the save most recently in Unix time.
+    /// cf. https://en.wikipedia.org/wiki/Unix_time
+    /// @ref SaveHeader::Format::foobar only
+    int64_t last_played_at;
+
+    /// The played duration in seconds.
+    /// @ref SaveHeader::Format::foobar only
+    int64_t play_seconds;
+
+
+
+    /**
+     * Get the title shown in the save selection menu.
+     *
+     * @return The title of the save.
+     */
+    std::string title() const;
+
+
+
+    /**
+     * Convert the save header to the displayed text.
+     *
+     * @return The lines of text.
+     */
+    std::vector<std::string> to_string() const;
+
+
+
+    template <typename Archive>
+    void serialize(Archive& ar)
+    {
+        /* clang-format off */
+        ELONA_SERIALIZATION_STRUCT_BEGIN(ar, "SaveHeader");
+
+        ELONA_SERIALIZATION_STRUCT_FIELD(*this, version);
+        ELONA_SERIALIZATION_STRUCT_FIELD(*this, name);
+        ELONA_SERIALIZATION_STRUCT_FIELD(*this, alias);
+        ELONA_SERIALIZATION_STRUCT_FIELD(*this, level);
+        ELONA_SERIALIZATION_STRUCT_FIELD(*this, race);
+        ELONA_SERIALIZATION_STRUCT_FIELD_WITH_NAME(*this, "class", class_);
+        ELONA_SERIALIZATION_STRUCT_FIELD(*this, location);
+        ELONA_SERIALIZATION_STRUCT_FIELD(*this, is_wizard);
+        ELONA_SERIALIZATION_STRUCT_FIELD(*this, ingame_time);
+        ELONA_SERIALIZATION_STRUCT_FIELD(*this, last_played_at);
+        ELONA_SERIALIZATION_STRUCT_FIELD(*this, play_seconds);
+
+        ELONA_SERIALIZATION_STRUCT_END();
+        /* clang-format on */
+    }
+
+
+
+    /*
+     * Load a save header file in @a save_dir. If both formats exist, @ref
+     * SaveHeader::Format::foobar is loaded.
+     *
+     * @param save_dir The save directory.
+     * @return The loaded save header.
+     */
+    static SaveHeader load(const fs::path& save_dir);
+
+
+
+    /*
+     * Save a save header file in @a save_dir.
+     *
+     * @param save_dir The save directory.
+     */
+    static void save(const fs::path& save_dir);
+
+
+
+    /*
+     * Check if a save header file exists in @a save_dir.
+     *
+     * @param save_dir The save directory.
+     * @return True if exists; false if not.
+     */
+    static bool exists(const fs::path& save_dir);
+
+
+
+private:
+    SaveHeader() = default;
+
+
+
+    /**
+     * Construct a save header instance by the current game state.
+     *
+     * @return The constructed save header.
+     */
+    static SaveHeader current_state();
+
+
+
+    /*
+     * Load a save header file in @a save_dir, whose format is @ref
+     * SaveHeader::Format::vanilla.
+     *
+     * @param save_dir The save directory.
+     * @return The loaded save header.
+     */
+    static SaveHeader load_vanilla(const fs::path& save_dir);
+
+
+
+    /*
+     * Load a save header file in @a save_dir, whose format is @ref
+     * SaveHeader::Format::foobar.
+     *
+     * @param save_dir The save directory.
+     * @return The loaded save header.
+     */
+    static SaveHeader load_foobar(const fs::path& save_dir);
+};
+
+} // namespace elona


### PR DESCRIPTION
# Summary

A new save header file, `header.json`, is created when you save existing saves or create new one in the new version of Elona foobar. It contains these information:

* The version which it was saved in
* Your name
* Your alias
* Your level
* Your race
* Your class
* The current location
* Whether Wizard mode is on or not
* The in-game time
* The time when you played it most recently
* The play time

The old header file, `header.txt`, is updated as it was to integrate with vanilla or variants. Thus, this change does not break compatibility.

# Screenshot

![image](https://user-images.githubusercontent.com/36858341/84562884-8798f400-ad92-11ea-98b5-971641e1de3f.png)
