### PR TITLE
Remove unnecessary calls of `cell_refresh()`

### DIFF
--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -1015,10 +1015,6 @@ void activity_others_end_steal(const ItemRef& steal_target)
     stolen_item->is_stolen() = true;
     stolen_item->own_state = 0;
     steal_target->modify_number(-in);
-    if (steal_target->number() <= 0)
-    {
-        cell_refresh(steal_target->pos().x, steal_target->pos().y);
-    }
     txt(i18n::s.get("core.activity.steal.succeed", stolen_item));
     const auto item_weight = stolen_item->weight;
     if (stolen_item->id == ItemId::gold_piece)

--- a/src/elona/blending.cpp
+++ b/src/elona/blending.cpp
@@ -953,9 +953,6 @@ void spend_materials(bool success)
         {
             chara_refresh(cdata.player());
         }
-        cell_refresh(
-            g_inv[rpref(10 + cnt * 2)]->pos().x,
-            g_inv[rpref(10 + cnt * 2)]->pos().y);
     }
     refresh_burden_state();
 }
@@ -1000,10 +997,6 @@ void blending_proc_on_success_events()
     if (item1->body_part != 0)
     {
         create_pcpic(cdata.player());
-    }
-    if (inv_getowner(item1) == -1)
-    {
-        cell_refresh(item1->pos().x, item1->pos().y);
     }
     chara_refresh(cdata.player());
 }

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -1053,7 +1053,6 @@ TurnResult do_throw_command_internal(
                                 snowman.unwrap()));
                         }
                         snowman->modify_number(-1);
-                        cell_refresh(tlocx, tlocy);
                         return TurnResult::turn_end;
                     }
                 }
@@ -1771,10 +1770,6 @@ TurnResult do_dip_command(const ItemRef& mix_item, const ItemRef& mix_target)
         mix_item->modify_number(-1);
         mix_target->color = mix_item->color;
         txt(i18n::s.get("core.action.dip.result.dyeing", mix_target));
-        if (inv_getowner(mix_target) == -1)
-        {
-            cell_refresh(mix_target->pos().x, mix_target->pos().y);
-        }
         if (mix_target->body_part != 0)
         {
             create_pcpic(cdata.player());
@@ -2314,7 +2309,6 @@ TurnResult do_use_command(ItemRef use_item)
                                 "core.action.use.leash.other.start.resists",
                                 cdata[target_chara_index]));
                             use_item->modify_number(-1);
-                            cell_refresh(use_item->pos().x, use_item->pos().y);
                             refresh_burden_state();
                             break;
                         }
@@ -2401,7 +2395,6 @@ TurnResult do_use_command(ItemRef use_item)
                         cdata[target_chara_index]));
                     animeload(8, cdata[target_chara_index]);
                     use_item->modify_number(-1);
-                    cell_refresh(use_item->pos().x, use_item->pos().y);
                     refresh_burden_state();
                 }
                 f = 1;
@@ -2511,7 +2504,6 @@ TurnResult do_use_command(ItemRef use_item)
             break;
         }
         use_item->modify_number(-1);
-        cell_refresh(use_item->pos().x, use_item->pos().y);
         txt(i18n::s.get("core.action.use.rune.use"));
         // Showroom is not supported now.
         break;
@@ -2618,7 +2610,6 @@ TurnResult do_use_command(ItemRef use_item)
             }
         }
         use_item->modify_number(-1);
-        cell_refresh(use_item->pos().x, use_item->pos().y);
         txt(i18n::s.get("core.action.use.nuke.set_up"));
         snd("core.build1");
         mef_add(
@@ -2795,7 +2786,6 @@ TurnResult do_use_command(ItemRef use_item)
         }
         snd("core.card1");
         use_item->modify_number(-1);
-        cell_refresh(use_item->pos().x, use_item->pos().y);
         txt(i18n::s.get("core.action.use.deck.add_card", use_item));
         ++card(0, use_item->subname);
         break;
@@ -5333,7 +5323,6 @@ PickUpItemResult pick_up_item(
             }
             in = item->number();
             item->remove();
-            cell_refresh(item->pos().x, item->pos().y);
             return {1, nullptr};
         }
     }
@@ -5673,7 +5662,6 @@ TurnResult do_bash(Character& chara)
             if (tree->param1 <= 0)
             {
                 tree->image = 592;
-                cell_refresh(x, y);
             }
             if (y + 1 < map_data.height)
             {
@@ -5946,7 +5934,6 @@ void proc_autopick()
             }
             txt(i18n::s.get("core.ui.autopick.destroyed", item));
             item->remove();
-            cell_refresh(x, y);
             cell_data.at(x, y).item_info_memory =
                 cell_data.at(x, y).item_info_actual;
             break;

--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -2034,7 +2034,6 @@ void character_drops_item(Character& victim)
             {
                 item->param1 = victim.image;
                 item->subname = charaid2int(victim.id);
-                cell_refresh(item->pos().x, item->pos().y);
             }
         }
         if (rnd(175) == 0 || victim.quality == Quality::special || 0 ||
@@ -2046,7 +2045,6 @@ void character_drops_item(Character& victim)
             {
                 item->param1 = victim.image;
                 item->subname = charaid2int(victim.id);
-                cell_refresh(item->pos().x, item->pos().y);
             }
         }
     }

--- a/src/elona/food.cpp
+++ b/src/elona/food.cpp
@@ -66,7 +66,6 @@ void _food_gets_rotten(int chara_idx, const ItemRef& food)
         food->id = ItemId::jerky;
         food->param1 = 0;
         food->param2 = 5;
