### PR TITLE
Merge `sdata` into `cdata`

### DIFF
--- a/doc/api/classes/LuaAbility.luadoc
+++ b/doc/api/classes/LuaAbility.luadoc
@@ -8,10 +8,10 @@
 --  @tfield num experience
 
 --- [RW] The skill's current level.
---  @tfield num current_level
+--  @tfield num level
 
---- [RW] The skill's original level.
---  @tfield num original_level
+--- [RW] The skill's base level.
+--  @tfield num base_level
 
 --- [RW] The skill's potential.
 --  @tfield num potential

--- a/runtime/mod/core/api/eating_effects.lua
+++ b/runtime/mod/core/api/eating_effects.lua
@@ -203,7 +203,7 @@ EatingEffects.nymph = eating_effect_ghost(400)
 function EatingEffects.quickling(eater)
    eat_message(eater, "quickling", "green")
 
-   local current = eater:get_skill("core.attribute_speed").current_level
+   local current = eater:get_skill("core.attribute_speed").level
    local amount = math.clamp(2500 - current * current // 10, 20, 2500)
    eater:gain_skill_exp("core.attribute_speed", amount);
 end

--- a/runtime/mod/core/api/impl/shop_inventory.lua
+++ b/runtime/mod/core/api/impl/shop_inventory.lua
@@ -189,7 +189,7 @@ shop_inventory.cargo_amount_rates = {
 }
 
 function shop_inventory.cargo_amount_modifier(amount)
-   return amount * (100 + Chara.player():get_skill("core.negotiation").current_level * 10) // 100 + 1
+   return amount * (100 + Chara.player():get_skill("core.negotiation").level * 10) // 100 + 1
 end
 
 -- Calculate adjusted amount of cargo items to be sold based on the

--- a/runtime/mod/core/data/buff.lua
+++ b/runtime/mod/core/data/buff.lua
@@ -13,7 +13,7 @@ local function mod_skill_level_clamp(args, id, amount)
 
    skill.level =
       math.clamp(skill.level + amount,
-                 skill.level and 1 or 0, 9999)
+                 skill.level > 0 and 1 or 0, 9999)
 end
 
 local function get_description(self, power)

--- a/runtime/mod/core/data/buff.lua
+++ b/runtime/mod/core/data/buff.lua
@@ -5,15 +5,15 @@ local I18N = ELONA.require("core.I18N")
 local function mod_skill_level(args, id, amount)
    local skill = args.chara:get_skill(id)
 
-   skill.current_level = skill.current_level + amount
+   skill.level = skill.level + amount
 end
 
 local function mod_skill_level_clamp(args, id, amount)
    local skill = args.chara:get_skill(id)
 
-   skill.current_level =
-      math.clamp(skill.current_level + amount,
-                 skill.current_level and 1 or 0, 9999)
+   skill.level =
+      math.clamp(skill.level + amount,
+                 skill.level and 1 or 0, 9999)
 end
 
 local function get_description(self, power)
