### PR TITLE
Handle syntax error of console command line

### DIFF
--- a/runtime/data/script/kernel/ush/execute.lua
+++ b/runtime/data/script/kernel/ush/execute.lua
@@ -125,7 +125,6 @@ function Executor:execute(command_name, ...)
 
    local args = {...}
    -- prelude.print("RUN  "..command_name.."  "..table.concat(args, " "))
-   -- return pcall(command, self._env, table.unpack(args))
    return pcall(command, table.unpack(args))
 end
 
@@ -134,5 +133,12 @@ end
 -- :: string -> Env -> (boolean, any)
 return function(input, env)
    local exe = Executor.new(env)
-   return exe:execute(parse(input))
+   local ok, result = pcall(parse, input)
+   if not ok then
+      return false, result
+   end
+   if not result then -- no input
+      return true, nil
+   end
+   return exe:execute(table.unpack(result))
 end

--- a/runtime/data/script/kernel/ush/parse.lua
+++ b/runtime/data/script/kernel/ush/parse.lua
@@ -127,11 +127,11 @@ end
 
 
 
--- string -> tokens
+-- string -> List<Token>?
 return function(src)
    local tokens = tokenize(src)
    if #tokens == 0 then
-      error("(ush) invalid command line: "..src)
+      return nil -- no input
    end
-   return table.unpack(tokens)
+   return tokens
 end


### PR DESCRIPTION
# Related Issues

Close #1676.


# Summary


The console now accepts empty command lines, and syntax errors which happen during parsing command lines don't cause the game to crash.