### PR TITLE
Refactor LuaAbility

### DIFF
--- a/src/elona/lua_env/api/classes/class_LuaAbility.cpp
+++ b/src/elona/lua_env/api/classes/class_LuaAbility.cpp
@@ -1,6 +1,7 @@
 #include "class_LuaAbility.hpp"
 
 #include "../../../ability.hpp"
+#include "../../../character.hpp"
 
 
 
@@ -22,7 +23,8 @@ namespace elona::lua::api::classes::class_LuaAbility
         { \
             return 0; \
         } \
-        return sdata.get(a.skill_id, a.index).name; \
+        auto& ref = *a.get_ref(); \
+        return sdata.get(a.skill_id, ref.index).name; \
     })
 
 #define ELONA_LUA_SKILL_PROPERTY(name) \
@@ -32,14 +34,16 @@ namespace elona::lua::api::classes::class_LuaAbility
             { \
                 return 0; \
             } \
-            return sdata.get(a.skill_id, a.index).name; \
+            auto& ref = *a.get_ref(); \
+            return sdata.get(a.skill_id, ref.index).name; \
         }, \
         [](classes::LuaAbility& a, int i) { \
             if (!a.is_valid()) \
             { \
                 return; \
             } \
-            sdata.get(a.skill_id, a.index).name = i; \
+            auto& ref = *a.get_ref(); \
+            sdata.get(a.skill_id, ref.index).name = i; \
         })
 
 void bind(sol::state& lua)

--- a/src/elona/lua_env/api/classes/class_LuaAbility.hpp
+++ b/src/elona/lua_env/api/classes/class_LuaAbility.hpp
@@ -8,12 +8,12 @@
 namespace elona::lua::api::classes
 {
 
-struct LuaAbility : LuaRef
+struct LuaAbility : LuaRef<Character>
 {
-    LuaAbility(int skill_id_, int index, std::string type, std::string uuid)
-        : LuaRef(index, type, uuid)
+    LuaAbility(int skill_id, const ObjId& obj_id)
+        : LuaRef(obj_id)
+        , skill_id(skill_id)
     {
-        skill_id = skill_id_;
     }
 
     int skill_id;

--- a/src/elona/lua_env/api/classes/class_LuaAbility.hpp
+++ b/src/elona/lua_env/api/classes/class_LuaAbility.hpp
@@ -1,60 +1,12 @@
 #pragma once
 
-#include "../../handle_manager.hpp"
 #include "../common.hpp"
+#include "lua_ref.hpp"
 
 
 
 namespace elona::lua::api::classes
 {
-
-/**
- * Userdata object used to validate the handle reference it was created from.
- * For example, when a skill reference is retrieved from a character, it can be
- * tested for validity by comparing the UUID of the reference to that of the
- * handle corresponding to the index on the reference. If they don't match, then
- * the handle is out of date and any method calls on the reference can be safely
- * ignored.
- */
-struct LuaRef
-{
-    LuaRef()
-        : index(-1)
-        , type("")
-        , uuid("")
-    {
-    }
-
-    LuaRef(int index, std::string type, std::string uuid)
-        : index(index)
-        , type(type)
-        , uuid(uuid)
-    {
-    }
-
-    bool is_valid()
-    {
-        if (index == -1)
-        {
-            return false;
-        }
-
-        auto handle = lua::lua->get_handle_manager().get_handle(index, type);
-        if (handle == sol::lua_nil)
-        {
-            return false;
-        }
-
-        std::string handle_uuid = handle["__uuid"];
-        return handle_uuid == uuid;
-    }
-
-    int index;
-    std::string type;
-    std::string uuid;
-};
-
-
 
 struct LuaAbility : LuaRef
 {

--- a/src/elona/lua_env/api/classes/class_LuaCharacter.cpp
+++ b/src/elona/lua_env/api/classes/class_LuaCharacter.cpp
@@ -274,11 +274,7 @@ sol::optional<LuaAbility> LuaCharacter_get_skill(
         return sol::nullopt;
     }
 
-    auto handle = lua::handle(self);
-    assert(handle != sol::lua_nil);
-
-    std::string uuid = handle["__uuid"];
-    return LuaAbility(data->legacy_id, self.index, Character::lua_type(), uuid);
+    return LuaAbility(data->legacy_id, self.obj_id);
 }
 
 

--- a/src/elona/lua_env/api/classes/lua_ref.hpp
+++ b/src/elona/lua_env/api/classes/lua_ref.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "../../handle_manager.hpp"
+#include "../common.hpp"
+
+
+
+namespace elona::lua::api::classes
+{
+
+/**
+ * Userdata object used to validate the handle reference it was created from.
+ * For example, when a skill reference is retrieved from a character, it can be
+ * tested for validity by comparing the UUID of the reference to that of the
+ * handle corresponding to the index on the reference. If they don't match, then
+ * the handle is out of date and any method calls on the reference can be safely
+ * ignored.
+ */
+struct LuaRef
+{
+    LuaRef()
+        : index(-1)
+        , type("")
+        , uuid("")
+    {
+    }
+
+    LuaRef(int index, std::string type, std::string uuid)
+        : index(index)
+        , type(type)
+        , uuid(uuid)
+    {
+    }
+
+    bool is_valid()
+    {
+        if (index == -1)
+        {
+            return false;
+        }
+
+        auto handle = lua::lua->get_handle_manager().get_handle(index, type);
+        if (handle == sol::lua_nil)
+        {
+            return false;
+        }
+
+        std::string handle_uuid = handle["__uuid"];
+        return handle_uuid == uuid;
+    }
+
+    int index;
+    std::string type;
+    std::string uuid;
+};
+
+} // namespace elona::lua::api::classes

--- a/src/elona/lua_env/handle_manager.hpp
+++ b/src/elona/lua_env/handle_manager.hpp
@@ -2,11 +2,6 @@
 
 #include <set>
 
-#include <boost/lexical_cast.hpp>
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
-
 #include "../../util/noncopyable.hpp"
 #include "../eobject/eobject.hpp"
 #include "lua_submodule.hpp"


### PR DESCRIPTION
# Summary

Changed internal structure of `LuaRef`, the base class of `LuaAbility`. Now `LuaRef` consists of only `obj_id`. It is enough to uniquely refer to an Elona object.