### PR TITLE
 Remove `Item.iter()` and `Chara.iter()`; fix LDoc

### DIFF
--- a/doc/api/Chara.luadoc
+++ b/doc/api/Chara.luadoc
@@ -87,3 +87,16 @@ function can_recruit_allies() end
 --  @tparam LuaCharacter ally
 --  @function remove_from_party
 function remove_from_party(ally) end
+
+--- Returns iterable object containing all characters.
+--
+--  @treturn table A sequential table containing all characters.
+--  @function all
+function all(state) end
+
+--- Returns iterable object containing characters except for you and your allies.
+--
+--  @treturn table A sequential table containing characters except for you and
+--  your allies.
+--  @function non_allies
+function non_allies(state) end

--- a/doc/api/Chara.luadoc
+++ b/doc/api/Chara.luadoc
@@ -92,11 +92,11 @@ function remove_from_party(ally) end
 --
 --  @treturn table A sequential table containing all characters.
 --  @function all
-function all(state) end
+function all() end
 
 --- Returns iterable object containing characters except for you and your allies.
 --
 --  @treturn table A sequential table containing characters except for you and
 --  your allies.
 --  @function non_allies
-function non_allies(state) end
+function non_allies() end

--- a/doc/api/Item.luadoc
+++ b/doc/api/Item.luadoc
@@ -80,3 +80,16 @@ function weight_string(weight) end
 --  @treturn True if the inventory has at least one free slot; false if not.
 --  @function has_free_slot
 function has_free_slot(inventory_id) end
+
+--- Gets the player's inventory.
+--
+--  @treturn The player's inventory.
+--  @function player_inventory
+function player_inventory(state) end
+
+--- Gets the map inventory. It contains all items on the ground in the current
+--  map.
+--
+--  @treturn The map inventory.
+--  @function map_inventory
+function map_inventory(state) end

--- a/doc/api/Item.luadoc
+++ b/doc/api/Item.luadoc
@@ -85,11 +85,11 @@ function has_free_slot(inventory_id) end
 --
 --  @treturn The player's inventory.
 --  @function player_inventory
-function player_inventory(state) end
+function player_inventory() end
 
 --- Gets the map inventory. It contains all items on the ground in the current
 --  map.
 --
 --  @treturn The map inventory.
 --  @function map_inventory
-function map_inventory(state) end
+function map_inventory() end

--- a/doc/api/JSON5.luadoc
+++ b/doc/api/JSON5.luadoc
@@ -9,7 +9,7 @@ module "JSON5"
 --  @treturn[2] nil If failed
 --  @treturn[2] string Error message
 --  @function parse
-function parse(source, state) end
+function parse(source) end
 
 --- Stringify arbitary value as JSON5.
 --  @function stringify

--- a/runtime/data/script/kernel/handle.lua
+++ b/runtime/data/script/kernel/handle.lua
@@ -314,39 +314,5 @@ function Handle.clear()
 end
 
 
-local function iter(a, i)
-   if i >= a.to then
-      return nil
-   end
-   local v = a.handles[i]
-   -- Skip over indices that point to invalid handles.
-   while not (v and Handle.is_valid(v)) do
-      i = i + 1
-      v = a.handles[i]
-      if i >= a.to then
-         return nil
-      end
-   end
-   i = i + 1
-   return i, v
-end
-
-function Handle.iter(kind, from, to)
-   if from > to then
-      return nil
-   end
-   return iter, {handles=handles_by_index[kind], to=to}, from
-end
-
--- These functions exist in the separate handle environment because I
--- couldn't quite figure out how to make a valid custom C++/Lua
--- iterator with Sol that returns Lua table references as values.
-
--- Chara.iter(from, to)
-Handle.iter_charas = function(from, to) return Handle.iter("LuaCharacter", from, to) end
-
--- Item.iter(from, to)
-Handle.iter_items = function(from, to) return Handle.iter("LuaItem", from, to) end
-
 
 return Handle

