### PR TITLE
Change the result of LuaItem:__tostring/LuaCharacter:__tostring

### DIFF
--- a/runtime/data/script/kernel/handle.lua
+++ b/runtime/data/script/kernel/handle.lua
@@ -124,6 +124,18 @@ local function generate_metatable(kind)
    mt.__eq = function(lhs, rhs)
       return lhs.__kind == rhs.__kind and lhs.__uuid == rhs.__uuid
    end
+   mt.__tostring = function(handle)
+      local ref = refs[handle.__kind][handle.__uuid]
+      if ref then
+         return userdata_table.__tostring(ref)
+      else
+         return "nil"
+      end
+   end
+   -- for serpent
+   mt.__serialize = function(handle)
+      return handle
+   end
 
    refs[kind] = {}
    handles_by_index[kind] = {}

--- a/src/elona/lua_env/api/classes/class_LuaCharacter.cpp
+++ b/src/elona/lua_env/api/classes/class_LuaCharacter.cpp
@@ -590,7 +590,7 @@ int LuaCharacter_get_ailment(Character& self, const EnumString& ailment)
 
 std::string LuaCharacter_metamethod_tostring(const Character& self)
 {
-    return Character::lua_type() + "(" + std::to_string(self.index) + ")";
+    return Character::lua_type() + "(" + self.obj_id.to_string() + ")";
 }
 
 

--- a/src/elona/lua_env/api/classes/class_LuaItem.cpp
+++ b/src/elona/lua_env/api/classes/class_LuaItem.cpp
@@ -49,7 +49,7 @@ void LuaItem_change_material(Item& self, const std::string& material_id)
 
 std::string LuaItem_metamethod_tostring(const Item& self)
 {
-    return Item::lua_type() + "(" + std::to_string(self.index()) + ")";
+    return Item::lua_type() + "(" + self.obj_id.to_string() + ")";
 }
 
 

--- a/src/tests/i18n.cpp
+++ b/src/tests/i18n.cpp
@@ -62,7 +62,7 @@ TEST_CASE("test format chara", "[I18N: Formatting]")
 
     REQUIRE(
         i18n::s.format("{$1}", chara) ==
-        u8"LuaCharacter("s + std::to_string(chara.index) + u8")"s);
+        u8"LuaCharacter("s + chara.obj_id.to_string() + u8")"s);
 
     REQUIRE(i18n::s.format("{name($1)}", chara) == u8"何か"s);
     REQUIRE(i18n::s.format("{basename($1)}", chara) == u8"プチ"s);
@@ -80,7 +80,7 @@ TEST_CASE("test format item", "[I18N: Formatting]")
 
     REQUIRE(
         i18n::s.format("{$1}", i) ==
-        u8"LuaItem("s + std::to_string(i.index) + u8")"s);
+        u8"LuaItem("s + i.obj_id.to_string() + u8")"s);
 
     REQUIRE(i18n::s.format("{itemname($1)}", i) == u8"3個のプチトロ"s);
     REQUIRE(i18n::s.format("{itembasename($1)}", i) == u8"プチトロ"s);


### PR DESCRIPTION
- Change the result of `LuaItem:__to_string` and `LuaCharacter:__tostring`.
  - Object ID is used instead of index.
- Fix `LuaItem`/`LuaCharacter:__tostring` not working when calling these via handles.
  - Function `__tostring` should be registered in class' metatable.