@@ -150,8 +150,8 @@ ELONA.data:add(
             return 8 + power // 30
          end,
          on_refresh = function(self, args)
-            args.chara:get_skill("core.attribute_speed").current_level =
-               args.chara:get_skill("core.attribute_speed").current_level - self._effect(args.power)
+            args.chara:get_skill("core.attribute_speed").level =
+               args.chara:get_skill("core.attribute_speed").level - self._effect(args.power)
          end,
          _effect = function(power)
             return math.min(20 + power // 20, 50)
@@ -353,10 +353,10 @@ ELONA.data:add(
          end,
          on_refresh = function(self, args)
             mod_skill_level(args, "core.attribute_speed", self._effect(args.power))
-            args.chara:get_skill("core.attribute_strength").current_level =
-               args.chara:get_skill("core.attribute_strength").current_level * 150 // 100 + 10
-            args.chara:get_skill("core.attribute_dexterity").current_level =
-               args.chara:get_skill("core.attribute_dexterity").current_level * 150 // 100 + 10
+            args.chara:get_skill("core.attribute_strength").level =
+               args.chara:get_skill("core.attribute_strength").level * 150 // 100 + 10
+            args.chara:get_skill("core.attribute_dexterity").level =
+               args.chara:get_skill("core.attribute_dexterity").level * 150 // 100 + 10
             mod_skill_level(args, "core.healing", 50)
             args.chara.pv = args.chara.pv * 150 // 100 + 25
             args.chara.dv = args.chara.dv * 150 // 100 + 25

--- a/src/elona/ability.hpp
+++ b/src/elona/ability.hpp
@@ -4,7 +4,6 @@
 
 #include <vector>
 
-#include "data/types/type_ability.hpp"
 #include "serialization/macros.hpp"
 
 
@@ -17,9 +16,9 @@ struct Ability
     // NOTE: Don't add new fields unless you add them to serialization, which
     // will break save compatibility.
 
-    int current_level = 0;
+    int level = 0;
 
-    int original_level = 0;
+    int base_level = 0;
 
     int experience = 0;
 
@@ -33,8 +32,8 @@ struct Ability
         /* clang-format off */
         ELONA_SERIALIZATION_STRUCT_BEGIN(ar, "Ability");
 
-        ELONA_SERIALIZATION_STRUCT_FIELD(*this, current_level);
-        ELONA_SERIALIZATION_STRUCT_FIELD(*this, original_level);
+        ELONA_SERIALIZATION_STRUCT_FIELD(*this, level);
+        ELONA_SERIALIZATION_STRUCT_FIELD(*this, base_level);
         ELONA_SERIALIZATION_STRUCT_FIELD(*this, experience);
         ELONA_SERIALIZATION_STRUCT_FIELD(*this, potential);
 
@@ -50,31 +49,29 @@ class SkillData
 public:
     SkillData();
 
+    SkillData(const SkillData&) = default;
+    SkillData(SkillData&&) = default;
+    SkillData& operator=(const SkillData&) = default;
+    SkillData& operator=(SkillData&&) = default;
 
-    int& operator()(int id, int chara_index)
+
+    Ability& get(int id)
     {
-        return get(id, chara_index).current_level;
+        return _storage.at(id);
     }
 
 
-    Ability& get(int id, int chara_index)
+    const Ability& get(int id) const
     {
-        assert(id < 600);
-        return storage[chara_index][id];
+        return _storage.at(id);
     }
 
-
-    void clear(int chara_index);
-
-    void copy(int destination_chara_index, int source_chara_index);
 
 
 private:
-    std::vector<std::vector<Ability>> storage;
+    std::vector<Ability> _storage;
 };
 
-
-extern SkillData sdata;
 
 
 struct Character;

--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -11,6 +11,7 @@
 #include "command.hpp"
 #include "config.hpp"
 #include "crafting.hpp"
+#include "data/types/type_ability.hpp"
 #include "dmgheal.hpp"
 #include "draw.hpp"
 #include "enchantment.hpp"
@@ -121,7 +122,7 @@ void search_material_spot()
     cell_featread(cdata.player().position.x, cdata.player().position.y);
     if (feat(1) == 27)
     {
-        atxlv += sdata(161, 0) / 3;
+        atxlv += cdata.player().get_skill(161).level / 3;
         atxspot = 16;
     }
     if (feat(1) == 26)
@@ -143,7 +144,9 @@ void search_material_spot()
             i = 5;
             if (atxspot == 14)
             {
-                if (sdata(163, 0) < rnd_capped(atxlv * 2 + 1) || rnd(10) == 0)
+                if (cdata.player().get_skill(163).level <
+                        rnd_capped(atxlv * 2 + 1) ||
+                    rnd(10) == 0)
                 {
                     txt(i18n::s.get("core.activity.material.digging.fails"));
                     break;
@@ -153,7 +156,9 @@ void search_material_spot()
             }
             if (atxspot == 13)
             {
-                if (sdata(185, 0) < rnd_capped(atxlv * 2 + 1) || rnd(10) == 0)
+                if (cdata.player().get_skill(185).level <
+                        rnd_capped(atxlv * 2 + 1) ||
+                    rnd(10) == 0)
                 {
                     txt(i18n::s.get("core.activity.material.fishing.fails"));
                     break;
@@ -163,7 +168,9 @@ void search_material_spot()
             }
             if (atxspot == 15)
             {
-                if (sdata(180, 0) < rnd_capped(atxlv * 2 + 1) || rnd(10) == 0)
+                if (cdata.player().get_skill(180).level <
+                        rnd_capped(atxlv * 2 + 1) ||
+                    rnd(10) == 0)
                 {
                     txt(i18n::s.get("core.activity.material.searching.fails"));
                     break;
@@ -205,7 +212,7 @@ int calc_performance_tips(const Character& performer, const Character& audience)
     // Instrument factor
     const auto I = performer.activity.item->param1;
 
-    const auto max = sdata(183, performer.index) * 100;
+    const auto max = performer.get_skill(183).level * 100;
 
     const auto m = Q * Q * (100 + I / 5) / 100 / 1000 + rnd(10);
     auto ret = clamp(audience.gold * clamp(m, 1, 100) / 125, 0, max);
@@ -358,7 +365,7 @@ std::pair<bool, int> activity_perform_proc_audience(
     Character& performer,
     Character& audience)
 {
-    const auto performer_skill = sdata(183, performer.index);
+    const auto performer_skill = performer.get_skill(183).level;
     const auto& instrument = performer.activity.item.unwrap();
 
     if (audience.state() != Character::State::alive)
@@ -635,7 +642,7 @@ void activity_perform_end(Character& performer)
     performer.activity.finish();
 
     const auto experience =
-        performer.quality_of_performance - sdata(183, performer.index) + 50;
+        performer.quality_of_performance - performer.get_skill(183).level + 50;
     if (experience > 0)
     {
         chara_gain_skill_exp(performer, 183, experience, 0, 0);
@@ -713,7 +720,8 @@ void activity_others_start(
         txt(i18n::s.get("core.activity.dig", activity_item.unwrap()));
         doer.activity.turn = 10 +
             clamp(activity_item->weight /
-                      (1 + sdata(10, 0) * 10 + sdata(180, 0) * 40),
+                      (1 + cdata.player().get_skill(10).level * 10 +
+                       cdata.player().get_skill(180).level * 40),
                   1,
                   100);
         break;
@@ -792,7 +800,8 @@ void activity_others_doing_steal(Character& doer, const ItemRef& steal_target)
             f2 = 1;
         }
     }
-    i = sdata(300, 0) * 5 + sdata(12, 0) + 25;
+    i = cdata.player().get_skill(300).level * 5 +
+        cdata.player().get_skill(12).level + 25;
     if (game_data.date.hour >= 19 || game_data.date.hour < 7)
     {
         i = i * 15 / 10;
@@ -835,7 +844,7 @@ void activity_others_doing_steal(Character& doer, const ItemRef& steal_target)
         {
             p = p * 2 / 3;
         }
-        if (rnd_capped(sdata(13, cnt) + 1) > p)
+        if (rnd_capped(cdata[cnt].get_skill(13).level + 1) > p)
         {
             if (is_in_fov(cdata[cnt]))
             {
@@ -918,7 +927,7 @@ void activity_others_doing_steal(Character& doer, const ItemRef& steal_target)
             f = 1;
         }
     }
-    if (steal_target->weight >= sdata(10, 0) * 500)
+    if (steal_target->weight >= cdata.player().get_skill(10).level * 500)
     {
         if (f != 1)
         {
@@ -956,21 +965,21 @@ void activity_others_doing(
         }
         if (rnd(6) == 0)
         {
-            if (rnd(55) > sdata.get(10, doer.index).original_level + 25)
+            if (rnd(55) > doer.get_skill(10).base_level + 25)
             {
                 chara_gain_skill_exp(doer, 10, 50);
             }
         }
         if (rnd(8) == 0)
         {
-            if (rnd(55) > sdata.get(11, doer.index).original_level + 28)
+            if (rnd(55) > doer.get_skill(11).base_level + 28)
             {
                 chara_gain_skill_exp(doer, 11, 50);
             }
         }
         if (rnd(10) == 0)
         {
-            if (rnd(55) > sdata.get(15, doer.index).original_level + 30)
+            if (rnd(55) > doer.get_skill(15).base_level + 30)
             {
                 chara_gain_skill_exp(doer, 15, 50);
             }
@@ -1461,7 +1470,7 @@ void activity_sex(Character& chara_a, optional_ref<Character> chara_b)
         }
         chara_gain_skill_exp(cdata[c], 17, 250 + (c >= 57) * 1000);
     }
-    int sexvalue = sdata(17, chara_a.index) * (50 + rnd(50)) + 100;
+    int sexvalue = chara_a.get_skill(17).level * (50 + rnd(50)) + 100;
 
     std::string dialog_head;
     std::string dialog_tail;
@@ -1756,7 +1765,8 @@ void spot_fishing(Character& fisher, OptionalItemRef rod)
                     await(g_config.animation_wait() * 2);
                 }
             }
-            if (the_fish_db[fish]->difficulty >= rnd_capped(sdata(185, 0) + 1))
+            if (the_fish_db[fish]->difficulty >=
+                rnd_capped(cdata.player().get_skill(185).level + 1))
             {
                 fishstat = 0;
             }
@@ -1940,11 +1950,11 @@ void spot_mining_or_wall(Character& chara)
         if (chip_data.for_cell(refx, refy).kind == 6)
         {
             if (rnd(12000) <
-                sdata(10, chara.index) + sdata(163, chara.index) * 10)
+                chara.get_skill(10).level + chara.get_skill(163).level * 10)
             {
                 f = 1;
             }
-            p = 30 - sdata(163, chara.index) / 2;
+            p = 30 - chara.get_skill(163).level / 2;
             if (p > 0)
             {
                 if (countdig <= p)
@@ -1956,11 +1966,11 @@ void spot_mining_or_wall(Character& chara)
         else
         {
             if (rnd(1500) <
-                sdata(10, chara.index) + sdata(163, chara.index) * 10)
+                chara.get_skill(10).level + chara.get_skill(163).level * 10)
             {
                 f = 1;
             }
-            p = 20 - sdata(163, chara.index) / 2;
+            p = 20 - chara.get_skill(163).level / 2;
             if (p > 0)
             {
                 if (countdig <= p)
@@ -2220,7 +2230,7 @@ void sleep_start(const OptionalItemRef& bed)
         i = 0;
         for (int cnt = 10; cnt < 18; ++cnt)
         {
-            i += sdata.get(cnt, 0).original_level;
+            i += cdata.player().get_skill(cnt).base_level;
         }
         i = clamp(i / 6, 10, 1000);
         exp = i * i * i / 10;

--- a/src/elona/adventurer.cpp
+++ b/src/elona/adventurer.cpp
@@ -6,6 +6,7 @@
 #include "area.hpp"
 #include "character.hpp"
 #include "character_status.hpp"
+#include "data/types/type_ability.hpp"
 #include "data/types/type_item.hpp"
 #include "equipment.hpp"
 #include "i18n.hpp"

--- a/src/elona/ai.cpp
+++ b/src/elona/ai.cpp
@@ -339,7 +339,7 @@ void _ally_trains(Character& chara)
         while (true)
         {
             const auto skill_id = rnd(4) == 0 ? rnd(8) + 10 : rnd(300) + 100;
-            if (sdata.get(skill_id, chara.index).original_level == 0)
+            if (chara.get_skill(skill_id).base_level == 0)
             {
                 continue;
             }

--- a/src/elona/attack.cpp
+++ b/src/elona/attack.cpp
@@ -403,15 +403,15 @@ bool do_physical_attack_internal(
             chara_gain_skill_exp(attacker, 186, 60 / expmodifer, 2);
             critical = 0;
         }
-        if (rtdmg > target.max_hp / 20 || rtdmg > sdata(154, target.index) ||
+        if (rtdmg > target.max_hp / 20 || rtdmg > target.get_skill(154).level ||
             rnd(5) == 0)
         {
             chara_gain_skill_exp(
                 attacker,
                 attackskill,
                 clamp(
-                    (sdata(173, target.index) * 2 -
-                     sdata(attackskill, attacker.index) + 1),
+                    (target.get_skill(173).level * 2 -
+                     attacker.get_skill(attackskill).level + 1),
                     5,
                     50) /
                     expmodifer,
@@ -555,12 +555,13 @@ bool do_physical_attack_internal(
         {
             snd("core.miss");
         }
-        if (sdata(attackskill, attacker.index) > sdata(173, target.index) ||
+        if (attacker.get_skill(attackskill).level >
+                target.get_skill(173).level ||
             rnd(5) == 0)
         {
             p = clamp(
-                    (sdata(attackskill, attacker.index) -
-                     sdata(173, target.index) / 2 + 1),
+                    (attacker.get_skill(attackskill).level -
+                     target.get_skill(173).level / 2 + 1),
                     1,
                     20) /
                 expmodifer;
@@ -785,7 +786,7 @@ void do_ranged_attack(
         tlocx = ammox;
         tlocy = ammoy;
         efid = 460;
-        efp = sdata(attackskill, attacker.index) * 8 + 10;
+        efp = attacker.get_skill(attackskill).level * 8 + 10;
         magic(cdata.player(), target);
     }
     ammoproc = -1;
@@ -828,7 +829,7 @@ void try_to_melee_attack(Character& attacker, Character& target)
     ele = 0;
     if (attacker.combat_style.shield())
     {
-        if (clamp(int(std::sqrt(sdata(168, attacker.index)) - 3), 1, 5) +
+        if (clamp(int(std::sqrt(attacker.get_skill(168).level) - 3), 1, 5) +
                 attacker.has_power_bash() * 5 >
             rnd(100))
         {
@@ -839,12 +840,12 @@ void try_to_melee_attack(Character& attacker, Character& target)
             }
             damage_hp(
                 target,
-                rnd_capped(sdata(168, attacker.index)) + 1,
+                rnd_capped(attacker.get_skill(168).level) + 1,
                 attacker.index);
             status_ailment_damage(
                 target,
                 StatusAilment::dimmed,
-                50 + int(std::sqrt(sdata(168, attacker.index))) * 15);
+                50 + int(std::sqrt(attacker.get_skill(168).level)) * 15);
             target.paralyzed += rnd(3);
         }
     }
@@ -1015,7 +1016,7 @@ void proc_weapon_enchantments(
                 {
                     efid = enc;
                     efp = weapon->enchantments[cnt].power +
-                        sdata(attackskill, attacker.index) * 10;
+                        attacker.get_skill(attackskill).level * 10;
                     magic(attacker, cdata[invoke_target]);
                 }
                 continue;
@@ -1039,7 +1040,7 @@ void proc_weapon_enchantments(
                 orgdmg * 2 / 3,
                 attacker.index,
                 rnd(11) + 50,
-                sdata(attackskill, attacker.index) * 10 + 100);
+                attacker.get_skill(attackskill).level * 10 + 100);
         }
     }
 }

--- a/src/elona/blending.cpp
+++ b/src/elona/blending.cpp
@@ -6,6 +6,7 @@
 #include "chara_db.hpp"
 #include "character.hpp"
 #include "config.hpp"
+#include "data/types/type_ability.hpp"
 #include "data/types/type_blending_recipe.hpp"
 #include "data/types/type_item.hpp"
 #include "draw.hpp"
@@ -127,7 +128,7 @@ int calc_success_rate(
          the_blending_recipe_db.ensure(recipe_id).required_skills)
     {
         const auto legacy_skill_id = the_ability_db.ensure(skill_id).legacy_id;
-        if (sdata(legacy_skill_id, 0) <= 0)
+        if (cdata.player().get_skill(legacy_skill_id).level <= 0)
         {
             rate -= 125;
             continue;
@@ -137,7 +138,9 @@ int calc_success_rate(
         {
             d = 1;
         }
-        int p = (d * 200 / sdata(legacy_skill_id, 0) - 200) * -1;
+        int p =
+            (d * 200 / cdata.player().get_skill(legacy_skill_id).level - 200) *
+            -1;
         if (p > 0)
         {
             p /= 5;
@@ -469,14 +472,16 @@ void window_recipe(
         {
             const auto legacy_skill_id =
                 the_ability_db.ensure(skill_id).legacy_id;
-            const auto text_color = (required_level > sdata(legacy_skill_id, 0))
+            const auto text_color =
+                (required_level >
+                 cdata.player().get_skill(legacy_skill_id).level)
                 ? snail::Color{150, 0, 0}
                 : snail::Color{0, 120, 0};
             mes(dx_ + cnt % 2 * 140,
                 dy_ + cnt / 2 * 17,
                 the_ability_db.get_text(skill_id, "name") + u8"  "s +
-                    required_level + u8"("s + sdata(legacy_skill_id, 0) +
-                    u8")"s,
+                    required_level + u8"("s +
+                    cdata.player().get_skill(legacy_skill_id).level + u8")"s,
                 text_color);
             ++cnt;
         }

--- a/src/elona/buff.cpp
+++ b/src/elona/buff.cpp
@@ -159,15 +159,15 @@ void buff_add(
     if (buff_data.type == BuffType::hex)
     {
         bool resists{};
-        if (sdata(60, chara.index) / 2 > rnd_capped(power * 2 + 100))
+        if (chara.get_skill(60).level / 2 > rnd_capped(power * 2 + 100))
         {
             resists = true;
         }
-        if (power * 3 < sdata(60, chara.index))
+        if (power * 3 < chara.get_skill(60).level)
         {
             resists = true;
         }
-        if (power / 3 > sdata(60, chara.index))
+        if (power / 3 > chara.get_skill(60).level)
         {
             resists = false;
         }

--- a/src/elona/building.cpp
+++ b/src/elona/building.cpp
@@ -128,7 +128,7 @@ int calc_num_of_shop_customers(int shop_level, const Character& shopkeeper)
     {
         ret += rnd(shop_level / 3 + 5);
     }
-    ret = ret * (80 + sdata(17, shopkeeper.index) * 3 / 2) / 100;
+    ret = ret * (80 + shopkeeper.get_skill(17).level * 3 / 2) / 100;
     if (ret < 1)
     {
         ret = 1;
@@ -213,7 +213,7 @@ std::vector<ItemForSale> list_items_for_sale()
 int calc_item_price_per_one(const ItemRef& item, const Character& shopkeeper)
 {
     const auto V = calcitemvalue(item, 2);
-    const auto I = sdata(156, shopkeeper.index);
+    const auto I = shopkeeper.get_skill(156).level;
 
     return V * static_cast<int>(10 + std::sqrt(I * 200)) / 100;
 }
@@ -1742,7 +1742,7 @@ void try_to_grow_plant(int val0)
             p = p * 2;
         }
     }
-    if (sdata(180, 0) < rnd(p + 1) || rnd(20) == 0)
+    if (cdata.player().get_skill(180).level < rnd(p + 1) || rnd(20) == 0)
     {
         feat(3) += 50;
     }
@@ -1777,7 +1777,8 @@ void harvest_plant(int val)
     {
         p = p * 4 / 3;
     }
-    if (sdata(180, 0) < rnd(p + 1) || rnd(5) == 0 || feat(2) == 40)
+    if (cdata.player().get_skill(180).level < rnd(p + 1) || rnd(5) == 0 ||
+        feat(2) == 40)
     {
         cell_data.at(cdata.player().position.x, cdata.player().position.y)
             .feats = 0;
@@ -1802,7 +1803,7 @@ void create_harvested_item()
 {
     chara_gain_skill_exp(cdata.player(), 180, 75);
     snd("core.bush1");
-    flt(sdata(180, 0) / 2 + 15, Quality::good);
+    flt(cdata.player().get_skill(180).level / 2 + 15, Quality::good);
     int item_id = 0;
     if (feat(2) == 39)
     {

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -4,6 +4,7 @@
 #include "area.hpp"
 #include "buff.hpp"
 #include "character.hpp"
+#include "data/types/type_ability.hpp"
 #include "data/types/type_item.hpp"
 #include "debug.hpp"
 #include "elona.hpp"
@@ -86,7 +87,8 @@ int rangedist = 0;
 optional<SkillDamage>
 calc_skill_damage(const Character& chara, int skill, int power)
 {
-    int x = sdata(the_ability_db[skill]->related_basic_attribute, chara.index);
+    int x =
+        chara.get_skill(the_ability_db[skill]->related_basic_attribute).level;
 
     switch (skill)
     {
@@ -408,7 +410,8 @@ int calcexpalive(int level)
 
 int calc_evasion(const Character& chara)
 {
-    return sdata(13, chara.index) / 3 + sdata(173, chara.index) + chara.dv + 25;
+    return chara.get_skill(13).level / 3 + chara.get_skill(173).level +
+        chara.dv + 25;
 }
 
 
@@ -425,21 +428,21 @@ int calc_accuracy(
 
     if (attackskill == 106)
     {
-        accuracy = sdata(12, attacker.index) / 5 +
-            sdata(10, attacker.index) / 2 + sdata(attackskill, attacker.index) +
-            50;
+        accuracy = attacker.get_skill(12).level / 5 +
+            attacker.get_skill(10).level / 2 +
+            attacker.get_skill(attackskill).level + 50;
         if (attacker.combat_style.shield())
         {
             accuracy = accuracy * 100 / 130;
         }
-        accuracy += sdata(12, attacker.index) / 5 +
-            sdata(10, attacker.index) / 10 + attacker.hit_bonus;
+        accuracy += attacker.get_skill(12).level / 5 +
+            attacker.get_skill(10).level / 10 + attacker.hit_bonus;
     }
     else
     {
-        accuracy = sdata(12, attacker.index) / 4 +
-            sdata(weapon->skill, attacker.index) / 3 +
-            sdata(attackskill, attacker.index) + 50;
+        accuracy = attacker.get_skill(12).level / 4 +
+            attacker.get_skill(weapon->skill).level / 3 +
+            attacker.get_skill(attackskill).level + 50;
         accuracy += attacker.hit_bonus + weapon->hit_bonus;
         if (ammo)
         {
@@ -467,7 +470,7 @@ int calc_accuracy(
                 accuracy += 25;
                 if (weapon->weight >= 4000)
                 {
-                    accuracy += sdata(167, attacker.index);
+                    accuracy += attacker.get_skill(167).level;
                 }
             }
             else if (attacker.combat_style.dual_wield())
@@ -477,13 +480,13 @@ int calc_accuracy(
                     if (weapon->weight >= 4000)
                     {
                         accuracy -= (weapon->weight - 4000 + 400) /
-                            (10 + sdata(166, attacker.index) / 5);
+                            (10 + attacker.get_skill(166).level / 5);
                     }
                 }
                 else if (weapon->weight > 1500)
                 {
                     accuracy -= (weapon->weight - 1500 + 100) /
-                        (10 + sdata(166, attacker.index) / 5);
+                        (10 + attacker.get_skill(166).level / 5);
                 }
             }
         }
@@ -494,23 +497,23 @@ int calc_accuracy(
         if (attacker.index == 0)
         {
             accuracy = accuracy * 100 /
-                clamp((150 - sdata(301, attacker.index) / 2), 115, 150);
+                clamp((150 - attacker.get_skill(301).level / 2), 115, 150);
             if (attackskill != 106 && attackrange == 0 &&
                 weapon->weight >= 4000)
             {
                 accuracy -= (weapon->weight - 4000 + 400) /
-                    (10 + sdata(301, attacker.index) / 5);
+                    (10 + attacker.get_skill(301).level / 5);
             }
         }
         if (attacker.index == game_data.mount)
         {
             accuracy = accuracy * 100 /
-                clamp((150 - sdata(10, attacker.index) / 2), 115, 150);
+                clamp((150 - attacker.get_skill(10).level / 2), 115, 150);
             if (attackskill != 106 && attackrange == 0 &&
                 weapon->weight >= 4000)
             {
                 accuracy -= (weapon->weight - 4000 + 400) /
-                    (10 + sdata(10, attacker.index) / 10);
+                    (10 + attacker.get_skill(10).level / 10);
             }
         }
     }
@@ -518,7 +521,8 @@ int calc_accuracy(
     if (attacknum > 1)
     {
         int twohit = 100 -
-            (attacknum - 1) * (10000 / (100 + sdata(166, attacker.index) * 10));
+            (attacknum - 1) *
+                (10000 / (100 + attacker.get_skill(166).level * 10));
         if (accuracy > 0)
         {
             accuracy = accuracy * twohit / 100;
@@ -571,35 +575,35 @@ int calcattackhit(
             tohit = tohit / 3 * 2;
         }
     }
-    if (sdata(187, target.index) != 0)
+    if (target.get_skill(187).level != 0)
     {
-        if (tohit < sdata(187, target.index) * 10 && tohit > 0)
+        if (tohit < target.get_skill(187).level * 10 && tohit > 0)
         {
             int evaderef = evasion * 100 / clamp(tohit, 1, tohit);
             if (evaderef > 300)
             {
-                if (rnd_capped(sdata(187, target.index) + 250) > 100)
+                if (rnd_capped(target.get_skill(187).level + 250) > 100)
                 {
                     return -2;
                 }
             }
             if (evaderef > 200)
             {
-                if (rnd_capped(sdata(187, target.index) + 250) > 150)
+                if (rnd_capped(target.get_skill(187).level + 250) > 150)
                 {
                     return -2;
                 }
             }
             if (evaderef > 150)
             {
-                if (rnd_capped(sdata(187, target.index) + 250) > 200)
+                if (rnd_capped(target.get_skill(187).level + 250) > 200)
                 {
                     return -2;
                 }
             }
         }
     }
-    if (rnd(5000) < sdata(13, attacker.index) + 50)
+    if (rnd(5000) < attacker.get_skill(13).level + 50)
     {
         critical = 1;
         return 1;
@@ -646,17 +650,17 @@ int calcattackdmg(
     int pierce;
     if (attackskill == 106)
     {
-        dmgfix = sdata(10, attacker.index) / 8 +
-            sdata(106, attacker.index) / 8 + attacker.damage_bonus;
+        dmgfix = attacker.get_skill(10).level / 8 +
+            attacker.get_skill(106).level / 8 + attacker.damage_bonus;
         dice1 = 2;
-        dice2 = sdata(106, attacker.index) / 8 + 5;
+        dice2 = attacker.get_skill(106).level / 8 + 5;
         dmgmulti = 0.5 +
             double(
-                (sdata(10, attacker.index) +
-                 sdata(attackskill, attacker.index) / 5 +
-                 sdata(152, attacker.index) * 2)) /
+                (attacker.get_skill(10).level +
+                 attacker.get_skill(attackskill).level / 5 +
+                 attacker.get_skill(152).level * 2)) /
                 40;
-        pierce = clamp(sdata(attackskill, attacker.index) / 5, 5, 50);
+        pierce = clamp(attacker.get_skill(attackskill).level / 5, 5, 50);
     }
     else
     {
@@ -669,20 +673,20 @@ int calcattackdmg(
             dmgfix += ammo->damage_bonus + ammo->dice_x * ammo->dice_y / 2;
             dmgmulti = 0.5 +
                 double(
-                    (sdata(13, attacker.index) +
-                     sdata(weapon->skill, attacker.index) / 5 +
-                     sdata(attackskill, attacker.index) / 5 +
-                     sdata(189, attacker.index) * 3 / 2)) /
+                    (attacker.get_skill(13).level +
+                     attacker.get_skill(weapon->skill).level / 5 +
+                     attacker.get_skill(attackskill).level / 5 +
+                     attacker.get_skill(189).level * 3 / 2)) /
                     40;
         }
         else
         {
             dmgmulti = 0.6 +
                 double(
-                    (sdata(10, attacker.index) +
-                     sdata(weapon->skill, attacker.index) / 5 +
-                     sdata(attackskill, attacker.index) / 5 +
-                     sdata(152, attacker.index) * 2)) /
+                    (attacker.get_skill(10).level +
+                     attacker.get_skill(weapon->skill).level / 5 +
+                     attacker.get_skill(attackskill).level / 5 +
+                     attacker.get_skill(152).level * 2)) /
                     45;
         }
         pierce = calc_rate_to_pierce(itemid2int(weapon->id));
@@ -706,7 +710,7 @@ int calcattackdmg(
         {
             dmgmulti *= 1.2;
         }
-        dmgmulti += 0.03 * sdata(167, attacker.index);
+        dmgmulti += 0.03 * attacker.get_skill(167).level;
     }
     if (attacker.index == 0)
     {
@@ -820,8 +824,9 @@ int calcattackdmg(
 
 CalcAttackProtectionResult calc_attack_protection(const Character& chara)
 {
-    const auto rate = chara.pv + sdata(chara_armor_class(chara), chara.index) +
-        sdata(12, chara.index) / 10;
+    const auto rate = chara.pv +
+        chara.get_skill(chara_armor_class(chara)).level +
+        chara.get_skill(12).level / 10;
     if (rate <= 0)
     {
         return {0, 1, 1};
@@ -970,7 +975,7 @@ int calcitemvalue(const ItemRef& item, int calc_mode)
     if (calc_mode == 0)
     {
         int max = ret / 2;
-        ret = ret * 100 / (100 + sdata(156, 0));
+        ret = ret * 100 / (100 + cdata.player().get_skill(156).level);
         if (game_data.guild.belongs_to_mages_guild != 0)
         {
             if (category == ItemCategory::spellbook)
@@ -985,12 +990,12 @@ int calcitemvalue(const ItemRef& item, int calc_mode)
     }
     if (calc_mode == 1)
     {
-        int max = sdata(156, 0) * 250 + 5000;
+        int max = cdata.player().get_skill(156).level * 250 + 5000;
         if (ret / 3 < max)
         {
             max = ret / 3;
         }
-        ret = ret * (100 + sdata(156, 0) * 5) / 1000;
+        ret = ret * (100 + cdata.player().get_skill(156).level * 5) / 1000;
         if (is_equipment(category))
         {
             ret /= 20;
@@ -1044,7 +1049,7 @@ int calcinvestvalue(const Character& shopkeeper)
     {
         ret = 500'000;
     }
-    return ret * 100 / (100 + sdata(160, 0) * 10) + 200;
+    return ret * 100 / (100 + cdata.player().get_skill(160).level * 10) + 200;
 }
 
 
@@ -1251,7 +1256,7 @@ int calcidentifyvalue(int type)
             cost = cost * need_to_identify * 70 / 100;
         }
     }
-    cost = cost * 100 / (100 + sdata(156, 0) * 2);
+    cost = cost * 100 / (100 + cdata.player().get_skill(156).level * 2);
 
     return game_data.guild.belongs_to_fighters_guild ? cost / 2 : cost;
 }
@@ -1260,7 +1265,7 @@ int calcidentifyvalue(int type)
 
 int calctraincost(int skill_id, int chara_index, bool discount)
 {
-    int platinum = sdata.get(skill_id, chara_index).original_level / 5 + 2;
+    int platinum = cdata[chara_index].get_skill(skill_id).base_level / 5 + 2;
     return discount ? platinum / 2 : platinum;
 }
 
@@ -1288,7 +1293,7 @@ int calc_resurrection_value(const Character& chara)
 
 int calc_slave_value(const Character& chara)
 {
-    int value = sdata(10, chara.index) * sdata(11, chara.index) +
+    int value = chara.get_skill(10).level * chara.get_skill(11).level +
         chara.level * chara.level + 1000;
     if (value > 50'000)
     {
@@ -1338,9 +1343,8 @@ int calc_spell_power(const Character& caster, int id)
     {
         if (the_ability_db[id]->related_basic_attribute != 0)
         {
-            return sdata(
-                       the_ability_db[id]->related_basic_attribute,
-                       caster.index) *
+            return caster.get_skill(the_ability_db[id]->related_basic_attribute)
+                       .level *
                 6 +
                 10;
         }
@@ -1348,13 +1352,13 @@ int calc_spell_power(const Character& caster, int id)
     }
     if (caster.index == 0)
     {
-        return sdata(id, caster.index) * 10 + 50;
+        return caster.get_skill(id).level * 10 + 50;
     }
-    if (sdata(172, caster.index) == 0 && caster.index >= 16)
+    if (caster.get_skill(172).level == 0 && caster.index >= 16)
     {
         return caster.level * 6 + 10;
     }
-    return sdata(172, caster.index) * 6 + 10;
+    return caster.get_skill(172).level * 6 + 10;
 }
 
 
@@ -1370,7 +1374,8 @@ int calc_spell_success_rate(const Character& caster, int id)
     {
         if (game_data.mount == caster.index)
         {
-            return 95 - clamp(30 - sdata(301, 0) / 2, 0, 30);
+            return 95 -
+                clamp(30 - cdata.player().get_skill(301).level / 2, 0, 30);
         }
         else
         {
@@ -1383,11 +1388,11 @@ int calc_spell_success_rate(const Character& caster, int id)
     int armor_skill = chara_armor_class(caster);
     if (armor_skill == 169)
     {
-        penalty = 17 - sdata(169, caster.index) / 5;
+        penalty = 17 - caster.get_skill(169).level / 5;
     }
     else if (armor_skill == 170)
     {
-        penalty = 12 - sdata(170, caster.index) / 5;
+        penalty = 12 - caster.get_skill(170).level / 5;
     }
     if (penalty < 4)
     {
@@ -1399,16 +1404,16 @@ int calc_spell_success_rate(const Character& caster, int id)
     }
     if (id == 441) // Wish
     {
-        penalty += sdata(id, caster.index);
+        penalty += caster.get_skill(id).level;
     }
     if (id == 464) // Harvest
     {
-        penalty += sdata(id, caster.index) / 3;
+        penalty += caster.get_skill(id).level / 3;
     }
 
-    int percentage = 90 + sdata(id, caster.index) -
+    int percentage = 90 + caster.get_skill(id).level -
         the_ability_db[id]->difficulty * penalty /
-            (5 + sdata(172, caster.index) * 4);
+            (5 + caster.get_skill(172).level * 4);
     if (armor_skill == 169)
     {
         if (percentage > 80)
@@ -1459,8 +1464,8 @@ int calc_spell_cost_mp(const Character& caster, int id)
         else
         {
             return the_ability_db[id]->cost *
-                (100 + sdata(id, caster.index) * 3) / 100 +
-                sdata(id, caster.index) / 8;
+                (100 + caster.get_skill(id).level * 3) / 100 +
+                caster.get_skill(id).level / 8;
         }
     }
     else
@@ -1477,7 +1482,7 @@ int calc_spell_cost_stock(const Character& caster, int id)
         return 1;
 
     int cost =
-        the_ability_db[id]->cost * 200 / (sdata(id, caster.index) * 3 + 100);
+        the_ability_db[id]->cost * 200 / (caster.get_skill(id).level * 3 + 100);
     if (cost < the_ability_db[id]->cost / 5)
     {
         cost = the_ability_db[id]->cost / 5;
@@ -1764,9 +1769,9 @@ int calc_exp_gain_healing(const Character& chara)
 {
     if (chara.hp != chara.max_hp)
     {
-        if (sdata(154, chara.index) < sdata(11, chara.index))
+        if (chara.get_skill(154).level < chara.get_skill(11).level)
         {
-            return 5 + sdata(154, chara.index) / 5;
+            return 5 + chara.get_skill(154).level / 5;
         }
     }
 
@@ -1777,9 +1782,9 @@ int calc_exp_gain_meditation(const Character& chara)
 {
     if (chara.mp != chara.max_mp)
     {
-        if (sdata(155, chara.index) < sdata(16, chara.index))
+        if (chara.get_skill(155).level < chara.get_skill(16).level)
         {
-            return 5 + sdata(155, chara.index) / 5;
+            return 5 + chara.get_skill(155).level / 5;
         }
     }
 

--- a/src/elona/casino.cpp
+++ b/src/elona/casino.cpp
@@ -630,7 +630,8 @@ bool casino_blackjack()
             }
             list(0, listmax) = 2;
             listn(0, listmax) = i18n::s.get(
-                "core.casino.blackjack.game.choices.cheat", sdata(12, 0));
+                "core.casino.blackjack.game.choices.cheat",
+                cdata.player().get_skill(12).level);
             ++listmax;
         }
         chatesc = -1;
@@ -653,7 +654,7 @@ bool casino_blackjack()
                 {
                     if (pileremain() > 10)
                     {
-                        if (rnd_capped(sdata(19, 0)) > 40)
+                        if (rnd_capped(cdata.player().get_skill(19).level) > 40)
                         {
                             txt(i18n::s.get(
                                 "core.casino.blackjack.game.bad_feeling"));
@@ -680,7 +681,7 @@ bool casino_blackjack()
             {
                 p = 60;
             }
-            if (rnd_capped(sdata(12, 0)) < rnd(p(0)))
+            if (rnd_capped(cdata.player().get_skill(12).level) < rnd(p(0)))
             {
                 atxinit();
                 noteadd(i18n::s.get("core.casino.blackjack.game.cheat.dialog"));

--- a/src/elona/chara_db.cpp
+++ b/src/elona/chara_db.cpp
@@ -2,6 +2,7 @@
 #include "calc.hpp"
 #include "character.hpp"
 #include "class.hpp"
+#include "data/types/type_ability.hpp"
 #include "draw.hpp"
 #include "elona.hpp"
 #include "food.hpp"
@@ -65,7 +66,7 @@ void chara_db_set_stats(Character& chara, CharaId chara_id)
     {
         if (const auto ability_data = the_ability_db[pair.first])
         {
-            sdata(ability_data->legacy_id, chara.index) = pair.second;
+            chara.get_skill(ability_data->legacy_id).level = pair.second;
         }
         else
         {

--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -697,7 +697,7 @@ void chara_refresh(Character& chara)
     }
     for (int cnt = 0; cnt < 600; ++cnt)
     {
-        sdata(cnt, chara.index) = sdata.get(cnt, chara.index).original_level;
+        chara.get_skill(cnt).level = chara.get_skill(cnt).base_level;
     }
     if (chara.index == 0)
     {
@@ -804,26 +804,27 @@ void chara_refresh(Character& chara)
                 rp2 = rp2 / 10000;
                 if (rp2 == 1)
                 {
-                    sdata(rp3, chara.index) += enchantment.power / 50 + 1;
+                    chara.get_skill(rp3).level += enchantment.power / 50 + 1;
                     continue;
                 }
                 if (rp2 == 2)
                 {
-                    sdata(rp3, chara.index) += enchantment.power / 2;
-                    if (sdata(rp3, chara.index) < 0)
+                    chara.get_skill(rp3).level += enchantment.power / 2;
+                    if (chara.get_skill(rp3).level < 0)
                     {
-                        sdata(rp3, chara.index) = 1;
+                        chara.get_skill(rp3).level = 1;
                     }
                     continue;
                 }
                 if (rp2 == 3)
                 {
-                    if (sdata.get(rp3, chara.index).original_level != 0)
+                    if (chara.get_skill(rp3).base_level != 0)
                     {
-                        sdata(rp3, chara.index) += enchantment.power / 50 + 1;
-                        if (sdata(rp3, chara.index) < 1)
+                        chara.get_skill(rp3).level +=
+                            enchantment.power / 50 + 1;
+                        if (chara.get_skill(rp3).level < 1)
                         {
-                            sdata(rp3, chara.index) = 1;
+                            chara.get_skill(rp3).level = 1;
                         }
                     }
                     continue;
@@ -849,7 +850,7 @@ void chara_refresh(Character& chara)
                 }
                 if (rp2 == 29)
                 {
-                    sdata(18, chara.index) += enchantment.power / 50 + 1;
+                    chara.get_skill(18).level += enchantment.power / 50 + 1;
                     if (chara.index == 0)
                     {
                         game_data.seven_league_boot_effect +=
@@ -977,10 +978,13 @@ void chara_refresh(Character& chara)
         buff += u8"<title1>◆ 装備による能力の修正<def>\n"s;
         for (int cnt = 0; cnt < 600; ++cnt)
         {
-            sdata(cnt, 56) = sdata.get(cnt, chara.index).original_level;
-            if (sdata(cnt, 56) != sdata(cnt, chara.index))
+            cdata.tmp().get_skill(cnt).level = chara.get_skill(cnt).base_level;
+            if (cdata.tmp().get_skill(cnt).level != chara.get_skill(cnt).level)
             {
-                cnvbonus(cnt, sdata(cnt, chara.index) - sdata(cnt, 56));
+                cnvbonus(
+                    cnt,
+                    chara.get_skill(cnt).level -
+                        cdata.tmp().get_skill(cnt).level);
             }
         }
     }
@@ -991,17 +995,17 @@ void chara_refresh(Character& chara)
             if (chara.quality >= Quality::miracle)
             {
                 if (chara.attr_adjs[cnt] <
-                    sdata.get(10 + cnt, chara.index).original_level / 5)
+                    chara.get_skill(10 + cnt).base_level / 5)
                 {
                     chara.attr_adjs[cnt] =
-                        sdata.get(10 + cnt, chara.index).original_level / 5;
+                        chara.get_skill(10 + cnt).base_level / 5;
                 }
             }
-            sdata(10 + cnt, chara.index) += chara.attr_adjs[cnt];
+            chara.get_skill(10 + cnt).level += chara.attr_adjs[cnt];
         }
-        if (sdata(10 + cnt, chara.index) < 1)
+        if (chara.get_skill(10 + cnt).level < 1)
         {
-            sdata(10 + cnt, chara.index) = 1;
+            chara.get_skill(10 + cnt).level = 1;
         }
     }
     if (chara.index == 0)
@@ -1020,7 +1024,7 @@ void chara_refresh(Character& chara)
         if (chara.pv > 0)
         {
             chara.pv = chara.pv *
-                (120 + int(std::sqrt(sdata(168, chara.index))) * 2) / 100;
+                (120 + int(std::sqrt(chara.get_skill(168).level)) * 2) / 100;
         }
     }
     else if (attacknum == 1)
@@ -1031,24 +1035,27 @@ void chara_refresh(Character& chara)
     {
         chara.combat_style.set_dual_wield();
     }
-    chara.max_mp = clamp(
-                       ((sdata(16, chara.index) * 2 + sdata(15, chara.index) +
-                         sdata(14, chara.index) / 3) *
-                            chara.level / 25 +
-                        sdata(16, chara.index)),
-                       1,
-                       1000000) *
-        sdata(3, chara.index) / 100;
-    chara.max_hp = clamp(
-                       ((sdata(11, chara.index) * 2 + sdata(10, chara.index) +
-                         sdata(15, chara.index) / 3) *
-                            chara.level / 25 +
-                        sdata(11, chara.index)),
-                       1,
-                       1000000) *
-            sdata(2, chara.index) / 100 +
+    chara.max_mp =
+        clamp(
+            ((chara.get_skill(16).level * 2 + chara.get_skill(15).level +
+              chara.get_skill(14).level / 3) *
+                 chara.level / 25 +
+             chara.get_skill(16).level),
+            1,
+            1000000) *
+        chara.get_skill(3).level / 100;
+    chara.max_hp =
+        clamp(
+            ((chara.get_skill(11).level * 2 + chara.get_skill(10).level +
+              chara.get_skill(15).level / 3) *
+                 chara.level / 25 +
+             chara.get_skill(11).level),
+            1,
+            1000000) *
+            chara.get_skill(2).level / 100 +
         5;
-    chara.max_sp = 100 + (sdata(15, chara.index) + sdata(11, chara.index)) / 5 +
+    chara.max_sp = 100 +
+        (chara.get_skill(15).level + chara.get_skill(11).level) / 5 +
         trait(24) * 8;
     if (chara.max_mp < 1)
     {
@@ -1090,12 +1097,12 @@ void chara_refresh(Character& chara)
     if (chara.combat_style.dual_wield())
     {
         chara.extra_attack +=
-            int(std::sqrt(sdata(166, chara.index))) * 3 / 2 + 4;
+            int(std::sqrt(chara.get_skill(166).level)) * 3 / 2 + 4;
     }
-    if (sdata(186, chara.index))
+    if (chara.get_skill(186).level)
     {
         chara.rate_of_critical_hit +=
-            int(std::sqrt(sdata(186, chara.index))) + 2;
+            int(std::sqrt(chara.get_skill(186).level)) + 2;
     }
     if (chara.rate_of_critical_hit > 30)
     {
@@ -1188,7 +1195,8 @@ int chara_get_free_slot()
 
 int chara_get_free_slot_ally()
 {
-    const auto max_allies = clamp(sdata(17, 0) / 5 + 1, 2, 15);
+    const auto max_allies =
+        clamp(cdata.player().get_skill(17).level / 5 + 1, 2, 15);
     for (int i = 1; i < max_allies + 1; ++i)
     {
         if (cdata[i].state() != Character::State::empty)
@@ -1425,7 +1433,6 @@ int chara_copy(const Character& source)
 
     // Copy from `source` to `destination`.
     Character::copy(source, destination);
-    sdata.copy(slot, source.index);
     lua::lua->get_handle_manager().create_chara_handle_run_callbacks(
         destination);
 
@@ -1501,7 +1508,6 @@ void chara_delete(int chara_index)
     {
         item->remove();
     }
-    sdata.clear(chara_index);
     cdata[chara_index].clear();
 }
 
@@ -1548,9 +1554,6 @@ void chara_relocate(
     source.is_livestock() = false;
 
     // Copy from `source` to `destination` and clear `source`
-    sdata.copy(destination.index, source.index);
-    sdata.clear(source.index);
-
     Character::copy(source, destination);
     source.clear();
 
@@ -1617,19 +1620,18 @@ void chara_relocate(
         for (int element = 50; element < 61; ++element)
         {
             auto resistance = 100;
-            if (sdata.get(element, destination.index).original_level >= 500 ||
-                sdata.get(element, destination.index).original_level <= 100)
+            if (destination.get_skill(element).base_level >= 500 ||
+                destination.get_skill(element).base_level <= 100)
             {
-                resistance =
-                    sdata.get(element, destination.index).original_level;
+                resistance = destination.get_skill(element).base_level;
             }
             if (resistance > 500)
             {
                 resistance = 500;
             }
-            sdata.get(element, destination.index).original_level = resistance;
-            sdata.get(element, destination.index).experience = 0;
-            sdata.get(element, destination.index).potential = 0;
+            destination.get_skill(element).base_level = resistance;
+            destination.get_skill(element).experience = 0;
+            destination.get_skill(element).potential = 0;
         }
     }
 
@@ -1726,7 +1728,7 @@ void initialize_pc_character()
     {
         item->set_number(2);
     }
-    if (sdata(150, 0) == 0)
+    if (cdata.player().get_skill(150).level == 0)
     {
         flt();
         if (const auto item = itemcreate_player_inv(68, 0))
@@ -2064,7 +2066,9 @@ void refresh_burden_state()
         clamp(inv_weight(g_inv.pc()), 0, 20000000) *
         (100 - trait(201) * 10 + trait(205) * 20) / 100;
     cdata.player().max_inventory_weight =
-        sdata(10, 0) * 500 + sdata(11, 0) * 250 + sdata(153, 0) * 2000 + 45000;
+        cdata.player().get_skill(10).level * 500 +
+        cdata.player().get_skill(11).level * 250 +
+        cdata.player().get_skill(153).level * 2000 + 45000;
     game_data.cargo_weight = inv_cargo_weight(g_inv.pc());
     for (int cnt = 0; cnt < 1; ++cnt)
     {
@@ -2517,7 +2521,7 @@ bool move_character_internal(Character& chara)
         refdiff = refdiff / 3;
         if (chara.index == 0)
         {
-            if (sdata(175, chara.index) != 0)
+            if (chara.get_skill(175).level != 0)
             {
                 if (try_to_disarm_trap(chara))
                 {

--- a/src/elona/character.hpp
+++ b/src/elona/character.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "../util/range.hpp"
+#include "ability.hpp"
 #include "consts.hpp"
 #include "data/types/type_character.hpp"
 #include "eobject/eobject.hpp"
@@ -404,6 +405,24 @@ public:
     data::InstanceId race;
     data::InstanceId class_;
     std::string talk;
+
+
+
+private:
+    SkillData _skills;
+
+
+public:
+    Ability& get_skill(int id)
+    {
+        return _skills.get(id);
+    }
+
+
+    const Ability& get_skill(int id) const
+    {
+        return _skills.get(id);
+    }
 
 
 

--- a/src/elona/character_making.cpp
+++ b/src/elona/character_making.cpp
@@ -5,6 +5,7 @@
 #include "character.hpp"
 #include "class.hpp"
 #include "config.hpp"
+#include "data/types/type_ability.hpp"
 #include "draw.hpp"
 #include "i18n.hpp"
 #include "input.hpp"
@@ -264,9 +265,11 @@ static void _reroll_character()
     cdata.player().level = 1;
     for (int cnt = 10; cnt < 18; ++cnt)
     {
-        sdata.get(cnt, 0).original_level = cmstats(cnt - 10) / 1'000'000;
-        sdata.get(cnt, 0).experience = cmstats(cnt - 10) % 1'000'000 / 1'000;
-        sdata.get(cnt, 0).potential = cmstats(cnt - 10) % 1'000;
+        cdata.player().get_skill(cnt).base_level =
+            cmstats(cnt - 10) / 1'000'000;
+        cdata.player().get_skill(cnt).experience =
+            cmstats(cnt - 10) % 1'000'000 / 1'000;
+        cdata.player().get_skill(cnt).potential = cmstats(cnt - 10) % 1'000;
     }
     initialize_character(cdata.player());
     initialize_pc_character();
@@ -445,37 +448,37 @@ void draw_race_or_class_info(const std::string& description)
             }
             r = cnt2 * 3 + cnt + 10;
             snail::Color text_color{0, 0, 0};
-            if (sdata.get(r, 0).original_level > 13)
+            if (cdata.player().get_skill(r).base_level > 13)
             {
                 p = 1;
                 text_color = snail::Color{0, 0, 200};
             }
-            else if (sdata.get(r, 0).original_level > 11)
+            else if (cdata.player().get_skill(r).base_level > 11)
             {
                 p = 2;
                 text_color = snail::Color{0, 0, 200};
             }
-            else if (sdata.get(r, 0).original_level > 9)
+            else if (cdata.player().get_skill(r).base_level > 9)
             {
                 p = 3;
                 text_color = snail::Color{0, 0, 150};
             }
-            else if (sdata.get(r, 0).original_level > 7)
+            else if (cdata.player().get_skill(r).base_level > 7)
             {
                 p = 4;
                 text_color = snail::Color{0, 0, 150};
             }
-            else if (sdata.get(r, 0).original_level > 5)
+            else if (cdata.player().get_skill(r).base_level > 5)
             {
                 p = 5;
                 text_color = snail::Color{0, 0, 0};
             }
-            else if (sdata.get(r, 0).original_level > 3)
+            else if (cdata.player().get_skill(r).base_level > 3)
             {
                 p = 6;
                 text_color = snail::Color{150, 0, 0};
             }
-            else if (sdata.get(r, 0).original_level > 0)
+            else if (cdata.player().get_skill(r).base_level > 0)
             {
                 p = 7;
                 text_color = snail::Color{200, 0, 0};
@@ -516,7 +519,7 @@ void draw_race_or_class_info(const std::string& description)
         "core.chara_making.select_race.race_info.trained_skill.proficient_in");
     for (int cnt = 100; cnt < 150; ++cnt)
     {
-        if (sdata.get(cnt, 0).original_level != 0)
+        if (cdata.player().get_skill(cnt).base_level != 0)
         {
             if (r != 0)
             {
@@ -535,7 +538,7 @@ void draw_race_or_class_info(const std::string& description)
     }
     for (int cnt = 150; cnt < 600; ++cnt)
     {
-        if (sdata.get(cnt, 0).original_level != 0)
+        if (cdata.player().get_skill(cnt).base_level != 0)
         {
             s = the_ability_db.get_text(cnt, "name");
             if (jp)

--- a/src/elona/character_status.cpp
+++ b/src/elona/character_status.cpp
@@ -198,8 +198,8 @@ void modify_ether_disease_stage(int delta)
 
 void modify_potential(Character& chara, int id, int delta)
 {
-    sdata.get(id, chara.index).potential =
-        clamp(sdata.get(id, chara.index).potential + delta, 2, 400);
+    chara.get_skill(id).potential =
+        clamp(chara.get_skill(id).potential + delta, 2, 400);
 }
 
 
@@ -326,7 +326,7 @@ void modify_height(Character& chara, int delta)
 
 void refresh_speed(Character& chara)
 {
-    chara.current_speed = sdata(18, chara.index) *
+    chara.current_speed = chara.get_skill(18).level *
         clamp((100 - chara.speed_correction_value), 0, 100) / 100;
     if (chara.current_speed < 10)
     {
@@ -339,13 +339,14 @@ void refresh_speed(Character& chara)
 
     if (game_data.mount != 0)
     {
-        const auto mount_speed = sdata(18, game_data.mount) *
+        const auto mount_speed = cdata[game_data.mount].get_skill(18).level *
             clamp(100 - cdata[game_data.mount].speed_correction_value, 0, 100) /
             100;
 
         cdata.player().current_speed = mount_speed * 100 /
-            clamp(100 + mount_speed - sdata(10, game_data.mount) * 3 / 2 -
-                      sdata(301, 0) * 2 -
+            clamp(100 + mount_speed -
+                      cdata[game_data.mount].get_skill(10).level * 3 / 2 -
+                      cdata.player().get_skill(301).level * 2 -
                       (cdata[game_data.mount].is_suitable_for_mount() == 1) *
                           50,
                   100,
@@ -356,13 +357,15 @@ void refresh_speed(Character& chara)
         }
         if (game_data.mount == chara.index)
         {
-            chara.current_speed =
-                clamp(sdata(10, chara.index) + sdata(301, 0), 10, mount_speed);
+            chara.current_speed = clamp(
+                chara.get_skill(10).level + cdata.player().get_skill(301).level,
+                10,
+                mount_speed);
             return;
         }
     }
 
-    gspdorg = sdata.get(18, 0).original_level;
+    gspdorg = cdata.player().get_skill(18).base_level;
 
     if (game_data.mount == 0)
     {
@@ -505,7 +508,7 @@ void gain_level(Character& chara)
     {
         addnews(2, chara.index);
     }
-    p = 5 * (100 + sdata.get(14, chara.index).original_level * 10) /
+    p = 5 * (100 + chara.get_skill(14).base_level * 10) /
             (300 + chara.level * 15) +
         1;
     if (chara.index == 0)
@@ -556,18 +559,18 @@ void grow_primary_skills(Character& chara)
 {
     for (int i = 10; i < 20; ++i)
     {
-        sdata.get(i, chara.index).original_level += rnd(3);
-        if (sdata.get(i, chara.index).original_level > 2000)
+        chara.get_skill(i).base_level += rnd(3);
+        if (chara.get_skill(i).base_level > 2000)
         {
-            sdata.get(i, chara.index).original_level = 2000;
+            chara.get_skill(i).base_level = 2000;
         }
     }
     for (const auto& skill : mainskill)
     {
-        sdata.get(skill, chara.index).original_level += rnd(3);
-        if (sdata.get(skill, chara.index).original_level > 2000)
+        chara.get_skill(skill).base_level += rnd(3);
+        if (chara.get_skill(skill).base_level > 2000)
         {
-            sdata.get(skill, chara.index).original_level = 2000;
+            chara.get_skill(skill).base_level = 2000;
         }
     }
 }
@@ -635,9 +638,9 @@ int gain_skills_by_geen_engineering(
     for (int cnt = 0; cnt < 100; ++cnt)
     {
         rtval = rnd(40) + 150;
-        if (sdata(rtval, original_ally.index) == 0)
+        if (original_ally.get_skill(rtval).level == 0)
         {
-            if (sdata(rtval, gene_ally.index) > 0)
+            if (gene_ally.get_skill(rtval).level > 0)
             {
                 dblist(0, dbmax) = rtval;
                 ++dbmax;

--- a/src/elona/class.cpp
+++ b/src/elona/class.cpp
@@ -2,6 +2,7 @@
 
 #include "ability.hpp"
 #include "character.hpp"
+#include "data/types/type_ability.hpp"
 #include "elona.hpp"
 #include "i18n.hpp"
 #include "variables.hpp"

--- a/src/elona/crafting.cpp
+++ b/src/elona/crafting.cpp
@@ -378,12 +378,12 @@ static Quality _determine_crafted_fixlv(const CraftingRecipe& recipe)
 {
     Quality ret = Quality::good;
     if (rnd(200 + recipe.required_skill_level * 2) <
-        sdata(recipe.skill_used, 0) + 20)
+        cdata.player().get_skill(recipe.skill_used).level + 20)
     {
         ret = Quality::miracle;
     }
     if (rnd(100 + recipe.required_skill_level * 2) <
-        sdata(recipe.skill_used, 0) + 20)
+        cdata.player().get_skill(recipe.skill_used).level + 20)
     {
         ret = Quality::great;
     }
@@ -396,7 +396,8 @@ static Quality _determine_crafted_fixlv(const CraftingRecipe& recipe)
 static void _craft_item(int matid, const CraftingRecipe& recipe)
 {
     fixlv = _determine_crafted_fixlv(recipe);
-    flt(calcobjlv(sdata(recipe.skill_used, 0)), calcfixlv(fixlv));
+    flt(calcobjlv(cdata.player().get_skill(recipe.skill_used).level),
+        calcfixlv(fixlv));
     nostack = 1;
     if (const auto item = itemcreate_player_inv(matid, 0))
     {

--- a/src/elona/ctrl_file.cpp
+++ b/src/elona/ctrl_file.cpp
@@ -564,7 +564,7 @@ void fmode_7_8(bool read, const fs::path& dir)
                 {
                     for (int i = 0; i < 600; ++i)
                     {
-                        ar(sdata.get(i, chara_index));
+                        ar(cdata[chara_index].get_skill(i));
                     }
                 }
             }
@@ -578,7 +578,7 @@ void fmode_7_8(bool read, const fs::path& dir)
             {
                 for (int i = 0; i < 600; ++i)
                 {
-                    ar(sdata.get(i, chara_index));
+                    ar(cdata[chara_index].get_skill(i));
                 }
             }
         }
@@ -948,7 +948,7 @@ void fmode_14_15(bool read)
                 {
                     for (int i = 0; i < 600; ++i)
                     {
-                        ar(sdata.get(i, chara_index));
+                        ar(cdata[chara_index].get_skill(i));
                     }
                 }
             }
@@ -963,7 +963,7 @@ void fmode_14_15(bool read)
             {
                 for (int i = 0; i < 600; ++i)
                 {
-                    ar(sdata.get(i, chara_index));
+                    ar(cdata[chara_index].get_skill(i));
                 }
             }
         }
@@ -1191,7 +1191,7 @@ void fmode_1_2(bool read)
             {
                 for (int i = 0; i < 600; ++i)
                 {
-                    ar(sdata.get(i, chara_index));
+                    ar(cdata[chara_index].get_skill(i));
                 }
             }
         }
@@ -1206,7 +1206,7 @@ void fmode_1_2(bool read)
             {
                 for (int i = 0; i < 600; ++i)
                 {
-                    ar(sdata.get(i, chara_index));
+                    ar(cdata[chara_index].get_skill(i));
                 }
             }
         }
@@ -1472,7 +1472,7 @@ void fmode_17()
         {
             for (int i = 0; i < 600; ++i)
             {
-                ar(sdata.get(i, chara_index));
+                ar(cdata[chara_index].get_skill(i));
             }
         }
     }

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -1742,9 +1742,9 @@ OnEnterResult on_enter_give(
         return OnEnterResult{result};
     }
     f = 0;
-    p = sdata(10, inventory_owner.index) * 500 +
-        sdata(11, inventory_owner.index) * 500 +
-        sdata(153, inventory_owner.index) * 2500 + 25000;
+    p = inventory_owner.get_skill(10).level * 500 +
+        inventory_owner.get_skill(11).level * 500 +
+        inventory_owner.get_skill(153).level * 2500 + 25000;
     if (inventory_owner.id == CharaId::golden_knight)
     {
         p *= 5;

--- a/src/elona/deferred_event.cpp
+++ b/src/elona/deferred_event.cpp
@@ -257,7 +257,7 @@ void eh_player_died(const DeferredEvent&)
     {
         for (int i = 10; i < 18; ++i)
         {
-            if (sdata(i, 0) != 0 && rnd(3) == 0)
+            if (cdata.player().get_skill(i).level != 0 && rnd(3) == 0)
             {
                 chara_gain_skill_exp(cdata.player(), i, -500);
             }

--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -198,7 +198,7 @@ int damage_hp(
     }
     if (element != 0 && element < 61)
     {
-        int resistance = sdata(element, victim.index) / 50;
+        int resistance = victim.get_skill(element).level / 50;
         if (resistance < 3)
         {
             dmg_at_m141 =
@@ -212,7 +212,7 @@ int damage_hp(
         {
             dmg_at_m141 = 0;
         }
-        dmg_at_m141 = dmg_at_m141 * 100 / (sdata(60, victim.index) / 2 + 50);
+        dmg_at_m141 = dmg_at_m141 * 100 / (victim.get_skill(60).level / 2 + 50);
     }
     if (attacker && attacker->index == 0)
     {
@@ -1227,7 +1227,7 @@ int damage_hp(
             {
                 catitem = attacker->index;
             }
-            if (int(std::sqrt(sdata(161, attacker->index))) > rnd(150))
+            if (int(std::sqrt(attacker->get_skill(161).level)) > rnd(150))
             {
                 rollanatomy = 1;
             }
@@ -1310,7 +1310,7 @@ void damage_mp(Character& chara, int delta)
     if (chara.mp < 0)
     {
         chara_gain_exp_mana_capacity(chara);
-        auto damage = -chara.mp * 400 / (100 + sdata(164, chara.index) * 10);
+        auto damage = -chara.mp * 400 / (100 + chara.get_skill(164).level * 10);
         if (chara.index == 0)
         {
             if (trait(156) == 1)
@@ -1382,7 +1382,7 @@ void damage_insanity(Character& chara, int delta)
     if (chara.quality >= Quality::miracle)
         return;
 
-    int resistance = std::max(sdata(54, chara.index) / 50, 1);
+    int resistance = std::max(chara.get_skill(54).level / 50, 1);
     if (resistance > 10)
         return;
 
@@ -2054,10 +2054,11 @@ void character_drops_item(Character& victim)
             remain_make(item.unwrap(), victim);
             if (victim.is_livestock() == 1)
             {
-                if (sdata(161, 0) != 0)
+                if (cdata.player().get_skill(161).level != 0)
                 {
-                    item->modify_number(
-                        rnd(1 + (sdata(161, 0) > victim.level)));
+                    item->modify_number(rnd(
+                        1 +
+                        (cdata.player().get_skill(161).level > victim.level)));
                 }
             }
         }

--- a/src/elona/dump_player_info.cpp
+++ b/src/elona/dump_player_info.cpp
@@ -93,10 +93,12 @@ void dump_player_info()
 
     ss << std::endl;
 
-    s(1) = u8"生命力    : " + std::to_string(sdata(2, 0)) + u8"(" +
-        std::to_string(sdata.get(2, 0).original_level) + u8")";
-    s(2) = u8"マナ      : " + std::to_string(sdata(3, 0)) + u8"(" +
-        std::to_string(sdata.get(3, 0).original_level) + u8")";
+    s(1) = u8"生命力    : " +
+        std::to_string(cdata.player().get_skill(2).level) + u8"(" +
+        std::to_string(cdata.player().get_skill(2).base_level) + u8")";
+    s(2) = u8"マナ      : " +
+        std::to_string(cdata.player().get_skill(3).level) + u8"(" +
+        std::to_string(cdata.player().get_skill(3).base_level) + u8")";
     s(3) = u8"狂気度    : " + std::to_string(cdata.player().insanity);
     s(4) = u8"速度      : " + std::to_string(cdata.player().current_speed);
     s(5) = u8"名声度    : " + std::to_string(cdata.player().fame);
@@ -108,7 +110,7 @@ void dump_player_info()
     for (int cnt = 0; cnt < 8; ++cnt)
     {
         s = "";
-        p = sdata.get(10 + cnt, 0).potential;
+        p = cdata.player().get_skill(10 + cnt).potential;
         if (p >= 200)
         {
             s += u8"superb"s;
@@ -132,8 +134,8 @@ void dump_player_info()
         s = fixtxt(s, 15);
         s = fixtxt(
                 i18n::s.get_enum("core.ui.attribute", cnt) + u8"    : "s +
-                    sdata((10 + cnt), 0) + u8"("s +
-                    sdata.get(10 + cnt, 0).original_level + u8")"s,
+                    cdata.player().get_skill(10 + cnt).level + u8"("s +
+                    cdata.player().get_skill(10 + cnt).base_level + u8")"s,
                 24) +
             s;
 

--- a/src/elona/element.cpp
+++ b/src/elona/element.cpp
@@ -4,6 +4,7 @@
 #include "animation.hpp"
 #include "audio.hpp"
 #include "character.hpp"
+#include "data/types/type_ability.hpp"
 #include "elona.hpp"
 #include "fov.hpp"
 #include "i18n.hpp"
@@ -107,8 +108,8 @@ void chara_gain_registance(Character& chara, int element, int delta)
             Message::color{ColorIndex::purple});
     }
 
-    sdata.get(element, chara.index).original_level =
-        clamp(sdata.get(element, chara.index).original_level + delta, 50, 200);
+    chara.get_skill(element).base_level =
+        clamp(chara.get_skill(element).base_level + delta, 50, 200);
     snd("core.atk_elec");
     animeload(15, chara);
 

--- a/src/elona/food.cpp
+++ b/src/elona/food.cpp
@@ -8,6 +8,7 @@
 #include "chara_db.hpp"
 #include "character.hpp"
 #include "character_status.hpp"
+#include "data/types/type_ability.hpp"
 #include "data/types/type_buff.hpp"
 #include "data/types/type_item.hpp"
 #include "debug.hpp"
@@ -405,18 +406,18 @@ void food_cook(Character& cook, const ItemRef& cook_tool, const ItemRef& food)
 
     const auto item_name_prev = itemname(food);
 
-    int dish_rank = rnd_capped(sdata(184, cook.index) + 6) +
+    int dish_rank = rnd_capped(cook.get_skill(184).level + 6) +
         rnd(cook_tool->param1 / 50 + 1);
-    if (dish_rank > sdata(184, cook.index) / 5 + 7)
+    if (dish_rank > cook.get_skill(184).level / 5 + 7)
     {
-        dish_rank = sdata(184, cook.index) / 5 + 7;
+        dish_rank = cook.get_skill(184).level / 5 + 7;
     }
     dish_rank = rnd(dish_rank + 1);
     if (dish_rank > 3)
     {
         dish_rank = rnd(dish_rank);
     }
-    if (sdata(184, cook.index) >= 5)
+    if (cook.get_skill(184).level >= 5)
     {
         if (dish_rank < 3)
         {
@@ -426,7 +427,7 @@ void food_cook(Character& cook, const ItemRef& cook_tool, const ItemRef& food)
             }
         }
     }
-    if (sdata(184, cook.index) >= 10)
+    if (cook.get_skill(184).level >= 10)
     {
         if (dish_rank < 3)
         {
@@ -1229,15 +1230,15 @@ void apply_general_eating_effect(Character& eater, const ItemRef& food)
             txt(i18n::s.get("core.food.effect.little_sister", eater),
                 Message::color{ColorIndex::green});
             if (rnd_capped(
-                    sdata.get(2, eater.index).original_level *
-                        sdata.get(2, eater.index).original_level +
+                    eater.get_skill(2).base_level *
+                        eater.get_skill(2).base_level +
                     1) < 2000)
             {
                 chara_gain_fixed_skill_exp(eater, 2, 1000);
             }
             if (rnd_capped(
-                    sdata.get(3, eater.index).original_level *
-                        sdata.get(3, eater.index).original_level +
+                    eater.get_skill(3).base_level *
+                        eater.get_skill(3).base_level +
                     1) < 2000)
             {
                 chara_gain_fixed_skill_exp(eater, 3, 1000);
@@ -1246,7 +1247,7 @@ void apply_general_eating_effect(Character& eater, const ItemRef& food)
             {
                 if (!the_ability_db[cnt] ||
                     the_ability_db[cnt]->related_basic_attribute == 0 ||
-                    sdata.get(cnt, eater.index).original_level == 0)
+                    eater.get_skill(cnt).base_level == 0)
                 {
                     continue;
                 }

--- a/src/elona/fov.cpp
+++ b/src/elona/fov.cpp
@@ -2,6 +2,7 @@
 
 #include "ability.hpp"
 #include "character.hpp"
+#include "data/types/type_ability.hpp"
 #include "map.hpp"
 #include "map_cell.hpp"
 #include "variables.hpp"

--- a/src/elona/god.cpp
+++ b/src/elona/god.cpp
@@ -127,7 +127,7 @@ void god_modify_piety(int amount)
     }
 
     // Faith skill is not enough.
-    if (sdata(181, 0) * 100 < cdata.player().piety_point)
+    if (cdata.player().get_skill(181).level * 100 < cdata.player().piety_point)
     {
         txt(i18n::s.get("core.god.indifferent"));
         return;
@@ -164,207 +164,207 @@ void set_npc_religion(Character& chara)
 void god_apply_blessing(Character& believer)
 {
     const auto P = believer.piety_point;
-    const auto F = sdata(181, believer.index);
+    const auto F = believer.get_skill(181).level;
 
     if (believer.god_id == core_god::mani)
     {
-        if (sdata(12, believer.index) > 0)
+        if (believer.get_skill(12).level > 0)
         {
-            sdata(12, believer.index) += clamp(P / 400, 1, 8 + F / 10);
+            believer.get_skill(12).level += clamp(P / 400, 1, 8 + F / 10);
         }
-        if (sdata(13, believer.index) > 0)
+        if (believer.get_skill(13).level > 0)
         {
-            sdata(13, believer.index) += clamp(P / 300, 1, 14 + F / 10);
+            believer.get_skill(13).level += clamp(P / 300, 1, 14 + F / 10);
         }
-        if (sdata(154, believer.index) > 0)
+        if (believer.get_skill(154).level > 0)
         {
-            sdata(154, believer.index) += clamp(P / 500, 1, 8 + F / 10);
+            believer.get_skill(154).level += clamp(P / 500, 1, 8 + F / 10);
         }
-        if (sdata(110, believer.index) > 0)
+        if (believer.get_skill(110).level > 0)
         {
-            sdata(110, believer.index) += clamp(P / 250, 1, 18 + F / 10);
+            believer.get_skill(110).level += clamp(P / 250, 1, 18 + F / 10);
         }
-        if (sdata(159, believer.index) > 0)
+        if (believer.get_skill(159).level > 0)
         {
-            sdata(159, believer.index) += clamp(P / 350, 1, 8 + F / 10);
+            believer.get_skill(159).level += clamp(P / 350, 1, 8 + F / 10);
         }
-        if (sdata(158, believer.index) > 0)
+        if (believer.get_skill(158).level > 0)
         {
-            sdata(158, believer.index) += clamp(P / 250, 1, 16 + F / 10);
+            believer.get_skill(158).level += clamp(P / 250, 1, 16 + F / 10);
         }
-        if (sdata(176, believer.index) > 0)
+        if (believer.get_skill(176).level > 0)
         {
-            sdata(176, believer.index) += clamp(P / 300, 1, 10 + F / 10);
+            believer.get_skill(176).level += clamp(P / 300, 1, 10 + F / 10);
         }
-        if (sdata(179, believer.index) > 0)
+        if (believer.get_skill(179).level > 0)
         {
-            sdata(179, believer.index) += clamp(P / 350, 1, 12 + F / 10);
+            believer.get_skill(179).level += clamp(P / 350, 1, 12 + F / 10);
         }
     }
     if (believer.god_id == core_god::lulwy)
     {
-        if (sdata(13, believer.index) > 0)
+        if (believer.get_skill(13).level > 0)
         {
-            sdata(13, believer.index) += clamp(P / 450, 1, 10 + F / 10);
+            believer.get_skill(13).level += clamp(P / 450, 1, 10 + F / 10);
         }
-        if (sdata(18, believer.index) > 0)
+        if (believer.get_skill(18).level > 0)
         {
-            sdata(18, believer.index) += clamp(P / 350, 1, 30 + F / 10);
+            believer.get_skill(18).level += clamp(P / 350, 1, 30 + F / 10);
         }
-        if (sdata(108, believer.index) > 0)
+        if (believer.get_skill(108).level > 0)
         {
-            sdata(108, believer.index) += clamp(P / 350, 1, 16 + F / 10);
+            believer.get_skill(108).level += clamp(P / 350, 1, 16 + F / 10);
         }
-        if (sdata(109, believer.index) > 0)
+        if (believer.get_skill(109).level > 0)
         {
-            sdata(109, believer.index) += clamp(P / 450, 1, 12 + F / 10);
+            believer.get_skill(109).level += clamp(P / 450, 1, 12 + F / 10);
         }
-        if (sdata(157, believer.index) > 0)
+        if (believer.get_skill(157).level > 0)
         {
-            sdata(157, believer.index) += clamp(P / 450, 1, 12 + F / 10);
+            believer.get_skill(157).level += clamp(P / 450, 1, 12 + F / 10);
         }
-        if (sdata(174, believer.index) > 0)
+        if (believer.get_skill(174).level > 0)
         {
-            sdata(174, believer.index) += clamp(P / 550, 1, 8 + F / 10);
+            believer.get_skill(174).level += clamp(P / 550, 1, 8 + F / 10);
         }
     }
     if (believer.god_id == core_god::itzpalt)
     {
-        if (sdata(16, believer.index) > 0)
+        if (believer.get_skill(16).level > 0)
         {
-            sdata(16, believer.index) += clamp(P / 300, 1, 18 + F / 10);
+            believer.get_skill(16).level += clamp(P / 300, 1, 18 + F / 10);
         }
-        if (sdata(155, believer.index) > 0)
+        if (believer.get_skill(155).level > 0)
         {
-            sdata(155, believer.index) += clamp(P / 350, 1, 15 + F / 10);
+            believer.get_skill(155).level += clamp(P / 350, 1, 15 + F / 10);
         }
-        if (sdata(50, believer.index) > 0)
+        if (believer.get_skill(50).level > 0)
         {
-            sdata(50, believer.index) += clamp(P / 50, 1, 200 + F / 10);
+            believer.get_skill(50).level += clamp(P / 50, 1, 200 + F / 10);
         }
-        if (sdata(51, believer.index) > 0)
+        if (believer.get_skill(51).level > 0)
         {
-            sdata(51, believer.index) += clamp(P / 50, 1, 200 + F / 10);
+            believer.get_skill(51).level += clamp(P / 50, 1, 200 + F / 10);
         }
-        if (sdata(52, believer.index) > 0)
+        if (believer.get_skill(52).level > 0)
         {
-            sdata(52, believer.index) += clamp(P / 50, 1, 200 + F / 10);
+            believer.get_skill(52).level += clamp(P / 50, 1, 200 + F / 10);
         }
     }
     if (believer.god_id == core_god::ehekatl)
     {
-        if (sdata(17, believer.index) > 0)
+        if (believer.get_skill(17).level > 0)
         {
-            sdata(17, believer.index) += clamp(P / 250, 1, 20 + F / 10);
+            believer.get_skill(17).level += clamp(P / 250, 1, 20 + F / 10);
         }
-        if (sdata(19, believer.index) > 0)
+        if (believer.get_skill(19).level > 0)
         {
-            sdata(19, believer.index) += clamp(P / 100, 1, 50 + F / 10);
+            believer.get_skill(19).level += clamp(P / 100, 1, 50 + F / 10);
         }
-        if (sdata(173, believer.index) > 0)
+        if (believer.get_skill(173).level > 0)
         {
-            sdata(173, believer.index) += clamp(P / 300, 1, 15 + F / 10);
+            believer.get_skill(173).level += clamp(P / 300, 1, 15 + F / 10);
         }
-        if (sdata(164, believer.index) > 0)
+        if (believer.get_skill(164).level > 0)
         {
-            sdata(164, believer.index) += clamp(P / 350, 1, 17 + F / 10);
+            believer.get_skill(164).level += clamp(P / 350, 1, 17 + F / 10);
         }
-        if (sdata(185, believer.index) > 0)
+        if (believer.get_skill(185).level > 0)
         {
-            sdata(185, believer.index) += clamp(P / 300, 1, 12 + F / 10);
+            believer.get_skill(185).level += clamp(P / 300, 1, 12 + F / 10);
         }
-        if (sdata(158, believer.index) > 0)
+        if (believer.get_skill(158).level > 0)
         {
-            sdata(158, believer.index) += clamp(P / 450, 1, 8 + F / 10);
+            believer.get_skill(158).level += clamp(P / 450, 1, 8 + F / 10);
         }
     }
     if (believer.god_id == core_god::opatos)
     {
-        if (sdata(10, believer.index) > 0)
+        if (believer.get_skill(10).level > 0)
         {
-            sdata(10, believer.index) += clamp(P / 450, 1, 11 + F / 10);
+            believer.get_skill(10).level += clamp(P / 450, 1, 11 + F / 10);
         }
-        if (sdata(11, believer.index) > 0)
+        if (believer.get_skill(11).level > 0)
         {
-            sdata(11, believer.index) += clamp(P / 350, 1, 16 + F / 10);
+            believer.get_skill(11).level += clamp(P / 350, 1, 16 + F / 10);
         }
-        if (sdata(168, believer.index) > 0)
+        if (believer.get_skill(168).level > 0)
         {
-            sdata(168, believer.index) += clamp(P / 350, 1, 15 + F / 10);
+            believer.get_skill(168).level += clamp(P / 350, 1, 15 + F / 10);
         }
-        if (sdata(153, believer.index) > 0)
+        if (believer.get_skill(153).level > 0)
         {
-            sdata(153, believer.index) += clamp(P / 300, 1, 16 + F / 10);
+            believer.get_skill(153).level += clamp(P / 300, 1, 16 + F / 10);
         }
-        if (sdata(163, believer.index) > 0)
+        if (believer.get_skill(163).level > 0)
         {
-            sdata(163, believer.index) += clamp(P / 350, 1, 12 + F / 10);
+            believer.get_skill(163).level += clamp(P / 350, 1, 12 + F / 10);
         }
-        if (sdata(174, believer.index) > 0)
+        if (believer.get_skill(174).level > 0)
         {
-            sdata(174, believer.index) += clamp(P / 450, 1, 8 + F / 10);
+            believer.get_skill(174).level += clamp(P / 450, 1, 8 + F / 10);
         }
     }
     if (believer.god_id == core_god::jure)
     {
-        if (sdata(15, believer.index) > 0)
+        if (believer.get_skill(15).level > 0)
         {
-            sdata(15, believer.index) += clamp(P / 300, 1, 16 + F / 10);
+            believer.get_skill(15).level += clamp(P / 300, 1, 16 + F / 10);
         }
-        if (sdata(154, believer.index) > 0)
+        if (believer.get_skill(154).level > 0)
         {
-            sdata(154, believer.index) += clamp(P / 250, 1, 18 + F / 10);
+            believer.get_skill(154).level += clamp(P / 250, 1, 18 + F / 10);
         }
-        if (sdata(155, believer.index) > 0)
+        if (believer.get_skill(155).level > 0)
         {
-            sdata(155, believer.index) += clamp(P / 400, 1, 10 + F / 10);
+            believer.get_skill(155).level += clamp(P / 400, 1, 10 + F / 10);
         }
-        if (sdata(161, believer.index) > 0)
+        if (believer.get_skill(161).level > 0)
         {
-            sdata(161, believer.index) += clamp(P / 400, 1, 9 + F / 10);
+            believer.get_skill(161).level += clamp(P / 400, 1, 9 + F / 10);
         }
-        if (sdata(184, believer.index) > 0)
+        if (believer.get_skill(184).level > 0)
         {
-            sdata(184, believer.index) += clamp(P / 450, 1, 8 + F / 10);
+            believer.get_skill(184).level += clamp(P / 450, 1, 8 + F / 10);
         }
-        if (sdata(174, believer.index) > 0)
+        if (believer.get_skill(174).level > 0)
         {
-            sdata(174, believer.index) += clamp(P / 400, 1, 10 + F / 10);
+            believer.get_skill(174).level += clamp(P / 400, 1, 10 + F / 10);
         }
-        if (sdata(164, believer.index) > 0)
+        if (believer.get_skill(164).level > 0)
         {
-            sdata(164, believer.index) += clamp(P / 400, 1, 12 + F / 10);
+            believer.get_skill(164).level += clamp(P / 400, 1, 12 + F / 10);
         }
     }
     if (believer.god_id == core_god::kumiromi)
     {
-        if (sdata(13, believer.index) > 0)
+        if (believer.get_skill(13).level > 0)
         {
-            sdata(13, believer.index) += clamp(P / 400, 1, 8 + F / 10);
+            believer.get_skill(13).level += clamp(P / 400, 1, 8 + F / 10);
         }
-        if (sdata(12, believer.index) > 0)
+        if (believer.get_skill(12).level > 0)
         {
-            sdata(12, believer.index) += clamp(P / 350, 1, 12 + F / 10);
+            believer.get_skill(12).level += clamp(P / 350, 1, 12 + F / 10);
         }
-        if (sdata(14, believer.index) > 0)
+        if (believer.get_skill(14).level > 0)
         {
-            sdata(14, believer.index) += clamp(P / 250, 1, 16 + F / 10);
+            believer.get_skill(14).level += clamp(P / 250, 1, 16 + F / 10);
         }
-        if (sdata(180, believer.index) > 0)
+        if (believer.get_skill(180).level > 0)
         {
-            sdata(180, believer.index) += clamp(P / 300, 1, 12 + F / 10);
+            believer.get_skill(180).level += clamp(P / 300, 1, 12 + F / 10);
         }
-        if (sdata(178, believer.index) > 0)
+        if (believer.get_skill(178).level > 0)
         {
-            sdata(178, believer.index) += clamp(P / 350, 1, 10 + F / 10);
+            believer.get_skill(178).level += clamp(P / 350, 1, 10 + F / 10);
         }
-        if (sdata(177, believer.index) > 0)
+        if (believer.get_skill(177).level > 0)
         {
-            sdata(177, believer.index) += clamp(P / 350, 1, 9 + F / 10);
+            believer.get_skill(177).level += clamp(P / 350, 1, 9 + F / 10);
         }
-        if (sdata(150, believer.index) > 0)
+        if (believer.get_skill(150).level > 0)
         {
-            sdata(150, believer.index) += clamp(P / 350, 1, 8 + F / 10);
+            believer.get_skill(150).level += clamp(P / 350, 1, 8 + F / 10);
         }
     }
 }

--- a/src/elona/initialize_map.cpp
+++ b/src/elona/initialize_map.cpp
@@ -1011,7 +1011,7 @@ void _notify_distance_traveled()
         cnvdate(game_data.departure_date, false)));
     p = 0;
     exp = cdata.player().level * game_data.distance_between_town *
-            sdata(182, 0) / 100 +
+            cdata.player().get_skill(182).level / 100 +
         1;
     for (auto&& chara : cdata.player_and_allies())
     {

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -15,6 +15,7 @@
 #include "character.hpp"
 #include "config.hpp"
 #include "crafting.hpp"
+#include "data/types/type_ability.hpp"
 #include "data/types/type_fish.hpp"
 #include "data/types/type_item.hpp"
 #include "data/types/type_item_material.hpp"
@@ -1702,7 +1703,7 @@ bool item_fire(Inventory& inv, const OptionalItemRef& burned_item)
     auto inv_owner = inv_get_owner(inv);
     if (const auto owner = inv_owner.as_character())
     {
-        if (sdata(50, owner->index) / 50 >= 6 ||
+        if (owner->get_skill(50).level / 50 >= 6 ||
             owner->quality >= Quality::miracle)
         {
             return false;
@@ -1931,7 +1932,7 @@ bool item_cold(Inventory& inv, const OptionalItemRef& destroyed_item)
     auto inv_owner = inv_get_owner(inv);
     if (const auto owner = inv_owner.as_character())
     {
-        if (sdata(51, owner->index) / 50 >= 6 ||
+        if (owner->get_skill(51).level / 50 >= 6 ||
             owner->quality >= Quality::miracle)
         {
             return false;
@@ -2230,7 +2231,8 @@ void auto_identify()
             continue;
         }
 
-        const auto skill = sdata(13, 0) + sdata(162, 0) * 5;
+        const auto skill = cdata.player().get_skill(13).level +
+            cdata.player().get_skill(162).level * 5;
         const auto difficulty = 1500 + item->difficulty_of_identification * 5;
         if (skill > rnd(difficulty * 5))
         {

--- a/src/elona/itemgen.cpp
+++ b/src/elona/itemgen.cpp
@@ -152,7 +152,7 @@ bool upgrade_item_quality(Inventory& inv)
     if (owner_chara && owner_chara->index != 0)
         return false;
 
-    return sdata(19, 0) > rnd(5000);
+    return cdata.player().get_skill(19).level > rnd(5000);
 }
 
 
@@ -519,7 +519,7 @@ OptionalItemRef do_create_item(int item_id, Inventory& inv, int x, int y)
     {
         if (reftype < 50000)
         {
-            if (rnd_capped(sdata(162, 0) + 1) > 5)
+            if (rnd_capped(cdata.player().get_skill(162).level + 1) > 5)
             {
                 item->identify_state = IdentifyState::almost;
             }

--- a/src/elona/lua_env/api/classes/class_LuaAbility.cpp
+++ b/src/elona/lua_env/api/classes/class_LuaAbility.cpp
@@ -62,18 +62,18 @@ void bind(sol::state& lua)
     LuaAbility.set("experience", ELONA_LUA_SKILL_PROPERTY_READONLY(experience));
 
     /**
-     * @luadoc current_level field num
+     * @luadoc level field num
      *
      * [RW] The skill's current level.
      */
-    LuaAbility.set("current_level", ELONA_LUA_SKILL_PROPERTY(level));
+    LuaAbility.set("level", ELONA_LUA_SKILL_PROPERTY(level));
 
     /**
-     * @luadoc original_level field num
+     * @luadoc base_level field num
      *
-     * [RW] The skill's original level.
+     * [RW] The skill's base level.
      */
-    LuaAbility.set("original_level", ELONA_LUA_SKILL_PROPERTY(base_level));
+    LuaAbility.set("base_level", ELONA_LUA_SKILL_PROPERTY(base_level));
 
     /**
      * @luadoc potential field num

--- a/src/elona/lua_env/api/classes/class_LuaAbility.cpp
+++ b/src/elona/lua_env/api/classes/class_LuaAbility.cpp
@@ -24,7 +24,7 @@ namespace elona::lua::api::classes::class_LuaAbility
             return 0; \
         } \
         auto& ref = *a.get_ref(); \
-        return sdata.get(a.skill_id, ref.index).name; \
+        return ref.get_skill(a.skill_id).name; \
     })
 
 #define ELONA_LUA_SKILL_PROPERTY(name) \
@@ -35,7 +35,7 @@ namespace elona::lua::api::classes::class_LuaAbility
                 return 0; \
             } \
             auto& ref = *a.get_ref(); \
-            return sdata.get(a.skill_id, ref.index).name; \
+            return ref.get_skill(a.skill_id).name; \
         }, \
         [](classes::LuaAbility& a, int i) { \
             if (!a.is_valid()) \
@@ -43,7 +43,7 @@ namespace elona::lua::api::classes::class_LuaAbility
                 return; \
             } \
             auto& ref = *a.get_ref(); \
-            sdata.get(a.skill_id, ref.index).name = i; \
+            ref.get_skill(a.skill_id).name = i; \
         })
 
 void bind(sol::state& lua)
@@ -66,14 +66,14 @@ void bind(sol::state& lua)
      *
      * [RW] The skill's current level.
      */
-    LuaAbility.set("current_level", ELONA_LUA_SKILL_PROPERTY(current_level));
+    LuaAbility.set("current_level", ELONA_LUA_SKILL_PROPERTY(level));
 
     /**
      * @luadoc original_level field num
      *
      * [RW] The skill's original level.
      */
-    LuaAbility.set("original_level", ELONA_LUA_SKILL_PROPERTY(original_level));
+    LuaAbility.set("original_level", ELONA_LUA_SKILL_PROPERTY(base_level));
 
     /**
      * @luadoc potential field num

--- a/src/elona/lua_env/api/classes/class_LuaCharacter.cpp
+++ b/src/elona/lua_env/api/classes/class_LuaCharacter.cpp
@@ -2,6 +2,7 @@
 #include "../../../buff.hpp"
 #include "../../../character.hpp"
 #include "../../../character_status.hpp"
+#include "../../../data/types/type_ability.hpp"
 #include "../../../data/types/type_buff.hpp"
 #include "../../../dmgheal.hpp"
 #include "../../../element.hpp"

--- a/src/elona/lua_env/api/modules/module_Skill.cpp
+++ b/src/elona/lua_env/api/modules/module_Skill.cpp
@@ -30,7 +30,7 @@ int Skill_resistance(const EnumString& element, LuaCharacterHandle chara)
 {
     auto& chara_ref = lua::ref<Character>(chara);
     Element element_value = LuaEnums::ElementTable.ensure_from_string(element);
-    return sdata(static_cast<int>(element_value), chara_ref.index);
+    return chara_ref.get_skill(static_cast<int>(element_value)).level;
 }
 
 

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -14,6 +14,7 @@
 #include "command.hpp"
 #include "config.hpp"
 #include "crafting.hpp"
+#include "data/types/type_ability.hpp"
 #include "data/types/type_asset.hpp"
 #include "data/types/type_buff.hpp"
 #include "data/types/type_item.hpp"
@@ -571,7 +572,7 @@ bool _magic_183(Character& subject, OptionalItemRef instrument)
             return false;
         }
     }
-    if (sdata(183, subject.index) == 0)
+    if (subject.get_skill(183).level == 0)
     {
         if (is_in_fov(subject))
         {
@@ -604,7 +605,7 @@ bool _magic_183(Character& subject, OptionalItemRef instrument)
 // Cooking
 bool _magic_184(Character& subject, const ItemRef& cook_tool)
 {
-    if (sdata(184, 0) == 0)
+    if (cdata.player().get_skill(184).level == 0)
     {
         txt(i18n::s.get("core.magic.cook.do_not_know"));
         return false;
@@ -644,7 +645,7 @@ bool _magic_184(Character& subject, const ItemRef& cook_tool)
 // Fishing
 bool _magic_185(Character& subject, const ItemRef& rod)
 {
-    if (sdata(185, 0) == 0)
+    if (cdata.player().get_skill(185).level == 0)
     {
         txt(i18n::s.get("core.magic.fish.do_not_know"));
         return false;
@@ -1372,7 +1373,7 @@ bool _magic_1143(Character& target)
             {
                 if (cnt <= 17)
                 {
-                    if (sdata(cnt, target.index) != 0)
+                    if (target.get_skill(cnt).level != 0)
                     {
                         chara_gain_skill_exp(target, cnt, -1000);
                     }
@@ -1399,7 +1400,7 @@ bool _magic_1105(Character& target)
             {
                 if (cnt < efstatusfix(0, 0, 100, 2000))
                 {
-                    if (sdata(p, target.index) != 0)
+                    if (target.get_skill(p).level != 0)
                     {
                         continue;
                     }
@@ -1418,7 +1419,7 @@ bool _magic_1105(Character& target)
             }
             else
             {
-                if (sdata(p, target.index) == 0)
+                if (target.get_skill(p).level == 0)
                 {
                     continue;
                 }
@@ -1497,7 +1498,7 @@ bool _magic_1119(Character& target)
             p = rnd(300) + 100;
             if (the_ability_db[p])
             {
-                if (sdata.get(p, target.index).original_level == 0)
+                if (target.get_skill(p).base_level == 0)
                 {
                     continue;
                 }
@@ -1583,9 +1584,7 @@ bool _magic_1113(Character& target)
         for (int cnt = 10; cnt < 18; ++cnt)
         {
             modify_potential(
-                target,
-                cnt,
-                rnd(sdata.get(cnt, target.index).potential / 20 + 3) + 1);
+                target, cnt, rnd(target.get_skill(cnt).potential / 20 + 3) + 1);
         }
         txt(i18n::s.get("core.magic.gain_potential.blessed", target));
         MiracleAnimation(MiracleAnimation::Mode::target_one, target).play();
@@ -1600,9 +1599,7 @@ bool _magic_1113(Character& target)
             txt(i18n::s.get(
                 "core.magic.gain_potential.increases", target, valn));
             modify_potential(
-                target,
-                i,
-                rnd(sdata.get(i, target.index).potential / 10 + 10) + 1);
+                target, i, rnd(target.get_skill(i).potential / 10 + 10) + 1);
             snd("core.ding2");
         }
         else
@@ -1612,7 +1609,7 @@ bool _magic_1113(Character& target)
             modify_potential(
                 target,
                 i,
-                (rnd(sdata.get(i, target.index).potential / 10 + 10) + 1) * -1);
+                (rnd(target.get_skill(i).potential / 10 + 10) + 1) * -1);
             snd("core.curse3");
         }
     }
@@ -1821,8 +1818,7 @@ bool _magic_440_439(Character& target)
             if (target.quality <= Quality::great)
             {
                 target.attr_adjs[attr] -=
-                    rnd(sdata.get(p(cnt), target.index).original_level) / 5 +
-                    rnd(5);
+                    rnd(target.get_skill(p(cnt)).base_level) / 5 + rnd(5);
                 continue;
             }
         }
@@ -1833,7 +1829,7 @@ bool _magic_440_439(Character& target)
         if (efstatus == CurseState::blessed)
         {
             target.attr_adjs[attr] =
-                sdata.get(p(cnt), target.index).original_level / 10 + 5;
+                target.get_skill(p(cnt)).base_level / 10 + 5;
         }
     }
     chara_refresh(target);
@@ -2053,7 +2049,7 @@ bool _magic_645_1114(Character& subject, Character& target)
             txt(i18n::s.get("core.magic.curse.spell", subject, target));
         }
     }
-    int p = 75 + sdata(19, target.index);
+    int p = 75 + target.get_skill(19).level;
     if (const auto anticurse = enchantment_find(target, 43))
     {
         p += *anticurse / 2;
@@ -2149,7 +2145,7 @@ bool _magic_1118(Character& target)
     for (int cnt = 0; cnt < 10; ++cnt)
     {
         p = rnd(11) + 50;
-        if (sdata.get(p, target.index).original_level >= 150)
+        if (target.get_skill(p).base_level >= 150)
         {
             ++f;
             chara_gain_registance(target, p, 50 * -1);
@@ -3207,7 +3203,7 @@ bool _magic_465(Character& subject)
             }
             if (cell_data.at(dx, dy).chara_index_plus_one != 0)
             {
-                dmg = sdata(16, subject.index) * efp / 10;
+                dmg = subject.get_skill(16).level * efp / 10;
                 damage_hp(
                     cdata[cell_data.at(dx, dy).chara_index_plus_one - 1],
                     dmg,
@@ -3267,9 +3263,17 @@ bool _magic_656(Character& subject)
                 Message::color{ColorIndex::blue});
         }
         buff_add(
-            cnt, "core.speed", sdata(17, subject.index) * 5 + 50, 15, subject);
+            cnt,
+            "core.speed",
+            subject.get_skill(17).level * 5 + 50,
+            15,
+            subject);
         buff_add(
-            cnt, "core.hero", sdata(17, subject.index) * 5 + 100, 60, subject);
+            cnt,
+            "core.hero",
+            subject.get_skill(17).level * 5 + 100,
+            60,
+            subject);
         buff_add(cnt, "core.contingency", 1500, 30, subject);
     }
     return true;
@@ -4174,8 +4178,7 @@ optional<bool> _proc_general_magic(Character& subject, Character& target)
             }
             if (p != -1)
             {
-                i = sdata.get(10 + p, target.index).original_level +
-                    target.attr_adjs[p];
+                i = target.get_skill(10 + p).base_level + target.attr_adjs[p];
                 if (i > 0)
                 {
                     i = i * efp / 2000 + 1;
@@ -4339,8 +4342,8 @@ optional<bool> _proc_general_magic(Character& subject, Character& target)
                 return true;
             }
             p = rnd_capped(cdata[target_index].gold / 10 + 1);
-            if (rnd_capped(sdata(13, target_index)) >
-                    rnd_capped(sdata(12, subject.index) * 4) ||
+            if (rnd_capped(cdata[target_index].get_skill(13).level) >
+                    rnd_capped(subject.get_skill(12).level * 4) ||
                 cdata[target_index].is_protected_from_thieves() == 1)
             {
                 txt(i18n::s.get(

--- a/src/elona/map.cpp
+++ b/src/elona/map.cpp
@@ -2084,7 +2084,8 @@ void map_global_proc_travel_events(Character& chara)
             chara.activity.turn = chara.activity.turn * 5 / 10;
         }
         chara.activity.turn = chara.activity.turn * 100 /
-            (100 + game_data.seven_league_boot_effect + sdata(182, 0));
+            (100 + game_data.seven_league_boot_effect +
+             cdata.player().get_skill(182).level);
         return;
     }
     if (cdata.player().nutrition <= 5000)

--- a/src/elona/map_special_events.cpp
+++ b/src/elona/map_special_events.cpp
@@ -77,7 +77,7 @@ static void _map_events_tower_of_fire()
 {
     if (rnd(5) == 0)
     {
-        r = sdata(50, 0) / 50;
+        r = cdata.player().get_skill(50).level / 50;
         if (r < 6)
         {
             dmg = (6 - r) * (6 - r) * 2;
@@ -160,7 +160,7 @@ static void _map_events_jail()
             txt(i18n::s.get("core.misc.map.jail.repent_of_sin"));
             modify_karma(cdata.player(), 1);
             p = rnd(8) + 10;
-            if (sdata.get(p, 0).original_level >= 10)
+            if (cdata.player().get_skill(p).base_level >= 10)
             {
                 chara_gain_fixed_skill_exp(cdata.player(), p, -300);
             }

--- a/src/elona/map_trainer_skills.cpp
+++ b/src/elona/map_trainer_skills.cpp
@@ -1,5 +1,6 @@
 #include "ability.hpp"
 #include "character.hpp"
+#include "data/types/type_ability.hpp"
 #include "gdata.hpp"
 #include "variables.hpp"
 
@@ -180,7 +181,7 @@ void map_get_trainer_skills(const Character& chara)
 
     for (const auto& skill_id : skills)
     {
-        if (sdata.get(skill_id, chara.index).original_level == 0)
+        if (chara.get_skill(skill_id).base_level == 0)
         {
             list(0, listmax) = skill_id;
             list(1, listmax) =

--- a/src/elona/mef.cpp
+++ b/src/elona/mef.cpp
@@ -213,7 +213,7 @@ void mef_proc(Character& chara)
     {
         if (chara.is_floating() == 0 || chara.gravity > 0)
         {
-            if (sdata(63, chara.index) / 50 < 7)
+            if (chara.get_skill(63).level / 50 < 7)
             {
                 if (is_in_fov(chara))
                 {
@@ -307,7 +307,8 @@ bool mef_proc_from_movement(Character& chara)
         {
             if (rnd_capped(mef(5, i) + 25) <
                     rnd_capped(
-                        sdata(10, chara.index) + sdata(12, chara.index) + 1) ||
+                        chara.get_skill(10).level + chara.get_skill(12).level +
+                        1) ||
                 chara.weight > 100)
             {
                 if (is_in_fov(chara))

--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -14,6 +14,7 @@
 #include "command.hpp"
 #include "config.hpp"
 #include "config_menu.hpp"
+#include "data/types/type_ability.hpp"
 #include "data/types/type_buff.hpp"
 #include "data/types/type_item.hpp"
 #include "data/types/type_portrait.hpp"
@@ -1367,7 +1368,7 @@ void screen_analyze_self()
     cdata.tmp().god_id = cdata.player().god_id;
     for (int cnt = 0; cnt < 600; ++cnt)
     {
-        sdata(cnt, 0) = 1;
+        cdata.player().get_skill(cnt).level = 1;
     }
     god_apply_blessing(cdata.tmp());
     if (cdata.player().god_id != core_god::eyth)
@@ -1376,7 +1377,7 @@ void screen_analyze_self()
             u8"による能力の恩恵<def>\n"s;
         for (int cnt = 0; cnt < 600; ++cnt)
         {
-            p = sdata(cnt, 0) - 1;
+            p = cdata.player().get_skill(cnt).level - 1;
             cnvbonus(cnt, p);
         }
     }

--- a/src/elona/quest.cpp
+++ b/src/elona/quest.cpp
@@ -818,8 +818,8 @@ int quest_generate()
         (game_data.current_map == mdata_t::MapId::palmia && rnd(8) == 0))
     {
         quest_data[rq].difficulty = clamp(
-            rnd_capped(sdata(183, 0) + 10),
-            int(1.5 * std::sqrt(sdata(183, 0))) + 1,
+            rnd_capped(cdata.player().get_skill(183).level + 10),
+            int(1.5 * std::sqrt(cdata.player().get_skill(183).level)) + 1,
             cdata.player().fame / 1000 + 10);
         quest_data[rq].deadline_hours =
             (rnd(6) + 2) * 24 + game_data.date.hours();

--- a/src/elona/race.cpp
+++ b/src/elona/race.cpp
@@ -2,6 +2,7 @@
 
 #include "ability.hpp"
 #include "character.hpp"
+#include "data/types/type_ability.hpp"
 #include "elona.hpp"
 #include "i18n.hpp"
 #include "random.hpp"
@@ -76,7 +77,7 @@ void race_init_chara(Character& chara, data::InstanceId race_id)
     {
         if (const auto ability_data = the_ability_db[pair.first])
         {
-            sdata(ability_data->legacy_id, chara.index) = pair.second;
+            chara.get_skill(ability_data->legacy_id).level = pair.second;
         }
         else
         {

--- a/src/elona/random_event.cpp
+++ b/src/elona/random_event.cpp
@@ -253,7 +253,7 @@ void run_random_event(RandomEvent event)
 
     listmax = 0;
 
-    if (event.is_evadable(sdata(19, 0)))
+    if (event.is_evadable(cdata.player().get_skill(19).level))
     {
         // Default to "Avoiding Misfortune" if Luck is good enough.
         event.id = 1;

--- a/src/elona/save.cpp
+++ b/src/elona/save.cpp
@@ -184,8 +184,6 @@ void load_gene_files()
     {
         cnt.set_state(Character::State::empty);
     }
-    sdata.copy(56, 0);
-    sdata.clear(0);
     Character::copy(cdata.player(), cdata.tmp());
     cdata.player().clear();
     inv_open_tmp_inv_no_physical_file();
@@ -265,11 +263,11 @@ void get_inheritance()
     {
         if (cnt >= 10 && cnt < 20)
         {
-            p += sdata.get(cnt, 56).original_level;
+            p += cdata.tmp().get_skill(cnt).base_level;
         }
         if (cnt >= 100 && cnt < 400)
         {
-            i += sdata.get(cnt, 56).original_level;
+            i += cdata.tmp().get_skill(cnt).base_level;
         }
     }
     p = (p - 250) / 7;

--- a/src/elona/status_ailment.cpp
+++ b/src/elona/status_ailment.cpp
@@ -26,7 +26,8 @@ int calc_power_decreased_by_resistance(
     int power,
     Element element)
 {
-    const auto resistance_level = sdata(int(element), chara_index) / 50;
+    const auto resistance_level =
+        cdata[chara_index].get_skill(static_cast<int>(element)).level / 50;
     power = (rnd_capped(power / 2 + 1) + power / 2) * 100 /
         (50 + resistance_level * 50);
 

--- a/src/elona/talk_house_visitor.cpp
+++ b/src/elona/talk_house_visitor.cpp
@@ -7,6 +7,7 @@
 #include "character.hpp"
 #include "character_status.hpp"
 #include "config.hpp"
+#include "data/types/type_ability.hpp"
 #include "i18n.hpp"
 #include "inventory.hpp"
 #include "item.hpp"
@@ -239,7 +240,7 @@ void _adventurer_train_skill(int skill_id)
         cdata.player(),
         skill_id,
         clamp(
-            15 - sdata.get(skill_id, cdata.player().index).potential / 15,
+            15 - cdata.player().get_skill(skill_id).potential / 15,
             2,
             15 - (skill_id < 18) * 10));
 }
@@ -254,7 +255,7 @@ TalkResult _talk_hv_adventurer_train(Character& speaker)
     listn(0, listmax) =
         i18n::s.get("core.talk.visitor.adventurer.train.choices.pass");
     ++listmax;
-    if (sdata.get(skill_id, 0).original_level == 0)
+    if (cdata.player().get_skill(skill_id).base_level == 0)
     {
         buff = i18n::s.get(
             "core.talk.visitor.adventurer.train.learn.dialog",

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -6,6 +6,7 @@
 #include "calc.hpp"
 #include "character.hpp"
 #include "character_status.hpp"
+#include "data/types/type_ability.hpp"
 #include "data/types/type_item.hpp"
 #include "deferred_event.hpp"
 #include "elona.hpp"
@@ -1229,7 +1230,7 @@ TalkResult talk_result_maid_chase_out(Character& speaker)
 TalkResult talk_prostitute_buy(Character& speaker)
 {
     int sexvalue =
-        sdata(17, speaker.index) * 25 + 100 + cdata.player().fame / 10;
+        speaker.get_skill(17).level * 25 + 100 + cdata.player().fame / 10;
     if (cdata.player().gold >= sexvalue)
     {
         ELONA_APPEND_RESPONSE(
@@ -1505,9 +1506,7 @@ TalkResult talk_trainer(Character& speaker, bool is_training)
                 selected_skill,
                 clamp(
                     15 -
-                        sdata.get(selected_skill, cdata.player().index)
-                                .potential /
-                            15,
+                        cdata.player().get_skill(selected_skill).potential / 15,
                     2,
                     15));
             buff =
@@ -1836,7 +1835,9 @@ TalkResult talk_npc(Character& speaker)
                     {
                         if (speaker.impression < 100)
                         {
-                            if (rnd_capped(sdata(17, 0) + 1) > 10)
+                            if (rnd_capped(
+                                    cdata.player().get_skill(17).level + 1) >
+                                10)
                             {
                                 chara_modify_impression(speaker, rnd(3));
                             }

--- a/src/elona/trait.cpp
+++ b/src/elona/trait.cpp
@@ -232,13 +232,13 @@ bool is_acquirable(int id)
     switch (id)
     {
     case 4: return trait(id) == 0 || cdata.player().level >= 5;
-    case 6: return sdata.get(159, 0).original_level > 0;
+    case 6: return cdata.player().get_skill(159).base_level > 0;
     case 7: return trait(id) == 0 || cdata.player().level >= 5;
-    case 10: return sdata.get(173, 0).original_level > 0;
-    case 12: return sdata.get(172, 0).original_level > 0;
-    case 16: return sdata.get(156, 0).original_level > 0;
-    case 19: return sdata.get(166, 0).original_level > 0;
-    case 43: return sdata.get(168, 0).original_level > 0;
+    case 10: return cdata.player().get_skill(173).base_level > 0;
+    case 12: return cdata.player().get_skill(172).base_level > 0;
+    case 16: return cdata.player().get_skill(156).base_level > 0;
+    case 19: return cdata.player().get_skill(166).base_level > 0;
+    case 43: return cdata.player().get_skill(168).base_level > 0;
     default: return true;
     }
 }
@@ -307,14 +307,18 @@ int trait_get_info(int traitmode, int tid)
     }
     if (tid == 21)
     {
-        sdata(17, 0) =
-            clamp(sdata(17, 0) + trait(tid) * 4, int{sdata(17, 0) > 0}, 9999);
+        cdata.player().get_skill(17).level = clamp(
+            cdata.player().get_skill(17).level + trait(tid) * 4,
+            int{cdata.player().get_skill(17).level > 0},
+            9999);
         return 1;
     }
     if (tid == 5)
     {
-        sdata(10, 0) =
-            clamp(sdata(10, 0) + trait(tid) * 3, int{sdata(10, 0) > 0}, 9999);
+        cdata.player().get_skill(10).level = clamp(
+            cdata.player().get_skill(10).level + trait(tid) * 3,
+            int{cdata.player().get_skill(10).level > 0},
+            9999);
         return 1;
     }
     if (tid == 38)
@@ -331,20 +335,26 @@ int trait_get_info(int traitmode, int tid)
     }
     if (tid == 9)
     {
-        sdata(11, 0) =
-            clamp(sdata(11, 0) + trait(tid) * 3, int{sdata(11, 0) > 0}, 9999);
+        cdata.player().get_skill(11).level = clamp(
+            cdata.player().get_skill(11).level + trait(tid) * 3,
+            int{cdata.player().get_skill(11).level > 0},
+            9999);
         return 1;
     }
     if (tid == 20)
     {
-        sdata(106, 0) =
-            clamp(sdata(106, 0) + trait(tid) * 3, int{sdata(106, 0) > 0}, 9999);
+        cdata.player().get_skill(106).level = clamp(
+            cdata.player().get_skill(106).level + trait(tid) * 3,
+            int{cdata.player().get_skill(106).level > 0},
+            9999);
         return 1;
     }
     if (tid == 12)
     {
-        sdata(172, 0) =
-            clamp(sdata(172, 0) + trait(tid) * 4, int{sdata(172, 0) > 0}, 9999);
+        cdata.player().get_skill(172).level = clamp(
+            cdata.player().get_skill(172).level + trait(tid) * 4,
+            int{cdata.player().get_skill(172).level > 0},
+            9999);
         return 1;
     }
     if (tid == 43)
@@ -358,62 +368,82 @@ int trait_get_info(int traitmode, int tid)
     }
     if (tid == 19)
     {
-        sdata(166, 0) =
-            clamp(sdata(166, 0) + trait(tid) * 4, int{sdata(166, 0) > 0}, 9999);
+        cdata.player().get_skill(166).level = clamp(
+            cdata.player().get_skill(166).level + trait(tid) * 4,
+            int{cdata.player().get_skill(166).level > 0},
+            9999);
         return 1;
     }
     if (tid == 15)
     {
-        sdata(53, 0) = clamp(
-            sdata(53, 0) + trait(tid) * 50 / 2, int{sdata(53, 0) > 0}, 9999);
+        cdata.player().get_skill(53).level = clamp(
+            cdata.player().get_skill(53).level + trait(tid) * 50 / 2,
+            int{cdata.player().get_skill(53).level > 0},
+            9999);
         return 1;
     }
     if (tid == 18)
     {
-        sdata(55, 0) = clamp(
-            sdata(55, 0) + trait(tid) * 50 / 2, int{sdata(55, 0) > 0}, 9999);
+        cdata.player().get_skill(55).level = clamp(
+            cdata.player().get_skill(55).level + trait(tid) * 50 / 2,
+            int{cdata.player().get_skill(55).level > 0},
+            9999);
         return 1;
     }
     if (tid == 16)
     {
-        sdata(156, 0) =
-            clamp(sdata(156, 0) + trait(tid) * 4, int{sdata(156, 0) > 0}, 9999);
+        cdata.player().get_skill(156).level = clamp(
+            cdata.player().get_skill(156).level + trait(tid) * 4,
+            int{cdata.player().get_skill(156).level > 0},
+            9999);
         return 1;
     }
     if (tid == 17)
     {
-        sdata(181, 0) =
-            clamp(sdata(181, 0) + trait(tid) * 4, int{sdata(181, 0) > 0}, 9999);
+        cdata.player().get_skill(181).level = clamp(
+            cdata.player().get_skill(181).level + trait(tid) * 4,
+            int{cdata.player().get_skill(181).level > 0},
+            9999);
         return 1;
     }
     if (tid == 1)
     {
-        sdata(19, 0) =
-            clamp(sdata(19, 0) + trait(tid) * 5, int{sdata(19, 0) > 0}, 9999);
+        cdata.player().get_skill(19).level = clamp(
+            cdata.player().get_skill(19).level + trait(tid) * 5,
+            int{cdata.player().get_skill(19).level > 0},
+            9999);
         return 1;
     }
     if (tid == 2)
     {
-        sdata(2, 0) =
-            clamp(sdata(2, 0) + trait(tid) * 5, int{sdata(2, 0) > 0}, 9999);
+        cdata.player().get_skill(2).level = clamp(
+            cdata.player().get_skill(2).level + trait(tid) * 5,
+            int{cdata.player().get_skill(2).level > 0},
+            9999);
         return 1;
     }
     if (tid == 11)
     {
-        sdata(3, 0) =
-            clamp(sdata(3, 0) + trait(tid) * 5, int{sdata(3, 0) > 0}, 9999);
+        cdata.player().get_skill(3).level = clamp(
+            cdata.player().get_skill(3).level + trait(tid) * 5,
+            int{cdata.player().get_skill(3).level > 0},
+            9999);
         return 1;
     }
     if (tid == 6)
     {
-        sdata(159, 0) =
-            clamp(sdata(159, 0) + trait(tid) * 3, int{sdata(159, 0) > 0}, 9999);
+        cdata.player().get_skill(159).level = clamp(
+            cdata.player().get_skill(159).level + trait(tid) * 3,
+            int{cdata.player().get_skill(159).level > 0},
+            9999);
         return 1;
     }
     if (tid == 4)
     {
-        sdata(18, 0) =
-            clamp(sdata(18, 0) + trait(tid) * 5, int{sdata(18, 0) > 0}, 9999);
+        cdata.player().get_skill(18).level = clamp(
+            cdata.player().get_skill(18).level + trait(tid) * 5,
+            int{cdata.player().get_skill(18).level > 0},
+            9999);
         return 1;
     }
     if (tid == 7)
@@ -434,8 +464,10 @@ int trait_get_info(int traitmode, int tid)
     }
     if (tid == 10)
     {
-        sdata(173, 0) =
-            clamp(sdata(173, 0) + trait(tid) * 2, int{sdata(173, 0) > 0}, 9999);
+        cdata.player().get_skill(173).level = clamp(
+            cdata.player().get_skill(173).level + trait(tid) * 2,
+            int{cdata.player().get_skill(173).level > 0},
+            9999);
         return 1;
     }
     if (tid == 41)
@@ -449,101 +481,133 @@ int trait_get_info(int traitmode, int tid)
     }
     if (tid == 26)
     {
-        sdata(12, 0) =
-            clamp(sdata(12, 0) + trait(tid) * 3, int{sdata(12, 0) > 0}, 9999);
+        cdata.player().get_skill(12).level = clamp(
+            cdata.player().get_skill(12).level + trait(tid) * 3,
+            int{cdata.player().get_skill(12).level > 0},
+            9999);
         return 1;
     }
     if (tid == 27)
     {
-        sdata(154, 0) =
-            clamp(sdata(154, 0) + trait(tid) * 4, int{sdata(154, 0) > 0}, 9999);
+        cdata.player().get_skill(154).level = clamp(
+            cdata.player().get_skill(154).level + trait(tid) * 4,
+            int{cdata.player().get_skill(154).level > 0},
+            9999);
         return 1;
     }
     if (tid == 28)
     {
-        sdata(18, 0) =
-            clamp(sdata(18, 0) + trait(tid) * 5, int{sdata(18, 0) > 0}, 9999);
+        cdata.player().get_skill(18).level = clamp(
+            cdata.player().get_skill(18).level + trait(tid) * 5,
+            int{cdata.player().get_skill(18).level > 0},
+            9999);
         return 1;
     }
     if (tid == 29)
     {
-        sdata(10, 0) =
-            clamp(sdata(10, 0) + trait(tid) * 3, int{sdata(10, 0) > 0}, 9999);
+        cdata.player().get_skill(10).level = clamp(
+            cdata.player().get_skill(10).level + trait(tid) * 3,
+            int{cdata.player().get_skill(10).level > 0},
+            9999);
         return 1;
     }
     if (tid == 30)
     {
-        sdata(17, 0) =
-            clamp(sdata(17, 0) + trait(tid) * 5, int{sdata(17, 0) > 0}, 9999);
+        cdata.player().get_skill(17).level = clamp(
+            cdata.player().get_skill(17).level + trait(tid) * 5,
+            int{cdata.player().get_skill(17).level > 0},
+            9999);
         return 1;
     }
     if (tid == 31)
     {
-        if (sdata.get(165, 0).original_level != 0)
+        if (cdata.player().get_skill(165).base_level != 0)
         {
-            sdata(165, 0) = clamp(
-                sdata(165, 0) + trait(tid) * 4, int{sdata(165, 0) > 0}, 9999);
+            cdata.player().get_skill(165).level = clamp(
+                cdata.player().get_skill(165).level + trait(tid) * 4,
+                int{cdata.player().get_skill(165).level > 0},
+                9999);
         }
         return 1;
     }
     if (tid == 32)
     {
-        sdata(60, 0) =
-            clamp(sdata(60, 0) + trait(tid) * 50, int{sdata(60, 0) > 0}, 9999);
+        cdata.player().get_skill(60).level = clamp(
+            cdata.player().get_skill(60).level + trait(tid) * 50,
+            int{cdata.player().get_skill(60).level > 0},
+            9999);
         return 1;
     }
     if (tid == 33)
     {
-        sdata(57, 0) =
-            clamp(sdata(57, 0) + trait(tid) * 50, int{sdata(57, 0) > 0}, 9999);
+        cdata.player().get_skill(57).level = clamp(
+            cdata.player().get_skill(57).level + trait(tid) * 50,
+            int{cdata.player().get_skill(57).level > 0},
+            9999);
         return 1;
     }
     if (tid == 34)
     {
-        sdata(50, 0) =
-            clamp(sdata(50, 0) + trait(tid) * 50, int{sdata(50, 0) > 0}, 9999);
+        cdata.player().get_skill(50).level = clamp(
+            cdata.player().get_skill(50).level + trait(tid) * 50,
+            int{cdata.player().get_skill(50).level > 0},
+            9999);
         return 1;
     }
     if (tid == 35)
     {
-        sdata(51, 0) =
-            clamp(sdata(51, 0) + trait(tid) * 50, int{sdata(51, 0) > 0}, 9999);
+        cdata.player().get_skill(51).level = clamp(
+            cdata.player().get_skill(51).level + trait(tid) * 50,
+            int{cdata.player().get_skill(51).level > 0},
+            9999);
         return 1;
     }
     if (tid == 36)
     {
-        sdata(52, 0) =
-            clamp(sdata(52, 0) + trait(tid) * 50, int{sdata(52, 0) > 0}, 9999);
+        cdata.player().get_skill(52).level = clamp(
+            cdata.player().get_skill(52).level + trait(tid) * 50,
+            int{cdata.player().get_skill(52).level > 0},
+            9999);
         return 1;
     }
     if (tid == 37)
     {
-        sdata(13, 0) =
-            clamp(sdata(13, 0) + trait(tid) * 5, int{sdata(13, 0) > 0}, 9999);
+        cdata.player().get_skill(13).level = clamp(
+            cdata.player().get_skill(13).level + trait(tid) * 5,
+            int{cdata.player().get_skill(13).level > 0},
+            9999);
         return 1;
     }
     if (tid == 150)
     {
-        sdata(50, 0) =
-            clamp(sdata(50, 0) + trait(tid) * 50, int{sdata(50, 0) > 0}, 9999);
+        cdata.player().get_skill(50).level = clamp(
+            cdata.player().get_skill(50).level + trait(tid) * 50,
+            int{cdata.player().get_skill(50).level > 0},
+            9999);
         return 1;
     }
     if (tid == 151)
     {
-        sdata(51, 0) =
-            clamp(sdata(51, 0) + trait(tid) * 50, int{sdata(51, 0) > 0}, 9999);
+        cdata.player().get_skill(51).level = clamp(
+            cdata.player().get_skill(51).level + trait(tid) * 50,
+            int{cdata.player().get_skill(51).level > 0},
+            9999);
         return 1;
     }
     if (tid == 152)
     {
-        sdata(55, 0) =
-            clamp(sdata(55, 0) + trait(tid) * 50, int{sdata(55, 0) > 0}, 9999);
+        cdata.player().get_skill(55).level = clamp(
+            cdata.player().get_skill(55).level + trait(tid) * 50,
+            int{cdata.player().get_skill(55).level > 0},
+            9999);
         return 1;
     }
     if (tid == 155)
     {
-        sdata(53, 0) =
-            clamp(sdata(53, 0) + trait(tid) * 50, int{sdata(53, 0) > 0}, 9999);
+        cdata.player().get_skill(53).level = clamp(
+            cdata.player().get_skill(53).level + trait(tid) * 50,
+            int{cdata.player().get_skill(53).level > 0},
+            9999);
         return 1;
     }
     if (tid == 156)
@@ -552,14 +616,38 @@ int trait_get_info(int traitmode, int tid)
     }
     if (tid == 160)
     {
-        sdata(60, 0) = clamp(sdata(60, 0) + 150, int{sdata(60, 0) > 0}, 9999);
-        sdata(52, 0) = clamp(sdata(52, 0) + 100, int{sdata(52, 0) > 0}, 9999);
-        sdata(53, 0) = clamp(sdata(53, 0) + 200, int{sdata(53, 0) > 0}, 9999);
-        sdata(57, 0) = clamp(sdata(57, 0) + 50, int{sdata(57, 0) > 0}, 9999);
-        sdata(59, 0) = clamp(sdata(59, 0) + 100, int{sdata(59, 0) > 0}, 9999);
-        sdata(54, 0) = clamp(sdata(54, 0) + 200, int{sdata(54, 0) > 0}, 9999);
-        sdata(58, 0) = clamp(sdata(58, 0) + 100, int{sdata(58, 0) > 0}, 9999);
-        sdata(51, 0) = clamp(sdata(51, 0) + 100, int{sdata(51, 0) > 0}, 9999);
+        cdata.player().get_skill(60).level = clamp(
+            cdata.player().get_skill(60).level + 150,
+            int{cdata.player().get_skill(60).level > 0},
+            9999);
+        cdata.player().get_skill(52).level = clamp(
+            cdata.player().get_skill(52).level + 100,
+            int{cdata.player().get_skill(52).level > 0},
+            9999);
+        cdata.player().get_skill(53).level = clamp(
+            cdata.player().get_skill(53).level + 200,
+            int{cdata.player().get_skill(53).level > 0},
+            9999);
+        cdata.player().get_skill(57).level = clamp(
+            cdata.player().get_skill(57).level + 50,
+            int{cdata.player().get_skill(57).level > 0},
+            9999);
+        cdata.player().get_skill(59).level = clamp(
+            cdata.player().get_skill(59).level + 100,
+            int{cdata.player().get_skill(59).level > 0},
+            9999);
+        cdata.player().get_skill(54).level = clamp(
+            cdata.player().get_skill(54).level + 200,
+            int{cdata.player().get_skill(54).level > 0},
+            9999);
+        cdata.player().get_skill(58).level = clamp(
+            cdata.player().get_skill(58).level + 100,
+            int{cdata.player().get_skill(58).level > 0},
+            9999);
+        cdata.player().get_skill(51).level = clamp(
+            cdata.player().get_skill(51).level + 100,
+            int{cdata.player().get_skill(51).level > 0},
+            9999);
         return 1;
     }
     if (tid == 161)
@@ -616,8 +704,10 @@ int trait_get_info(int traitmode, int tid)
     }
     if (tid == 153)
     {
-        sdata(60, 0) =
-            clamp(sdata(60, 0) + trait(tid) * 50, int{sdata(60, 0) > 0}, 9999);
+        cdata.player().get_skill(60).level = clamp(
+            cdata.player().get_skill(60).level + trait(tid) * 50,
+            int{cdata.player().get_skill(60).level > 0},
+            9999);
         return 1;
     }
     if (tid == 0)
@@ -634,46 +724,51 @@ int trait_get_info(int traitmode, int tid)
     }
     if (tid == 202)
     {
-        sdata(17, 0) = clamp(
-            sdata(17, 0) + trait(tid) * (4 + cdata.player().level / 5),
-            int{sdata(17, 0) > 0},
+        cdata.player().get_skill(17).level = clamp(
+            cdata.player().get_skill(17).level +
+                trait(tid) * (4 + cdata.player().level / 5),
+            int{cdata.player().get_skill(17).level > 0},
             9999);
         return 1;
     }
     if (tid == 203)
     {
-        sdata(18, 0) = clamp(
-            sdata(18, 0) + (20 + cdata.player().level / 2),
-            int{sdata(18, 0) > 0},
+        cdata.player().get_skill(18).level = clamp(
+            cdata.player().get_skill(18).level +
+                (20 + cdata.player().level / 2),
+            int{cdata.player().get_skill(18).level > 0},
             9999);
         return 1;
     }
     if (tid == 204)
     {
-        sdata(17, 0) = clamp(
-            sdata(17, 0) + (5 + cdata.player().level / 3) * -1,
-            int{sdata(17, 0) > 0},
+        cdata.player().get_skill(17).level = clamp(
+            cdata.player().get_skill(17).level +
+                (5 + cdata.player().level / 3) * -1,
+            int{cdata.player().get_skill(17).level > 0},
             9999);
-        sdata(13, 0) = clamp(
-            sdata(13, 0) + (5 + cdata.player().level / 3),
-            int{sdata(13, 0) > 0},
+        cdata.player().get_skill(13).level = clamp(
+            cdata.player().get_skill(13).level + (5 + cdata.player().level / 3),
+            int{cdata.player().get_skill(13).level > 0},
             9999);
         return 1;
     }
     if (tid == 205)
     {
         cdata.player().is_floating() = true;
-        sdata(18, 0) = clamp(
-            sdata(18, 0) + (12 + cdata.player().level / 4),
-            int{sdata(18, 0) > 0},
+        cdata.player().get_skill(18).level = clamp(
+            cdata.player().get_skill(18).level +
+                (12 + cdata.player().level / 4),
+            int{cdata.player().get_skill(18).level > 0},
             9999);
         return 1;
     }
     if (tid == 206)
     {
-        sdata(17, 0) = clamp(
-            sdata(17, 0) + (5 + cdata.player().level / 5) * -1,
-            int{sdata(17, 0) > 0},
+        cdata.player().get_skill(17).level = clamp(
+            cdata.player().get_skill(17).level +
+                (5 + cdata.player().level / 5) * -1,
+            int{cdata.player().get_skill(17).level > 0},
             9999);
         cdata.player().pv += 12 + cdata.player().level;
         return 1;
@@ -685,21 +780,23 @@ int trait_get_info(int traitmode, int tid)
     }
     if (tid == 208)
     {
-        sdata(11, 0) = clamp(
-            sdata(11, 0) + (5 + cdata.player().level / 3) * -1,
-            int{sdata(11, 0) > 0},
+        cdata.player().get_skill(11).level = clamp(
+            cdata.player().get_skill(11).level +
+                (5 + cdata.player().level / 3) * -1,
+            int{cdata.player().get_skill(11).level > 0},
             9999);
-        sdata(12, 0) = clamp(
-            sdata(12, 0) + (4 + cdata.player().level / 4) * -1,
-            int{sdata(12, 0) > 0},
+        cdata.player().get_skill(12).level = clamp(
+            cdata.player().get_skill(12).level +
+                (4 + cdata.player().level / 4) * -1,
+            int{cdata.player().get_skill(12).level > 0},
             9999);
-        sdata(14, 0) = clamp(
-            sdata(14, 0) + (6 + cdata.player().level / 2),
-            int{sdata(14, 0) > 0},
+        cdata.player().get_skill(14).level = clamp(
+            cdata.player().get_skill(14).level + (6 + cdata.player().level / 2),
+            int{cdata.player().get_skill(14).level > 0},
             9999);
-        sdata(15, 0) = clamp(
-            sdata(15, 0) + (2 + cdata.player().level / 6),
-            int{sdata(15, 0) > 0},
+        cdata.player().get_skill(15).level = clamp(
+            cdata.player().get_skill(15).level + (2 + cdata.player().level / 6),
+            int{cdata.player().get_skill(15).level > 0},
             9999);
         return 1;
     }
@@ -713,27 +810,36 @@ int trait_get_info(int traitmode, int tid)
     }
     if (tid == 211)
     {
-        sdata(10, 0) = clamp(
-            sdata(10, 0) + (4 + cdata.player().level / 2) * -1,
-            int{sdata(10, 0) > 0},
+        cdata.player().get_skill(10).level = clamp(
+            cdata.player().get_skill(10).level +
+                (4 + cdata.player().level / 2) * -1,
+            int{cdata.player().get_skill(10).level > 0},
             9999);
-        sdata(2, 0) = clamp(sdata(2, 0) + -15, int{sdata(2, 0) > 0}, 9999);
+        cdata.player().get_skill(2).level = clamp(
+            cdata.player().get_skill(2).level + -15,
+            int{cdata.player().get_skill(2).level > 0},
+            9999);
         return 1;
     }
     if (tid == 212)
     {
-        sdata(16, 0) = clamp(
-            sdata(16, 0) + (4 + cdata.player().level / 2) * -1,
-            int{sdata(16, 0) > 0},
+        cdata.player().get_skill(16).level = clamp(
+            cdata.player().get_skill(16).level +
+                (4 + cdata.player().level / 2) * -1,
+            int{cdata.player().get_skill(16).level > 0},
             9999);
-        sdata(3, 0) = clamp(sdata(3, 0) + -15, int{sdata(3, 0) > 0}, 9999);
+        cdata.player().get_skill(3).level = clamp(
+            cdata.player().get_skill(3).level + -15,
+            int{cdata.player().get_skill(3).level > 0},
+            9999);
         return 1;
     }
     if (tid == 213)
     {
-        sdata(18, 0) = clamp(
-            sdata(18, 0) + (20 + cdata.player().level / 2) * -1,
-            int{sdata(18, 0) > 0},
+        cdata.player().get_skill(18).level = clamp(
+            cdata.player().get_skill(18).level +
+                (20 + cdata.player().level / 2) * -1,
+            int{cdata.player().get_skill(18).level > 0},
             9999);
         cdata.player().pv += 15 + cdata.player().level / 2;
         return 1;
@@ -748,7 +854,10 @@ int trait_get_info(int traitmode, int tid)
     }
     if (tid == 216)
     {
-        sdata(55, 0) = clamp(sdata(55, 0) + 100, int{sdata(55, 0) > 0}, 9999);
+        cdata.player().get_skill(55).level = clamp(
+            cdata.player().get_skill(55).level + 100,
+            int{cdata.player().get_skill(55).level > 0},
+            9999);
         return 1;
     }
     return 0;

--- a/src/elona/turn_sequence.cpp
+++ b/src/elona/turn_sequence.cpp
@@ -1507,7 +1507,7 @@ void proc_turn_end(Character& chara)
     }
     if (chara.poisoned > 0)
     {
-        damage_hp(chara, rnd_capped(2 + sdata(11, chara.index) / 10), -4);
+        damage_hp(chara, rnd_capped(2 + chara.get_skill(11).level / 10), -4);
         status_ailment_heal(chara, StatusAilment::poisoned, 1);
         if (chara.poisoned > 0)
         {
@@ -1563,7 +1563,7 @@ void proc_turn_end(Character& chara)
             if (!enchantment_find(chara, 60010 + p))
             {
                 chara.attr_adjs[p] -=
-                    sdata.get(10 + p, chara.index).original_level / 25 + 1;
+                    chara.get_skill(10 + p).base_level / 25 + 1;
                 chara_refresh(chara);
             }
         }
@@ -1755,11 +1755,11 @@ void proc_turn_end(Character& chara)
     {
         if (rnd(6) == 0)
         {
-            heal_hp(chara, rnd_capped(sdata(154, chara.index) / 3 + 1) + 1);
+            heal_hp(chara, rnd_capped(chara.get_skill(154).level / 3 + 1) + 1);
         }
         if (rnd(5) == 0)
         {
-            heal_mp(chara, rnd_capped(sdata(155, chara.index) / 2 + 1) + 1);
+            heal_mp(chara, rnd_capped(chara.get_skill(155).level / 2 + 1) + 1);
         }
     }
 }

--- a/src/elona/ui.cpp
+++ b/src/elona/ui.cpp
@@ -6,6 +6,7 @@
 #include "cell_draw.hpp"
 #include "character.hpp"
 #include "config.hpp"
+#include "data/types/type_ability.hpp"
 #include "data/types/type_asset.hpp"
 #include "debug.hpp"
 #include "draw.hpp"
@@ -486,7 +487,10 @@ void render_basic_attributes_and_pv_dv()
             const auto text_color = cdata.player().attr_adjs[i] < 0
                 ? snail::Color{200, 0, 0}
                 : snail::Color{0, 0, 0};
-            mes(x, y, std::to_string(sdata(10 + i, 0)), text_color);
+            mes(x,
+                y,
+                std::to_string(cdata.player().get_skill(10 + i).level),
+                text_color);
         }
         else if (i == 8)
         {
@@ -684,8 +688,9 @@ void render_skill_trackers()
             16,
             inf_clocky + 107 + y * 16);
         bmes(
-            ""s + sdata.get(skill, chara).original_level + u8"."s +
-                std::to_string(1000 + sdata.get(skill, chara).experience % 1000)
+            ""s + cdata[chara].get_skill(skill).base_level + u8"."s +
+                std::to_string(
+                    1000 + cdata[chara].get_skill(skill).experience % 1000)
                     .substr(1),
             66,
             inf_clocky + 107 + y * 16);
@@ -693,20 +698,20 @@ void render_skill_trackers()
         {
             elona::snail::Color col{255, 130, 130};
 
-            if (sdata.get(skill, chara).potential >
+            if (cdata[chara].get_skill(skill).potential >
                 elona::g_config.enhanced_skill_upperbound())
             {
                 col = {130, 255, 130};
             }
             else if (
-                sdata.get(skill, chara).potential >
+                cdata[chara].get_skill(skill).potential >
                 elona::g_config.enhanced_skill_lowerbound())
             {
                 col = {255, 255, 130};
             }
 
             bmes(
-                ""s + sdata.get(skill, chara).potential + u8"%"s,
+                ""s + cdata[chara].get_skill(skill).potential + u8"%"s,
                 128,
                 inf_clocky + 107 + y * 16,
                 col);

--- a/src/elona/ui/ui_menu_charamake_attributes.cpp
+++ b/src/elona/ui/ui_menu_charamake_attributes.cpp
@@ -4,6 +4,7 @@
 #include "../audio.hpp"
 #include "../character_making.hpp"
 #include "../class.hpp"
+#include "../data/types/type_ability.hpp"
 #include "../draw.hpp"
 #include "../i18n.hpp"
 #include "../menu.hpp"
@@ -31,17 +32,18 @@ void UIMenuCharamakeAttributes::_reroll_attributes()
         {
             if (_minimum)
             {
-                sdata.get(cnt, 0).original_level -=
-                    sdata.get(cnt, 0).original_level / 2;
+                cdata.player().get_skill(cnt).base_level -=
+                    cdata.player().get_skill(cnt).base_level / 2;
             }
             else
             {
-                sdata.get(cnt, 0).original_level -=
-                    rnd(sdata.get(cnt, 0).original_level / 2 + 1);
+                cdata.player().get_skill(cnt).base_level -=
+                    rnd(cdata.player().get_skill(cnt).base_level / 2 + 1);
             }
-            _attributes(cnt - 10) = sdata.get(cnt, 0).original_level * 1000000 +
-                sdata.get(cnt, 0).experience * 1000 +
-                sdata.get(cnt, 0).potential;
+            _attributes(cnt - 10) =
+                cdata.player().get_skill(cnt).base_level * 1000000 +
+                cdata.player().get_skill(cnt).experience * 1000 +
+                cdata.player().get_skill(cnt).potential;
         }
     }
 }

--- a/src/elona/ui/ui_menu_crafting.cpp
+++ b/src/elona/ui/ui_menu_crafting.cpp
@@ -24,7 +24,8 @@ static int _can_produce_item(int created_item_id)
         return -1;
     }
 
-    if (recipe->required_skill_level > sdata(recipe->skill_used, 0))
+    if (recipe->required_skill_level >
+        cdata.player().get_skill(recipe->skill_used).level)
     {
         return -1;
     }
@@ -75,7 +76,8 @@ static bool _should_show_entry(int item_id, int _prodtype)
             return false;
         }
     }
-    if (sdata(recipe->skill_used, 0) + 3 < recipe->required_skill_level)
+    if (cdata.player().get_skill(recipe->skill_used).level + 3 <
+        recipe->required_skill_level)
     {
         return false;
     }
@@ -180,10 +182,10 @@ void UIMenuCrafting::_draw_recipe_desc(const CraftingRecipe& recipe)
     }
 
     desc += u8" "s + recipe.required_skill_level + u8"("s +
-        sdata(recipe.skill_used, 0) + u8")"s;
+        cdata.player().get_skill(recipe.skill_used).level + u8")"s;
 
-    const auto text_color =
-        recipe.required_skill_level <= sdata(recipe.skill_used, 0)
+    const auto text_color = recipe.required_skill_level <=
+            cdata.player().get_skill(recipe.skill_used).level
         ? snail::Color{30, 30, 200}
         : snail::Color{200, 30, 30};
     mes(wx + 37, wy + 288, desc + u8" "s, text_color);

--- a/src/elona/ui/ui_menu_ctrl_ally.cpp
+++ b/src/elona/ui/ui_menu_ctrl_ally.cpp
@@ -5,6 +5,7 @@
 #include "../audio.hpp"
 #include "../calc.hpp"
 #include "../character.hpp"
+#include "../data/types/type_ability.hpp"
 #include "../draw.hpp"
 #include "../i18n.hpp"
 #include "../menu.hpp"
@@ -267,7 +268,7 @@ snail::Color UIMenuCtrlAlly::_draw_get_color(const Character& chara)
 {
     if (_operation == ControlAllyOperation::gene_engineer)
     {
-        if (chara.level > sdata(151, 0) + 5)
+        if (chara.level > cdata.player().get_skill(151).level + 5)
         {
             return {160, 10, 10};
         }
@@ -335,8 +336,8 @@ std::string UIMenuCtrlAlly::_get_specific_ally_info(const Character& chara)
 
     if (area_data[game_data.current_map].id == mdata_t::MapId::shop)
     {
-        _s = u8"   "s + sdata(17, chara.index) + u8" / " +
-            sdata(156, chara.index);
+        _s = u8"   "s + chara.get_skill(17).level + u8" / " +
+            chara.get_skill(156).level;
     }
     else if (area_data[game_data.current_map].id == mdata_t::MapId::ranch)
     {
@@ -526,7 +527,7 @@ void UIMenuCtrlAlly::draw()
 
 optional<UIMenuCtrlAlly::Result> UIMenuCtrlAlly::_select_gene_engineer(int _p)
 {
-    if (cdata[_p].level > sdata(151, 0) + 5)
+    if (cdata[_p].level > cdata.player().get_skill(151).level + 5)
     {
         snd("core.fail1");
         txt(i18n::s.get("core.ui.ally_list.gene_engineer.skill_too_low"));

--- a/src/elona/ui/ui_menu_skills.cpp
+++ b/src/elona/ui/ui_menu_skills.cpp
@@ -2,6 +2,7 @@
 
 #include "../ability.hpp"
 #include "../audio.hpp"
+#include "../data/types/type_ability.hpp"
 #include "../i18n.hpp"
 #include "../keybind/keybind.hpp"
 #include "../menu.hpp"
@@ -16,7 +17,7 @@ static void _populate_skill_list()
 {
     for (int cnt = 300; cnt < 400; ++cnt)
     {
-        if (sdata(cnt, cdata.player().index) > 0)
+        if (cdata.player().get_skill(cnt).level > 0)
         {
             list(0, listmax) = cnt;
             list(1, listmax) =

--- a/src/elona/ui/ui_menu_spells.cpp
+++ b/src/elona/ui/ui_menu_spells.cpp
@@ -3,6 +3,7 @@
 #include "../ability.hpp"
 #include "../audio.hpp"
 #include "../calc.hpp"
+#include "../data/types/type_ability.hpp"
 #include "../i18n.hpp"
 #include "../keybind/keybind.hpp"
 #include "../menu.hpp"
@@ -157,7 +158,7 @@ void UIMenuSpells::_draw_spell_power(int cnt, int spell_id)
         strutil::take_by_width(make_spell_description(spell_id), 40);
     mes(wx + 340,
         wy + 66 + cnt * 19 + 2,
-        ""s + sdata(spell_id, cdata.player().index) + u8"/"s +
+        ""s + cdata.player().get_skill(spell_id).level + u8"/"s +
             calc_spell_success_rate(cdata.player(), spell_id) + u8"%"s);
     mes(wx + 420, wy + 66 + cnt * 19 + 2, spell_power);
 }

--- a/src/elona/wish.cpp
+++ b/src/elona/wish.cpp
@@ -11,6 +11,7 @@
 #include "character.hpp"
 #include "character_status.hpp"
 #include "config.hpp"
+#include "data/types/type_ability.hpp"
 #include "data/types/type_item.hpp"
 #include "debug.hpp"
 #include "deferred_event.hpp"
@@ -732,7 +733,7 @@ bool wish_for_skill(const std::string& input)
         const auto name = the_ability_db.get_text(id, "name");
         if (!name.empty())
         {
-            if (sdata.get(id, 0).original_level == 0)
+            if (cdata.player().get_skill(id).base_level == 0)
             {
                 txt(i18n::s.get("core.wish.you_learn_skill", name),
                     Message::color{ColorIndex::orange});

--- a/src/tests/lua/classes/LuaCharacter.lua
+++ b/src/tests/lua/classes/LuaCharacter.lua
@@ -53,11 +53,11 @@ lrun("test LuaCharacter:gain_skill_exp", function()
         Testing.start_in_debug_map()
 
         local putit = Chara.create(0, 0, "core.putit")
-        lequal(putit:get_skill("core.attribute_strength").current_level, 4)
+        lequal(putit:get_skill("core.attribute_strength").level, 4)
 
         putit:gain_skill_exp("core.attribute_strength", 10000)
 
-        lequal(putit:get_skill("core.attribute_strength").current_level, 14)
+        lequal(putit:get_skill("core.attribute_strength").level, 14)
 end)
 
 lrun("test LuaCharacter:modify_resistance", function()

--- a/src/tests/lua_handles.cpp
+++ b/src/tests/lua_handles.cpp
@@ -738,14 +738,14 @@ TEST_CASE("Test validity check of lua reference userdata", "[Lua: Handles]")
 local Chara = ELONA.require("core.Chara")
 local chara = Chara.create(0, 0, "core.putit")
 local skill = chara:get_skill("core.attribute_strength")
-assert(skill.original_level > 0)
+assert(skill.base_level > 0)
 
 local old_index = chara.index
 chara:damage_hp(chara.max_hp + 1)
 local chara = Chara.create(0, 0, "core.putit")
 assert(chara.index == old_index)
 
-assert(skill.original_level == 0)
+assert(skill.base_level == 0)
 )"));
 }
 

--- a/src/tests/serialization.cpp
+++ b/src/tests/serialization.cpp
@@ -113,10 +113,10 @@ TEST_CASE("Test ability data compatibility", "[C++: Serialization]")
     int ability_idx = 170; // Medium Armor
     int chara_idx = 57;
     load_previous_savefile();
-    REQUIRE(elona::sdata.get(ability_idx, chara_idx).current_level == 28);
-    REQUIRE(elona::sdata.get(ability_idx, chara_idx).original_level == 28);
-    REQUIRE(elona::sdata.get(ability_idx, chara_idx).experience == 0);
-    REQUIRE(elona::sdata.get(ability_idx, chara_idx).potential == 22);
+    REQUIRE(elona::cdata[chara_idx].get_skill(ability_idx).level == 28);
+    REQUIRE(elona::cdata[chara_idx].get_skill(ability_idx).base_level == 28);
+    REQUIRE(elona::cdata[chara_idx].get_skill(ability_idx).experience == 0);
+    REQUIRE(elona::cdata[chara_idx].get_skill(ability_idx).potential == 22);
 }
 
 TEST_CASE("Test foobar save data compatibility", "[C++: Serialization]")


### PR DESCRIPTION
# Summary

## Internal data structure

`sdata` is one of the global variables which also exist in vanilla's source code. It holds all "skill data" of all characters. It should be merged into character data. In this commit, save data are kept compatible.

| Old | New | Vanilla |
|---|---|---|
| `sdata(skill_id, chara.index)` | `chara.get_skill(skill_id).level` | `sdata(skill_id, chara_index)` |
| `sdata.get(skill_id, chara.index).original_level` | `chara.get_skill(skill_id).base_level` | `sORG(skill_id, chara_index)` |
| `sdata.get(skill_id, chara.index).experience` | `chara.get_skill(skill_id).experience` | `sEXP(skill_id, chara_index)` |
| `sdata.get(skill_id, chara.index).potential` | `chara.get_skill(skill_id).potential` | `sGROWTH(skill_id, chara_index)` |


## Lua API

Rename some fields of `LuaAbility`.

* `LuaAbility.current_level` -> `level`
* `LuaAbility.original_level` -> `base_level`


## Fix a trivial bug

Fix buff effect's calculation (Element scar and Nightmare):

```diff
skill.level =
      math.clamp(skill.level + amount,
-                 skill.level and 1 or 0, 9999)
+                 skill.level > 0 and 1 or 0, 9999)
```

Since all numbers are truthy in Lua, this expression `skill.level and 1 or 0` always returns `1`. The fixed one is intended.