### PR TITLE
Refactor inventory-related routines

### DIFF
--- a/runtime/data/script/kernel/handle.lua
+++ b/runtime/data/script/kernel/handle.lua
@@ -51,7 +51,7 @@ local function handle_error(handle, key)
    end
 
    if handle then
-      print("Error: handle is not valid! " .. handle.__kind .. ":" .. handle.__index)
+      print("Error: handle is not valid! " .. handle.__kind .. ":" .. handle.__uuid)
    else
       print("Error: handle is not valid! " .. tostring(handle))
    end
@@ -191,7 +191,6 @@ function Handle.create_handle(cpp_ref, kind, uuid)
    local handle = {
       __uuid = uuid,
       __kind = kind,
-      __index = cpp_ref.index,
       __handle = true
    }
 
@@ -221,15 +220,13 @@ function Handle.remove_handle(cpp_ref, kind)
 end
 
 
---- Moves a handle from one integer index to another and updates its
---- __index field with the new value, if it exists. If the handle
---- exists, the target slot must not be occupied. If not, the
---- destination slot will be set to empty as well.
+--- Moves a handle from one integer index to another if it exists. If the handle
+--- exists, the target slot must not be occupied. If not, the destination slot
+--- will be set to empty as well.
 function Handle.relocate_handle(cpp_ref, dest_cpp_ref, new_index, kind)
    local handle = handles_by_index[kind][cpp_ref.index]
 
    if Handle.is_valid(handle) then
-      handle.__index = new_index
       handles_by_index[kind][new_index] = handle
       Handle.set_ref(handle, dest_cpp_ref)
    else

--- a/runtime/data/script/kernel/serial.lua
+++ b/runtime/data/script/kernel/serial.lua
@@ -31,7 +31,7 @@ local function remove_volatile_data(value)
          -- It's a private field, skipping.
       else
          -- This rule is only applied to top-level fields because we have to
-         -- save Handle object with its private fields such as `__index`.
+         -- save Handle object with its private fields such as `__uuid`.
          result[k] = v
       end
    end

