### PR TITLE
Make the length of text in input box unlimited

### DIFF
--- a/src/elona/character_making.cpp
+++ b/src/elona/character_making.cpp
@@ -368,8 +368,8 @@ MainMenuResult character_making_final_phase()
         i18n::s.get("core.chara_making.final_screen.what_is_your_name"));
 
     inputlog = "";
-    bool canceled = input_text_dialog(
-        (windoww - 230) / 2 + inf_screenx, winposy(120), 10, true);
+    bool canceled =
+        input_text_dialog((windoww - 230) / 2 + inf_screenx, winposy(120), 10);
     if (canceled)
     {
         return MainMenuResult::character_making_final_phase;

--- a/src/elona/input.cpp
+++ b/src/elona/input.cpp
@@ -164,12 +164,7 @@ void input_number_dialog(int x, int y, int max_number, int initial_number)
 
 
 
-bool input_text_dialog(
-    int x,
-    int y,
-    int val2,
-    bool is_cancelable,
-    bool limit_length)
+bool input_text_dialog(int x, int y, int val2, bool is_cancelable)
 {
     bool canceled = false;
 
@@ -228,15 +223,7 @@ bool input_text_dialog(
         }
         noteget(s, 0);
 
-        if (limit_length && p(4) == 20)
-        {
-            if (inputlog(0).back() != '\n')
-            {
-                inputlog = strutil::take_by_width(inputlog, 20);
-            }
-            s = strutil::take_by_width(s, 20);
-        }
-        else if (!limit_length && p(4) > 18)
+        if (p(4) > 18)
         {
             p(4) = 18;
             s = strutil::take_by_width(s, 18);
@@ -262,12 +249,6 @@ bool input_text_dialog(
             if (is_cancelable)
             {
                 canceled = true;
-            }
-        }
-        if (is_cancelable)
-        {
-            if (canceled)
-            {
                 inputlog = "";
                 keywait = 1;
                 break;

--- a/src/elona/input.hpp
+++ b/src/elona/input.hpp
@@ -23,12 +23,7 @@ enum class PromptType
 
 void input_number_dialog(int x, int y, int max_number, int initial_number = 0);
 
-bool input_text_dialog(
-    int x,
-    int y,
-    int val2,
-    bool is_cancelable = true,
-    bool limit_length = true);
+bool input_text_dialog(int x, int y, int val2, bool is_cancelable = true);
 
 StickKey stick(StickKey allow_repeat_keys = StickKey::none);
 

--- a/src/elona/lua_env/api/modules/module_Input.cpp
+++ b/src/elona/lua_env/api/modules/module_Input.cpp
@@ -168,11 +168,7 @@ sol::optional<std::string> Input_prompt_text(
 {
     txt(message + i18n::space_if_needed());
     bool canceled = input_text_dialog(
-        (windoww - 360) / 2 + inf_screenx,
-        winposy(90),
-        20,
-        is_cancelable,
-        true);
+        (windoww - 360) / 2 + inf_screenx, winposy(90), 20, is_cancelable);
     if (canceled)
     {
         return sol::nullopt;

--- a/src/elona/main_menu.cpp
+++ b/src/elona/main_menu.cpp
@@ -1576,7 +1576,7 @@ MainMenuResult main_menu_mods_develop()
         {
             inputlog = "";
             const auto canceled = input_text_dialog(
-                (windoww - 230) / 2 + inf_screenx, winposy(120), 10, true);
+                (windoww - 230) / 2 + inf_screenx, winposy(120), 10);
             if (!canceled && !inputlog(0).empty())
             {
                 const auto new_mod_id = inputlog(0);

--- a/src/elona/wish.cpp
+++ b/src/elona/wish.cpp
@@ -776,8 +776,7 @@ bool process_wish(Character& chara, optional<std::string> wish)
     }
     else
     {
-        input_text_dialog(
-            (windoww - 290) / 2 + inf_screenx, winposy(90), 16, false);
+        input_text_dialog((windoww - 290) / 2 + inf_screenx, winposy(90), 16);
     }
 
     txt(i18n::s.get("core.wish.your_wish", inputlog(0)));

--- a/src/snail/backends/sdl/hsp.cpp
+++ b/src/snail/backends/sdl/hsp.cpp
@@ -273,6 +273,10 @@ void mes(int x, int y, const std::string& text, const snail::Color& color)
 
     if (copy.size() >= 25 /* TODO */)
     {
+        if (copy.size() >= 300)
+        {
+            copy = strutil::take_by_width(copy, 100); // too long, truncate
+        }
         renderer.render_multiline_text(copy, x, y, color);
     }
     else


### PR DESCRIPTION
# Summary

Previously, the input box only accepts up to 20 bytes. It was too short, especially for multi-byte characters like Japanese. The reason why the length was limited is rendering too long text caused crash. To resolve the issue, function `mes()`, now, truncates the given string if it is too long to render (300 bytes for now).