--- a/runtime/mod/core/data/buff.lua
+++ b/runtime/mod/core/data/buff.lua
@@ -306,7 +306,7 @@ ELONA.data:add(
             if not Chara.is_player(args.chara) then
                return
             end
-            for _, chara in Chara.iter(16, 245) do
+            for _, chara in ipairs(Chara.non_allies()) do
                if Chara.is_alive(chara) then
                   if chara.role == 14 and Chara.player().karma < -30 then
                      chara.relationship = "aggressive"

--- a/runtime/mod/core/data/dialog/unique/icolle.lua
+++ b/runtime/mod/core/data/dialog/unique/icolle.lua
@@ -10,7 +10,7 @@ local function give_monster_balls()
    local flag = Internal.get_quest_flag("ambitious_scientist")
    local found = false
 
-   for _, item in Item.iter(0, 200) do
+   for _, item in ipairs(Item.player_inventory()) do
       if flag >= 6 then
          break
       end

--- a/runtime/mod/core/data/dialog/unique/renton.lua
+++ b/runtime/mod/core/data/dialog/unique/renton.lua
@@ -8,7 +8,7 @@ local common = require("../common.lua")
 
 local function take_books()
    local taken_books = {}
-   for _, item in Item.iter(0, 200) do
+   for _, item in ipairs(Item.player_inventory()) do
       if item.number ~= 0 and item.id == "core.book_of_rachel" and item.param2 >= 1 and item.param2 <= 4 then
          if not taken_books[item.param2] then
             item.number = item.number - 1
@@ -56,7 +56,7 @@ return {
 
          local found_books = {}
          local total_books = 0
-         for _, item in Item.iter(0, 200) do
+         for _, item in ipairs(Item.player_inventory()) do
             if item.number ~= 0 and item.id == "core.book_of_rachel" and item.param2 >= 1 and item.param2 <= 4 then
                if not found_books[item.param2] then
                   total_books = total_books + 1

--- a/runtime/mod/core/data/dialog/unique/rogue_boss.lua
+++ b/runtime/mod/core/data/dialog/unique/rogue_boss.lua
@@ -15,7 +15,7 @@ local function surrender()
    GUI.play_sound("core.paygold1")
    Chara.player().gold = Chara.player().gold - surrender_cost()
 
-   for _, item in Item.iter(0, 200) do
+   for _, item in ipairs(Item.player_inventory()) do
       if item.number > 0 and item.prototype.is_cargo then
          GUI.txt(I18N.get("core.talk.npc.common.hand_over", item))
          item:remove()

--- a/src/elona/lua_env/api/common.hpp
+++ b/src/elona/lua_env/api/common.hpp
@@ -21,6 +21,18 @@ using LuaItemHandle = sol::table;
 
 
 
+// For LDoc generation.
+// As LibClang, internally used by tools/docgen, is not a compiler, it is not
+// good at name resolution. To assist it, this declares `sol::this_state`.
+namespace sol
+{
+
+struct this_state;
+
+} // namespace sol
+
+
+
 #define ELONA_LUA_API_BIND_FUNCTION(name, ...) \
     do \
     { \

--- a/src/elona/lua_env/api/modules/module_Chara.cpp
+++ b/src/elona/lua_env/api/modules/module_Chara.cpp
@@ -358,6 +358,53 @@ void Chara_remove_from_party(LuaCharacterHandle ally)
 
 
 
+/**
+ * @luadoc all
+ *
+ * Returns iterable object containing all characters.
+ *
+ * @treturn table A sequential table containing all characters.
+ */
+sol::table Chara_all(sol::this_state state)
+{
+    sol::state_view L = state;
+
+    sol::table ret = L.create_table();
+    for (auto& chara : cdata.all())
+    {
+        ret.add(lua::handle(chara));
+    }
+    return ret;
+}
+
+
+
+/**
+ * @luadoc non_allies
+ *
+ * Returns iterable object containing characters except for you and your allies.
+ *
+ * @treturn table A sequential table containing characters except for you and
+ * your allies.
+ */
+sol::table Chara_non_allies(sol::this_state state)
+{
+    sol::state_view L = state;
+
+    sol::table ret = L.create_table();
+    for (auto& chara : cdata.adventurers())
+    {
+        ret.add(lua::handle(chara));
+    }
+    for (auto& chara : cdata.others())
+    {
+        ret.add(lua::handle(chara));
+    }
+    return ret;
+}
+
+
+
 void bind(sol::table api_table)
 {
     /* clang-format off */
@@ -374,6 +421,8 @@ void bind(sol::table api_table)
     ELONA_LUA_API_BIND_FUNCTION("find", Chara_find);
     ELONA_LUA_API_BIND_FUNCTION("can_recruit_allies", Chara_can_recruit_allies);
     ELONA_LUA_API_BIND_FUNCTION("remove_from_party", Chara_remove_from_party);
+    ELONA_LUA_API_BIND_FUNCTION("all", Chara_all);
+    ELONA_LUA_API_BIND_FUNCTION("non_allies", Chara_non_allies);
 
     /* clang-format on */
 }

--- a/src/elona/lua_env/api/modules/module_Item.cpp
+++ b/src/elona/lua_env/api/modules/module_Item.cpp
@@ -371,6 +371,49 @@ bool Item_has_free_slot(int inventory_id)
 
 
 
+/**
+ * @luadoc player_inventory
+ *
+ * Gets the player's inventory.
+ *
+ * @treturn The player's inventory.
+ */
+sol::table Item_player_inventory(sol::this_state state)
+{
+    sol::state_view L = state;
+
+    sol::table ret = L.create_table();
+    for (auto& item : inv.pc())
+    {
+        ret.add(lua::handle(item));
+    }
+    return ret;
+}
+
+
+
+/**
+ * @luadoc map_inventory
+ *
+ * Gets the map inventory. It contains all items on the ground in the current
+ * map.
+ *
+ * @treturn The map inventory.
+ */
+sol::table Item_map_inventory(sol::this_state state)
+{
+    sol::state_view L = state;
+
+    sol::table ret = L.create_table();
+    for (auto& item : inv.ground())
+    {
+        ret.add(lua::handle(item));
+    }
+    return ret;
+}
+
+
+
 void bind(sol::table api_table)
 {
     /* clang-format off */
@@ -385,6 +428,8 @@ void bind(sol::table api_table)
     ELONA_LUA_API_BIND_FUNCTION("find", Item_find);
     ELONA_LUA_API_BIND_FUNCTION("weight_string", Item_weight_string);
     ELONA_LUA_API_BIND_FUNCTION("has_free_slot", Item_has_free_slot);
+    ELONA_LUA_API_BIND_FUNCTION("player_inventory", Item_player_inventory);
+    ELONA_LUA_API_BIND_FUNCTION("map_inventory", Item_map_inventory);
 
     /* clang-format on */
 }

--- a/src/elona/lua_env/handle_manager.cpp
+++ b/src/elona/lua_env/handle_manager.cpp
@@ -28,24 +28,6 @@ HandleManager::HandleManager(LuaEnv& lua)
 
     // Load the Lua chunk for storing handles.
     safe_script(R"(Handle = require("handle"))");
-
-    bind(lua);
-}
-
-
-
-void HandleManager::bind(LuaEnv& lua)
-{
-    sol::table core = lua.get_api_manager().get_core_api_table();
-    sol::table Chara = core["Chara"];
-    sol::table Item = core["Item"];
-
-    // Add iterating methods implemented in Lua.
-    // TODO: See if this can be migrated to Sol's iteration scheme
-    // (last time I tried it didn't work because of "not a valid
-    // container" errors)
-    Chara.set("iter", env()["Handle"]["iter_charas"]);
-    Item.set("iter", env()["Handle"]["iter_items"]);
 }
 
 

--- a/src/elona/lua_env/handle_manager.hpp
+++ b/src/elona/lua_env/handle_manager.hpp
@@ -202,8 +202,6 @@ private:
         env()["Handle"]["remove_handle"](obj, T::lua_type());
         obj.obj_id = ObjId::nil();
     }
-
-    void bind(LuaEnv&);
 };
 
 } // namespace lua

