### PR TITLE
Fix throwing object animation

### DIFF
--- a/doc/api/Animation.luadoc
+++ b/doc/api/Animation.luadoc
@@ -50,12 +50,12 @@ function play_bolt(attacker_pos, target_pos, element_name, distance) end
 
 --- Play throwing object animation.
 --
---  @tparam LuaPosition attacker_pos The attacker's position.
+--  @tparam LuaPosition thrower_pos The thrower's position.
 --  @tparam LuaPosition target_pos The target's position.
 --  @tparam number item_chip The item chip of the thrown object
 --  @tparam number item_color The item color of the thrown object
 --  @function play_throwing_object
-function play_throwing_object(attacker_pos, target_pos, item_chip, item_color) end
+function play_throwing_object(thrower_pos, target_pos, item_chip, item_color) end
 
 --- Play swarm animation.
 --

--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -309,7 +309,7 @@ void activity_perform_generate_item(
         item->modify_number(-1);
         cell_refresh(item->pos().x, item->pos().y);
         ThrowingObjectAnimation(
-            item->pos(), audience.position, item->image, item->color)
+            audience.position, item->pos(), item->image, item->color)
             .play();
         item->modify_number(1);
         cell_refresh(item->pos().x, item->pos().y);

--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -303,16 +303,50 @@ void activity_perform_generate_item(
         }
     }
 
+    /*
+     * Generate an item and play throwing animation.
+     * The generated item should be hidden during the animation is playing, and
+     * then appear when the animation finishes. In vanilla, it is done by
+     * removing the item once and restore it after the animation. For vanilla's
+     * implementation, see diff of Pull Request #1687.
+     * https://github.com/elonafoobar/elonafoobar/pull/1687/files#diff-df8c633c69661a36d5d606d01e0bf6ca
+     * It does not work in foobar because these oprations trigger event
+     * `core.item_created` and `core.item_removed`, calling registered event
+     * handlers. To avoid firing events, only the drawing information is removed
+     * temporarily and then restored, instead of modifying the item itself.
+     */
+
+    // Save drawing information of the cell *before* tip generation.
+    const auto item_info_actual_before_tip_generation =
+        cell_data.at(x, y).item_info_actual;
+    const auto item_info_memory_before_tip_generation =
+        cell_data.at(x, y).item_info_memory;
     if (const auto item = itemcreate_extra_inv(item_id, x, y, 1))
     {
-        // NOTE: may cause Lua creation callbacks to run twice.
-        item->modify_number(-1);
-        cell_refresh(item->pos().x, item->pos().y);
+        // Save drawing information of the cell *after* tip generation.
+        const auto item_info_actual_after_tip_generation =
+            cell_data.at(x, y).item_info_actual;
+        const auto item_info_memory_after_tip_generation =
+            cell_data.at(x, y).item_info_memory;
+        // Restore drawing information of the cell *before* tip generation.
+        // It actually does hiding the generated item during the throwing
+        // animation is playing.
+        cell_data.at(x, y).item_info_actual =
+            item_info_actual_before_tip_generation;
+        cell_data.at(x, y).item_info_memory =
+            item_info_memory_before_tip_generation;
+        // Play animation.
         ThrowingObjectAnimation(
             audience.position, item->pos(), item->image, item->color)
             .play();
-        item->modify_number(1);
-        cell_refresh(item->pos().x, item->pos().y);
+        // Restore drawing information of the cell *after* tip generation.
+        // It fixes the inconsistency that the drawing information is different
+        // from the actual item. Now, all invariant constraints are properly
+        // restored.
+        cell_data.at(x, y).item_info_actual =
+            item_info_actual_after_tip_generation;
+        cell_data.at(x, y).item_info_memory =
+            item_info_memory_after_tip_generation;
         ++performance_tips;
     }
 }

--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -309,7 +309,7 @@ void activity_perform_generate_item(
         item->modify_number(-1);
         cell_refresh(item->pos().x, item->pos().y);
         ThrowingObjectAnimation(
-            item->pos(), performer.position, item->image, item->color)
+            item->pos(), audience.position, item->image, item->color)
             .play();
         item->modify_number(1);
         cell_refresh(item->pos().x, item->pos().y);

