### PR TITLE
Add tool to increment mod API/mod versions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -67,3 +67,16 @@ Fix crash when calling function xxx()
 * Neither `fix`, `Fixed` nor `fixing`.
 * No period.
 * Other appropriate verbs are allowed.
+
+
+
+# Versioning convention
+
+## Application
+
+Ignore Semantic Versioning.
+
+
+## Built-in mods
+
+Follow Semantic Versioning. Each mod has its own version, not synchronized with each other.

--- a/doc/api/env.luadoc
+++ b/doc/api/env.luadoc
@@ -2,10 +2,8 @@
 --  @usage local Env = ELONA.require("core.Env")
 module "Env"
 
---- Mod API Version.
---  WARNING***: it always returns "0.1" so far, and *not* incremented every
---  release until the mod API is stabilized.
---  @tfield string MOD_API_VERSION
+--- Elona foobar version. E.g., "1.2.3"
+--  @tfield string ELONA_FOOBAR_VERSION
 
 --- Lua version. E.g., "5.3". Note that it is different from "_VERSION", one of
 --  the Lua built-in global constants.
@@ -16,8 +14,3 @@ module "Env"
 
 --- Elona foobar version. E.g., "1.2.3"
 --  @tfield string ELONA_FOOBAR_VERSION
-
---- Mod API Version.
---  WARNING***: it always returns "0.1" so far, and *not* incremented every
---  release until the mod API is stabilized.
---  @tfield string MOD_API_VERSION

--- a/src/elona/lua_env/lua_api/lua_api_env.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_env.cpp
@@ -31,14 +31,6 @@ namespace LuaApiEnv
  * Elona foobar version. E.g., "1.2.3"
  */
 
-/**
- * @luadoc MOD_API_VERSION field string
- *
- * Mod API Version.
- * ***WARNING***: it always returns "0.1" so far, and *not* incremented every
- * release until the mod API is stabilized.
- */
-
 void bind(sol::table& api_table)
 {
     LUA_API_BIND_CONSTANT(
@@ -46,10 +38,6 @@ void bind(sol::table& api_table)
     LUA_API_BIND_CONSTANT(api_table, ELONA_VERSION, "1.22");
     LUA_API_BIND_CONSTANT(
         api_table, ELONA_FOOBAR_VERSION, latest_version.short_string());
-
-    // TODO: you need to define it properly after mod API is stabilized!
-    // Currently it always returns "0.1".
-    LUA_API_BIND_CONSTANT(api_table, MOD_API_VERSION, "0.1");
 }
 
 } // namespace LuaApiEnv

--- a/src/tests/lua_api.cpp
+++ b/src/tests/lua_api.cpp
@@ -86,7 +86,6 @@ local Env = ELONA.require("core.Env")
 assert(Env.LUA_VERSION, "5.3") -- _VERSION is not available.
 assert(Env.ELONA_VERSION, "1.22")
 assert(Env.ELONA_FOOBAR_VERSION, foobar_ver)
-assert(Env.MOD_API_VERSION, "0.1")
 )"));
 }
 


### PR DESCRIPTION
# Summary

Add tool to increment mod API/mod versions (`tools/incver.py`).

## Usage

```
$ ./tools/incver.py --help

usage: incver.py [-h] [-n] target {major,minor,patch}

Increment Elona foobar version.

positional arguments:
  target
  {major,minor,patch}

optional arguments:
  -h, --help           show this help message and exit
  -n, --dry-run
```

`target` is either of `APP` or any mods.