### PR TITLE
Fix dialog error (#1674 and more)

### DIFF
--- a/runtime/mod/core/data/dialog/common.lua
+++ b/runtime/mod/core/data/dialog/common.lua
@@ -18,8 +18,8 @@ local function args_name()
    return {Chara.player().basename}
 end
 
-local function args_title()
-   return {Chara.player().title}
+local function args_alias()
+   return {Chara.player().alias}
 end
 
 local function args_speaker(t)
@@ -31,6 +31,6 @@ return {
    quest_completed = quest_completed,
 
    args_name = args_name,
-   args_title = args_title,
+   args_alias = args_alias,
    args_speaker = args_speaker,
 }

--- a/runtime/mod/core/data/dialog/common.lua
+++ b/runtime/mod/core/data/dialog/common.lua
@@ -14,6 +14,10 @@ local function quest_completed()
    GUI.show_journal_update_message()
 end
 
+local function journal_updated()
+   GUI.show_journal_update_message()
+end
+
 local function args_name()
    return {Chara.player().basename}
 end
@@ -29,6 +33,7 @@ end
 return {
    create_downstairs = create_downstairs,
    quest_completed = quest_completed,
+   journal_updated = journal_updated,
 
    args_name = args_name,
    args_alias = args_alias,

--- a/runtime/mod/core/data/dialog/unique/ainc.lua
+++ b/runtime/mod/core/data/dialog/unique/ainc.lua
@@ -40,7 +40,7 @@ return {
       },
       quest_yes = {
          text = {
-            GUI.show_journal_update_message,
+            common.journal_updated,
             {"quest.do_it"},
          },
          on_finish = function()

--- a/runtime/mod/core/data/dialog/unique/arnord.lua
+++ b/runtime/mod/core/data/dialog/unique/arnord.lua
@@ -39,7 +39,7 @@ return {
       },
       quest_yes = {
          text = {
-            GUI.show_journal_update_message,
+            common.journal_updated,
             {"quest.yes"},
          },
          on_finish = function()
@@ -63,7 +63,7 @@ return {
       },
       quest_begin_yes = {
          text = {
-            GUI.show_journal_update_message,
+            common.journal_updated,
             {"quest.begin.yes"},
          },
          on_finish = function()

--- a/runtime/mod/core/data/dialog/unique/balzak.lua
+++ b/runtime/mod/core/data/dialog/unique/balzak.lua
@@ -39,7 +39,7 @@ return {
       },
       quest_yes = {
          text = {
-            GUI.show_journal_update_message,
+            common.journal_updated,
             {"quest.yes"},
          },
          on_finish = function()

--- a/runtime/mod/core/data/dialog/unique/conery.lua
+++ b/runtime/mod/core/data/dialog/unique/conery.lua
@@ -39,7 +39,7 @@ return {
       },
       quest_yes = {
          text = {
-            GUI.show_journal_update_message,
+            common.journal_updated,
             {"quest.do_it"},
          },
          on_finish = function()

--- a/runtime/mod/core/data/dialog/unique/erystia.lua
+++ b/runtime/mod/core/data/dialog/unique/erystia.lua
@@ -30,7 +30,7 @@ return {
          text = {
             {"late._0"},
             {"late._1"},
-            {"late._2", args = function() return {Chara.player().title, Chara.player().basename} end},
+            {"late._2", args = function() return {Chara.player().alias, Chara.player().basename} end},
          },
          choices = {
             {"__END__", "__MORE__"},

--- a/runtime/mod/core/data/dialog/unique/gilbert.lua
+++ b/runtime/mod/core/data/dialog/unique/gilbert.lua
@@ -47,7 +47,7 @@ return {
       },
       quest_yes = {
          text = {
-            GUI.show_journal_update_message,
+            common.journal_updated,
             {"quest.yes"},
          },
          on_finish = function()

--- a/runtime/mod/core/data/dialog/unique/gilbert.lua
+++ b/runtime/mod/core/data/dialog/unique/gilbert.lua
@@ -36,7 +36,7 @@ return {
       },
       quest_ask = {
          text = {
-            {"quest.dialog._0", args = common.args_title},
+            {"quest.dialog._0", args = common.args_alias},
             {"quest.dialog._1"},
          },
          choices = {

--- a/runtime/mod/core/data/dialog/unique/lomias.lua
+++ b/runtime/mod/core/data/dialog/unique/lomias.lua
@@ -209,7 +209,7 @@ return {
          text = {
             {"after.get_out.dialog._0", args = common.args_name, speaker = "core.larnneire"},
             {"after.get_out.dialog._1", speaker = "core.lomias"},
-            {"after.get_out.dialog._2", args = common.args_title},
+            {"after.get_out.dialog._2", args = common.args_alias},
          },
          on_finish = function()
             Chara.find("core.larnneire", "others"):vanquish()

--- a/runtime/mod/core/data/dialog/unique/loyter.lua
+++ b/runtime/mod/core/data/dialog/unique/loyter.lua
@@ -50,7 +50,7 @@ return {
       },
       quest_yes = {
          text = {
-             GUI.show_journal_update_message,
+            common.journal_updated,
             {"quest.yes"},
          },
          on_finish = function()
@@ -74,7 +74,7 @@ return {
       },
       quest_begin_yes = {
          text = {
-            GUI.show_journal_update_message,
+            common.journal_updated,
             {"quest.begin.yes"},
          },
          on_finish = function()

--- a/runtime/mod/core/data/dialog/unique/loyter.lua
+++ b/runtime/mod/core/data/dialog/unique/loyter.lua
@@ -39,7 +39,7 @@ return {
       },
       quest_ask = {
          text = {
-            {"quest.dialog._0", args = common.args_title},
+            {"quest.dialog._0", args = common.args_alias},
             {"quest.dialog._1"},
          },
          choices = {

--- a/runtime/mod/core/data/dialog/unique/marks.lua
+++ b/runtime/mod/core/data/dialog/unique/marks.lua
@@ -34,7 +34,7 @@ return {
       },
       quest_ask = {
          text = {
-            {"quest.dialog._0", args = common.args_title},
+            {"quest.dialog._0", args = common.args_alias},
             {"quest.dialog._1"},
          },
          choices = function()

--- a/runtime/mod/core/data/dialog/unique/mia.lua
+++ b/runtime/mod/core/data/dialog/unique/mia.lua
@@ -37,7 +37,7 @@ return {
       },
       quest_yes = {
          text = {
-            GUI.show_journal_update_message,
+            common.journal_updated,
             {"quest.yes"},
          },
          on_finish = function()

--- a/runtime/mod/core/data/dialog/unique/miches.lua
+++ b/runtime/mod/core/data/dialog/unique/miches.lua
@@ -39,7 +39,7 @@ return {
       },
       quest_yes = {
          text = {
-            GUI.show_journal_update_message,
+            common.journal_updated,
             {"quest.yes"},
          },
          on_finish = function()

--- a/runtime/mod/core/data/dialog/unique/raphael.lua
+++ b/runtime/mod/core/data/dialog/unique/raphael.lua
@@ -6,6 +6,8 @@ local Internal = ELONA.require("core.Internal")
 local Item = ELONA.require("core.Item")
 local table = table
 
+local common = require("../common.lua")
+
 local function give_wife(raphael, wife)
    if not table.contains(wife.prototype.tags, "man") then
       raphael:apply_ailment("insane", 1000)
@@ -48,7 +50,7 @@ return {
       },
       quest_yes = {
          text = {
-            GUI.show_journal_update_message,
+            common.journal_updated,
             {"quest.yes"},
          },
          on_finish = function()

--- a/runtime/mod/core/data/dialog/unique/rilian.lua
+++ b/runtime/mod/core/data/dialog/unique/rilian.lua
@@ -37,7 +37,7 @@ return {
       },
       quest_yes = {
          text = {
-            GUI.show_journal_update_message,
+            common.journal_updated,
             {"quest.do_it"},
          },
          on_finish = function()

--- a/runtime/mod/core/data/dialog/unique/shena.lua
+++ b/runtime/mod/core/data/dialog/unique/shena.lua
@@ -39,7 +39,7 @@ return {
       },
       quest_yes = {
          text = {
-            GUI.show_journal_update_message,
+            common.journal_updated,
             {"quest.yes"},
          },
          on_finish = function()


### PR DESCRIPTION

# Related Issues

Close #1674.


# Summary

Fix #1674: fix `LuaCharacter.title` to `LuaCharacter.alias`.

Fix dialog error in talk with some of unique NPCs. `GUI.show_journal_update_message()` is a function implemented in C++,
which takes no parameter. It is exposed to Lua via `sol` library. `sol` checks the number of the arguments passed to C++ functions and their types, so calling `GUI.show_journal_update_message()` with extra arguments results in runtime error. Because `sol` does not say nothing to Lua side functions, the error can be suppressed by wrapping `GUI.show_journal_update_message()` in Lua.
