### PR TITLE
Fix issue where The Oracle records unexpected items

### DIFF
--- a/src/elona/wish.cpp
+++ b/src/elona/wish.cpp
@@ -274,7 +274,9 @@ void wish_for_character()
 void wish_for_card()
 {
     flt();
+    nooracle = 1;
     chara_create(56, select_wished_character(inputlog), -3, 0);
+    nooracle = 0;
     flt();
     if (const auto item = itemcreate_extra_inv(504, cdata.player().position, 0))
     {
@@ -291,7 +293,9 @@ void wish_for_card()
 void wish_for_figure()
 {
     flt();
+    nooracle = 1;
     chara_create(56, select_wished_character(inputlog), -3, 0);
+    nooracle = 0;
     flt();
     if (const auto item = itemcreate_extra_inv(503, cdata.player().position, 0))
     {


### PR DESCRIPTION
# Summary

When you wish "card <someone>" or "figure <someone>", unique artifacts the character has were recorded in The Oracle. For example, wishing "card mani" or "figure mani" appended "cat's tail" to The Oracle.
