### PR TITLE
Fix assert()'s condition when you pick something up after shopping

### DIFF
--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -5281,7 +5281,7 @@ PickUpItemResult pick_up_item(
     optional_ref<Character> shopkeeper,
     bool play_sound)
 {
-    if (invctrl == 11 || invctrl == 12)
+    if (mode == 6 && (invctrl == 11 || invctrl == 12))
     {
         assert(shopkeeper);
     }


### PR DESCRIPTION
# Bug

The debug build crashes due to `assert()` when you pick something up after shopping. It didn't happen in release builds.