### PR TITLE
Fix damage handling/message which the player deals

### DIFF
--- a/runtime/mod/core/locale/en/damage.lua
+++ b/runtime/mod/core/locale/en/damage.lua
@@ -117,11 +117,26 @@ ELONA.i18n:add {
       },
 
       levels = {
-         scratch = "make{s($2)} a scratch.",
-         slightly = "slightly wound{s($2)} {him($1)}.",
-         moderately = "moderately wound{s($2)} {him($1)}.",
-         severely = "severely wound{s($2)} {him($1)}.",
-         critically = "critically wound{s($2)} {him($1)}!",
+         scratch = {
+            by_spell = "makes a scratch.",
+            by_chara = "make{s($2)} a scratch.",
+         },
+         slightly = {
+            by_spell = "slightly wounds {him($1)}.",
+            by_chara = "slightly wound{s($2)} {him($1)}.",
+         },
+         moderately = {
+            by_spell = "moderately wounds {him($1)}.",
+            by_chara = "moderately wound{s($2)} {him($1)}.",
+         },
+         severely = {
+            by_spell = "severely wounds {him($1)}.",
+            by_chara = "severely wound{s($2)} {him($1)}.",
+         },
+         critically = {
+            by_spell = "critically wounds {him($1)}!",
+            by_chara = "critically wound{s($2)} {him($1)}!",
+         },
       },
 
       reactions = {

--- a/runtime/mod/core/locale/en/death.lua
+++ b/runtime/mod/core/locale/en/death.lua
@@ -3,19 +3,31 @@ ELONA.i18n:add {
       chara = {
          -- _1 is victim, _2 is attacker.
          transformed_into_meat = {
-            active = "transform{s($2)} {him($1)} into several pieces of meat.",
+            active = {
+               by_spell = "transforms {him($1)} into several pieces of meat.",
+               by_chara = "transform{s($2)} {him($1)} into several pieces of meat.",
+            },
             passive = "{name($1)} {is($1)} transformed into several pieces of meat.",
          },
          destroyed = {
-            active = "destroy{s($2)} {him($1)}.",
+            active = {
+               by_spell = "destroys {him($1)}.",
+               by_chara = "destroy{s($2)} {him($1)}.",
+            },
             passive = "{name($1)} {is($1)} killed.",
          },
          minced = {
-            active = "mince{s($2)} {him($1)}.",
+            active = {
+               by_spell = "minces {him($1)}.",
+               by_chara = "mince{s($2)} {him($1)}.",
+            },
             passive = "{name($1)} {is($1)} minced.",
          },
          killed = {
-            active = "kill{s($2)} {him($1)}.",
+            active = {
+               by_spell = "kills {him($1)}.",
+               by_chara = "kill{s($2)} {him($1)}.",
+            },
             passive = "{name($1)} {is($1)} slain.",
          },
          death_cause = "was killed by {basename($1)}",
@@ -23,57 +35,96 @@ ELONA.i18n:add {
       element = {
          -- _1 is victim, _2 is attacker.
          default = {
-            active = "kill{s($2)} {him($1)}.",
+            active = {
+               by_spell = "kills {him($1)}.",
+               by_chara = "kill{s($2)} {him($1)}.",
+            },
             passive = "{name($1)} {is($1)} killed.",
          },
          _50 = {
-            active = "burn{s($2)} {him($1)} to death.",
+            active = {
+               by_spell = "burns {him($1)} to death.",
+               by_chara = "burn{s($2)} {him($1)} to death.",
+            },
             passive = "{name($1)} {is($1)} burnt to ashes.",
          },
          _51 = {
-            active = "transform{s($2)} {him($1)} to an ice sculpture.",
+            active = {
+               by_spell = "transforms {him($1)} to an ice sculpture.",
+               by_chara = "transform{s($2)} {him($1)} to an ice sculpture.",
+            },
             passive = "{name($1)} {is($1)} frozen and turn{s($1)} into an ice sculpture.",
          },
          _52 = {
-            active = "electrocute{s($2)} {him($1)} to death.",
+            active = {
+               by_spell = "electrocutes {him($1)} to death.",
+               by_chara = "electrocute{s($2)} {him($1)} to death.",
+            },
             passive = "{name($1)} {is($1)} struck by lightning and die{s($1)}.",
          },
          _53 = {
-            active = "let{s($2)} the depths swallow {him($1)}.",
+            active = {
+               by_spell = "lets the depths swallow {him($1)}.",
+               by_chara = "let{s($2)} the depths swallow {him($1)}.",
+            },
             passive = "{name($1)} {is($1)} consumed by darkness.",
          },
          _54 = {
-            active = "completely disable{s($2)} {him($1)}.",
+            active = {
+               by_spell = "completely disables {him($1)}.",
+               by_chara = "completely disable{s($2)} {him($1)}.",
+            },
             passive = "{name($1)} lose{s($1)} {his($1)} mind and commit{s($1)} a suicide.",
          },
          _55 = {
-            active = "kill{s($2)} {him($1)} with poison.",
+            active = {
+               by_spell = "kills {him($1)} with poison.",
+               by_chara = "kill{s($2)} {him($1)} with poison.",
+            },
             passive = "{name($1)} {is($1)} poisoned to death.",
          },
          _56 = {
-            active = "entrap{s($2)} {him($1)} into the inferno.",
+            active = {
+               by_spell = "entraps {him($1)} into the inferno.",
+               by_chara = "entrap{s($2)} {him($1)} into the inferno.",
+            },
             passive = "{name($1)} go{s($1, true)} to hell.",
          },
          _57 = {
-            active = "shatter{s($2)} {him($1)} to atoms.",
+            active = {
+               by_spell = "shatters {him($1)} to atoms.",
+               by_chara = "shatter{s($2)} {him($1)} to atoms.",
+            },
             passive = "{name($1)} resonate{s($1)} and break up.",
          },
          _58 = {
-            active = "destroy{s($2)} {his($1)} nerves.",
+            active = {
+               by_spell = "destroys {his($1)} nerves.",
+               by_chara = "destroy{s($2)} {his($1)} nerves.",
+            },
             passive = "{name($1)} die{s($1)} from neurofibroma.",
          },
          _59 = {
-            active = "let{s($2)} the chaos consume {him($1)}.",
+            active = {
+               by_spell = "lets the chaos consume {him($1)}.",
+               by_chara = "let{s($2)} the chaos consume {him($1)}.",
+            },
             passive = "{name($1)} {is($1)} drawn into a chaotic vortex.",
          },
          -- _60
          _61 = {
-            active = "cut{s($2)} {him($1)} into thin strips.",
+            active = {
+               by_spell = "cuts {him($1)} into thin strips.",
+               by_chara = "cut{s($2)} {him($1)} into thin strips.",
+            },
             passive = "{name($1)} {is($1)} cut into thin strips.",
          },
          -- _62
          _63 = {
-            active = "melt{s($2)} {him($1)} away.",
+            active = {
+               by_spell = "melts {him($1)} away.",
+               by_chara = "melt{s($2)} {him($1)} away.",
+            },
             passive = "{name($1)} melt{s($1)}.",
          },
       },

--- a/runtime/mod/core/locale/jp/damage.lua
+++ b/runtime/mod/core/locale/jp/damage.lua
@@ -103,11 +103,26 @@ ELONA.i18n:add {
       },
 
       levels = {
-         scratch = "かすり傷をつけた。",
-         slightly = "軽い傷を負わせた。",
-         moderately = "傷つけた。",
-         severely = "深い傷を負わせた。",
-         critically = "致命傷を与えた。",
+         scratch = {
+            by_spell = "かすり傷をつけた。",
+            by_chara = "かすり傷をつけた。",
+         },
+         slightly = {
+            by_spell = "軽い傷を負わせた。",
+            by_chara = "軽い傷を負わせた。",
+         },
+         moderately = {
+            by_spell = "傷つけた。",
+            by_chara = "傷つけた。",
+         },
+         severely = {
+            by_spell = "深い傷を負わせた。",
+            by_chara = "深い傷を負わせた。",
+         },
+         critically = {
+            by_spell = "致命傷を与えた。",
+            by_chara = "致命傷を与えた。",
+         },
       },
 
       reactions = {

--- a/runtime/mod/core/locale/jp/death.lua
+++ b/runtime/mod/core/locale/jp/death.lua
@@ -2,76 +2,127 @@ ELONA.i18n:add {
    death_by = {
       chara = {
          transformed_into_meat = {
-            active = "粉々の肉片に変えた。",
+            active = {
+               by_spell = "粉々の肉片に変えた。",
+               by_chara = "粉々の肉片に変えた。",
+            },
             passive = "{name($1)}は粉々の肉片に変えられた。",
          },
          destroyed = {
-            active = "破壊した。",
+            active = {
+               by_spell = "破壊した。",
+               by_chara = "破壊した。",
+            },
             passive = "{name($1)}は破壊された。",
          },
          minced = {
-            active = "ミンチにした。",
+            active = {
+               by_spell = "ミンチにした。",
+               by_chara = "ミンチにした。",
+            },
             passive = "{name($1)}はミンチにされた。",
          },
          killed = {
-            active = "殺した。",
+            active = {
+               by_spell = "殺した。",
+               by_chara = "殺した。",
+            },
             passive = "{name($1)}は殺された。",
          },
          death_cause = "{basename($1)}に殺された。",
       },
       element = {
          default = {
-            active = "殺した。",
+            active = {
+               by_spell = "殺した。",
+               by_chara = "殺した。",
+            },
             passive = "{name($1)}は死んだ。",
          },
          _50 = {
-            active = "燃やし尽くした。",
+            active = {
+               by_spell = "燃やし尽くした。",
+               by_chara = "燃やし尽くした。",
+            },
             passive = "{name($1)}は燃え尽きて灰になった。",
          },
          _51 = {
-            active = "氷の塊に変えた。",
+            active = {
+               by_spell = "氷の塊に変えた。",
+               by_chara = "氷の塊に変えた。",
+            },
             passive = "{name($1)}は氷の彫像になった。",
          },
          _52 = {
-            active = "焦げカスにした。",
+            active = {
+               by_spell = "焦げカスにした。",
+               by_chara = "焦げカスにした。",
+            },
             passive = "{name($1)}は雷に打たれ死んだ。",
          },
          _53 = {
-            active = "闇に飲み込んだ。",
+            active = {
+               by_spell = "闇に飲み込んだ。",
+               by_chara = "闇に飲み込んだ。",
+            },
             passive = "{name($1)}は闇に蝕まれて死んだ。",
          },
          _54 = {
-            active = "再起不能にした。",
+            active = {
+               by_spell = "再起不能にした。",
+               by_chara = "再起不能にした。",
+            },
             passive = "{name($1)}は発狂して死んだ。",
          },
          _55 = {
-            active = "毒殺した。",
+            active = {
+               by_spell = "毒殺した。",
+               by_chara = "毒殺した。",
+            },
             passive = "{name($1)}は毒に蝕まれて死んだ。",
          },
          _56 = {
-            active = "冥界に墜とした。",
+            active = {
+               by_spell = "冥界に墜とした。",
+               by_chara = "冥界に墜とした。",
+            },
             passive = "{name($1)}は冥界に墜ちた。",
          },
          _57 = {
-            active = "聴覚を破壊し殺した。",
+            active = {
+               by_spell = "聴覚を破壊し殺した。",
+               by_chara = "聴覚を破壊し殺した。",
+            },
             passive = "{name($1)}は朦朧となって死んだ。",
          },
          _58 = {
-            active = "神経を破壊した。",
+            active = {
+               by_spell = "神経を破壊した。",
+               by_chara = "神経を破壊した。",
+            },
             passive = "{name($1)}は神経を蝕まれて死んだ。",
          },
          _59 = {
-            active = "混沌の渦に吸い込んだ。",
+            active = {
+               by_spell = "混沌の渦に吸い込んだ。",
+               by_chara = "混沌の渦に吸い込んだ。",
+            },
             passive = "{name($1)}は混沌の渦に吸収された。",
          },
          -- _60
          _61 = {
-            active = "千切りにした。",
+            active = {
+               by_spell = "千切りにした。",
+               by_chara = "千切りにした。",
+            },
             passive = "{name($1)}は千切りになった。",
          },
          -- _62
          _63 = {
-            active = "ドロドロに溶かした。",
+            active = {
+               by_spell = "ドロドロに溶かした。",
+               by_chara = "ドロドロに溶かした。",
+            },
             passive = "{name($1)}は酸に焼かれ溶けた。",
          },
       },

--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -222,7 +222,7 @@ int damage_hp(
         }
         dmg_at_m141 = dmg_at_m141 * 100 / (sdata(60, victim.index) / 2 + 50);
     }
-    if (attacker_is_player)
+    if (attacker && attacker->index == 0)
     {
         if (critical)
         {
@@ -518,7 +518,7 @@ int damage_hp(
                         {
                             runs_away = false;
                         }
-                        if (attacker_is_player)
+                        if (attacker && attacker->index == 0)
                         {
                             if (trait(44)) // Gentle Face
                             {
@@ -660,7 +660,7 @@ int damage_hp(
                 txt(i18n::s.get("core.damage.sleep_is_disturbed", victim));
             }
         }
-        if (attacker_is_player)
+        if (attacker && attacker->index == 0)
         {
             hostileaction(0, victim.index);
             game_data.chara_last_attacked_by_player = victim.index;
@@ -765,7 +765,7 @@ int damage_hp(
                     apply_hate = true;
                 }
             }
-            if (!attacker_is_player)
+            if (attacker->index != 0)
             {
                 if (attacker->enemy_id == victim.index)
                 {
@@ -970,7 +970,7 @@ int damage_hp(
         }
         if (attacker)
         {
-            if (!attacker_is_player)
+            if (attacker->index != 0)
             {
                 chara_custom_talk(attacker->index, 103);
             }
@@ -987,7 +987,7 @@ int damage_hp(
                 gained_exp /= 20;
             }
             attacker->experience += gained_exp;
-            if (attacker_is_player)
+            if (attacker->index == 0)
             {
                 game_data.sleep_experience += gained_exp;
             }
@@ -1176,7 +1176,7 @@ int damage_hp(
                 }
             }
         }
-        if (attacker_is_player)
+        if (attacker && attacker->index == 0)
         {
             if (game_data.catches_god_signal)
             {

--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -175,7 +175,6 @@ int damage_hp(
     int damage_level = 0;
     elona_vector1<int> p_at_m141;
     int gained_exp = 0;
-    bool attacker_is_player = false;
 
     optional_ref<Character> attacker = none;
     if (damage_source >= 0)
@@ -183,14 +182,10 @@ int damage_hp(
         attacker = cdata[damage_source];
     }
 
-    if (txt3rd == 0)
-    {
-        attacker_is_player = damage_source == 0;
-    }
-    else
-    {
-        attacker_is_player = false;
-    }
+    // E.g., the case that the casted spell is the subject.
+    // It controls 3rd-person singular present 's' in English message.
+    const bool damage_statements_subject_is_noncharacter = txt3rd == 1;
+
     if (victim.state() != Character::State::alive)
     {
         end_dmghp(victim);
@@ -429,32 +424,86 @@ int damage_hp(
             assert(attacker);
             if (damage_level == -1)
             {
-                txt(i18n::s.get(
-                    "core.damage.levels.scratch", victim, *attacker));
+                if (damage_statements_subject_is_noncharacter)
+                {
+                    txt(i18n::s.get(
+                        "core.damage.levels.scratch.by_spell", victim));
+                }
+                else
+                {
+                    txt(i18n::s.get(
+                        "core.damage.levels.scratch.by_chara",
+                        victim,
+                        *attacker));
+                }
             }
             if (damage_level == 0)
             {
-                txt(i18n::s.get(
-                        "core.damage.levels.slightly", victim, *attacker),
-                    Message::color{ColorIndex::orange});
+                if (damage_statements_subject_is_noncharacter)
+                {
+                    txt(i18n::s.get(
+                            "core.damage.levels.slightly.by_spell", victim),
+                        Message::color{ColorIndex::orange});
+                }
+                else
+                {
+                    txt(i18n::s.get(
+                            "core.damage.levels.slightly.by_chara",
+                            victim,
+                            *attacker),
+                        Message::color{ColorIndex::orange});
+                }
             }
             if (damage_level == 1)
             {
-                txt(i18n::s.get(
-                        "core.damage.levels.moderately", victim, *attacker),
-                    Message::color{ColorIndex::gold});
+                if (damage_statements_subject_is_noncharacter)
+                {
+                    txt(i18n::s.get(
+                            "core.damage.levels.moderately.by_spell", victim),
+                        Message::color{ColorIndex::gold});
+                }
+                else
+                {
+                    txt(i18n::s.get(
+                            "core.damage.levels.moderately.by_chara",
+                            victim,
+                            *attacker),
+                        Message::color{ColorIndex::gold});
+                }
             }
             if (damage_level == 2)
             {
-                txt(i18n::s.get(
-                        "core.damage.levels.severely", victim, *attacker),
-                    Message::color{ColorIndex::light_red});
+                if (damage_statements_subject_is_noncharacter)
+                {
+                    txt(i18n::s.get(
+                            "core.damage.levels.severely.by_spell", victim),
+                        Message::color{ColorIndex::light_red});
+                }
+                else
+                {
+                    txt(i18n::s.get(
+                            "core.damage.levels.severely.by_chara",
+                            victim,
+                            *attacker),
+                        Message::color{ColorIndex::light_red});
+                }
             }
             if (damage_level >= 3)
             {
-                txt(i18n::s.get(
-                        "core.damage.levels.critically", victim, *attacker),
-                    Message::color{ColorIndex::red});
+                if (damage_statements_subject_is_noncharacter)
+                {
+                    txt(i18n::s.get(
+                            "core.damage.levels.critically.by_spell", victim),
+                        Message::color{ColorIndex::red});
+                }
+                else
+                {
+                    txt(i18n::s.get(
+                            "core.damage.levels.critically.by_chara",
+                            victim,
+                            *attacker),
+                        Message::color{ColorIndex::red});
+                }
             }
             rowact_check(victim);
         }
@@ -809,7 +858,14 @@ int damage_hp(
                     game_data.proc_damage_events_flag == 2)
                 {
                     Message::instance().continue_sentence();
-                    txteledmg(1, *attacker, victim.index, element);
+                    if (damage_statements_subject_is_noncharacter)
+                    {
+                        txteledmg(1, none, victim.index, element);
+                    }
+                    else
+                    {
+                        txteledmg(1, *attacker, victim.index, element);
+                    }
                 }
                 else
                 {
@@ -825,10 +881,19 @@ int damage_hp(
                         game_data.proc_damage_events_flag == 2)
                     {
                         Message::instance().continue_sentence();
-                        txt(i18n::s.get(
-                            "core.death_by.chara.transformed_into_meat.active",
-                            victim,
-                            *attacker));
+                        if (damage_statements_subject_is_noncharacter)
+                        {
+                            txt(i18n::s.get(
+                                "core.death_by.chara.transformed_into_meat.active.by_spell",
+                                victim));
+                        }
+                        else
+                        {
+                            txt(i18n::s.get(
+                                "core.death_by.chara.transformed_into_meat.active.by_chara",
+                                victim,
+                                *attacker));
+                        }
                     }
                     else
                     {
@@ -843,10 +908,19 @@ int damage_hp(
                         game_data.proc_damage_events_flag == 2)
                     {
                         Message::instance().continue_sentence();
-                        txt(i18n::s.get(
-                            "core.death_by.chara.destroyed.active",
-                            victim,
-                            *attacker));
+                        if (damage_statements_subject_is_noncharacter)
+                        {
+                            txt(i18n::s.get(
+                                "core.death_by.chara.destroyed.active.by_spell",
+                                victim));
+                        }
+                        else
+                        {
+                            txt(i18n::s.get(
+                                "core.death_by.chara.destroyed.active.by_chara",
+                                victim,
+                                *attacker));
+                        }
                     }
                     else
                     {
@@ -860,10 +934,19 @@ int damage_hp(
                         game_data.proc_damage_events_flag == 2)
                     {
                         Message::instance().continue_sentence();
-                        txt(i18n::s.get(
-                            "core.death_by.chara.minced.active",
-                            victim,
-                            *attacker));
+                        if (damage_statements_subject_is_noncharacter)
+                        {
+                            txt(i18n::s.get(
+                                "core.death_by.chara.minced.active.by_spell",
+                                victim));
+                        }
+                        else
+                        {
+                            txt(i18n::s.get(
+                                "core.death_by.chara.minced.active.by_chara",
+                                victim,
+                                *attacker));
+                        }
                     }
                     else
                     {
@@ -877,10 +960,19 @@ int damage_hp(
                         game_data.proc_damage_events_flag == 2)
                     {
                         Message::instance().continue_sentence();
-                        txt(i18n::s.get(
-                            "core.death_by.chara.killed.active",
-                            victim,
-                            *attacker));
+                        if (damage_statements_subject_is_noncharacter)
+                        {
+                            txt(i18n::s.get(
+                                "core.death_by.chara.killed.active.by_spell",
+                                victim));
+                        }
+                        else
+                        {
+                            txt(i18n::s.get(
+                                "core.death_by.chara.killed.active.by_chara",
+                                victim,
+                                *attacker));
+                        }
                     }
                     else
                     {

--- a/src/elona/element.cpp
+++ b/src/elona/element.cpp
@@ -138,23 +138,43 @@ void txteledmg(
     }
     else if (type == 1)
     {
-        assert(attacker);
-        auto text = i18n::s.get_enum_property_optional(
-            "core.death_by.element"s,
-            "active",
-            element,
-            cdata[target],
-            *attacker);
-        if (text)
+        if (attacker)
         {
-            txt(*text);
+            auto text = i18n::s.get_enum_property_optional(
+                "core.death_by.element"s,
+                "active.by_chara",
+                element,
+                cdata[target],
+                *attacker);
+            if (text)
+            {
+                txt(*text);
+            }
+            else
+            {
+                txt(i18n::s.get(
+                    "core.death_by.element.default.active.by_chara",
+                    cdata[target],
+                    *attacker));
+            }
         }
         else
         {
-            txt(i18n::s.get(
-                "core.death_by.element.default.active",
-                cdata[target],
-                *attacker));
+            auto text = i18n::s.get_enum_property_optional(
+                "core.death_by.element"s,
+                "active.by_spell",
+                element,
+                cdata[target]);
+            if (text)
+            {
+                txt(*text);
+            }
+            else
+            {
+                txt(i18n::s.get(
+                    "core.death_by.element.default.active.by_spell",
+                    cdata[target]));
+            }
         }
     }
     else if (type == 2)


### PR DESCRIPTION
# Summary

This PR fixes 2 issues related to damage handling (`damage_hp()` function).

* Fix some routines related to player's damage by spells or rods.
  * Attacks by spells or rods were not regarded as player's. It caused some issues: e.g., casting attack spell against town citizens was not treated as a hostile action.
* Fix damage messages in English, especially when casting spells. (English mode only)
  * 3rd-person singular present 's' was not appended to the spell caused by the player character.