--- a/src/tests/lua/chara.lua
+++ b/src/tests/lua/chara.lua
@@ -52,7 +52,7 @@ end)
 
 local function tally()
    local count = 0
-   for _, c in Chara.iter(0, 245) do
+   for _, c in ipairs(Chara.all()) do
       count = count + 1
    end
    return count

--- a/src/tests/lua/item.lua
+++ b/src/tests/lua/item.lua
@@ -31,7 +31,7 @@ end)
 local function tally()
    print("=====")
    local count = 0
-   for _, i in Item.iter(5080, 5480) do
+   for _, i in ipairs(Item.map_inventory()) do
       print(i.basename)
       count = count + 1
    end

--- a/tools/docgen/src/main.rs
+++ b/tools/docgen/src/main.rs
@@ -15,6 +15,10 @@ const LUA_CLASS: &str = "class_";
 const VARARGS: &str = "sol::variadic_args";
 const EXTRA_COMPILE_OPTIONS: &[&str] = &["-DELONA_DOCGEN"];
 
+// sol::this_state is an implicit parameter passed by sol runtime. It should not be included in
+// documentation.
+const SOL_THIS_STATE: &str = "sol::this_state";
+
 #[derive(Debug, Clone)]
 struct ModuleComment {
     is_class: bool,
@@ -252,6 +256,7 @@ impl Comment {
                 let arg_entities = entity.get_arguments().unwrap();
                 let mut args = arg_entities
                     .iter()
+                    .filter(|a| a.get_type().unwrap().get_display_name() != SOL_THIS_STATE)
                     .map(|a| a.get_name().unwrap())
                     .collect::<Vec<String>>();
 


### PR DESCRIPTION
# Summary

## Remove `Item.iter()` and `Chara.iter()`

Instead, some functions to iterate over objects are added:

* `Chara.all()`
* `Chara.non_allies()`
* `Item.player_inventory()`
* `Item.map_inventory()`

## Remove `sol::this_state` from LDoc documentations

`sol::this_state` is an implicit parameter passed by sol runtime. It should not be included in documentation.

# TODO

- [x] Test new APIs