### PR TITLE
Fix compile error in release build

### DIFF
--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -198,7 +198,7 @@ Item& AllInventory::operator[](int index)
             return inv.at(static_cast<size_t>(index) - inv.index_start());
         }
     }
-    assert(0);
+    throw "unreachable";
 }
 
 


### PR DESCRIPTION
# Summary

Replace a `assert` macro with a `throw` statement because the former is removed in release build.