### PR TITLE
Skip validity check (item number is 0) during iterating over an inventory

### DIFF
--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -1836,10 +1836,6 @@ void spot_digging(Character& chara)
     {
         for (auto&& item : inv.pc())
         {
-            if (item.number() == 0)
-            {
-                continue;
-            }
             if (item.id == ItemId::treasure_map && item.param1 != 0 &&
                 item.param1 == cdata.player().position.x &&
                 item.param2 == cdata.player().position.y)

--- a/src/elona/ai.cpp
+++ b/src/elona/ai.cpp
@@ -301,10 +301,6 @@ void _ally_sells_item(Character& chara)
 
     for (auto&& item : inv.for_chara(chara))
     {
-        if (item.number() == 0)
-        {
-            continue;
-        }
         if (the_item_db[itemid2int(item.id)]->category == ItemCategory::ore)
         {
             sold_item_count += item.number();

--- a/src/elona/blending.cpp
+++ b/src/elona/blending.cpp
@@ -209,10 +209,6 @@ bool find_blending_materials(int inventory, int recipe_id, int step)
     const auto check_pos = inventory == -1;
     for (auto&& item : inventory == -1 ? inv.ground() : inv.pc())
     {
-        if (item.number() <= 0)
-        {
-            continue;
-        }
         if (check_one_blending_material(item, recipe_id, step, check_pos))
         {
             return true; // found
@@ -233,10 +229,6 @@ int count_blending_materials(int inventory, int recipe_id, int step)
     int ret = 0;
     for (auto&& item : inventory == -1 ? inv.ground() : inv.pc())
     {
-        if (item.number() <= 0)
-        {
-            continue;
-        }
         if (check_one_blending_material(item, recipe_id, step, check_pos))
         {
             ret += item.number();
@@ -262,10 +254,6 @@ void collect_blending_materials(
         if (result.size() >= 500)
         {
             break;
-        }
-        if (item.number() <= 0)
-        {
-            continue;
         }
         if (check_one_blending_material(item, recipe_id, step, check_pos))
         {

--- a/src/elona/building.cpp
+++ b/src/elona/building.cpp
@@ -157,10 +157,6 @@ std::vector<ItemForSale> list_items_for_sale()
 
     for (auto&& item : inv.ground())
     {
-        if (item.number() <= 0)
-        {
-            continue;
-        }
         if (item.id == ItemId::shop_strongbox)
         {
             continue;
@@ -464,21 +460,17 @@ TurnResult show_house_board()
     }
     p(0) = 0;
     p(1) = 0;
-    p(2) = 0;
+    p(2) = 400;
     for (const auto& item : inv.ground())
     {
-        ++p(2);
-        if (item.number() != 0)
+        if (the_item_db[itemid2int(item.id)]->category !=
+            ItemCategory::furniture)
         {
-            if (the_item_db[itemid2int(item.id)]->category !=
-                ItemCategory::furniture)
-            {
-                ++p;
-            }
-            else
-            {
-                ++p(1);
-            }
+            ++p;
+        }
+        else
+        {
+            ++p(1);
         }
     }
     if (map_data.max_item_count != 0)
@@ -1194,10 +1186,6 @@ void update_shop()
     }
     for (const auto& item : inv.ground())
     {
-        if (item.number() <= 0)
-        {
-            continue;
-        }
         x = item.position.x;
         y = item.position.y;
         if (x < 0 || x >= map_data.width || y < 0 || y >= map_data.height)
@@ -1249,10 +1237,6 @@ void update_museum()
     DIM3(dblist, 2, 800);
     for (const auto& item : inv.ground())
     {
-        if (item.number() == 0)
-        {
-            continue;
-        }
         if (item.id != ItemId::figurine && item.id != ItemId::card)
         {
             continue;
@@ -1317,10 +1301,6 @@ std::vector<HomeRankHeirloom> building_update_home_rank()
     std::vector<HomeRankHeirloom> heirlooms;
     for (auto&& item : inv.ground())
     {
-        if (item.number() == 0)
-        {
-            continue;
-        }
         if (wpeek(
                 cell_data.at(item.position.x, item.position.y)
                     .item_appearances_actual,

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -1191,8 +1191,6 @@ int calccostreload(int owner, bool do_reload)
 
     for (auto&& item : inv.for_chara(cdata[owner]))
     {
-        if (item.number() == 0)
-            continue;
         if (the_item_db[itemid2int(item.id)]->category != ItemCategory::ammo)
             continue;
 
@@ -1250,10 +1248,6 @@ int calcidentifyvalue(int type)
         int need_to_identify{};
         for (const auto& item : inv.pc())
         {
-            if (item.number() == 0)
-            {
-                continue;
-            }
             if (item.identify_state != IdentifyState::completely)
             {
                 ++need_to_identify;

--- a/src/elona/casino.cpp
+++ b/src/elona/casino.cpp
@@ -356,8 +356,7 @@ void casino_acquire_items()
 {
     mtilefilecur = -1;
     draw_prepare_map_chips();
-    const auto have_any_rewards = range::any_of(
-        inv.ground(), [](const auto& item) { return item.number() != 0; });
+    const auto have_any_rewards = (inv_sum(-1) != 0);
     if (have_any_rewards)
     {
         if (cdata.player().hp >= 0)

--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -1795,10 +1795,6 @@ void initialize_pc_character()
     cdata.player().total_skill_bonus = 5 + trait(154);
     for (auto&& item : inv.pc())
     {
-        if (item.number() == 0)
-        {
-            continue;
-        }
         item.identify_state = IdentifyState::completely;
     }
     chara_refresh(cdata.player());

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -95,10 +95,6 @@ void _search_for_crystal()
     optional<int> d;
     for (const auto& item : inv.ground())
     {
-        if (item.number() == 0)
-        {
-            continue;
-        }
         if (item.own_state != 5)
         {
             continue;
@@ -5626,10 +5622,6 @@ PickUpItemResult pick_up_item(
                 f = 0;
                 for (const auto& item_ : inv.ground())
                 {
-                    if (item_.number() == 0)
-                    {
-                        continue;
-                    }
                     if (item_.id == ItemId::campfire)
                     {
                         f = 1;
@@ -5883,8 +5875,6 @@ void proc_autopick()
 
     for (auto&& item : inv.ground())
     {
-        if (item.number() == 0)
-            continue;
         if (item.position != cdata.player().position)
             continue;
         if (item.own_state > 0)

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -280,12 +280,6 @@ void make_item_list(
 
         for (auto& item : inv.by_index(p))
         {
-            if (item.number() <= 0)
-            {
-                item.remove();
-                continue;
-            }
-
             // compatibility?
             if (item.id == ItemId::training_machine)
             {

--- a/src/elona/deferred_event.cpp
+++ b/src/elona/deferred_event.cpp
@@ -989,8 +989,6 @@ void eh_guest_visit(const DeferredEvent&)
         auto distance_to_guest_chair = 6;
         for (const auto& item : inv.ground())
         {
-            if (item.number() == 0)
-                continue;
             if (item.function != 44)
                 continue;
             if (chara.index == guest->index)

--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -77,10 +77,6 @@ void dmgheal_death_by_backpack(Character& chara)
 
     for (auto&& item : inv.for_chara(chara))
     {
-        if (item.number() == 0)
-        {
-            continue;
-        }
         if (item.weight > heaviest_weight)
         {
             heaviest_item = item;
@@ -1429,10 +1425,6 @@ void character_drops_item(Character& victim)
         }
         for (auto&& item : inv.for_chara(victim))
         {
-            if (item.number() == 0)
-            {
-                continue;
-            }
             if (map_data.refresh_type == 0)
             {
                 if (item.body_part != 0)
@@ -1605,10 +1597,6 @@ void character_drops_item(Character& victim)
     }
     for (auto&& item : inv.for_chara(victim))
     {
-        if (item.number() == 0)
-        {
-            continue;
-        }
         f = 0;
         if (victim.role == Role::user)
         {

--- a/src/elona/equipment.cpp
+++ b/src/elona/equipment.cpp
@@ -243,7 +243,7 @@ void wear_most_valuable_equipment_for_all_body_parts(Character& chara)
 {
     for (auto&& item : inv.for_chara(chara))
     {
-        if (item.number() == 0 || item.body_part != 0)
+        if (item.body_part != 0)
         {
             continue;
         }

--- a/src/elona/food.cpp
+++ b/src/elona/food.cpp
@@ -267,12 +267,9 @@ void chara_vomit(Character& chara)
         auto p = 2;
         for (const auto& item : inv.ground())
         {
-            if (item.number() > 0)
+            if (item.id == ItemId::vomit)
             {
-                if (item.id == ItemId::vomit)
-                {
-                    ++p;
-                }
+                ++p;
             }
         }
         if (rnd_capped(p * p * p) == 0 || chara.index == 0)
@@ -1490,10 +1487,6 @@ void foods_get_rotten()
 
         for (auto&& item : inv.by_index(chara))
         {
-            if (item.number() == 0)
-            {
-                continue;
-            }
             _food_gets_rotten(chara, item);
         }
     }

--- a/src/elona/initialize_map_types.cpp
+++ b/src/elona/initialize_map_types.cpp
@@ -1003,10 +1003,6 @@ static void _init_map_your_home()
                 FileOperation2::map_items_read, u8"inv_"s + mid + u8".s2");
             for (auto&& item : inv.ground())
             {
-                if (item.number() == 0)
-                {
-                    continue;
-                }
                 item.position.x = map_data.width / 2;
                 item.position.y = map_data.height / 2;
                 cell_refresh(item.position.x, item.position.y);

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -274,6 +274,9 @@ public:
     bool contains(size_t index) const;
     Item& at(size_t index);
 
+    bool has_free_slot() const;
+    optional_ref<Item> get_free_slot();
+
 
     size_t index_start() const noexcept
     {
@@ -288,44 +291,95 @@ public:
 
 
 
-    using iterator = storage_type::iterator;
-    using const_iterator = storage_type::const_iterator;
+    template <typename Itr>
+    struct iterator_base
+    {
+    public:
+        iterator_base(Itr itr, Itr end)
+            : _itr(itr)
+            , _end(end)
+        {
+            skip_over_null_elements();
+        }
+
+
+        bool operator==(const iterator_base& other) const
+        {
+            return _itr == other._itr;
+        }
+
+
+        bool operator!=(const iterator_base& other) const
+        {
+            return !(*this == other);
+        }
+
+
+        auto& operator*() const
+        {
+            return *_itr;
+        }
+
+
+        iterator_base& operator++()
+        {
+            ++_itr;
+            skip_over_null_elements();
+            return *this;
+        }
+
+
+
+    private:
+        Itr _itr;
+        Itr _end;
+
+
+        void skip_over_null_elements()
+        {
+            while (_itr != _end && _itr->number() == 0)
+            {
+                ++_itr;
+            }
+        }
+    };
+
+
+    using iterator = iterator_base<storage_type::iterator>;
+    using const_iterator = iterator_base<storage_type::const_iterator>;
 
 
 
     iterator begin()
     {
-        return _storage.begin();
+        return iterator(_storage.begin(), _storage.end());
     }
-
 
     iterator end()
     {
-        return _storage.end();
+        return iterator(_storage.end(), _storage.end());
     }
 
 
     const_iterator begin() const
     {
-        return _storage.begin();
+        return const_iterator(_storage.begin(), _storage.end());
     }
-
 
     const_iterator end() const
     {
-        return _storage.end();
+        return const_iterator(_storage.end(), _storage.end());
     }
 
 
     const_iterator cbegin() const
     {
-        return _storage.cbegin();
+        return begin();
     }
-
 
     const_iterator cend() const
     {
-        return _storage.cend();
+        return end();
     }
 
 

--- a/src/elona/lua_env/lua_api/lua_api_debug.cpp
+++ b/src/elona/lua_env/lua_api/lua_api_debug.cpp
@@ -76,13 +76,12 @@ void LuaApiDebug::dump_items()
     ELONA_LOG("lua.debug") << "===== Items  =====";
     for (auto&& item : inv.ground())
     {
-        if (item.number() != 0)
-            ELONA_LOG("lua.debug")
-                << item.index() << ") Name: " << elona::itemname(item)
-                << ", Pos: " << item.position
-                << ", Curse: " << static_cast<int>(item.curse_state)
-                << ", Ident: " << static_cast<int>(item.identify_state)
-                << ", Count: " << item.count;
+        ELONA_LOG("lua.debug")
+            << item.index() << ") Name: " << elona::itemname(item)
+            << ", Pos: " << item.position
+            << ", Curse: " << static_cast<int>(item.curse_state)
+            << ", Ident: " << static_cast<int>(item.identify_state)
+            << ", Count: " << item.count;
     }
 }
 

--- a/src/elona/lua_env/lua_env.cpp
+++ b/src/elona/lua_env/lua_env.cpp
@@ -94,10 +94,7 @@ void LuaEnv::clear()
     {
         for (auto&& item : inv_)
         {
-            if (item.number() != 0)
-            {
-                handle_mgr->remove_item_handle(item);
-            }
+            handle_mgr->remove_item_handle(item);
         }
     }
 

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -559,10 +559,6 @@ bool _magic_183(Character& subject, optional_ref<Item> instrument)
     {
         for (auto&& item : inv.for_chara(subject))
         {
-            if (item.number() == 0)
-            {
-                continue;
-            }
             if (item.skill == 183)
             {
                 instrument = item;
@@ -1156,10 +1152,6 @@ bool _magic_412(Character& subject, Character& target)
     p(2) = 0;
     for (auto&& item : inv.for_chara(target))
     {
-        if (item.number() == 0)
-        {
-            continue;
-        }
         if (!is_cursed(item.curse_state))
         {
             continue;
@@ -3400,10 +3392,6 @@ bool _magic_651(Character& subject, Character& target)
     optional_ref<Item> eat_item_opt;
     for (auto&& item : inv.for_chara(target))
     {
-        if (item.number() == 0)
-        {
-            continue;
-        }
         if (item.id == ItemId::fish_a)
         {
             eat_item_opt = item;
@@ -3414,10 +3402,6 @@ bool _magic_651(Character& subject, Character& target)
     {
         for (auto&& item : inv.for_chara(target))
         {
-            if (item.number() == 0)
-            {
-                continue;
-            }
             if (item.is_precious())
             {
                 continue;

--- a/src/elona/map.cpp
+++ b/src/elona/map.cpp
@@ -380,16 +380,13 @@ void map_reload(const std::string& map_filename)
 
     for (auto&& item : inv.ground())
     {
-        if (item.number() > 0)
+        if (item.own_state == 1)
         {
-            if (item.own_state == 1)
+            if (the_item_db[itemid2int(item.id)]->category ==
+                ItemCategory::food)
             {
-                if (the_item_db[itemid2int(item.id)]->category ==
-                    ItemCategory::food)
-                {
-                    item.remove();
-                    cell_refresh(item.position.x, item.position.y);
-                }
+                item.remove();
+                cell_refresh(item.position.x, item.position.y);
             }
         }
     }
@@ -732,11 +729,6 @@ static void _modify_items_on_regenerate()
 {
     for (auto&& item : inv.ground())
     {
-        if (item.number() == 0)
-        {
-            continue;
-        }
-
         // Update tree of fruits.
         if (item.id == ItemId::tree_of_fruits)
         {
@@ -2189,10 +2181,6 @@ void map_global_proc_travel_events(Character& chara)
     {
         for (auto&& item : inv.for_chara(chara))
         {
-            if (item.number() == 0)
-            {
-                continue;
-            }
             if (the_item_db[itemid2int(item.id)]->category ==
                 ItemCategory::travelers_food)
             {

--- a/src/elona/map_cell.cpp
+++ b/src/elona/map_cell.cpp
@@ -188,7 +188,7 @@ std::pair<int, optional_ref<Item>> cell_itemoncell(const Position& pos)
 
     for (auto&& item : inv.ground())
     {
-        if (item.number() > 0 && item.position == pos)
+        if (item.position == pos)
         {
             ++number;
             item_ = item;

--- a/src/elona/mapgen.cpp
+++ b/src/elona/mapgen.cpp
@@ -2934,10 +2934,7 @@ int initialize_quest_map_party()
     }
     for (auto&& item : inv.ground())
     {
-        if (item.number() > 0)
-        {
-            item.own_state = 1;
-        }
+        item.own_state = 1;
     }
     return 1;
 }
@@ -2986,10 +2983,6 @@ void initialize_quest_map_town()
     }
     for (auto&& item : inv.ground())
     {
-        if (item.number() == 0)
-        {
-            continue;
-        }
         f = 0;
         if (item.id == ItemId::well || item.id == ItemId::fountain)
         {

--- a/src/elona/save.cpp
+++ b/src/elona/save.cpp
@@ -192,10 +192,6 @@ void load_gene_files()
     }
     for (auto&& item : inv.pc())
     {
-        if (item.number() == 0)
-        {
-            continue;
-        }
         if (item.id == ItemId::secret_experience_of_lomias)
         {
             lomiaseaster = 1;

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -98,10 +98,6 @@ TalkResult talk_wizard_identify(Character& speaker, int chatval_)
     p = 0;
     for (const auto& item : inv.pc())
     {
-        if (item.number() == 0)
-        {
-            continue;
-        }
         if (item.identify_state != IdentifyState::completely)
         {
             ++p;
@@ -121,10 +117,6 @@ TalkResult talk_wizard_identify(Character& speaker, int chatval_)
         p(1) = 0;
         for (auto&& item : inv.pc())
         {
-            if (item.number() == 0)
-            {
-                continue;
-            }
             if (item.identify_state != IdentifyState::completely)
             {
                 const auto result = item_identify(item, 250);
@@ -218,10 +210,7 @@ TalkResult talk_trade(Character& speaker)
     invsubroutine = 1;
     for (auto&& item : inv.for_chara(speaker))
     {
-        if (item.number() != 0)
-        {
-            item.identify_state = IdentifyState::completely;
-        }
+        item.identify_state = IdentifyState::completely;
     }
     invctrl(0) = 20;
     invctrl(1) = 0;
@@ -2177,10 +2166,6 @@ TalkResult talk_npc(Character& speaker)
                     deliver = cnt;
                     for (auto&& item : inv.pc())
                     {
-                        if (item.number() == 0)
-                        {
-                            continue;
-                        }
                         if (item.id == int2itemid(p))
                         {
                             item_to_deliver = item;
@@ -2201,10 +2186,6 @@ TalkResult talk_npc(Character& speaker)
         {
             for (auto&& item : inv.pc())
             {
-                if (item.number() == 0)
-                {
-                    continue;
-                }
                 if (item.is_marked_as_no_drop())
                 {
                     continue;

--- a/src/elona/turn_sequence_pc_actions.cpp
+++ b/src/elona/turn_sequence_pc_actions.cpp
@@ -230,8 +230,6 @@ optional<TurnResult> handle_pc_action(std::string& action)
         p = 0;
         for (const auto& item : inv.ground())
         {
-            if (item.number() == 0)
-                continue;
             if (item.position != cdata.player().position)
                 continue;
             if (the_item_db[itemid2int(item.id)]->category ==


### PR DESCRIPTION
# Summary

Instead, it is encapsulated to inventory iterators (`Inventory::(const_)iterator`). Invalid items, whose number is 0, are automatically skipped by the iterator. Now that you don't have to check its validity by yourself in inventory iterations.

