### PR TITLE
Fix migration code from v18 to v19

### DIFF
--- a/src/elona/save_update.cpp
+++ b/src/elona/save_update.cpp
@@ -1190,8 +1190,16 @@ boost::uuids::uuid _update_save_data_18_convert_item_index_to_object_id(
         std::string,
         std::unordered_map<int64_t, boost::uuids::uuid>>& item_obj_id_registry,
     const std::string& map_id,
-    int64_t item_index)
+    int64_t item_index_plus_one)
 {
+    if (item_index_plus_one == 0) // null reference
+    {
+        boost::uuids::uuid ret;
+        std::fill(std::begin(ret), std::end(ret), 0);
+        return ret;
+    }
+
+    int64_t item_index = item_index_plus_one - 1;
     if (item_index < 1320)
     {
         return item_obj_id_registry[""][item_index];

--- a/src/elona/save_update.cpp
+++ b/src/elona/save_update.cpp
@@ -33,7 +33,7 @@ void for_each_cdata(const fs::path& save_dir, F f)
         std::ostringstream out;
         serialization::binary::OArchive oar{out};
 
-        const auto is_cdatas1 = entry.path().extension() == "s1";
+        const auto is_cdatas1 = entry.path().extension() == ".s1";
         const auto begin = is_cdatas1 ? 0 : 57;
         const auto end = is_cdatas1 ? 57 : 245;
         for (int idx = begin; idx < end; ++idx)

--- a/src/elona/save_update.cpp
+++ b/src/elona/save_update.cpp
@@ -1626,7 +1626,8 @@ void _update_save_data_18(const fs::path& save_dir)
             }
             else
             {
-                ELONA_LOG("save.update") << "chara(" << chara_index << "): nil";
+                ELONA_LOG("save.update")
+                    << "chara(" << chara_index << "): " << obj_id;
 
                 activity_item_ =
                     _update_save_data_18_convert_item_index_to_object_id(


### PR DESCRIPTION
# Summary

Fixes 2 issues in save data migration from v18 to v19.

**Bug 1**

Elona foobar checks file extension in save data migration to distinguish global files (`*.s1`) and map-local files (`*.s2`).

```cpp
const auto is_cdatas1 = entry.path().extension() == "s1";
```

It is incorrect because a return value of `boost::filesystem::path::extension()` includes a dot.


**Bug 2**

Fix save migration from item index to item object id.

Old file's index field is an actual item index plus one, so we have to subtract one.