-        cell_refresh(food->pos().x, food->pos().y);
         return;
     }
 
@@ -77,11 +76,6 @@ void _food_gets_rotten(int chara_idx, const ItemRef& food)
 
     food->param3 = -1;
     food->image = 336;
-
-    if (chara_idx == -1)
-    {
-        cell_refresh(food->pos().x, food->pos().y);
-    }
 
     if (chara_idx == 0 && cdata.player().god_id == core_god::kumiromi)
     {

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -1608,10 +1608,6 @@ item_stack(int inventory_id, const ItemRef& base_item, bool show_message)
             item->modify_number(base_item->number());
             base_item->remove();
 
-            if (mode != 6 && inv_getowner(base_item) == -1)
-            {
-                cell_refresh(base_item->pos().x, base_item->pos().y);
-            }
             if (show_message)
             {
                 txt(i18n::s.get("core.item.stacked", item, item->number()));
@@ -1867,7 +1863,6 @@ bool item_fire(int owner, const OptionalItemRef& burned_item)
                 Message::color{ColorIndex::purple});
         }
         item->modify_number(-p_);
-        cell_refresh(item->pos().x, item->pos().y);
         burned = true;
     }
 
@@ -1910,7 +1905,6 @@ void mapitem_fire(optional_ref<Character> arsonist, int x, int y)
                     arsonist ? arsonist->index : -1);
             }
         }
-        cell_refresh(x, y);
     }
 }
 
@@ -2059,7 +2053,6 @@ void mapitem_cold(int x, int y)
     if (destroyed_item)
     {
         item_cold(-1, destroyed_item);
-        cell_refresh(x, y);
     }
 }
 
@@ -2136,11 +2129,6 @@ ItemRef inv_compress(int owner)
             {
                 item->remove();
                 ++number_of_deleted_items;
-                if (item->pos().x >= 0 && item->pos().x < map_data.width &&
-                    item->pos().y >= 0 && item->pos().y < map_data.height)
-                {
-                    cell_refresh(item->pos().x, item->pos().y);
-                }
             }
             if (number_of_deleted_items > 10)
             {
@@ -2161,14 +2149,6 @@ ItemRef inv_compress(int owner)
     // Destroy 1 existing item forcely.
     const auto item = get_random_inv(owner);
     item->remove();
-    if (mode != 6)
-    {
-        if (item->pos().x >= 0 && item->pos().x < map_data.width &&
-            item->pos().y >= 0 && item->pos().y < map_data.height)
-        {
-            cell_refresh(item->pos().x, item->pos().y);
-        }
-    }
 
     return item;
 }
@@ -2601,7 +2581,6 @@ void dipcursed(const ItemRef& item)
             txt(i18n::s.get("core.action.dip.rots", item));
             item->param3 = -1;
             item->image = 336;
-            cell_refresh(item->pos().x, item->pos().y);
         }
         else
         {

--- a/src/elona/map.cpp
+++ b/src/elona/map.cpp
@@ -293,7 +293,6 @@ void map_reload(const std::string& map_filename)
                 ItemCategory::food)
             {
                 item->remove();
-                cell_refresh(item->pos().x, item->pos().y);
             }
         }
     }
@@ -315,7 +314,6 @@ void map_reload(const std::string& map_filename)
                     item->own_state = cmapdata(3, i);
                 }
             }
-            cell_refresh(x, y);
         }
     }
 }
@@ -643,7 +641,6 @@ static void _modify_items_on_regenerate()
             {
                 item->param1 += 1;
                 item->image = 591;
-                cell_refresh(item->pos().x, item->pos().y);
             }
         }
 
@@ -657,7 +654,6 @@ static void _modify_items_on_regenerate()
             if (item->own_state == 0)
             {
                 item->remove();
-                cell_refresh(item->pos().x, item->pos().y);
             }
         }
     }
@@ -881,8 +877,6 @@ void map_reload_noyel()
             continue;
         }
         item->remove();
-
-        cell_refresh(item->pos().x, item->pos().y);
     }
 
     if (area_data[game_data.current_map].christmas_festival)

--- a/src/elona/wish.cpp
+++ b/src/elona/wish.cpp
@@ -283,7 +283,6 @@ void wish_for_card()
         item->subname = charaid2int(cdata.tmp().id);
         item->param1 = cdata.tmp().image;
         chara_vanquish(cdata.tmp());
-        cell_refresh(cdata.player().position.x, cdata.player().position.y);
         txt(i18n::s.get(
             "core.wish.something_appears_from_nowhere", item.unwrap()));
     }
@@ -303,7 +302,6 @@ void wish_for_figure()
         item->subname = charaid2int(cdata.tmp().id);
         item->param1 = cdata.tmp().image;
         chara_vanquish(cdata.tmp());
-        cell_refresh(cdata.player().position.x, cdata.player().position.y);
         txt(i18n::s.get(
             "core.wish.something_appears_from_nowhere", item.unwrap()));
     }
@@ -610,7 +608,6 @@ bool wish_for_item(Character& chara, const std::string& input)
                 selector.remove(id);
                 item->remove();
                 --itemmemory(1, itemid2int(item->id));
-                cell_refresh(item->pos().x, item->pos().y);
                 continue;
             }
         }


### PR DESCRIPTION
# Summary

It is unnecessary to call `cell_refresh()` explicitly when an item is removed, because `Item::set_number()` internally calls it.

TODO

- [x] merge #1677