--- a/src/elona/animation.cpp
+++ b/src/elona/animation.cpp
@@ -582,18 +582,18 @@ void BoltAnimation::do_play()
 
 void ThrowingObjectAnimation::do_play()
 {
-    if (!is_in_fov(target_pos))
+    if (!is_in_fov(thrower_pos))
         return;
 
     prepare_item_image(item_chip, item_color);
-    int x = (target_pos.x - scx) * inf_tiles;
-    int y = (target_pos.y - scy) * inf_tiles;
-    int p = dist(target_pos, attacker_pos.x, attacker_pos.y) / 2 + 1;
+    int x = (thrower_pos.x - scx) * inf_tiles;
+    int y = (thrower_pos.y - scy) * inf_tiles;
+    int p = dist(thrower_pos, target_pos) / 2 + 1;
 
     for (int t = 0; t < p; ++t)
     {
-        x -= (target_pos.x - attacker_pos.x) * inf_tiles / p;
-        y -= (target_pos.y - attacker_pos.y) * inf_tiles / p;
+        x -= (thrower_pos.x - target_pos.x) * inf_tiles / p;
+        y -= (thrower_pos.y - target_pos.y) * inf_tiles / p;
 
         gsel(4);
         gmode(0);
@@ -613,8 +613,8 @@ void ThrowingObjectAnimation::do_play()
                 x + inf_tiles / 2,
                 y,
                 std::atan2(
-                    attacker_pos.x - target_pos.x,
-                    target_pos.y - attacker_pos.y));
+                    target_pos.x - thrower_pos.x,
+                    thrower_pos.y - target_pos.y));
         }
         redraw();
         gmode(0);

--- a/src/elona/animation.hpp
+++ b/src/elona/animation.hpp
@@ -174,11 +174,11 @@ class ThrowingObjectAnimation : public AbstractAnimation
 {
 public:
     ThrowingObjectAnimation(
-        const Position& attacker_pos,
+        const Position& thrower_pos,
         const Position& target_pos,
         int item_chip,
         int item_color)
-        : attacker_pos(attacker_pos)
+        : thrower_pos(thrower_pos)
         , target_pos(target_pos)
         , item_chip(item_chip)
         , item_color(item_color)
@@ -191,7 +191,7 @@ protected:
 
 
 private:
-    const Position& attacker_pos;
+    const Position& thrower_pos;
     const Position& target_pos;
     int item_chip;
     int item_color;

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -1154,7 +1154,7 @@ TurnResult do_throw_command(Character& thrower, const ItemRef& throw_item)
         }
     }
     ThrowingObjectAnimation(
-        {tlocx, tlocy}, thrower.position, throw_item->image, throw_item->color)
+        thrower.position, {tlocx, tlocy}, throw_item->image, throw_item->color)
         .play();
 
     if (throw_item->id == ItemId::monster_ball)

--- a/src/elona/lua_env/api/modules/module_Animation.cpp
+++ b/src/elona/lua_env/api/modules/module_Animation.cpp
@@ -126,18 +126,18 @@ void Animation_play_bolt(
  *
  * Play throwing object animation.
  *
- * @tparam LuaPosition attacker_pos The attacker's position.
+ * @tparam LuaPosition thrower_pos The thrower's position.
  * @tparam LuaPosition target_pos The target's position.
  * @tparam number item_chip The item chip of the thrown object
  * @tparam number item_color The item color of the thrown object
  */
 void Animation_play_throwing_object(
-    const Position& attacker_pos,
+    const Position& thrower_pos,
     const Position& target_pos,
     int item_chip,
     int item_color)
 {
-    ThrowingObjectAnimation(target_pos, attacker_pos, item_chip, item_color)
+    ThrowingObjectAnimation(thrower_pos, target_pos, item_chip, item_color)
         .play();
 }
 

--- a/src/elona/talk_house_visitor.cpp
+++ b/src/elona/talk_house_visitor.cpp
@@ -128,7 +128,7 @@ void _adventurer_hate_action(Character& speaker)
             txt(i18n::s.get(
                 "core.talk.visitor.adventurer.hate.throws", speaker));
             snd("core.throw2");
-            ThrowingObjectAnimation({tlocx, tlocy}, speaker.position, 223, 0)
+            ThrowingObjectAnimation(speaker.position, {tlocx, tlocy}, 223, 0)
                 .play();
             mef_add(tlocx, tlocy, 5, 24, rnd(15) + 20, 50, speaker.index);
             mapitem_fire(speaker, tlocx, tlocy);


### PR DESCRIPTION
# Related issues

close #1680 

# Summary

* Fix glitch of throwing object animation thrown by performance audiences (#1680).
* Refactor parameters of `ThrowingObjectAnimation`. The parameter `attacker_pos` of `ThrowingObjectAnimation` was used as target position and `target_pos` was used as attacker position. Since it was confusing, the parameters were renamed.
  * `attacker_pos` -> `target_pos`
  * `target_pos` -> `thrower_pos`
* Prevent item's create/remove events from triggering when playing throwing object animation.
  * Instead of modifying `Item::number`, temporarily change `CellData::item_info_actual`/`CellData::item_info_memory`.
  * See source code comments for details.