### PR TITLE
Change handles_by_index to handles_by_pointer

### DIFF
--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -1578,8 +1578,7 @@ void chara_relocate(
         // not always exist, since if the mode is "change" the
         // source's state will be empty. If the source's state is empty, the
         // destination slot will instead be set to empty as well.
-        lua::lua->get_handle_manager().relocate_handle<Character>(
-            source, destination, destination.index);
+        lua::lua->get_handle_manager().relocate_handle(source, destination);
     }
     else
     {

--- a/src/elona/ctrl_file.cpp
+++ b/src/elona/ctrl_file.cpp
@@ -426,11 +426,12 @@ void restore_handles(int index_start, int index_end)
     sol::table obj_ids = lua::lua->get_state()->create_table();
     for (int index = index_start; index < index_end; ++index)
     {
-        obj_ids[index] = get_nth_object<T>(index).obj_id.to_string();
+        auto& obj = get_nth_object<T>(index);
+        const auto key = reinterpret_cast<int64_t>(std::addressof(obj));
+        obj_ids[key] = obj.obj_id.to_string();
     }
 
     auto& handle_mgr = lua::lua->get_handle_manager();
-    handle_mgr.clear_handle_range(T::lua_type(), index_start, index_end);
     handle_mgr.merge_handles(T::lua_type(), obj_ids);
 
     ELONA_LOG("lua.mod") << "Loaded handle data for " << T::lua_type()

--- a/src/elona/initialize_map.cpp
+++ b/src/elona/initialize_map.cpp
@@ -1240,14 +1240,7 @@ void _init_tileset_minimap_and_scroll()
 void _initialize_map_local_handles()
 {
     lua::lua->get_mod_manager().clear_map_local_stores();
-
-    auto& handle_mgr = lua::lua->get_handle_manager();
-    handle_mgr.clear_handle_range(
-        Character::lua_type(),
-        ELONA_MAX_PARTY_CHARACTERS,
-        ELONA_MAX_CHARACTERS);
-    handle_mgr.clear_handle_range(
-        Item::lua_type(), ELONA_OTHER_INVENTORIES_INDEX, ELONA_MAX_ITEMS);
+    lua::lua->get_handle_manager().clear_map_local_handles();
 }
 
 

--- a/src/tests/lua_handles.cpp
+++ b/src/tests/lua_handles.cpp
@@ -737,7 +737,7 @@ TEST_CASE(
     run_in_temporary_map(2, 0, []() {
         REQUIRE(
             elona::lua::lua->get_handle_manager().get_handle(
-                57, Character::lua_type()) != sol::lua_nil);
+                elona::cdata[57]) != sol::lua_nil);
     });
 }
 
@@ -751,6 +751,6 @@ TEST_CASE(
     run_in_temporary_map(5, 1, []() {
         REQUIRE(
             elona::lua::lua->get_handle_manager().get_handle(
-                57, Character::lua_type()) != sol::lua_nil);
+                elona::cdata[57]) != sol::lua_nil);
     });
 }


### PR DESCRIPTION
# Summary

Now, handle objects are indexed by raw pointer of corresponding C++ object. It is safe to cast a raw pointer to Lua's integer type because the size of a raw pointer is greater than or equal to the size of Lua integer.


# TODOs

- [x] Merge #1661
- [x] Merge #1662