--- a/runtime/mod/core/locale/en/ctrl_inventory.lua
+++ b/runtime/mod/core/locale/en/ctrl_inventory.lua
@@ -57,7 +57,7 @@ ELONA.i18n:add {
             does_not_exist = "The item doesn't exist.",
             inventory_is_full = "Your inventory is full.",
 
-            invalid = "Invalid Item Id found. Item No:{$1}, Id:{$2} has been removed from your inventory.",
+            invalid = "Invalid Item ID found ({$1}). It has been removed from your inventory.",
          },
 
          examine = {

--- a/runtime/mod/core/locale/jp/ctrl_inventory.lua
+++ b/runtime/mod/core/locale/jp/ctrl_inventory.lua
@@ -57,7 +57,7 @@ ELONA.i18n:add {
             does_not_exist = "そのアイテムは存在しない。",
             inventory_is_full = "バックパックが一杯だ。",
 
-            invalid = "Invalid Item Id found. Item No:{$1}, Id:{$2} has been removed from your inventory.",
+            invalid = "Invalid Item ID found ({$1}). It has been removed from your inventory.",
          },
 
          examine = {

--- a/src/elona/blending.cpp
+++ b/src/elona/blending.cpp
@@ -274,7 +274,7 @@ void collect_blending_materials(
                 bool has_already_used = false;
                 for (int i = 0; i < step; ++i)
                 {
-                    if (rpref(10 + i * 2) == item.index)
+                    if (rpref(10 + i * 2) == item.index())
                     {
                         has_already_used = true;
                         break;
@@ -287,7 +287,7 @@ void collect_blending_materials(
             }
 
             result.emplace_back(
-                item.index,
+                item.index(),
                 static_cast<int>(the_item_db[itemid2int(item.id)]->category) *
                         1000 +
                     itemid2int(item.id));
@@ -988,7 +988,7 @@ void blending_proc_on_success_events()
     }
     else
     {
-        int stat = item_separate(inv[item1_index]).index;
+        int stat = item_separate(inv[item1_index]).index();
         if (rpref(10) == stat)
         {
             rpref(10) = -2;

--- a/src/elona/blending.cpp
+++ b/src/elona/blending.cpp
@@ -788,7 +788,7 @@ void blending_menu_2()
             p = list(0, p);
             s = itemname(inv[p]);
             s = strutil::take_by_width(s, 28);
-            if (p >= ELONA_ITEM_ON_GROUND_INDEX)
+            if (inv_getowner(inv[p]) == -1)
             {
                 s += i18n::s.get("core.blending.steps.ground");
             }

--- a/src/elona/building.cpp
+++ b/src/elona/building.cpp
@@ -1674,16 +1674,7 @@ void supply_income()
         if (cdata.player().level > 5)
         {
             save_set_autosave();
-            p = -1;
-            for (const auto& item : inv.ground())
-            {
-                if (item.number() == 0)
-                {
-                    p = item.index;
-                    break;
-                }
-            }
-            if (p == -1)
+            if (!inv_getspace(-1))
             {
                 inv_compress(-1);
             }

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -888,7 +888,7 @@ int calcitemvalue(const Item& item, int calc_mode)
         else
         {
             ret = cdata.player().level / 5 *
-                    ((game_data.random_seed + item.index * 31) %
+                    ((game_data.random_seed + item.index() * 31) %
                          cdata.player().level +
                      4) +
                 10;

--- a/src/elona/cell_draw.cpp
+++ b/src/elona/cell_draw.cpp
@@ -1299,19 +1299,20 @@ void draw_items(int x, int y, int dx, int dy, int scrturn_)
             // Several items are stacked.
             std::array<int, 3> items;
             p_ = -cell_data.at(x, y).item_appearances_memory;
-            items[0] = p_ % 1000 + ELONA_ITEM_ON_GROUND_INDEX;
-            items[1] = p_ / 1000 % 1000 + ELONA_ITEM_ON_GROUND_INDEX;
-            items[2] = p_ / 1000000 % 1000 + ELONA_ITEM_ON_GROUND_INDEX;
+            items[0] = p_ % 1000;
+            items[1] = p_ / 1000 % 1000;
+            items[2] = p_ / 1000000 % 1000;
             int stack_height{};
             for (int i = 2; i >= 0; --i)
             {
-                if (items[i] == 6079) // 5080 + 999
+                if (items[i] == 999)
                 {
                     continue;
                 }
-                p_ = inv[items[i]].image;
-                i_ = inv[items[i]].color;
-                auto rect = prepare_item_image(p_, i_, inv[items[i]].param1);
+                const auto& item = inv.ground().at(items[i]);
+                p_ = item.image;
+                i_ = item.color;
+                auto rect = prepare_item_image(p_, i_, item.param1);
                 if (map_data.type == mdata_t::MapType::world_map)
                 {
                     draw_item_chip_in_world_map(

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -5017,11 +5017,7 @@ int do_zap(Character& doer, Item& rod)
     efsource = 0;
     if (rod.number() == 0)
     {
-        if (rod.index >= ELONA_ITEM_ON_GROUND_INDEX)
-        {
-            cell_refresh(rod.position.x, rod.position.y);
-            return 1;
-        }
+        return 1;
     }
     item_separate(rod);
     --rod.count;

--- a/src/elona/ctrl_file.cpp
+++ b/src/elona/ctrl_file.cpp
@@ -542,11 +542,6 @@ void fmode_7_8(bool read, const fs::path& dir)
             if (fs::exists(filepath))
             {
                 load(filepath, inv, 0, ELONA_OTHER_INVENTORIES_INDEX);
-                for (int index = 0; index < ELONA_OTHER_INVENTORIES_INDEX;
-                     index++)
-                {
-                    inv[index].index = index;
-                }
             }
         }
         else
@@ -943,11 +938,6 @@ void fmode_14_15(bool read)
             if (fs::exists(filepath))
             {
                 load(filepath, inv, 0, ELONA_OTHER_INVENTORIES_INDEX);
-                for (int index = 0; index < ELONA_OTHER_INVENTORIES_INDEX;
-                     index++)
-                {
-                    inv[index].index = index;
-                }
             }
         }
         else
@@ -1325,11 +1315,6 @@ void fmode_3_4(bool read, const fs::path& filename)
     {
         tmpload(filename);
         load(filepath, inv, ELONA_OTHER_INVENTORIES_INDEX, ELONA_MAX_ITEMS);
-        for (int index = ELONA_OTHER_INVENTORIES_INDEX; index < ELONA_MAX_ITEMS;
-             index++)
-        {
-            inv[index].index = index;
-        }
     }
     else
     {

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -680,7 +680,7 @@ void make_item_list(
             }
 
             // リスト追加
-            list(0, listmax) = item.index;
+            list(0, listmax) = item.index();
 
             // ソート情報
             list(1, listmax) = reftype * 1000 + itemid2int(item.id);

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -239,7 +239,7 @@ void restore_cursor()
 
 void make_item_list(
     optional_ref<Character> inventory_owner,
-    int& mainweapon,
+    ItemRef& mainweapon,
     ItemRef citrade,
     ItemRef cidip)
 {
@@ -296,9 +296,7 @@ void make_item_list(
             if (itemid2int(item.id) >= maxitemid || itemid2int(item.id) < 0)
             {
                 dialog(i18n::s.get(
-                    "core.ui.inv.common.invalid",
-                    item.index,
-                    itemid2int(item.id)));
+                    "core.ui.inv.common.invalid", itemid2int(item.id)));
                 item.remove();
                 item.id = ItemId::none;
                 continue;
@@ -370,10 +368,9 @@ void make_item_list(
             {
                 if (reftype == 10000)
                 {
-                    if (mainweapon == -1 ||
-                        item.body_part < inv[mainweapon].body_part)
+                    if (!mainweapon || item.body_part < mainweapon->body_part)
                     {
-                        mainweapon = item.index;
+                        mainweapon = ItemRef::from_ref(item);
                     }
                 }
             }
@@ -1172,7 +1169,7 @@ void update_key_list()
 
 
 
-void draw_item_list(int mainweapon)
+void draw_item_list(ItemRef mainweapon)
 {
     for (int cnt = 0, cnt_end = (pagesize); cnt < cnt_end; ++cnt)
     {
@@ -1202,7 +1199,7 @@ void draw_item_list(int mainweapon)
         if (invctrl != 3 && invctrl != 11 && invctrl != 22 && invctrl != 27 &&
             invctrl != 28)
         {
-            if (p >= ELONA_ITEM_ON_GROUND_INDEX)
+            if (inv_getowner(inv[p]) == -1)
             {
                 s += i18n::space_if_needed() + "(" +
                     i18n::s.get("core.ui.inv.window.ground") + ")";
@@ -1225,7 +1222,7 @@ void draw_item_list(int mainweapon)
         if (inv[p].body_part != 0)
         {
             draw("equipped", wx + 46, wy + 72 + cnt * 18 - 3);
-            if (p == mainweapon)
+            if (inv[p] == mainweapon)
             {
                 s += i18n::space_if_needed() + "(" +
                     i18n::s.get("core.ui.inv.window.main_hand") + ")";
@@ -2276,10 +2273,9 @@ OnEnterResult on_enter_small_medal(Item& selected_item)
         return OnEnterResult{1};
     }
     auto& slot = *slot_opt;
-    if (const auto small_medals =
-            item_find(622, 3, ItemFindLocation::player_inventory))
+    optional_ref<Item> small_medals;
+    if ((small_medals = item_find(622, 3, ItemFindLocation::player_inventory)))
     {
-        i = small_medals->index;
         p = small_medals->number();
     }
     else
@@ -2292,7 +2288,8 @@ OnEnterResult on_enter_small_medal(Item& selected_item)
         snd("core.fail1");
         return OnEnterResult{1};
     }
-    inv[i].modify_number(-calcmedalvalue(selected_item));
+    assert(small_medals);
+    small_medals->modify_number(-calcmedalvalue(selected_item));
     snd("core.paygold1");
     item_copy(selected_item, slot);
     txt(i18n::s.get("core.ui.inv.trade_medals.you_receive", slot));
@@ -2637,7 +2634,7 @@ bool on_assign_shortcut(const std::string& action, int shortcut)
 
 CtrlInventoryResult ctrl_inventory(optional_ref<Character> inventory_owner)
 {
-    int mainweapon = -1;
+    ItemRef mainweapon;
     ItemRef citrade;
     ItemRef cidip;
     bool dropcontinue = false;
@@ -2654,7 +2651,7 @@ CtrlInventoryResult ctrl_inventory(optional_ref<Character> inventory_owner)
 
             fallback_to_default_command_if_unavailable();
             restore_cursor();
-            mainweapon = -1;
+            mainweapon = ItemRef::null();
             make_item_list(inventory_owner, mainweapon, citrade, cidip);
             if (const auto result = check_command(inventory_owner, citrade))
             {

--- a/src/elona/deferred_event.cpp
+++ b/src/elona/deferred_event.cpp
@@ -1012,7 +1012,7 @@ void eh_guest_visit(const DeferredEvent&)
             {
                 break;
             }
-            else if (item.index == chair_for_guest->index)
+            else if (item == *chair_for_guest)
             {
                 continue;
             }

--- a/src/elona/initialize_map.cpp
+++ b/src/elona/initialize_map.cpp
@@ -118,9 +118,12 @@ void _clear_map_and_objects()
     {
         cnt.set_state(Character::State::empty);
     }
-    for (auto&& item : inv.map_local())
+    for (auto&& inv_ : inv.map_local())
     {
-        item.remove();
+        for (auto&& item : inv_)
+        {
+            item.remove();
+        }
     }
 
     map_data.clear();

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -871,7 +871,6 @@ void itemname_additional_info(Item& item)
 
 std::string itemname(Item& item, int number, bool with_article)
 {
-    elona_vector1<int> iqiality_;
     int num2_ = 0;
     std::string s2_;
     std::string s3_;
@@ -882,10 +881,6 @@ std::string itemname(Item& item, int number, bool with_article)
         static_cast<size_t>(itemid2int(item.id)) > ioriginalnameref.size())
     {
         return i18n::s.get("core.item.unknown_item");
-    }
-    if (item.quality >= Quality::godly)
-    {
-        iqiality_(item.index) = 5;
     }
     item_checkknown(item);
     if (number == 0)

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -491,12 +491,12 @@ void Item::remove()
 
 void item_refresh(Item& i)
 {
-    if (i.index >= ELONA_ITEM_ON_GROUND_INDEX && mode != 6)
+    if (inv_getowner(i) == -1 && mode != 6)
     {
         // Refresh the cell the item is on if it's on the ground.
         cell_refresh(i.position.x, i.position.y);
     }
-    else if (i.index < 200)
+    else if (inv_getowner(i) == 0)
     {
         // Refresh the player's burden state if the item is in their
         // inventory.

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -467,7 +467,7 @@ void item_copy(Item& src, Item& dst)
 
 void item_exchange(Item& a, Item& b)
 {
-    if (a.index == b.index)
+    if (a == b)
     {
         return;
     }
@@ -1523,8 +1523,7 @@ ItemStackResult item_stack(int inventory_id, Item& base_item, bool show_message)
 
     for (auto&& item : inv.by_index(inventory_id))
     {
-        if (item.index == base_item.index || item.number() == 0 ||
-            item.id != base_item.id)
+        if (item == base_item || item.number() == 0 || item.id != base_item.id)
             continue;
 
         bool stackable;
@@ -2492,8 +2491,7 @@ Item& item_convert_artifact(Item& artifact, bool ignore_external_container)
         }
         for (const auto& item : inv.for_chara(chara))
         {
-            if (item.number() > 0 && item.id == artifact.id &&
-                item.index != artifact.index)
+            if (item.number() > 0 && item.id == artifact.id && item != artifact)
             {
                 found = true;
                 break;
@@ -2508,8 +2506,7 @@ Item& item_convert_artifact(Item& artifact, bool ignore_external_container)
     {
         for (const auto& item : inv.ground())
         {
-            if (item.number() > 0 && item.id == artifact.id &&
-                item.index != artifact.index)
+            if (item.number() > 0 && item.id == artifact.id && item != artifact)
             {
                 found = true;
                 break;

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -46,7 +46,7 @@ namespace elona
 {
 
 
-Inventory inv;
+AllInventory inv;
 
 int ci_at_m138 = 0;
 int p_at_m138 = 0;
@@ -98,34 +98,104 @@ bool Item::almost_equals(const Item& other, bool ignore_position) const
 
 
 
-Inventory::Inventory()
-    : storage(ELONA_MAX_ITEMS)
+Inventory::Inventory(
+    size_t index_start,
+    size_t inventory_size,
+    int inventory_id)
+    : _index_start(index_start)
+    , _storage(inventory_size)
+    , _inventory_id(inventory_id)
 {
-    for (size_t i = 0; i < storage.size(); ++i)
+    size_t i = index_start;
+    for (auto&& item : _storage)
     {
-        storage[i]._index = static_cast<int>(i);
+        item._index = i;
+        item._inventory = this;
+        ++i;
     }
 }
 
 
 
-InventorySlice Inventory::for_chara(const Character& chara)
+Inventory::Inventory(Inventory&& other)
+    : _index_start(other._index_start)
+    , _storage(std::move(other._storage))
+    , _inventory_id(other._inventory_id)
 {
-    if (chara.index == 0)
+    for (auto&& item : _storage)
     {
-        return pc();
-    }
-    else
-    {
-        return {
-            std::begin(storage) + 200 + 20 * (chara.index - 1),
-            std::begin(storage) + 200 + 20 * (chara.index - 1) + 20};
+        item._inventory = this;
     }
 }
 
 
 
-InventorySlice Inventory::by_index(int index)
+bool Inventory::contains(size_t index) const
+{
+    return _index_start <= index && index < _index_start + _storage.size();
+}
+
+
+
+Item& Inventory::at(size_t index)
+{
+    assert(index < size());
+    return _storage.at(index);
+}
+
+
+
+AllInventory::AllInventory()
+{
+    size_t index_start = 0;
+    _inventories.emplace_back(index_start, 200, 0);
+    index_start += _inventories.back().size();
+    for (size_t i = 1; i < 245; ++i)
+    {
+        _inventories.emplace_back(index_start, 20, static_cast<int>(i));
+        index_start += _inventories.back().size();
+    }
+    _inventories.emplace_back(index_start, 400, -1);
+}
+
+
+
+Item& AllInventory::operator[](int index)
+{
+    for (auto&& inv : _inventories)
+    {
+        if (inv.contains(static_cast<size_t>(index)))
+        {
+            return inv.at(static_cast<size_t>(index) - inv.index_start());
+        }
+    }
+    assert(0);
+}
+
+
+
+Inventory& AllInventory::pc()
+{
+    return _inventories.front();
+}
+
+
+
+Inventory& AllInventory::ground()
+{
+    return _inventories.back();
+}
+
+
+
+Inventory& AllInventory::for_chara(const Character& chara)
+{
+    return _inventories.at(chara.index);
+}
+
+
+
+Inventory& AllInventory::by_index(int index)
 {
     if (index == -1)
     {
@@ -135,6 +205,31 @@ InventorySlice Inventory::by_index(int index)
     {
         return for_chara(cdata[index]);
     }
+}
+
+
+
+AllInventory::iterator_pair_type AllInventory::all()
+{
+    return {_inventories.begin(), _inventories.end()};
+}
+
+
+
+AllInventory::iterator_pair_type AllInventory::global()
+{
+    auto end = _inventories.begin();
+    std::advance(end, 57);
+    return {_inventories.begin(), end};
+}
+
+
+
+AllInventory::iterator_pair_type AllInventory::map_local()
+{
+    auto begin = _inventories.begin();
+    std::advance(begin, 57);
+    return {begin, _inventories.end()};
 }
 
 
@@ -354,7 +449,8 @@ void cell_refresh(int x, int y)
         {
             if (item.position.x == x && item.position.y == y)
             {
-                floorstack(p_at_m55) = item.index();
+                floorstack(p_at_m55) =
+                    item.index() - inv.ground().index_start();
                 ++p_at_m55;
                 wpoke(
                     cell_data.at(x, y).item_appearances_actual, 0, item.image);
@@ -401,22 +497,20 @@ void cell_refresh(int x, int y)
                         continue;
                     }
                 }
-                if (inv[floorstack(cnt)].turn > i_at_m55)
+                if (inv.ground().at(floorstack(cnt)).turn > i_at_m55)
                 {
                     n_at_m55(cnt2_at_m55) = cnt;
-                    i_at_m55 = inv[floorstack(cnt)].turn;
+                    i_at_m55 = inv.ground().at(floorstack(cnt)).turn;
                 }
             }
         }
-        cell_data.at(x, y).item_appearances_actual =
-            floorstack(n_at_m55(0)) - ELONA_ITEM_ON_GROUND_INDEX;
+        cell_data.at(x, y).item_appearances_actual = floorstack(n_at_m55(0));
         cell_data.at(x, y).item_appearances_actual +=
-            (floorstack(n_at_m55(1)) - ELONA_ITEM_ON_GROUND_INDEX) * 1000;
+            floorstack(n_at_m55(1)) * 1000;
         if (p_at_m55 > 2)
         {
             cell_data.at(x, y).item_appearances_actual +=
-                (floorstack(n_at_m55(2)) - ELONA_ITEM_ON_GROUND_INDEX) *
-                1000000;
+                floorstack(n_at_m55(2)) * 1000000;
         }
         else
         {
@@ -2017,42 +2111,25 @@ void mapitem_cold(int x, int y)
 
 Item& get_random_inv(int owner)
 {
-    const auto tmp = inv_getheader(owner);
-    const auto index = tmp.first + rnd(tmp.second);
-    return inv[index];
+    auto& inv_ = inv.by_index(owner);
+    return inv_.at(rnd(inv_.size()));
 }
 
 
 
 std::pair<int, int> inv_getheader(int owner)
 {
-    if (owner == 0)
-    {
-        return {0, 200};
-    }
-    else if (owner == -1)
-    {
-        return {ELONA_ITEM_ON_GROUND_INDEX, 400};
-    }
-    else
-    {
-        return {200 + 20 * (owner - 1), 20};
-    }
+    return {
+        static_cast<int>(inv.by_index(owner).index_start()),
+        static_cast<int>(inv.by_index(owner).size()),
+    };
 }
 
 
 
 int inv_getowner(const Item& item)
 {
-    if (item.index() < 200)
-    {
-        return 0;
-    }
-    if (item.index() >= ELONA_ITEM_ON_GROUND_INDEX)
-    {
-        return -1;
-    }
-    return (item.index() - 200) / 20 + 1;
+    return item.inventory()->inventory_id();
 }
 
 

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -103,7 +103,7 @@ Inventory::Inventory()
 {
     for (size_t i = 0; i < storage.size(); ++i)
     {
-        storage[i].index = static_cast<int>(i);
+        storage[i]._index = static_cast<int>(i);
     }
 }
 
@@ -354,7 +354,7 @@ void cell_refresh(int x, int y)
         {
             if (item.position.x == x && item.position.y == y)
             {
-                floorstack(p_at_m55) = item.index;
+                floorstack(p_at_m55) = item.index();
                 ++p_at_m55;
                 wpoke(
                     cell_data.at(x, y).item_appearances_actual, 0, item.image);
@@ -2044,15 +2044,15 @@ std::pair<int, int> inv_getheader(int owner)
 
 int inv_getowner(const Item& item)
 {
-    if (item.index < 200)
+    if (item.index() < 200)
     {
         return 0;
     }
-    if (item.index >= ELONA_ITEM_ON_GROUND_INDEX)
+    if (item.index() >= ELONA_ITEM_ON_GROUND_INDEX)
     {
         return -1;
     }
-    return (item.index - 200) / 20 + 1;
+    return (item.index() - 200) / 20 + 1;
 }
 
 

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -66,6 +66,8 @@ private:
     // creation and load.
     int _index = -1;
 
+    Inventory* _inventory = nullptr;
+
     friend Inventory;
 
 public:
@@ -74,6 +76,11 @@ public:
     int index() const noexcept
     {
         return _index;
+    }
+
+    Inventory* inventory() const noexcept
+    {
+        return _inventory;
     }
 
 private:
@@ -189,8 +196,10 @@ public:
     static void copy(const Item& from, Item& to)
     {
         const auto index_save = to._index;
+        const auto inventory_save = to._inventory;
         to = from;
         to._index = index_save;
+        to._inventory = inventory_save;
     }
 
 
@@ -249,87 +258,127 @@ public:
 
 
 
-struct InventorySlice
-{
-    using iterator = std::vector<Item>::iterator;
-
-    InventorySlice(const iterator& begin, const iterator& end)
-        : _begin(begin)
-        , _end(end)
-    {
-    }
-
-    iterator begin()
-    {
-        return _begin;
-    }
-
-    iterator end()
-    {
-        return _end;
-    }
-
-private:
-    const iterator _begin;
-    const iterator _end;
-};
-
-
-
 struct Character;
+
 
 
 struct Inventory
 {
-    Inventory();
+public:
+    using storage_type = std::vector<Item>;
 
 
-    Item& operator[](int index)
+    Inventory(size_t index_start, size_t inventory_size, int inventory_id);
+    Inventory(Inventory&&);
+
+    bool contains(size_t index) const;
+    Item& at(size_t index);
+
+
+    size_t index_start() const noexcept
     {
-        return storage[index];
+        return _index_start;
     }
 
 
-    InventorySlice all()
+    size_t size() const noexcept
     {
-        return {std::begin(storage), std::end(storage)};
+        return _storage.size();
     }
 
 
-    InventorySlice pc()
+
+    using iterator = storage_type::iterator;
+    using const_iterator = storage_type::const_iterator;
+
+
+
+    iterator begin()
     {
-        return {std::begin(storage), std::begin(storage) + 200};
+        return _storage.begin();
     }
 
 
-    InventorySlice ground()
+    iterator end()
     {
-        return {
-            std::begin(storage) + ELONA_ITEM_ON_GROUND_INDEX,
-            std::begin(storage) + ELONA_ITEM_ON_GROUND_INDEX + 400};
+        return _storage.end();
     }
 
 
-    InventorySlice map_local()
+    const_iterator begin() const
     {
-        return {
-            std::begin(storage) + ELONA_OTHER_INVENTORIES_INDEX,
-            std::end(storage)};
+        return _storage.begin();
     }
 
 
-    InventorySlice for_chara(const Character& chara);
+    const_iterator end() const
+    {
+        return _storage.end();
+    }
 
-    InventorySlice by_index(int index);
+
+    const_iterator cbegin() const
+    {
+        return _storage.cbegin();
+    }
+
+
+    const_iterator cend() const
+    {
+        return _storage.cend();
+    }
+
+
+
+    int inventory_id() const noexcept
+    {
+        return _inventory_id;
+    }
 
 
 
 private:
-    std::vector<Item> storage;
+    size_t _index_start;
+    storage_type _storage;
+    int _inventory_id;
 };
 
 
-extern Inventory inv;
+
+struct AllInventory
+{
+private:
+    using storage_type = std::vector<Inventory>;
+    using iterator_type = storage_type::iterator;
+    using iterator_pair_type = range::iterator_pair_t<iterator_type>;
+
+
+
+public:
+    AllInventory();
+
+
+    Item& operator[](int index);
+
+
+    Inventory& pc();
+    Inventory& ground();
+    Inventory& for_chara(const Character& chara);
+    Inventory& by_index(int index);
+
+    iterator_pair_type all();
+    iterator_pair_type global();
+    iterator_pair_type map_local();
+
+
+
+private:
+    std::vector<Inventory> _inventories;
+};
+
+
+
+extern AllInventory inv;
 
 
 

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -50,20 +50,31 @@ struct Enchantment
 
 
 
+struct Inventory;
+
+
+
 struct Item
 {
 private:
     using FlagSet = std::bitset<32>;
 
 
-public:
-    Item();
-
     // Index of this item into the global cdata array.
     // Used for communicating with legacy code that takes integer index
     // arguments. New code should pass Item& instead. Not serialized; set on
     // creation and load.
-    int index = -1;
+    int _index = -1;
+
+    friend Inventory;
+
+public:
+    Item();
+
+    int index() const noexcept
+    {
+        return _index;
+    }
 
 private:
     int number_ = 0;
@@ -177,9 +188,9 @@ public:
 
     static void copy(const Item& from, Item& to)
     {
-        const auto index_save = to.index;
+        const auto index_save = to._index;
         to = from;
-        to.index = index_save;
+        to._index = index_save;
     }
 
 

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -162,6 +162,19 @@ public:
 
 
 
+    bool operator==(const Item& other) const noexcept
+    {
+        return this == &other;
+    }
+
+
+    bool operator!=(const Item& other) const noexcept
+    {
+        return !(*this == other);
+    }
+
+
+
     static void copy(const Item& from, Item& to)
     {
         const auto index_save = to.index;

--- a/src/elona/item_ref.cpp
+++ b/src/elona/item_ref.cpp
@@ -9,7 +9,7 @@ namespace elona
 
 ItemRef ItemRef::from_ref(Item& item) noexcept
 {
-    return from_index(item.index);
+    return from_index(item.index());
 }
 
 
@@ -23,7 +23,7 @@ ItemRef ItemRef::from_opt(optional_ref<Item> item) noexcept
 
 bool ItemRef::operator==(const Item& other) const noexcept
 {
-    return *this == ItemRef::from_index(other.index);
+    return *this == ItemRef::from_index(other.index());
 }
 
 
@@ -32,7 +32,7 @@ bool ItemRef::operator==(optional_ref<const Item>& other) const noexcept
 {
     if (other)
     {
-        return *this == ItemRef::from_index(other->index);
+        return *this == ItemRef::from_index(other->index());
     }
     else
     {

--- a/src/elona/lua_env/handle_manager.cpp
+++ b/src/elona/lua_env/handle_manager.cpp
@@ -127,13 +127,6 @@ void HandleManager::remove_chara_handle_run_callbacks(const Character& chara)
         return;
     }
 
-    // If the handle already exists, the object it references has to be invalid.
-    // Otherwise the handle would be mistakenly invalidated when the thing it
-    // points to is still valid.
-    int index = handle["__index"];
-    (void)index;
-    assert(cdata[index].state() != Character::State::alive);
-
     lua().get_event_manager().trigger(
         lua::CharacterInstanceEvent("core.character_removed", chara));
     remove_chara_handle(chara);
@@ -148,13 +141,6 @@ void HandleManager::remove_item_handle_run_callbacks(const Item& item)
     {
         return;
     }
-
-    // If the handle already exists, the object it references has to be invalid.
-    // Otherwise the handle would be mistakenly invalidated when the thing it
-    // points to is still valid.
-    int index = handle["__index"];
-    (void)index;
-    assert(inv[index].number() == 0);
 
     lua().get_event_manager().trigger(
         lua::ItemInstanceEvent("core.item_removed", item));

--- a/src/elona/lua_env/handle_manager.cpp
+++ b/src/elona/lua_env/handle_manager.cpp
@@ -163,9 +163,12 @@ void HandleManager::clear_map_local_handles()
     {
         remove_chara_handle(cdata[i]);
     }
-    for (auto&& item : inv.map_local())
+    for (auto&& inv_ : inv.map_local())
     {
-        remove_item_handle(item);
+        for (auto&& item : inv_)
+        {
+            remove_item_handle(item);
+        }
     }
 }
 

--- a/src/elona/lua_env/handle_manager.hpp
+++ b/src/elona/lua_env/handle_manager.hpp
@@ -130,7 +130,14 @@ public:
     template <typename T>
     sol::table get_handle(T& obj)
     {
-        return get_handle(obj.index, T::lua_type());
+        if constexpr (std::is_same_v<std::remove_cv_t<T>, Item>)
+        {
+            return get_handle(obj.index(), T::lua_type());
+        }
+        else
+        {
+            return get_handle(obj.index, T::lua_type());
+        }
     }
 
 

--- a/src/elona/lua_env/lua_api/lua_api_debug.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_debug.cpp
@@ -78,7 +78,7 @@ void LuaApiDebug::dump_items()
     {
         if (item.number() != 0)
             ELONA_LOG("lua.debug")
-                << item.index << ") Name: " << elona::itemname(item)
+                << item.index() << ") Name: " << elona::itemname(item)
                 << ", Pos: " << item.position
                 << ", Curse: " << static_cast<int>(item.curse_state)
                 << ", Ident: " << static_cast<int>(item.identify_state)

--- a/src/elona/lua_env/lua_class/lua_class_item.cpp
+++ b/src/elona/lua_env/lua_class/lua_class_item.cpp
@@ -45,7 +45,7 @@ void LuaItem::change_material(Item& self, const std::string& material_id)
 
 std::string LuaItem::metamethod_tostring(const Item& self)
 {
-    return Item::lua_type() + "(" + std::to_string(self.index) + ")";
+    return Item::lua_type() + "(" + std::to_string(self.index()) + ")";
 }
 
 
@@ -62,7 +62,8 @@ void LuaItem::bind(sol::state& lua)
      *
      * [R] The index of this item in the global items array.
      */
-    LuaItem.set("index", sol::readonly(&Item::index));
+    LuaItem.set(
+        "index", sol::property([](const Item& it) { return it.index(); }));
 
 
     /**

--- a/src/elona/lua_env/lua_env.cpp
+++ b/src/elona/lua_env/lua_env.cpp
@@ -90,11 +90,14 @@ void LuaEnv::load_mods()
 
 void LuaEnv::clear()
 {
-    for (auto&& item : inv.all())
+    for (auto&& inv_ : inv.all())
     {
-        if (item.number() != 0)
+        for (auto&& item : inv_)
         {
-            handle_mgr->remove_item_handle(item);
+            if (item.number() != 0)
+            {
+                handle_mgr->remove_item_handle(item);
+            }
         }
     }
 

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -521,7 +521,6 @@ TalkResult talk_guard_return_item(Character& speaker)
         wallet_opt = itemfind(0, 283);
     }
     Item& wallet = *wallet_opt;
-    p = wallet.index;
     wallet.modify_number(-1);
     if (wallet.param1 == 0)
     {

--- a/src/elona/text.cpp
+++ b/src/elona/text.cpp
@@ -2561,13 +2561,13 @@ std::string txtitemoncell(int x, int y)
         {
             std::array<int, 3> item_indice;
             const auto i = -cell_data.at(x, y).item_appearances_memory;
-            item_indice[0] = i % 1000 + ELONA_ITEM_ON_GROUND_INDEX;
-            item_indice[1] = i / 1000 % 1000 + ELONA_ITEM_ON_GROUND_INDEX;
-            item_indice[2] = i / 1000000 % 1000 + ELONA_ITEM_ON_GROUND_INDEX;
+            item_indice[0] = i % 1000;
+            item_indice[1] = i / 1000 % 1000;
+            item_indice[2] = i / 1000000 % 1000;
             size_t counter{};
             for (const auto& item_index : item_indice)
             {
-                if (item_index == 6079)
+                if (item_index == 999)
                 {
                     continue;
                 }
@@ -2575,7 +2575,7 @@ std::string txtitemoncell(int x, int y)
                 {
                     items_text += i18n::s.get("core.misc.and");
                 }
-                items_text += itemname(inv[item_index]);
+                items_text += itemname(inv.ground().at(item_index));
                 ++counter;
             }
         }

--- a/src/tests/item.cpp
+++ b/src/tests/item.cpp
@@ -1,26 +1,3 @@
-#include "../elona/item.hpp"
-
-#include "../elona/itemgen.hpp"
-#include "../elona/testing.hpp"
-#include "../elona/variables.hpp"
-#include "../thirdparty/catch2/catch.hpp"
-#include "tests.hpp"
-
-TEST_CASE("Test that index of copied item is set", "[C++: Item]")
-{
-    testing::start_in_debug_map();
-    int amount = 1;
-
-    const auto i_opt =
-        itemcreate_extra_inv(itemid2int(PUTITORO_PROTO_ID), 4, 8, amount);
-    REQUIRE_SOME(i_opt);
-    Item& i = *i_opt;
-
-    const auto slot_opt = elona::inv_get_free_slot(-1);
-    REQUIRE_SOME(slot_opt);
-    auto& slot = *slot_opt;
-    elona::Item::copy(i, slot);
-
-    REQUIRE(elona::inv[i.index].index == i.index);
-    REQUIRE(elona::inv[slot.index].index == slot.index);
-}
+/*
+ * No test cases about items for now
+ */

--- a/src/tests/lua_callbacks.cpp
+++ b/src/tests/lua_callbacks.cpp
@@ -283,10 +283,8 @@ TEST_CASE("Test item created callback", "[Lua: Callbacks]")
 local Event = ELONA.require("core.Event")
 
 local function my_item_created_handler(e)
-   mod.store.global.items[e.item.index] = e.item
+   mod.store.global.event_handler_called = true
 end
-
-mod.store.global.items = {}
 
 Event.register("core.item_created", my_item_created_handler)
 )"));
@@ -294,15 +292,10 @@ Event.register("core.item_created", my_item_created_handler)
     const auto item =
         elona::itemcreate_extra_inv(itemid2int(PUTITORO_PROTO_ID), 4, 8, 3);
     REQUIRE_SOME(item);
-    int idx = item->index;
-    REQUIRE(idx != -1);
-    elona::lua::lua->get_mod_manager()
-        .get_mod("test_item_created")
-        ->env.raw_set("idx", idx);
 
     REQUIRE_NOTHROW(elona::lua::lua->get_mod_manager().run_in_mod(
         "test_item_created",
-        R"(assert(mod.store.global.items[idx].index == idx))"));
+        R"(assert(mod.store.global.event_handler_called == true))"));
 }
 
 TEST_CASE("Test map unloading callback", "[Lua: Callbacks]")

--- a/src/tests/lua_handles.cpp
+++ b/src/tests/lua_handles.cpp
@@ -421,16 +421,13 @@ TEST_CASE("Test relocation of character handle", "[Lua: Handles]")
 
     int first_index = chara_opt->index;
     std::string uuid = handle["__uuid"];
-    REQUIRE(handle["__index"].get<int>() == first_index);
 
     const auto ally = new_ally_joins(chara);
     REQUIRE_SOME(ally);
 
     REQUIRE(handle_mgr.handle_is_valid(handle) == true);
     REQUIRE(ally->index != first_index);
-    REQUIRE(handle["__index"].get<int>() == ally->index);
     REQUIRE(handle["__uuid"].get<std::string>() == uuid);
-    REQUIRE(handle["__index"].get<int>() == handle["index"].get<int>());
 }
 
 TEST_CASE(
@@ -447,7 +444,6 @@ TEST_CASE(
 
     int first_index = chara_opt->index;
     std::string uuid = handle["__uuid"];
-    REQUIRE(handle["__index"].get<int>() == first_index);
 
     int tc = chara_opt->index;
     flt(20, Quality::good);
@@ -457,7 +453,6 @@ TEST_CASE(
     chara_relocate(cdata.tmp(), cdata[tc], CharaRelocationMode::change);
 
     REQUIRE(handle_mgr.handle_is_valid(handle) == true);
-    REQUIRE(handle["__index"].get<int>() == cdata[tc].index);
     REQUIRE(handle["__uuid"].get<std::string>() == uuid);
     REQUIRE(handle_mgr.handle_is_valid(temporary_handle) == false);
 }
@@ -708,11 +703,6 @@ TEST_CASE("Test swapping of item handles", "[Lua: Handles]")
     elona::item_exchange(item_a, item_b);
 
     // Disabled temporarily.
-    // TODO: rethink how should swapping behave.
-    // // Handle indices should reflect the swapped item indices.
-    // REQUIRE(handle_a["__index"].get<int>() == item_b.index);
-    // REQUIRE(handle_b["__index"].get<int>() == item_a.index);
-
     // // UUIDs should still be the same as before.
     // REQUIRE(handle_a["__uuid"].get<std::string>() == uuid_a);
     // REQUIRE(handle_b["__uuid"].get<std::string>() == uuid_b);

--- a/src/tests/serialization.cpp
+++ b/src/tests/serialization.cpp
@@ -39,7 +39,7 @@ TEST_CASE("Test item saving and reloading", "[C++: Serialization]")
     const auto item =
         itemcreate_extra_inv(itemid2int(PUTITORO_PROTO_ID), x, y, number);
     REQUIRE_SOME(item);
-    int index = item->index;
+    int index = item->index();
     elona::inv[index].is_aphrodisiac() = true;
     elona::inv[index].curse_state = CurseState::blessed;
 
@@ -80,19 +80,6 @@ TEST_CASE("Test other character index preservation", "[C++: Serialization]")
     REQUIRE(elona::cdata[index].index == index);
 }
 
-TEST_CASE("Test item index preservation", "[C++: Serialization]")
-{
-    start_in_debug_map();
-    const auto item =
-        itemcreate_extra_inv(itemid2int(PUTITORO_PROTO_ID), 0, 0, 0);
-    REQUIRE_SOME(item);
-    int index = item->index;
-
-    save_and_reload();
-
-    REQUIRE(elona::inv[index].index == index);
-}
-
 TEST_CASE("Test character data compatibility", "[C++: Serialization]")
 {
     int player_idx = 0;
@@ -111,18 +98,14 @@ TEST_CASE("Test other character data compatibility", "[C++: Serialization]")
 
 TEST_CASE("Test item data compatibility (in inventory)", "[C++: Serialization]")
 {
-    int item_idx = 0;
     load_previous_savefile();
-    REQUIRE(elona::inv[item_idx].index == item_idx);
-    REQUIRE(elona::itemname(inv[item_idx]) == u8"ブロンズの兜 [0,1]");
+    REQUIRE(elona::itemname(inv[0]) == u8"ブロンズの兜 [0,1]");
 }
 
 TEST_CASE("Test item data compatibility (on ground)", "[C++: Serialization]")
 {
-    int item_idx = 5080;
     load_previous_savefile();
-    REQUIRE(elona::inv[item_idx].index == item_idx);
-    REQUIRE(elona::itemname(inv[item_idx]) == u8"割れたつぼ");
+    REQUIRE(elona::itemname(inv[5080]) == u8"割れたつぼ");
 }
 
 TEST_CASE("Test ability data compatibility", "[C++: Serialization]")

--- a/src/tests/util.cpp
+++ b/src/tests/util.cpp
@@ -84,19 +84,19 @@ Item& create_item(int id, int number)
 
 void invalidate_item(Item& item)
 {
-    int old_index = item.index;
+    const Item* old_address = &item;
     int old_id = itemid2int(item.id);
     int old_x = item.position.x;
     int old_y = item.position.y;
 
     // Delete the item and create new ones until the index is taken again.
-    inv[old_index].remove();
-    inv[old_index].clear();
+    item.remove();
+    item.clear();
     while (true)
     {
         const auto new_item = itemcreate_extra_inv(old_id, old_x, old_y, 3);
         REQUIRE_SOME(new_item);
-        if (new_item->index != old_index)
+        if (&(*new_item) != old_address)
         {
             break;
         }

--- a/src/util/range.hpp
+++ b/src/util/range.hpp
@@ -167,75 +167,44 @@ void remove_erase_if(Range& range, Predicate&& predicate)
 
 
 
-template <typename T>
-struct iota
+template <typename BeginIterator, typename EndIterator = BeginIterator>
+struct iterator_pair_t
 {
-    iota(T first, T last)
-        : first(first)
-        , last(last)
+    using begin_iterator_type = BeginIterator;
+    using end_iterator_type = EndIterator;
+
+
+
+    iterator_pair_t(begin_iterator_type begin_itr, end_iterator_type end_itr)
+        : _begin_itr(begin_itr)
+        , _end_itr(end_itr)
     {
     }
 
 
-    iota(T last)
-        : iota(0, last)
+    begin_iterator_type begin() const
     {
+        return _begin_itr;
     }
 
 
-    struct iterator
+    end_iterator_type end() const
     {
-        using value_type = const T;
-        using difference_type = size_t;
-        using pointer = const T*;
-        using reference = const T&;
-        using iterator_category = std::random_access_iterator_tag;
-
-
-        iterator(T n)
-            : n(n)
-        {
-        }
-
-
-        void operator++()
-        {
-            ++n;
-        }
-
-
-        reference operator*() const
-        {
-            return n;
-        }
-
-
-        bool operator!=(const iterator& other) const
-        {
-            return n != other.n;
-        }
-
-
-    private:
-        T n;
-    };
-
-
-    iterator begin() const
-    {
-        return {first};
-    }
-
-
-    iterator end() const
-    {
-        return {last};
+        return _end_itr;
     }
 
 
 private:
-    const T first;
-    const T last;
+    begin_iterator_type _begin_itr;
+    end_iterator_type _end_itr;
 };
+
+
+
+template <typename BeginIterator, typename EndIterator = BeginIterator>
+auto iterator_pair(BeginIterator begin_itr, EndIterator end_itr)
+{
+    return iterator_pair_t<BeginIterator, EndIterator>(begin_itr, end_itr);
+}
 
 } // namespace range


### PR DESCRIPTION
# Summary

This PR refactors inventory-related routines a lot for future ambitious goals: 1) unlimited-size inventory and 2) tracking items from the cradle to the grave.

# Details

* Remove `__index` field of object handles. The field was for integration with legacy code and no longer necessary.
  * Note that this change does not break compatibility: all old save can be loaded without errors.
* Remove unnecessary variable: `iqiality`
  * It should be a typo of `iQuality`. `iQuality` is a `#define` macro in vanilla's source code, which is equivalent to `Item::quality` field in foobar. Judging from the lines where `iqiality` appears, the variable is totally unnecessary and should be removed.
* Add equality operators (`==` and `!=`) to `Item` struct.
  * They compare items by the memory address. This change can reduce some uses of `Item::index`.
* Remove meaningless statements related to `Item::index`.
  * See the commit message of b6d2f2e for the reason why these statements are "meaningless" and can be removed safely.
* Reduce uses of `Item::index` field.
  * `git diff` is enough to explain the change.
* Make `Item::index` private.
  * The field is also renamed to `Item::_index`, and getter `Item::index()` is added instead. What is the most important is that `Item` no longer exposes `index` field as writable because it does not provide the setter.
* Rewrite `Inventory` struct for high-level abstraction.
  * Previously, all items in the game were stored in one large array, variable `inv`. Now, it is separated into each inventory, e.g., on-ground inventory, yours and each character's.

I have to refactor inventory-related code more and more for the above goals, but I guess the expected whole changes should be too large for one pull request. So I send/review/merge this PR first.
