### PR TITLE
Reduce uses of `Character::index`

### DIFF
--- a/doc/api/Chara.luadoc
+++ b/doc/api/Chara.luadoc
@@ -9,14 +9,14 @@ module "Chara"
 --  @function is_alive
 function is_alive(chara) end
 
---- Checks if a character is the player (has index 0).
+--- Checks if a character is the player.
 --
 --  @tparam LuaCharacter chara (const) a character
 --  @treturn bool true if the character is the player
 --  @function is_player
 function is_player(chara) end
 
---- Checks if a character is a member of the player's party (has index < 16)
+--- Checks if a character is a member of the player's party.
 --
 --  @tparam LuaCharacter chara (const) a character
 --  @treturn bool true if the character is in the player's party

--- a/src/elona/ability.cpp
+++ b/src/elona/ability.cpp
@@ -142,7 +142,7 @@ void chara_gain_skill(Character& chara, int id, int initial_level, int stock)
 {
     if (id >= 400)
     {
-        if (chara.index == 0)
+        if (chara.is_player())
         {
             spell(id - 400) += stock;
             modify_potential(chara, id, 1);
@@ -226,7 +226,7 @@ void chara_gain_fixed_skill_exp(Character& chara, int id, int experience)
         set_ability(chara, id, lv, exp, potential);
         if (is_in_fov(chara))
         {
-            if (chara.index == 0 || chara.index < 16)
+            if (chara.is_player() || chara.is_player_or_ally())
             {
                 snd("core.ding3");
                 Message::instance().txtef(ColorIndex::green);
@@ -254,7 +254,7 @@ void chara_gain_fixed_skill_exp(Character& chara, int id, int experience)
         lv -= lv_delta;
         potential = increase_potential(potential, lv_delta);
         set_ability(chara, id, lv, exp, potential);
-        if (chara.index == 0 || chara.index < 16)
+        if (chara.is_player() || chara.is_player_or_ally())
         {
             if (is_in_fov(chara))
             {
@@ -338,7 +338,7 @@ void chara_gain_skill_exp(
                 const auto lvl_exp = calc_chara_exp_from_skill_exp(
                     chara, exp, experience_divisor_of_character_level);
                 chara.experience += lvl_exp;
-                if (chara.index == 0)
+                if (chara.is_player())
                 {
                     game_data.sleep_experience += lvl_exp;
                 }
@@ -356,7 +356,7 @@ void chara_gain_skill_exp(
         set_ability(chara, id, lv, new_exp_level, potential);
         if (is_in_fov(chara))
         {
-            if (chara.index == 0 || chara.index < 16)
+            if (chara.is_player() || chara.is_player_or_ally())
             {
                 snd("core.ding3");
                 Message::instance().txtef(ColorIndex::green);
@@ -387,7 +387,7 @@ void chara_gain_skill_exp(
         set_ability(chara, id, lv, new_exp_level, potential);
         if (is_in_fov(chara))
         {
-            if (chara.index == 0 || chara.index < 16)
+            if (chara.is_player() || chara.is_player_or_ally())
             {
                 if (lv_delta != 0)
                 {
@@ -449,7 +449,7 @@ void chara_gain_exp_detection(Character& chara)
 
 void chara_gain_exp_casting(Character& chara, int spell_id)
 {
-    if (chara.index == 0)
+    if (chara.is_player())
     {
         chara_gain_skill_exp(
             chara, spell_id, calc_spell_exp_gain(spell_id), 4, 5);
@@ -502,7 +502,7 @@ void chara_gain_exp_weight_lifting(Character& chara)
 
 void chara_gain_exp_magic_device(Character& chara)
 {
-    if (chara.index == 0)
+    if (chara.is_player())
     {
         chara_gain_skill_exp(chara, 174, 40);
     }

--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -1431,39 +1431,49 @@ void activity_sex(Character& chara_a, optional_ref<Character> chara_b)
         chara_a.activity.finish();
         return;
     }
-    for (int cnt = 0; cnt < 2; ++cnt)
+
     {
-        int c{};
-        if (cnt == 0)
-        {
-            c = chara_a.index;
-        }
-        else
-        {
-            c = target_index;
-        }
         chara_a.drunk = 0;
-        if (cnt == 1)
-        {
-            if (rnd(3) == 0)
-            {
-                status_ailment_damage(cdata[c], StatusAilment::insane, 500);
-            }
-            if (rnd(5) == 0)
-            {
-                status_ailment_damage(cdata[c], StatusAilment::paralyzed, 500);
-            }
-            status_ailment_damage(cdata[c], StatusAilment::insane, 300);
-            heal_insanity(cdata[c], 10);
-            chara_gain_skill_exp(cdata[c], 11, 250 + (c >= 57) * 1000);
-            chara_gain_skill_exp(cdata[c], 15, 250 + (c >= 57) * 1000);
-        }
         if (rnd(15) == 0)
         {
-            status_ailment_damage(cdata[c], StatusAilment::sick, 200);
+            status_ailment_damage(chara_a, StatusAilment::sick, 200);
         }
-        chara_gain_skill_exp(cdata[c], 17, 250 + (c >= 57) * 1000);
+        chara_gain_skill_exp(
+            chara_a, 17, 250 + (chara_a.is_map_local()) * 1000);
     }
+
+    {
+        if (rnd(3) == 0)
+        {
+            status_ailment_damage(
+                cdata[target_index], StatusAilment::insane, 500);
+        }
+        if (rnd(5) == 0)
+        {
+            status_ailment_damage(
+                cdata[target_index], StatusAilment::paralyzed, 500);
+        }
+        status_ailment_damage(cdata[target_index], StatusAilment::insane, 300);
+        heal_insanity(cdata[target_index], 10);
+        chara_gain_skill_exp(
+            cdata[target_index],
+            11,
+            250 + (cdata[target_index].is_map_local()) * 1000);
+        chara_gain_skill_exp(
+            cdata[target_index],
+            15,
+            250 + (cdata[target_index].is_map_local()) * 1000);
+        if (rnd(15) == 0)
+        {
+            status_ailment_damage(
+                cdata[target_index], StatusAilment::sick, 200);
+        }
+        chara_gain_skill_exp(
+            cdata[target_index],
+            17,
+            250 + (cdata[target_index].is_map_local()) * 1000);
+    }
+
     int sexvalue = chara_a.get_skill(17).level * (50 + rnd(50)) + 100;
 
     std::string dialog_head;

--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -2175,26 +2175,24 @@ void sleep_start(const OptionalItemRef& bed)
     }
     if (game_data.character_and_status_for_gene != 0)
     {
-        auto gene_chara_index = -1;
-        for (const auto& ally : cdata.allies())
+        optional_ref<Character> gene_chara;
+        for (auto& ally : cdata.allies())
         {
-            if (ally.has_made_gene())
+            if (ally.state() == Character::State::alive)
             {
-                if (ally.state() == Character::State::alive)
+                if (ally.has_made_gene())
                 {
-                    gene_chara_index = ally.index;
+                    gene_chara = ally;
                     break;
                 }
             }
         }
-        if (gene_chara_index != -1)
+        if (gene_chara)
         {
-            cdata[gene_chara_index].has_made_gene() = false;
+            gene_chara->has_made_gene() = false;
             show_random_event_window(
                 i18n::s.get("core.activity.sleep.new_gene.title"),
-                i18n::s.get(
-                    "core.activity.sleep.new_gene.text",
-                    cdata[gene_chara_index]),
+                i18n::s.get("core.activity.sleep.new_gene.text", *gene_chara),
                 {i18n::s.get_enum("core.activity.sleep.new_gene.choices", 0)},
                 u8"bg_re14");
             save_gene();

--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -881,7 +881,7 @@ void activity_others_doing_steal(Character& doer, const ItemRef& steal_target)
                 if (owner->sleep == 0)
                 {
                     owner->relationship = -2;
-                    hostileaction(0, owner->index);
+                    chara_act_hostile_action(cdata.player(), *owner);
                     chara_modify_impression(*owner, -20);
                 }
             }

--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -217,7 +217,7 @@ int calc_performance_tips(const Character& performer, const Character& audience)
     const auto m = Q * Q * (100 + I / 5) / 100 / 1000 + rnd(10);
     auto ret = clamp(audience.gold * clamp(m, 1, 100) / 125, 0, max);
 
-    if (audience.index < 16)
+    if (audience.is_player_or_ally())
     {
         ret = rnd(clamp(ret, 1, 100)) + 1;
     }
@@ -418,7 +418,7 @@ std::pair<bool, int> activity_perform_proc_audience(
         audience.hate = 30;
         return std::make_pair(false, 0);
     }
-    if (performer.index == 0)
+    if (performer.is_player())
     {
         audience.interest -= rnd(15);
         audience.time_interest_revive = game_data.date.hours() + 12;
@@ -474,7 +474,7 @@ std::pair<bool, int> activity_perform_proc_audience(
     {
         if (game_data.executing_immediate_quest_type == 1009)
         {
-            if (audience.index >= 57)
+            if (audience.is_map_local())
             {
                 audience.impression += rnd(3);
                 calcpartyscore();
@@ -510,7 +510,7 @@ std::pair<bool, int> activity_perform_proc_audience(
                     Message::color{ColorIndex::cyan});
             }
             performer.quality_of_performance += audience.level + 5;
-            if (performer.index == 0 && audience.index >= 16)
+            if (performer.is_player() && !audience.is_player_or_ally())
             {
                 if (rnd_capped(performance_tips * 2 + 2) == 0)
                 {
@@ -536,7 +536,7 @@ void activity_perform_start(Character& performer, ItemRef instrument)
     performer.activity.item = instrument;
     performer.quality_of_performance = 40;
     performer.tip_gold = 0;
-    if (performer.index == 0)
+    if (performer.is_player())
     {
         performance_tips = 0;
     }
@@ -618,7 +618,7 @@ int calc_performance_quality_level(int quality)
 
 void activity_perform_end(Character& performer)
 {
-    if (performer.index == 0)
+    if (performer.is_player())
     {
         const auto quality_level =
             calc_performance_quality_level(performer.quality_of_performance);
@@ -659,7 +659,7 @@ void activity_eating_start(Character& eater, const ItemRef& food)
     if (is_in_fov(eater))
     {
         snd("core.eat1");
-        if (food->own_state == 1 && eater.index < 16)
+        if (food->own_state == 1 && eater.is_player_or_ally())
         {
             txt(i18n::s.get("core.activity.eat.start.in_secret", eater, food));
         }
@@ -1224,7 +1224,7 @@ void rowact_item(const ItemRef& item)
 void activity_handle_damage(Character& chara)
 {
     bool stop = false;
-    if (chara.index == 0)
+    if (chara.is_player())
     {
         if (chara.activity.type != Activity::Type::eat &&
             chara.activity.type != Activity::Type::read &&
@@ -1264,7 +1264,7 @@ optional<TurnResult> activity_proc(Character& chara)
     --chara.activity.turn;
 
     const auto auto_turn = [&](int delay) {
-        if (chara.index == 0)
+        if (chara.is_player())
         {
             elona::auto_turn(delay);
         }
@@ -1334,7 +1334,7 @@ optional<TurnResult> activity_proc(Character& chara)
         return TurnResult::turn_end;
     }
     chara.activity.finish();
-    if (chara.index == 0)
+    if (chara.is_player())
     {
         if (chatteleport == 1)
         {
@@ -1406,7 +1406,7 @@ void activity_sex(Character& chara_a, optional_ref<Character> chara_b)
         cdata[target_index].activity.finish();
         return;
     }
-    if (chara_a.index == 0)
+    if (chara_a.is_player())
     {
         if (!action_sp(cdata.player(), 1 + rnd(2)))
         {
@@ -1500,7 +1500,7 @@ void activity_sex(Character& chara_a, optional_ref<Character> chara_b)
                     "core.activity.sex.take_all_i_have", cdata[target_index]);
                 if (rnd(3) == 0)
                 {
-                    if (chara_a.index != 0)
+                    if (!chara_a.is_player())
                     {
                         dialog_after = i18n::s.get(
                             "core.activity.sex.gets_furious", chara_a);
@@ -1516,7 +1516,7 @@ void activity_sex(Character& chara_a, optional_ref<Character> chara_b)
             sexvalue = cdata[target_index].gold;
         }
         cdata[target_index].gold -= sexvalue;
-        if (chara_a.index == 0)
+        if (chara_a.is_player())
         {
             chara_modify_impression(cdata[target_index], 5);
             flt();
@@ -1568,7 +1568,7 @@ void activity_eating_finish(Character& eater, const ItemRef& food)
 {
     apply_general_eating_effect(eater, food);
 
-    if (eater.index == 0)
+    if (eater.is_player())
     {
         item_identify(food, IdentifyState::partly);
     }
@@ -1579,7 +1579,7 @@ void activity_eating_finish(Character& eater, const ItemRef& food)
 
     food->modify_number(-1);
 
-    if (eater.index == 0)
+    if (eater.is_player())
     {
         show_eating_message(eater);
     }
@@ -1632,7 +1632,7 @@ void activity_eating_finish(Character& eater, const ItemRef& food)
 
 void activity_others(Character& doer, const OptionalItemRef& activity_item)
 {
-    if (doer.index != 0)
+    if (!doer.is_player())
     {
         doer.activity.finish();
         return;

--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -562,13 +562,7 @@ void activity_perform_doing(Character& performer)
     if (performer.activity.turn % 20 == 0)
     {
         int gold = 0;
-        make_sound(
-            performer.position.x,
-            performer.position.y,
-            5,
-            1,
-            1,
-            performer.index);
+        make_sound(performer, 5, 1, true);
         for (auto&& audience : cdata.all())
         {
             const auto result =
@@ -814,7 +808,7 @@ void activity_others_doing_steal(Character& doer, const ItemRef& steal_target)
     {
         i = i * 5 / 10;
     }
-    make_sound(cdata.player().position.x, cdata.player().position.y, 5, 8);
+    make_sound(cdata.player(), 5, 8, false);
     for (int cnt = 16; cnt < ELONA_MAX_CHARACTERS; ++cnt)
     {
         if (cdata[cnt].state() != Character::State::alive)

--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -402,7 +402,7 @@ std::pair<bool, int> activity_perform_proc_audience(
     {
         return std::make_pair(false, 0); // TODO: unreachable?
     }
-    if (audience.index == performer.index)
+    if (audience == performer)
     {
         return std::make_pair(false, 0);
     }

--- a/src/elona/adventurer.cpp
+++ b/src/elona/adventurer.cpp
@@ -111,36 +111,32 @@ void create_adventurer(Character& adv)
 
 
 
-int advfavoriteskill(int seed)
+int adventurer_favorite_skill(const Character& adv)
 {
+    const auto seed = adv.index;
     randomize(seed);
-    rtval = 0;
-    i_at_m145 = 0;
-    while (1)
+    std::vector<int> skills;
+    while (skills.size() < 2)
     {
-        rtval(i_at_m145) = rnd(300) + 100;
-        if (!the_ability_db[rtval(i_at_m145)])
+        const auto skill_id = rnd(300) + 100;
+        if (the_ability_db[skill_id])
         {
-            continue;
-        }
-        ++i_at_m145;
-        if (i_at_m145 >= 2)
-        {
-            break;
+            skills.push_back(skill_id);
         }
     }
     randomize();
-    return i_at_m145;
+    return choice(skills);
 }
 
 
 
-int advfavoritestat(int seed)
+int adventurer_favorite_stat(const Character& adv)
 {
+    const auto seed = adv.index;
     randomize(seed);
-    i_at_m145 = rnd(8) + 10;
+    const auto ret = rnd(8) + 10;
     randomize();
-    return i_at_m145;
+    return ret;
 }
 
 

--- a/src/elona/adventurer.cpp
+++ b/src/elona/adventurer.cpp
@@ -24,6 +24,35 @@
 namespace elona
 {
 
+namespace
+{
+
+void add_news_entry(std::string news_content, bool show_message)
+{
+    if (show_message)
+    {
+        txt(u8"[News] "s + news_content,
+            Message::color{ColorIndex::light_brown});
+    }
+    talk_conv(news_content, 38 - en * 5);
+    newsbuff += news_content + u8"\n"s;
+}
+
+
+
+void add_news_topic(const std::string& mark, const std::string& news_content)
+{
+    const auto date = std::to_string(game_data.date.year) + "/" +
+        std::to_string(game_data.date.month) + "/" +
+        std::to_string(game_data.date.day) + " h" +
+        std::to_string(game_data.date.hour);
+    add_news_entry(mark + " " + date + " " + news_content, false);
+}
+
+} // namespace
+
+
+
 int i_at_m145 = 0;
 
 
@@ -116,84 +145,61 @@ int advfavoritestat(int seed)
 
 
 
-void addnews2(const std::string& news_content, int show_message)
-{
-    std::string n_at_m36 = news_content;
-    if (show_message)
-    {
-        txt(u8"[News] "s + n_at_m36, Message::color{ColorIndex::light_brown});
-    }
-    talk_conv(n_at_m36, 38 - en * 5);
-    newsbuff += n_at_m36 + u8"\n"s;
-}
-
-
-
-void addnewstopic(const std::string& mark, const std::string& news_content)
-{
-    addnews2(
-        mark + u8" "s + game_data.date.year + u8"/"s + game_data.date.month +
-        u8"/"s + game_data.date.day + u8" h"s + game_data.date.hour + ""s +
-        u8" "s + news_content);
-}
-
-
-
-void addnews(int news_type, int adventurer, int fame, const std::string& valn)
+void adventurer_add_news(
+    NewsType news_type,
+    const Character& adventurer,
+    const std::string& extra_info)
 {
     switch (news_type)
     {
-    case 0: addnews2(valn); break;
-    case 1:
-        addnewstopic(u8"@01"s, i18n::s.get("core.news.discovery.title"));
-        addnews2(
+    case NewsType::discovery:
+        add_news_topic(u8"@01"s, i18n::s.get("core.news.discovery.title"));
+        add_news_entry(
             i18n::s.get(
                 "core.news.discovery.text",
-                cdata[adventurer].alias,
-                cdata[adventurer].name,
-                valn,
-                mapname(cdata[adventurer].current_map)),
-            1);
+                adventurer.alias,
+                adventurer.name,
+                extra_info /* discovered artifact */,
+                mapname(adventurer.current_map)),
+            true);
         break;
-    case 2:
-        addnewstopic(u8"@02"s, i18n::s.get("core.news.growth.title"));
-        addnews2(
+    case NewsType::growth:
+        add_news_topic(u8"@02"s, i18n::s.get("core.news.growth.title"));
+        add_news_entry(
             i18n::s.get(
                 "core.news.growth.text",
-                cdata[adventurer].alias,
-                cdata[adventurer].name,
-                cdata[adventurer].level),
-            1);
+                adventurer.alias,
+                adventurer.name,
+                adventurer.level),
+            true);
         break;
-    case 3:
-        addnewstopic(u8"@02"s, i18n::s.get("core.news.recovery.title"));
-        addnews2(
+    case NewsType::recovery:
+        add_news_topic(u8"@02"s, i18n::s.get("core.news.recovery.title"));
+        add_news_entry(
             i18n::s.get(
-                "core.news.recovery.text",
-                cdata[adventurer].alias,
-                cdata[adventurer].name),
-            1);
+                "core.news.recovery.text", adventurer.alias, adventurer.name),
+            true);
         break;
-    case 4:
-        addnewstopic(u8"@03"s, i18n::s.get("core.news.accomplishment.title"));
-        addnews2(
+    case NewsType::accomplishment:
+        add_news_topic(u8"@03"s, i18n::s.get("core.news.accomplishment.title"));
+        add_news_entry(
             i18n::s.get(
                 "core.news.accomplishment.text",
-                cdata[adventurer].alias,
-                cdata[adventurer].name,
-                fame),
-            1);
+                adventurer.alias,
+                adventurer.name,
+                extra_info /* gained fame */),
+            true);
         break;
-    case 5:
-        addnewstopic(u8"@04"s, i18n::s.get("core.news.retirement.title"));
-        addnews2(
+    case NewsType::retirement:
+        add_news_topic(u8"@04"s, i18n::s.get("core.news.retirement.title"));
+        add_news_entry(
             i18n::s.get(
-                "core.news.retirement.text",
-                cdata[adventurer].alias,
-                cdata[adventurer].name),
-            1);
+                "core.news.retirement.text", adventurer.alias, adventurer.name),
+            true);
         break;
+    default: assert(0); break;
     }
+
     newsbuff += u8"\n"s;
 }
 
@@ -226,13 +232,13 @@ void adventurer_update()
                 {
                     if (rnd(3) == 0)
                     {
-                        addnews(5, adv.index);
+                        adventurer_add_news(NewsType::retirement, adv);
                         adv.set_state(Character::State::empty);
                         create_adventurer(adv);
                     }
                     else
                     {
-                        addnews(3, adv.index);
+                        adventurer_add_news(NewsType::recovery, adv);
                         adv.set_state(
                             Character::State::adventurer_in_other_map);
                     }
@@ -297,7 +303,8 @@ void adventurer_update()
                 clamp(adv.level, 1, 1000) * clamp(adv.level, 1, 1000) * 100;
             int fame = rnd_capped(adv.level * adv.level / 20 + 10) + 10;
             adv.fame += fame;
-            addnews(4, adv.index, fame);
+            adventurer_add_news(
+                NewsType::accomplishment, adv, std::to_string(fame));
             adventurer_discover_equipment(adv);
         }
         if (adv.experience >= adv.required_experience)
@@ -365,7 +372,8 @@ void adventurer_discover_equipment(Character& adv)
         {
             if (is_equipment(the_item_db[itemid2int(item->id)]->category))
             {
-                addnews(1, adv.index, 0, itemname(item.unwrap()));
+                adventurer_add_news(
+                    NewsType::discovery, adv, itemname(item.unwrap()));
             }
         }
         wear_most_valuable_equipment(adv, item.unwrap());

--- a/src/elona/adventurer.hpp
+++ b/src/elona/adventurer.hpp
@@ -15,8 +15,9 @@ void create_all_adventurers();
 void create_adventurer(Character& adv);
 void adventurer_update();
 void adventurer_discover_equipment(Character& adv);
-int advfavoriteskill(int = 0);
-int advfavoritestat(int = 0);
+
+int adventurer_favorite_skill(const Character& adv);
+int adventurer_favorite_stat(const Character& adv);
 
 
 

--- a/src/elona/adventurer.hpp
+++ b/src/elona/adventurer.hpp
@@ -18,8 +18,20 @@ void adventurer_discover_equipment(Character& adv);
 int advfavoriteskill(int = 0);
 int advfavoritestat(int = 0);
 
-void addnews(int = 0, int = 0, int = 0, const std::string& = "");
-void addnews2(const std::string&, int = 0);
-void addnewstopic(const std::string&, const std::string&);
+
+
+enum class NewsType
+{
+    discovery,
+    growth,
+    recovery,
+    accomplishment,
+    retirement,
+};
+
+void adventurer_add_news(
+    NewsType news_type,
+    const Character& adventurer,
+    const std::string& extra_info = "");
 
 } // namespace elona

--- a/src/elona/ai.cpp
+++ b/src/elona/ai.cpp
@@ -362,7 +362,7 @@ bool _is_valid_position(int x, int y)
 
 bool _will_crush_wall(const Character& chara, int x, int y)
 {
-    return chara.index >= 16 && chara.quality >= Quality::miracle &&
+    return !chara.is_player_or_ally() && chara.quality >= Quality::miracle &&
         chara.relationship <= -2 && _is_valid_position(x, y) &&
         (chip_data.for_cell(x, y).effect & 4);
 }
@@ -604,7 +604,7 @@ TurnResult ai_proc_basic(Character& chara, int& enemy_index)
         efid = act;
         if (chara.mp < chara.max_mp / 7)
         {
-            if (rnd(3) || chara.index < 16 ||
+            if (rnd(3) || chara.is_player_or_ally() ||
                 chara.quality >= Quality::miracle ||
                 chara.cures_mp_frequently())
             {
@@ -638,7 +638,7 @@ TurnResult ai_proc_basic(Character& chara, int& enemy_index)
         {
             try_to_melee_attack(chara, cdata[enemy_index]);
         }
-        else if (rnd(3) == 0 || chara.index < 16)
+        else if (rnd(3) == 0 || chara.is_player_or_ally())
         {
             const auto ok = _try_do_melee_attack(chara, cdata[enemy_index]);
             if (ok)
@@ -691,7 +691,7 @@ TurnResult ai_proc_basic(Character& chara, int& enemy_index)
 TurnResult
 proc_npc_movement_event(Character& chara, int& enemy_index, bool retreat)
 {
-    if (map_data.type == mdata_t::MapType::town && chara.index < 16)
+    if (map_data.type == mdata_t::MapType::town && chara.is_player_or_ally())
     {
         if (rnd(100) == 0)
         {
@@ -900,8 +900,8 @@ TurnResult ai_proc_misc_map_events(Character& chara, int& enemy_index)
     }
 
     // Falls into sleep.
-    if (chara.index >= 16 && map_is_town_or_guild() && _is_at_night() &&
-        !chara.activity)
+    if (!chara.is_player_or_ally() && map_is_town_or_guild() &&
+        _is_at_night() && !chara.activity)
     {
         if (rnd(100) == 0)
         {

--- a/src/elona/ai.cpp
+++ b/src/elona/ai.cpp
@@ -754,7 +754,7 @@ proc_npc_movement_event(Character& chara, int& enemy_index, bool retreat)
         {
             if (chara.enemy_id != enemy_index)
             {
-                const auto did_swap = cell_swap(chara.index, enemy_index);
+                const auto did_swap = cell_swap(chara, cdata[enemy_index]);
                 if (did_swap && is_in_fov(chara))
                 {
                     txt(i18n::s.get(

--- a/src/elona/animation.cpp
+++ b/src/elona/animation.cpp
@@ -900,14 +900,14 @@ void MiracleAnimation::do_play()
         }
         if (_mode == Mode::target_one)
         {
-            if (cnt.index != _chara.index)
+            if (cnt != _chara)
             {
                 continue;
             }
         }
         else
         {
-            if (cnt.index == _chara.index)
+            if (cnt == _chara)
             {
                 continue;
             }

--- a/src/elona/attack.cpp
+++ b/src/elona/attack.cpp
@@ -65,11 +65,11 @@ void build_target_list(const Character& attacker)
             {
                 continue;
             }
-            if (attacker.index == 0 || attacker.relationship >= 0)
+            if (attacker.is_player() || attacker.relationship >= 0)
             {
                 if (cnt.relationship == 10)
                 {
-                    if (cnt.index == 0)
+                    if (cnt.is_player())
                     {
                         continue;
                     }
@@ -240,7 +240,7 @@ bool do_physical_attack_internal(
     {
         if (critical)
         {
-            if (attacker.index == 0)
+            if (attacker.is_player())
             {
                 txt(i18n::s.get("core.damage.critical_hit"),
                     Message::color{ColorIndex::red});
@@ -253,7 +253,7 @@ bool do_physical_attack_internal(
             ammo,
             AttackDamageCalculationMode::actual_damage);
         attackdmg = dmg;
-        if (attacker.index == 0)
+        if (attacker.is_player())
         {
             if (g_config.attack_animation())
             {
@@ -324,7 +324,7 @@ bool do_physical_attack_internal(
             }
             if (attackskill == 106)
             {
-                if (target.index >= 16)
+                if (!target.is_player_or_ally())
                 {
                     game_data.proc_damage_events_flag = 2;
                     txt(i18n::s.get(
@@ -357,7 +357,7 @@ bool do_physical_attack_internal(
                 }
                 if (weapon_name)
                 {
-                    if (target.index >= 16)
+                    if (!target.is_player_or_ally())
                     {
                         game_data.proc_damage_events_flag = 2;
                         if (attackskill == 111)
@@ -437,7 +437,7 @@ bool do_physical_attack_internal(
             {
                 chara_gain_skill_exp(attacker, 189, 25 / expmodifer, 0, 4);
             }
-            if (attacker.index == 0)
+            if (attacker.is_player())
             {
                 if (game_data.mount != 0)
                 {
@@ -551,7 +551,7 @@ bool do_physical_attack_internal(
     }
     else
     {
-        if (attacker.index == 0)
+        if (attacker.is_player())
         {
             snd("core.miss");
         }
@@ -578,7 +578,7 @@ bool do_physical_attack_internal(
                 txt(i18n::s.get("core.damage.furthermore"));
                 Message::instance().continue_sentence();
             }
-            if (target.index < 16)
+            if (target.is_player_or_ally())
             {
                 txt(i18n::s.get("core.damage.miss.ally", attacker, target));
             }
@@ -598,7 +598,7 @@ bool do_physical_attack_internal(
                 txt(i18n::s.get("core.damage.furthermore"));
                 Message::instance().continue_sentence();
             }
-            if (target.index < 16)
+            if (target.is_player_or_ally())
             {
                 txt(i18n::s.get("core.damage.evade.ally", attacker, target));
             }
@@ -695,7 +695,7 @@ void do_ranged_attack(
             else
             {
                 ammoproc = ammo->enchantments[ammo->count].id % 10000;
-                if (attacker.index == 0)
+                if (attacker.is_player())
                 {
                     if (cdata.player().sp < 50)
                     {
@@ -756,7 +756,7 @@ void do_ranged_attack(
                 break;
             }
             const auto shot_target = list(0, rnd(listmax));
-            if (attacker.index == 0 || attacker.relationship >= 0)
+            if (attacker.is_player() || attacker.relationship >= 0)
             {
                 if (cdata[shot_target].relationship >= 0)
                 {
@@ -797,7 +797,7 @@ void do_ranged_attack(
 
 void try_to_melee_attack(Character& attacker, Character& target)
 {
-    if (attacker.index != 0)
+    if (!attacker.is_player())
     {
         if (target.damage_reaction_info)
         {
@@ -1063,7 +1063,7 @@ int find_enemy_target(Character& chara, bool silent)
         if (listmax != 0)
         {
             f = 0;
-            if (chara.index == 0 || chara.relationship >= 0)
+            if (chara.is_player() || chara.relationship >= 0)
             {
                 p(0) = -3;
                 p(1) = -1;
@@ -1096,7 +1096,7 @@ int find_enemy_target(Character& chara, bool silent)
     }
     if (chara.enemy_id == 0 || chara.blind != 0)
     {
-        if (chara.index == 0 && !silent)
+        if (chara.is_player() && !silent)
         {
             txt(i18n::s.get("core.action.ranged.no_target"));
             update_screen();

--- a/src/elona/buff.cpp
+++ b/src/elona/buff.cpp
@@ -205,7 +205,7 @@ void buff_add(
         }
         if (doer && doer->is_player())
         {
-            hostileaction(0, chara.index);
+            chara_act_hostile_action(cdata.player(), chara);
         }
     }
 

--- a/src/elona/buff.cpp
+++ b/src/elona/buff.cpp
@@ -203,7 +203,7 @@ void buff_add(
             }
             return;
         }
-        if (doer && doer->index == 0)
+        if (doer && doer->is_player())
         {
             hostileaction(0, chara.index);
         }
@@ -233,7 +233,7 @@ void buff_add(
 
 void buff_delete(Character& chara, int slot)
 {
-    if (chara.index == 0)
+    if (chara.is_player())
     {
         txt(i18n::s.get(
                 "core.magic.buff.ends",

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -1274,10 +1274,13 @@ int calc_skill_training_cost(
 
 
 
-int calclearncost(int skill_id, int chara_index, bool discount)
+int calc_skill_learning_cost(
+    int skill_id,
+    const Character& chara,
+    bool discount)
 {
     (void)skill_id;
-    (void)chara_index;
+    (void)chara;
 
     int platinum = 15 + 3 * game_data.number_of_learned_skills_by_trainer;
     return discount ? platinum * 2 / 3 : platinum;

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -1183,11 +1183,11 @@ int calcmealvalue()
 
 
 
-int calccostreload(int owner, bool do_reload)
+int calc_ammo_reloading_cost(Character& owner, bool do_reload)
 {
     int cost{};
 
-    for (const auto& item : g_inv.for_chara(cdata[owner]))
+    for (const auto& item : g_inv.for_chara(owner))
     {
         if (the_item_db[itemid2int(item->id)]->category != ItemCategory::ammo)
             continue;

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -494,7 +494,7 @@ int calc_accuracy(
 
     if (game_data.mount != 0)
     {
-        if (attacker.index == 0)
+        if (attacker.is_player())
         {
             accuracy = accuracy * 100 /
                 clamp((150 - attacker.get_skill(301).level / 2), 115, 150);
@@ -712,7 +712,7 @@ int calcattackdmg(
         }
         dmgmulti += 0.03 * attacker.get_skill(167).level;
     }
-    if (attacker.index == 0)
+    if (attacker.is_player())
     {
         if (trait(207))
         {
@@ -801,7 +801,7 @@ int calcattackdmg(
         }
     }
     damage = damagenormal + damagepierce;
-    if (attacker.index == 0)
+    if (attacker.is_player())
     {
         if (trait(164) != 0)
         {
@@ -1350,11 +1350,11 @@ int calc_spell_power(const Character& caster, int id)
         }
         return 100;
     }
-    if (caster.index == 0)
+    if (caster.is_player())
     {
         return caster.get_skill(id).level * 10 + 50;
     }
-    if (caster.get_skill(172).level == 0 && caster.index >= 16)
+    if (caster.get_skill(172).level == 0 && !caster.is_player_or_ally())
     {
         return caster.level * 6 + 10;
     }
@@ -1370,7 +1370,7 @@ int calc_spell_success_rate(const Character& caster, int id)
         return 100;
     }
 
-    if (caster.index != 0)
+    if (!caster.is_player())
     {
         if (game_data.mount == caster.index)
         {
@@ -1454,7 +1454,7 @@ int calc_spell_cost_mp(const Character& caster, int id)
     if (debug::voldemort)
         return 1;
 
-    if (caster.index == 0)
+    if (caster.is_player())
     {
         if (id == 413 || id == 461 || id == 457 || id == 438 || id == 409 ||
             id == 408 || id == 410 || id == 466)
@@ -1670,7 +1670,7 @@ int calc_initial_resistance_level(
     int initial_level,
     int element_id)
 {
-    if (chara.index == 0)
+    if (chara.is_player())
     {
         return 100;
     }

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -1263,9 +1263,12 @@ int calcidentifyvalue(int type)
 
 
 
-int calctraincost(int skill_id, int chara_index, bool discount)
+int calc_skill_training_cost(
+    int skill_id,
+    const Character& chara,
+    bool discount)
 {
-    int platinum = cdata[chara_index].get_skill(skill_id).base_level / 5 + 2;
+    int platinum = chara.get_skill(skill_id).base_level / 5 + 2;
     return discount ? platinum / 2 : platinum;
 }
 

--- a/src/elona/calc.hpp
+++ b/src/elona/calc.hpp
@@ -91,7 +91,10 @@ int calc_skill_training_cost(
     int skill_id,
     const Character& chara,
     bool discount = false);
-int calclearncost(int, int, bool = false);
+int calc_skill_learning_cost(
+    int skill_id,
+    const Character& chara,
+    bool discount = false);
 int calc_resurrection_value(const Character& chara);
 int calc_slave_value(const Character& chara);
 int calcrestorecost();

--- a/src/elona/calc.hpp
+++ b/src/elona/calc.hpp
@@ -83,7 +83,7 @@ void calccosthire();
 int calccostbuilding();
 int calccosttax();
 int calcmealvalue();
-int calccostreload(int, bool = false);
+int calc_ammo_reloading_cost(Character& owner, bool do_reload = false);
 int calccargoupdate();
 int calccargoupdatecost();
 int calcidentifyvalue(int);

--- a/src/elona/calc.hpp
+++ b/src/elona/calc.hpp
@@ -87,7 +87,10 @@ int calccostreload(int, bool = false);
 int calccargoupdate();
 int calccargoupdatecost();
 int calcidentifyvalue(int);
-int calctraincost(int, int, bool = false);
+int calc_skill_training_cost(
+    int skill_id,
+    const Character& chara,
+    bool discount = false);
 int calclearncost(int, int, bool = false);
 int calc_resurrection_value(const Character& chara);
 int calc_slave_value(const Character& chara);

--- a/src/elona/cell_draw.cpp
+++ b/src/elona/cell_draw.cpp
@@ -740,7 +740,7 @@ void draw_hp_bar(const Character& chara, int x, int y)
     if (ratio <= 0)
         return;
 
-    if (chara.index < 16)
+    if (chara.is_player_or_ally())
     {
         if (map_data.type != mdata_t::MapType::world_map)
         {

--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -1902,63 +1902,58 @@ void make_sound(
 
 
 
-void hostileaction(int chara_index1, int chara_index2)
+void chara_act_hostile_action(Character& attacker, Character& target)
 {
-    if (chara_index1 >= 16 || chara_index2 == 0)
+    if (!attacker.is_player_or_ally() || target.is_player())
     {
         return;
     }
-    if (cdata[chara_index2].relationship != -3)
+    if (target.relationship != -3)
     {
-        cdata[chara_index2].emotion_icon = 418;
+        target.emotion_icon = 418;
     }
-    if (cdata[chara_index2].relationship == 10)
+    if (target.relationship == 10)
     {
-        txt(i18n::s.get(
-                "core.misc.hostile_action.glares_at_you", cdata[chara_index2]),
+        txt(i18n::s.get("core.misc.hostile_action.glares_at_you", target),
             Message::color{ColorIndex::purple});
     }
     else
     {
-        if (cdata[chara_index2].relationship == 0)
+        if (target.relationship == 0)
         {
             modify_karma(cdata.player(), -2);
         }
-        if (cdata[chara_index2].id == CharaId::ebon)
+        if (target.id == CharaId::ebon)
         {
             if (game_data.released_fire_giant == 0)
             {
                 txt(i18n::s.get(
-                        "core.misc.hostile_action.glares_at_you",
-                        cdata[chara_index2]),
+                        "core.misc.hostile_action.glares_at_you", target),
                     Message::color{ColorIndex::purple});
                 return;
             }
         }
-        if (cdata[chara_index2].relationship > -2)
+        if (target.relationship > -2)
         {
-            txt(i18n::s.get(
-                    "core.misc.hostile_action.glares_at_you",
-                    cdata[chara_index2]),
+            txt(i18n::s.get("core.misc.hostile_action.glares_at_you", target),
                 Message::color{ColorIndex::purple});
-            cdata[chara_index2].relationship = -2;
+            target.relationship = -2;
         }
         else
         {
-            if (cdata[chara_index2].relationship != -3)
+            if (target.relationship != -3)
             {
                 txt(i18n::s.get(
-                        "core.misc.hostile_action.gets_furious",
-                        cdata[chara_index2]),
+                        "core.misc.hostile_action.gets_furious", target),
                     Message::color{ColorIndex::purple});
             }
-            cdata[chara_index2].relationship = -3;
-            cdata[chara_index2].hate = 80;
-            cdata[chara_index2].enemy_id = chara_index1;
+            target.relationship = -3;
+            target.hate = 80;
+            target.enemy_id = attacker.index;
         }
-        chara_custom_talk(cdata[chara_index2], 101);
+        chara_custom_talk(target, 101);
     }
-    if (cdata[chara_index2].is_livestock() == 1)
+    if (target.is_livestock())
     {
         if (rnd(50) == 0)
         {
@@ -1975,7 +1970,7 @@ void hostileaction(int chara_index1, int chara_index2)
             }
         }
     }
-    cdata[chara_index2].activity.finish();
+    target.activity.finish();
 }
 
 

--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -1839,15 +1839,15 @@ void ride_end()
 
 
 
-void turn_aggro(int chara_index, int target_index, int hate)
+void turn_aggro(Character& chara, Character& target, int hate)
 {
-    if (target_index < 16)
+    if (target.is_player_or_ally())
     {
-        cdata[chara_index].relationship = -3;
+        chara.relationship = -3;
     }
-    cdata[chara_index].hate = hate;
-    cdata[chara_index].emotion_icon = 218;
-    cdata[chara_index].enemy_id = target_index;
+    chara.hate = hate;
+    chara.emotion_icon = 218;
+    chara.enemy_id = target.index;
 }
 
 
@@ -1889,7 +1889,7 @@ void make_sound(
                             Message::color{ColorIndex::cyan});
                         txt(i18n::s.get("core.misc.sound.can_no_longer_stand"));
                     }
-                    turn_aggro(chara.index, source_chara.index, 80);
+                    turn_aggro(chara, source_chara, 80);
                 }
             }
         }

--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -586,7 +586,7 @@ CData::CData()
 
 bool chara_place(Character& chara)
 {
-    if (chara.index == cdata.tmp().index)
+    if (chara == cdata.tmp())
     {
         chara.set_state(Character::State::empty);
         return false;

--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -120,7 +120,7 @@ optional<int> chara_create_internal(int slot, int chara_id)
             return none;
         }
     }
-    chara_delete(slot);
+    chara_delete(cdata[slot]);
     if (slot == 0)
     {
         p = 10;
@@ -1468,7 +1468,7 @@ int chara_copy(const Character& source)
     }
 
     // Delete completely the previous character in `slot`.
-    chara_delete(slot);
+    chara_delete(cdata[slot]);
 
     // Copy from `source` to `destination`.
     Character::copy(source, destination);
@@ -1506,18 +1506,15 @@ int chara_copy(const Character& source)
 
 
 
-void chara_delete(int chara_index)
+void chara_delete(Character& chara)
 {
-    if (chara_index != -1)
-    {
-        cdata[chara_index].set_state(Character::State::empty);
-    }
+    chara.set_state(Character::State::empty);
 
-    for (const auto& item : g_inv.for_chara(cdata[chara_index]))
+    for (const auto& item : g_inv.for_chara(chara))
     {
         item->remove();
     }
-    cdata[chara_index].clear();
+    chara.clear();
 }
 
 

--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -2362,38 +2362,35 @@ void proc_negative_enchantments(Character& chara)
 
 
 
-void lovemiracle(int chara_index)
+void lovemiracle(Character& chara)
 {
-    if (rnd(2) || chara_index == 0)
+    if (rnd(2) || chara.is_player())
     {
         return;
     }
+
     txt(i18n::s.get("core.misc.love_miracle.uh"),
         Message::color{ColorIndex::cyan});
     flt();
     if (rnd(2))
     {
-        if (const auto item =
-                itemcreate_map_inv(573, cdata[chara_index].position, 0))
+        if (const auto item = itemcreate_map_inv(573, chara.position, 0))
         {
-            item->subname = charaid2int(cdata[chara_index].id);
-            item->weight = cdata[chara_index].weight * 10 + 250;
-            item->value = clamp(
-                cdata[chara_index].weight * cdata[chara_index].weight / 10000,
-                200,
-                40000);
+            item->subname = charaid2int(chara.id);
+            item->weight = chara.weight * 10 + 250;
+            item->value =
+                clamp(chara.weight * chara.weight / 10000, 200, 40000);
         }
     }
     else
     {
-        if (const auto item =
-                itemcreate_map_inv(574, cdata[chara_index].position, 0))
+        if (const auto item = itemcreate_map_inv(574, chara.position, 0))
         {
-            item->subname = charaid2int(cdata[chara_index].id);
+            item->subname = charaid2int(chara.id);
         }
     }
     snd("core.atk_elec");
-    animeload(15, cdata[chara_index]);
+    animeload(15, chara);
 }
 
 

--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -2046,15 +2046,15 @@ void incognitoend()
 
 
 
-void wet(int chara_index, int turns)
+void chara_get_wet(Character& chara, int turns)
 {
-    cdata[chara_index].wet += turns;
-    if (is_in_fov(cdata[chara_index]))
+    chara.wet += turns;
+    if (is_in_fov(chara))
     {
-        txt(i18n::s.get("core.misc.wet.gets_wet", cdata[chara_index]));
-        if (cdata[chara_index].is_invisible())
+        txt(i18n::s.get("core.misc.wet.gets_wet", chara));
+        if (chara.is_invisible())
         {
-            txt(i18n::s.get("core.misc.wet.is_revealed", cdata[chara_index]));
+            txt(i18n::s.get("core.misc.wet.is_revealed", chara));
         }
     }
 }
@@ -2810,7 +2810,7 @@ TurnResult proc_movement_event(Character& chara)
         addefmap(chara.position.x, chara.position.y, 1, 3);
         if (chara.wet == 0)
         {
-            wet(chara.index, 20);
+            chara_get_wet(chara, 20);
         }
     }
     sense_map_feats_on_move(chara);

--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -1253,27 +1253,27 @@ int chara_get_free_slot_ally()
 }
 
 
-int chara_custom_talk(int chara_index, int talk_type)
+
+bool chara_custom_talk(Character& speaker, int talk_type)
 {
     std::vector<std::string> talk_file_buffer;
 
     bool use_external_file = false;
 
-    if (cdata[chara_index].has_custom_talk())
+    if (speaker.has_custom_talk())
     {
         const auto filepath =
-            filesystem::dirs::user() / u8"talk" / cdata[chara_index].talk;
+            filesystem::dirs::user() / u8"talk" / speaker.talk;
         if (!fs::exists(filepath))
-            return 0;
+            return false;
         range::copy(
             fileutil::read_by_line(filepath),
             std::back_inserter(talk_file_buffer));
         use_external_file = true;
     }
-    else if (cdata[chara_index].id == CharaId::user)
+    else if (speaker.id == CharaId::user)
     {
-        talk_file_buffer =
-            strutil::split_lines(usertxt(cdata[chara_index].cnpc_id));
+        talk_file_buffer = strutil::split_lines(usertxt(speaker.cnpc_id));
         use_external_file = true;
     }
 
@@ -1336,18 +1336,18 @@ int chara_custom_talk(int chara_index, int talk_type)
                 }
             }
         }
-        return 1;
+        return true;
     }
 
     if (talk_type == 106)
-        return 0;
+        return false;
 
-    if (cdata[chara_index].can_talk != 0)
+    if (speaker.can_talk != 0)
     {
-        chara_db_get_talk(cdata[chara_index].id, talk_type);
-        return 1;
+        chara_db_get_talk(speaker.id, talk_type);
+        return true;
     }
-    return 0;
+    return false;
 }
 
 
@@ -1994,7 +1994,7 @@ void hostileaction(int chara_index1, int chara_index2)
             cdata[chara_index2].hate = 80;
             cdata[chara_index2].enemy_id = chara_index1;
         }
-        chara_custom_talk(chara_index2, 101);
+        chara_custom_talk(cdata[chara_index2], 101);
     }
     if (cdata[chara_index2].is_livestock() == 1)
     {

--- a/src/elona/character.hpp
+++ b/src/elona/character.hpp
@@ -473,6 +473,16 @@ public:
     }
 
 
+
+    bool is_player() const;
+    bool is_ally() const;
+    bool is_player_or_ally() const;
+    bool is_adventurer() const;
+    bool is_global() const;
+    bool is_map_local() const;
+
+
+
     ELONA_CHARACTER_DEFINE_FLAG_ACCESSORS
 
 

--- a/src/elona/character.hpp
+++ b/src/elona/character.hpp
@@ -819,7 +819,7 @@ void incognitobegin();
 void incognitoend();
 void initialize_pc_character();
 void lost_body_part(int);
-void lovemiracle(int = 0);
+void lovemiracle(Character& chara);
 void monster_respawn();
 void move_character(Character& chara);
 void proc_negative_enchantments(Character& chara);

--- a/src/elona/character.hpp
+++ b/src/elona/character.hpp
@@ -768,7 +768,7 @@ void chara_refresh(Character& chara);
  */
 int chara_copy(const Character& source);
 
-void chara_delete(int = 0);
+void chara_delete(Character& chara);
 void chara_vanquish(Character& chara);
 void chara_killed(Character&);
 

--- a/src/elona/character.hpp
+++ b/src/elona/character.hpp
@@ -806,7 +806,7 @@ void refresh_burden_state();
 void go_hostile();
 void get_pregnant(Character& chara);
 void wet(int = 0, int = 0);
-void hostileaction(int = 0, int = 0);
+void chara_act_hostile_action(Character& attacker, Character& target);
 void turn_aggro(int = 0, int = 0, int = 0);
 void ride_begin(int = 0);
 void ride_end();

--- a/src/elona/character.hpp
+++ b/src/elona/character.hpp
@@ -807,7 +807,7 @@ void go_hostile();
 void get_pregnant(Character& chara);
 void chara_get_wet(Character& chara, int turns);
 void chara_act_hostile_action(Character& attacker, Character& target);
-void turn_aggro(int = 0, int = 0, int = 0);
+void turn_aggro(Character& chara, Character& target, int hate);
 void ride_begin(int = 0);
 void ride_end();
 void make_sound(

--- a/src/elona/character.hpp
+++ b/src/elona/character.hpp
@@ -495,6 +495,19 @@ public:
 
 
 
+    bool operator==(const Character& other) const noexcept
+    {
+        return this == &other;
+    }
+
+
+    bool operator!=(const Character& other) const noexcept
+    {
+        return this != &other;
+    }
+
+
+
 private:
     Character(const Character&) = default;
     Character(Character&&) = default;

--- a/src/elona/character.hpp
+++ b/src/elona/character.hpp
@@ -769,7 +769,6 @@ void chara_refresh(Character& chara);
 int chara_copy(const Character& source);
 
 void chara_delete(int = 0);
-void chara_remove(Character&);
 void chara_vanquish(Character& chara);
 void chara_killed(Character&);
 

--- a/src/elona/character.hpp
+++ b/src/elona/character.hpp
@@ -810,7 +810,11 @@ void chara_act_hostile_action(Character& attacker, Character& target);
 void turn_aggro(int = 0, int = 0, int = 0);
 void ride_begin(int = 0);
 void ride_end();
-void make_sound(int = 0, int = 0, int = 0, int = 0, int = 0, int = 0);
+void make_sound(
+    Character& source_chara,
+    int distance_threshold,
+    int waken,
+    bool may_make_angry);
 void incognitobegin();
 void incognitoend();
 void initialize_pc_character();

--- a/src/elona/character.hpp
+++ b/src/elona/character.hpp
@@ -805,7 +805,7 @@ optional_ref<Character> new_ally_joins(Character& new_ally);
 void refresh_burden_state();
 void go_hostile();
 void get_pregnant(Character& chara);
-void wet(int = 0, int = 0);
+void chara_get_wet(Character& chara, int turns);
 void chara_act_hostile_action(Character& attacker, Character& target);
 void turn_aggro(int = 0, int = 0, int = 0);
 void ride_begin(int = 0);

--- a/src/elona/character.hpp
+++ b/src/elona/character.hpp
@@ -784,7 +784,7 @@ int chara_find_ally(int id);
 int chara_get_free_slot();
 int chara_get_free_slot_ally();
 bool chara_unequip(const ItemRef& item);
-int chara_custom_talk(int = 0, int = 0);
+bool chara_custom_talk(Character& speaker, int talk_type);
 int chara_impression_level(int = 0);
 void chara_modify_impression(Character& chara, int delta);
 void chara_set_ai_item(Character& chara, ItemRef item);

--- a/src/elona/character_making.cpp
+++ b/src/elona/character_making.cpp
@@ -257,7 +257,7 @@ static void _reroll_character()
 {
     const auto portrait_save = cdata.player().portrait;
 
-    chara_delete(0);
+    chara_delete(cdata.player());
     race_init_chara(cdata.player(), cmrace);
     class_init_chara(cdata.player(), cmclass);
     cdata.player().name = u8"????"s;

--- a/src/elona/character_status.cpp
+++ b/src/elona/character_status.cpp
@@ -506,7 +506,7 @@ void gain_level(Character& chara)
     }
     else
     {
-        addnews(2, chara.index);
+        adventurer_add_news(NewsType::growth, chara);
     }
     p = 5 * (100 + chara.get_skill(14).base_level * 10) /
             (300 + chara.level * 15) +

--- a/src/elona/character_status.cpp
+++ b/src/elona/character_status.cpp
@@ -334,7 +334,7 @@ void refresh_speed(Character& chara)
     }
     chara.speed_percentage_in_next_turn = 0;
 
-    if (chara.index != 0 && game_data.mount != chara.index)
+    if (!chara.is_player() && game_data.mount != chara.index)
         return;
 
     if (game_data.mount != 0)
@@ -491,7 +491,7 @@ void gain_level(Character& chara)
     {
         if (r2 == 0)
         {
-            if (chara.index == 0)
+            if (chara.is_player())
             {
                 txt(i18n::s.get(
                         "core.chara.gain_level.self", chara, chara.level),
@@ -511,7 +511,7 @@ void gain_level(Character& chara)
     p = 5 * (100 + chara.get_skill(14).base_level * 10) /
             (300 + chara.level * 15) +
         1;
-    if (chara.index == 0)
+    if (chara.is_player())
     {
         if (chara.level % 5 == 0)
         {
@@ -528,7 +528,7 @@ void gain_level(Character& chara)
     }
     chara.skill_bonus += p;
     chara.total_skill_bonus += p;
-    if (chara.race == "core.mutant" || (chara.index == 0 && trait(0) == 1))
+    if (chara.race == "core.mutant" || (chara.is_player() && trait(0) == 1))
     {
         if (chara.level < 37)
         {
@@ -545,7 +545,7 @@ void gain_level(Character& chara)
     {
         chara.max_level = chara.level;
     }
-    if (chara.index >= 16)
+    if (!chara.is_player_or_ally())
     {
         grow_primary_skills(chara);
     }

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -996,7 +996,7 @@ TurnResult do_throw_command_internal(
                 {
                     txt(i18n::s.get(
                         "core.action.throw.hits", cdata[target_index]));
-                    wet(target_index, 25);
+                    chara_get_wet(cdata[target_index], 25);
                 }
                 rowact_check(cdata[target_index]);
                 if (throw_item->id == ItemId::handful_of_snow)

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -2753,13 +2753,7 @@ TurnResult do_use_command(ItemRef use_item)
     case 39:
         txt(i18n::s.get("core.action.use.whistle.use"),
             Message::color{ColorIndex::cyan});
-        make_sound(
-            cdata.player().position.x,
-            cdata.player().position.y,
-            10,
-            1,
-            1,
-            cdata.player().index);
+        make_sound(cdata.player(), 10, 1, true);
         break;
     case 37:
         tcgdeck();

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -302,7 +302,7 @@ TurnResult _bump_into_character(Character& chara)
                 cdata.player().next_position = chara.position;
                 ui_scroll_screen();
             }
-            cell_swap(cdata.player().index, chara.index);
+            cell_swap(cdata.player(), chara);
             txt(i18n::s.get("core.action.move.displace.text", chara));
             if (chara.id == CharaId::rogue)
             {

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -1033,7 +1033,7 @@ TurnResult do_throw_command_internal(
                 }
                 if (target_index >= 16)
                 {
-                    hostileaction(thrower.index, target_index);
+                    chara_act_hostile_action(thrower, cdata[target_index]);
                 }
                 potionthrow = 100;
                 item_db_on_drink(
@@ -5704,7 +5704,7 @@ TurnResult do_bash(Character& chara)
                     "core.action.bash.execute",
                     chara,
                     cdata[bash_target_index]));
-                hostileaction(chara.index, bash_target_index);
+                chara_act_hostile_action(chara, cdata[bash_target_index]);
             }
         }
         else

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -1893,7 +1893,7 @@ OnEnterResult on_enter_give(
                 .stacked_item;
         chara_set_ai_item(inventory_owner, stacked_item);
         wear_most_valuable_equipment_for_all_body_parts(inventory_owner);
-        if (inventory_owner.index < 16)
+        if (inventory_owner.is_player_or_ally())
         {
             create_pcpic(inventory_owner);
         }
@@ -2065,7 +2065,7 @@ OnEnterResult on_enter_trade_target(
     item_convert_artifact(citrade.unwrap());
 
     wear_most_valuable_equipment_for_all_body_parts(inventory_owner);
-    if (inventory_owner.index >= 16)
+    if (!inventory_owner.is_player_or_ally())
     {
         supply_new_equipment(inventory_owner);
     }
@@ -2238,7 +2238,7 @@ OnEnterResult on_enter_receive(
         item_convert_artifact(stacked_item);
     }
     wear_most_valuable_equipment_for_all_body_parts(inventory_owner);
-    if (inventory_owner.index < 16)
+    if (inventory_owner.is_player_or_ally())
     {
         create_pcpic(inventory_owner);
     }

--- a/src/elona/deferred_event.cpp
+++ b/src/elona/deferred_event.cpp
@@ -482,8 +482,8 @@ void eh_okaeri(const DeferredEvent&)
                 cdata[chara_index].current_map == game_data.current_map)
             {
                 cdata[chara_index].emotion_icon = 2006;
-                int stat = chara_custom_talk(chara_index, 104);
-                if (stat == 0)
+                bool did_speak = chara_custom_talk(cdata[chara_index], 104);
+                if (!did_speak)
                 {
                     ++i;
                 }

--- a/src/elona/deferred_event.cpp
+++ b/src/elona/deferred_event.cpp
@@ -1019,13 +1019,13 @@ void eh_guest_visit(const DeferredEvent&)
             {
                 if (cell_data.at(item->pos().x, item->pos().y)
                             .chara_index_plus_one == 0 ||
-                    chara.index == 0 || chara.index == guest->index)
+                    chara.is_player() || chara.index == guest->index)
                 {
                     chair = item;
                     distance_to_guest_chair = d;
                 }
             }
-            if (chara.index == 0 && item->param1 == 1)
+            if (chara.is_player() && item->param1 == 1)
             {
                 chair = item;
                 break;
@@ -1040,7 +1040,7 @@ void eh_guest_visit(const DeferredEvent&)
             chara.position.y,
             guest->position.x,
             guest->position.y);
-        if (chara.index == 0)
+        if (chara.is_player())
         {
             game_data.player_next_move_direction = chara.direction;
         }

--- a/src/elona/deferred_event.cpp
+++ b/src/elona/deferred_event.cpp
@@ -996,7 +996,7 @@ void eh_guest_visit(const DeferredEvent&)
             {
                 if (item->param1 == 2)
                 {
-                    cell_swap(chara.index, -1, item->pos().x, item->pos().y);
+                    cell_swap(chara, item->pos());
                     chair_for_guest = item;
                     chair = item;
                     break;
@@ -1033,7 +1033,7 @@ void eh_guest_visit(const DeferredEvent&)
         }
         if (chair)
         {
-            cell_swap(chara.index, -1, chair->pos().x, chair->pos().y);
+            cell_swap(chara, chair->pos());
         }
         chara.direction = direction(
             chara.position.x,

--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -410,7 +410,7 @@ int damage_hp(
         }
         if (game_data.proc_damage_events_flag == 1)
         {
-            txteledmg(0, none, victim.index, element);
+            txteledmg(0, none, victim, element);
         }
         else if (game_data.proc_damage_events_flag == 2)
         {
@@ -854,16 +854,16 @@ int damage_hp(
                     Message::instance().continue_sentence();
                     if (damage_statements_subject_is_noncharacter)
                     {
-                        txteledmg(1, none, victim.index, element);
+                        txteledmg(1, none, victim, element);
                     }
                     else
                     {
-                        txteledmg(1, *attacker, victim.index, element);
+                        txteledmg(1, *attacker, victim, element);
                     }
                 }
                 else
                 {
-                    txteledmg(2, none, victim.index, element);
+                    txteledmg(2, none, victim, element);
                 }
             }
             else

--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -1023,7 +1023,7 @@ int damage_hp(
         }
         if (game_data.mount != victim.index || victim.is_player())
         {
-            cell_removechara(victim.position.x, victim.position.y);
+            cell_removechara(victim.position);
         }
 
         Character::State new_state = dmgheal_set_death_status(victim);

--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -705,7 +705,7 @@ int damage_hp(
         }
         if (attacker && attacker->is_player())
         {
-            hostileaction(0, victim.index);
+            chara_act_hostile_action(cdata.player(), victim);
             game_data.chara_last_attacked_by_player = victim.index;
         }
         if (victim.is_player())

--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -355,7 +355,7 @@ int damage_hp(
         {
             for (auto&& chara : cdata.player_and_allies())
             {
-                if (victim.index == chara.index)
+                if (victim == chara)
                 {
                     continue;
                 }

--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -1058,7 +1058,7 @@ int damage_hp(
         {
             if (!attacker->is_player())
             {
-                chara_custom_talk(attacker->index, 103);
+                chara_custom_talk(*attacker, 103);
             }
             gained_exp = clamp(victim.level, 1, 200) *
                     clamp((victim.level + 1), 1, 200) *
@@ -1191,7 +1191,7 @@ int damage_hp(
         if (!victim.is_player())
         {
             ++npcmemory(0, charaid2int(victim.id));
-            chara_custom_talk(victim.index, 102);
+            chara_custom_talk(victim, 102);
             if (victim.is_player_or_ally())
             {
                 txt(i18n::s.get("core.damage.you_feel_sad"));

--- a/src/elona/dmgheal.hpp
+++ b/src/elona/dmgheal.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "optional.hpp"
+
 
 
 namespace elona
@@ -24,7 +26,7 @@ void heal_insanity(Character& chara, int delta);
 
 
 void character_drops_item(Character& victim);
-void check_kill(int = 0, int = 0);
+void check_kill(optional_ref<Character> killer_chara, Character& victim);
 void heal_both_rider_and_mount(Character& target);
 void heal_completely(Character& target);
 

--- a/src/elona/element.cpp
+++ b/src/elona/element.cpp
@@ -121,20 +121,20 @@ void chara_gain_registance(Character& chara, int element, int delta)
 void txteledmg(
     int type,
     optional_ref<const Character> attacker,
-    int target,
+    const Character& target,
     int element)
 {
-    if (type == 0 && is_in_fov(cdata[target]))
+    if (type == 0 && is_in_fov(target))
     {
-        auto text = i18n::s.get_enum_optional(
-            "core.element.damage"s, element, cdata[target]);
+        auto text =
+            i18n::s.get_enum_optional("core.element.damage"s, element, target);
         if (text)
         {
             txt(*text);
         }
         else
         {
-            txt(i18n::s.get("core.element.damage.default", cdata[target]));
+            txt(i18n::s.get("core.element.damage.default", target));
         }
     }
     else if (type == 1)
@@ -145,7 +145,7 @@ void txteledmg(
                 "core.death_by.element"s,
                 "active.by_chara",
                 element,
-                cdata[target],
+                target,
                 *attacker);
             if (text)
             {
@@ -155,17 +155,14 @@ void txteledmg(
             {
                 txt(i18n::s.get(
                     "core.death_by.element.default.active.by_chara",
-                    cdata[target],
+                    target,
                     *attacker));
             }
         }
         else
         {
             auto text = i18n::s.get_enum_property_optional(
-                "core.death_by.element"s,
-                "active.by_spell",
-                element,
-                cdata[target]);
+                "core.death_by.element"s, "active.by_spell", element, target);
             if (text)
             {
                 txt(*text);
@@ -173,23 +170,21 @@ void txteledmg(
             else
             {
                 txt(i18n::s.get(
-                    "core.death_by.element.default.active.by_spell",
-                    cdata[target]));
+                    "core.death_by.element.default.active.by_spell", target));
             }
         }
     }
     else if (type == 2)
     {
         auto text = i18n::s.get_enum_property_optional(
-            "core.death_by.element"s, "passive", element, cdata[target]);
+            "core.death_by.element"s, "passive", element, target);
         if (text)
         {
             txt(*text);
         }
         else
         {
-            txt(i18n::s.get(
-                "core.death_by.element.default.passive", cdata[target]));
+            txt(i18n::s.get("core.death_by.element.default.passive", target));
         }
     }
 }

--- a/src/elona/element.hpp
+++ b/src/elona/element.hpp
@@ -41,7 +41,7 @@ void chara_gain_registance(Character& chara, int element, int delta);
 void txteledmg(
     int type,
     optional_ref<const Character> attacker,
-    int target,
+    const Character& target,
     int element);
 
 } // namespace elona

--- a/src/elona/equipment.cpp
+++ b/src/elona/equipment.cpp
@@ -426,7 +426,10 @@ void supply_new_equipment(Character& chara)
                 {
                     if (chara.role == Role::adventurer)
                     {
-                        addnews(1, chara.index, 0, itemname(item.unwrap()));
+                        adventurer_add_news(
+                            NewsType::discovery,
+                            chara,
+                            itemname(item.unwrap()));
                     }
                 }
             }

--- a/src/elona/equipment.cpp
+++ b/src/elona/equipment.cpp
@@ -1355,7 +1355,7 @@ void equip_item(
         return;
     }
     item_separate(equipment);
-    if (chara.index == 0)
+    if (chara.is_player())
     {
         item_identify(equipment, IdentifyState::almost);
     }

--- a/src/elona/food.cpp
+++ b/src/elona/food.cpp
@@ -1328,7 +1328,7 @@ void apply_general_eating_effect(Character& eater, const ItemRef& food)
             eater.emotion_icon = 317;
             chara_modify_impression(eater, 30);
             modify_karma(cdata.player(), -10);
-            lovemiracle(eater.index);
+            lovemiracle(eater);
         }
         status_ailment_damage(eater, StatusAilment::dimmed, 500);
         eater.emotion_icon = 317;

--- a/src/elona/food.cpp
+++ b/src/elona/food.cpp
@@ -212,7 +212,7 @@ void cure_anorexia(Character& chara)
         return;
 
     chara.has_anorexia() = false;
-    if (is_in_fov(chara) || chara.index < 16)
+    if (is_in_fov(chara) || chara.is_player_or_ally())
     {
         txt(i18n::s.get("core.food.anorexia.recovers_from", chara));
         snd("core.offer1");
@@ -268,12 +268,12 @@ void chara_vomit(Character& chara)
                 ++p;
             }
         }
-        if (rnd_capped(p * p * p) == 0 || chara.index == 0)
+        if (rnd_capped(p * p * p) == 0 || chara.is_player())
         {
             flt();
             if (const auto item = itemcreate_map_inv(704, chara.position, 0))
             {
-                if (chara.index != 0)
+                if (!chara.is_player())
                 {
                     item->subname = charaid2int(chara.id);
                 }
@@ -289,8 +289,8 @@ void chara_vomit(Character& chara)
     }
     else
     {
-        if ((chara.index < 16 && chara.anorexia_count > 10) ||
-            (chara.index >= 16 && rnd(4) == 0))
+        if ((chara.is_player_or_ally() && chara.anorexia_count > 10) ||
+            (!chara.is_player_or_ally() && rnd(4) == 0))
         {
             if (rnd(5) == 0)
             {
@@ -679,12 +679,12 @@ void apply_general_eating_effect(Character& eater, const ItemRef& food)
             fdlist(1, cnt) = fdlist(1, cnt) * 100 / (food->param2 * 50);
         }
     }
-    if (eater.index == 0)
+    if (eater.is_player())
     {
         p = food->param1 / 1000;
         for (int cnt = 0; cnt < 1; ++cnt)
         {
-            if (eater.index == 0)
+            if (eater.is_player())
             {
                 if (trait(41))
                 {
@@ -810,7 +810,7 @@ void apply_general_eating_effect(Character& eater, const ItemRef& food)
             ++fdmax;
         }
         nutrition = 2500;
-        if (eater.index == 0)
+        if (eater.is_player())
         {
             txt(i18n::s.get("core.food.effect.herb.curaria"),
                 Message::color{ColorIndex::green});
@@ -870,7 +870,7 @@ void apply_general_eating_effect(Character& eater, const ItemRef& food)
         nutrition = 500;
         modify_potential(eater, 10, 2);
         modify_potential(eater, 11, 2);
-        if (eater.index == 0)
+        if (eater.is_player())
         {
             txt(i18n::s.get("core.food.effect.herb.morgia"),
                 Message::color{ColorIndex::green});
@@ -930,7 +930,7 @@ void apply_general_eating_effect(Character& eater, const ItemRef& food)
         nutrition = 500;
         modify_potential(eater, 16, 2);
         modify_potential(eater, 15, 2);
-        if (eater.index == 0)
+        if (eater.is_player())
         {
             txt(i18n::s.get("core.food.effect.herb.mareilon"),
                 Message::color{ColorIndex::green});
@@ -990,7 +990,7 @@ void apply_general_eating_effect(Character& eater, const ItemRef& food)
         modify_potential(eater, 12, 2);
         modify_potential(eater, 13, 2);
         nutrition = 500;
-        if (eater.index == 0)
+        if (eater.is_player())
         {
             txt(i18n::s.get("core.food.effect.herb.spenseweed"),
                 Message::color{ColorIndex::green});
@@ -1050,7 +1050,7 @@ void apply_general_eating_effect(Character& eater, const ItemRef& food)
         nutrition = 500;
         modify_potential(eater, 17, 2);
         modify_potential(eater, 14, 2);
-        if (eater.index == 0)
+        if (eater.is_player())
         {
             txt(i18n::s.get("core.food.effect.herb.alraunia"),
                 Message::color{ColorIndex::green});
@@ -1113,7 +1113,7 @@ void apply_general_eating_effect(Character& eater, const ItemRef& food)
     {
         nutrition = 750;
     }
-    if (eater.index == 0)
+    if (eater.is_player())
     {
         if (food->material == 35)
         {
@@ -1126,7 +1126,7 @@ void apply_general_eating_effect(Character& eater, const ItemRef& food)
     if (food->id == ItemId::corpse)
     {
         s = chara_db_get_filter(int2charaid(food->subname));
-        if (eater.index == 0)
+        if (eater.is_player())
         {
             if (strutil::contains(s(0), u8"/man/"))
             {
@@ -1172,7 +1172,7 @@ void apply_general_eating_effect(Character& eater, const ItemRef& food)
             p = (eater.nutrition - 5000) / 25;
             i = i * 100 / (100 + p);
         }
-        if (eater.index != 0)
+        if (!eater.is_player())
         {
             i = 1500;
             if (food->material == 35)
@@ -1278,7 +1278,7 @@ void apply_general_eating_effect(Character& eater, const ItemRef& food)
     }
     if (food->id == ItemId::fortune_cookie)
     {
-        if (eater.index < 16)
+        if (eater.is_player_or_ally())
         {
             txt(i18n::s.get("core.food.effect.fortune_cookie", eater));
             read_talk_file(u8"%COOKIE2");
@@ -1305,7 +1305,7 @@ void apply_general_eating_effect(Character& eater, const ItemRef& food)
         damage_hp(eater, rnd(250) + 250, -4);
         if (eater.state() != Character::State::alive)
         {
-            if (eater.index != 0)
+            if (!eater.is_player())
             {
                 if (eater.relationship >= 0)
                 {
@@ -1317,7 +1317,7 @@ void apply_general_eating_effect(Character& eater, const ItemRef& food)
     }
     if (food->is_aphrodisiac())
     {
-        if (eater.index == 0)
+        if (eater.is_player())
         {
             txt(i18n::s.get("core.food.effect.spiked.self"));
         }
@@ -1395,7 +1395,7 @@ void apply_general_eating_effect(Character& eater, const ItemRef& food)
                     eater,
                     enc,
                     (food->enchantments[cnt].power / 50 + 1) * 100 *
-                        (1 + (eater.index != 0) * 5));
+                        (1 + (!eater.is_player()) * 5));
                 continue;
             }
             if (enc2 == 6)
@@ -1414,7 +1414,7 @@ void apply_general_eating_effect(Character& eater, const ItemRef& food)
                     eater,
                     *buff_id,
                     (food->enchantments[cnt].power / 50 + 1) * 5 *
-                        (1 + (eater.index != 0) * 2),
+                        (1 + (!eater.is_player()) * 2),
                     2000);
 
                 continue;

--- a/src/elona/god.cpp
+++ b/src/elona/god.cpp
@@ -146,7 +146,7 @@ void god_modify_piety(int amount)
 void set_npc_religion(Character& chara)
 {
     if (chara.god_id != core_god::eyth || chara.has_learned_words() ||
-        chara.index == 0)
+        chara.is_player())
     {
         return;
     }

--- a/src/elona/initialize_map.cpp
+++ b/src/elona/initialize_map.cpp
@@ -596,7 +596,7 @@ void _refresh_map_character(Character& cnt)
 {
     cnt.was_passed_item_by_you_just_now() = false;
 
-    if (cnt.index < 57)
+    if (cnt.is_global())
     {
         if (mode == 11)
         {
@@ -621,11 +621,11 @@ void _refresh_map_character(Character& cnt)
 
     _level_up_if_guard(cnt);
 
-    if (cnt.index >= 57)
+    if (cnt.is_map_local())
     {
         _refresh_map_character_other(cnt);
     }
-    if (cnt.index == 0 || game_data.mount != cnt.index)
+    if (cnt.is_player() || game_data.mount != cnt.index)
     {
         if (_position_blocked(cnt))
         {
@@ -1019,7 +1019,7 @@ void _notify_distance_traveled()
         {
             continue;
         }
-        if (chara.index != 0 && chara.current_map)
+        if (!chara.is_player() && chara.current_map)
         {
             continue;
         }

--- a/src/elona/initialize_map_types.cpp
+++ b/src/elona/initialize_map_types.cpp
@@ -788,7 +788,7 @@ static void _init_map_arena()
         {
             if (chara.relationship == 10)
             {
-                if (chara.index != 0)
+                if (!chara.is_player())
                 {
                     cell_data.at(chara.position.x, chara.position.y)
                         .chara_index_plus_one = 0;

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -412,7 +412,7 @@ int itemusingfind(const ItemRef& item, bool disallow_pc)
         if (chara.activity && chara.activity.type != Activity::Type::sex &&
             chara.activity.turn > 0 && chara.activity.item == item)
         {
-            if (!disallow_pc || chara.index != 0)
+            if (!disallow_pc || !chara.is_player())
             {
                 return chara.index;
             }
@@ -2513,7 +2513,7 @@ void equip_melee_weapon(Character& chara)
                     weapon));
             }
         }
-        if (chara.index == 0)
+        if (chara.is_player())
         {
             if (game_data.mount != 0)
             {

--- a/src/elona/itemgen.cpp
+++ b/src/elona/itemgen.cpp
@@ -149,7 +149,7 @@ int get_random_item_id()
 bool upgrade_item_quality(Inventory& inv)
 {
     const auto owner_chara = inv_get_owner(inv).as_character();
-    if (owner_chara && owner_chara->index != 0)
+    if (owner_chara && !owner_chara->is_player())
         return false;
 
     return cdata.player().get_skill(19).level > rnd(5000);

--- a/src/elona/lua_env/api/classes/class_LuaCharacter.cpp
+++ b/src/elona/lua_env/api/classes/class_LuaCharacter.cpp
@@ -512,7 +512,7 @@ void LuaCharacter_move_to_xy(Character& self, int x, int y)
 {
     // NOTE: setting self.next_position may be safer if the position is changed
     // in the middle of the current turn.
-    cell_movechara(self.index, x, y);
+    cell_movechara(self, x, y);
 
     if (self.is_player())
     {

--- a/src/elona/lua_env/api/classes/class_LuaCharacter.cpp
+++ b/src/elona/lua_env/api/classes/class_LuaCharacter.cpp
@@ -465,7 +465,7 @@ void LuaCharacter_act_hostile_against(
     LuaCharacterHandle target)
 {
     auto& target_ref = lua::ref<Character>(target);
-    hostileaction(self.index, target_ref.index);
+    chara_act_hostile_action(self, target_ref);
 }
 
 

--- a/src/elona/lua_env/api/classes/class_LuaCharacter.cpp
+++ b/src/elona/lua_env/api/classes/class_LuaCharacter.cpp
@@ -203,8 +203,7 @@ void LuaCharacter_set_growth_buff(Character& self, int index, int power)
  */
 bool LuaCharacter_recruit_as_ally(Character& self)
 {
-    if (self.state() == Character::State::empty ||
-        (self.index != 0 && self.index <= 16) || self.index == 0)
+    if (self.state() == Character::State::empty || self.is_player_or_ally())
     {
         return false;
     }
@@ -388,7 +387,7 @@ void LuaCharacter_modify_sanity(Character& self, int delta)
  */
 void LuaCharacter_modify_karma(Character& self, int delta)
 {
-    if (self.index != 0)
+    if (!self.is_player())
     {
         return;
     }
@@ -407,7 +406,7 @@ void LuaCharacter_modify_karma(Character& self, int delta)
  */
 void LuaCharacter_modify_corruption(Character& self, int delta)
 {
-    if (self.index != 0)
+    if (!self.is_player())
     {
         return;
     }
@@ -492,7 +491,7 @@ void LuaCharacter_refresh(Character& self)
  */
 void LuaCharacter_refresh_burden_state(Character& self)
 {
-    if (self.index != 0)
+    if (!self.is_player())
     {
         return;
     }
@@ -515,7 +514,7 @@ void LuaCharacter_move_to_xy(Character& self, int x, int y)
     // in the middle of the current turn.
     cell_movechara(self.index, x, y);
 
-    if (self.index == 0)
+    if (self.is_player())
     {
         update_screen();
     }

--- a/src/elona/lua_env/api/modules/module_Chara.cpp
+++ b/src/elona/lua_env/api/modules/module_Chara.cpp
@@ -56,7 +56,7 @@ bool Chara_is_alive(
 /**
  * @luadoc is_player
  *
- * Checks if a character is the player (has index 0).
+ * Checks if a character is the player.
  *
  * @tparam LuaCharacter chara (const) a character
  * @treturn bool true if the character is the player
@@ -64,7 +64,7 @@ bool Chara_is_alive(
 bool Chara_is_player(LuaCharacterHandle chara)
 {
     auto& chara_ref = lua::ref<Character>(chara);
-    return chara_ref.index == 0;
+    return chara_ref.is_player();
 }
 
 
@@ -72,7 +72,7 @@ bool Chara_is_player(LuaCharacterHandle chara)
 /**
  * @luadoc is_ally
  *
- * Checks if a character is a member of the player's party (has index < 16)
+ * Checks if a character is a member of the player's party.
  *
  * @tparam LuaCharacter chara (const) a character
  * @treturn bool true if the character is in the player's party
@@ -80,7 +80,7 @@ bool Chara_is_player(LuaCharacterHandle chara)
 bool Chara_is_ally(LuaCharacterHandle chara)
 {
     auto& chara_ref = lua::ref<Character>(chara);
-    return 0 < chara_ref.index && chara_ref.index < 16;
+    return chara_ref.is_ally();
 }
 
 

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -174,7 +174,7 @@ bool _magic_1135(Character& target)
 {
     if (is_cursed(efstatus))
     {
-        if (target.index == 0)
+        if (target.is_player())
         {
             food_apply_curse_state(target, efstatus);
         }
@@ -195,7 +195,7 @@ bool _magic_1135(Character& target)
         lovemiracle(target.index);
         return true;
     }
-    if (target.index == 0)
+    if (target.is_player())
     {
         txt(i18n::s.get("core.magic.love_potion.self", target));
     }
@@ -243,7 +243,7 @@ bool _magic_1101(Character& subject, Character& target)
         snd("core.atk_elec");
         if (is_cursed(efstatus))
         {
-            if (target.index == 0)
+            if (target.is_player())
             {
                 txt(i18n::s.get("core.magic.milk.cursed.self"));
             }
@@ -253,7 +253,7 @@ bool _magic_1101(Character& subject, Character& target)
                     Message::color{ColorIndex::cyan});
             }
         }
-        else if (target.index == 0)
+        else if (target.is_player())
         {
             txt(i18n::s.get("core.magic.milk.self"));
         }
@@ -272,7 +272,7 @@ bool _magic_1101(Character& subject, Character& target)
         modify_height(target, (rnd(5) + 1) * -1);
     }
     target.nutrition += 1000 * (efp / 100);
-    if (target.index == 0)
+    if (target.is_player())
     {
         show_eating_message(subject);
     }
@@ -311,7 +311,7 @@ bool _magic_1116(Character& target)
 {
     if (is_in_fov(target))
     {
-        if (target.index == 0)
+        if (target.is_player())
         {
             txt(i18n::s.get("core.magic.acid.self"));
         }
@@ -337,7 +337,7 @@ bool _magic_1103(Character& target)
 {
     if (is_in_fov(target))
     {
-        if (target.index == 0)
+        if (target.is_player())
         {
             txt(i18n::s.get("core.magic.water.self"));
         }
@@ -416,7 +416,7 @@ bool _magic_1130(Character& target)
 {
     if (is_in_fov(target))
     {
-        if (target.index == 0)
+        if (target.is_player())
         {
             txt(i18n::s.get("core.magic.dirty_water.self"));
         }
@@ -440,7 +440,7 @@ bool _magic_300(Character& subject, Character& target)
         txt(i18n::s.get("core.magic.steal.in_quest"));
         return false;
     }
-    if (subject.index == 0)
+    if (subject.is_player())
     {
         if (cdata.player().sp < 50)
         {
@@ -463,8 +463,8 @@ bool _magic_300(Character& subject, Character& target)
     // In Pickpocket spact, target == player means that you attempts to steal
     // items on the ground, not in someone's inventory.
     ctrl_inventory(
-        target.index == 0 ? optional_ref<Character>{}
-                          : optional_ref<Character>{target});
+        target.is_player() ? optional_ref<Character>{}
+                           : optional_ref<Character>{target});
     return true;
 }
 
@@ -473,7 +473,7 @@ bool _magic_300(Character& subject, Character& target)
 // Riding
 bool _magic_301(Character& subject, Character& target)
 {
-    if (subject.index == 0)
+    if (subject.is_player())
     {
         if (cdata.player().sp < 50)
         {
@@ -510,7 +510,7 @@ bool _magic_301(Character& subject, Character& target)
             return true;
         }
     }
-    if (target.index >= 16)
+    if (!target.is_player_or_ally())
     {
         txt(i18n::s.get("core.magic.mount.only_ally"));
         return true;
@@ -555,9 +555,9 @@ bool _magic_301(Character& subject, Character& target)
 // Performance
 bool _magic_183(Character& subject, OptionalItemRef instrument)
 {
-    assert(subject.index != 0 || instrument);
+    assert(!subject.is_player() || instrument);
 
-    if (subject.index != 0)
+    if (!subject.is_player())
     {
         for (const auto& item : g_inv.for_chara(subject))
         {
@@ -580,7 +580,7 @@ bool _magic_183(Character& subject, OptionalItemRef instrument)
             return false;
         }
     }
-    if (subject.index == 0)
+    if (subject.is_player())
     {
         if (cdata.player().sp < 50)
         {
@@ -620,7 +620,7 @@ bool _magic_184(Character& subject, const ItemRef& cook_tool)
     }
     assert(food_opt);
     const auto food = food_opt.unwrap();
-    if (subject.index == 0)
+    if (subject.is_player())
     {
         if (cdata.player().sp < 50)
         {
@@ -726,7 +726,7 @@ bool _magic_185(Character& subject, const ItemRef& rod)
     fishx = x;
     fishy = y;
     addefmap(fishx, fishy, 1, 3);
-    if (subject.index == 0)
+    if (subject.is_player())
     {
         if (cdata.player().sp < 50)
         {
@@ -818,7 +818,7 @@ bool _magic_1120(Character& target)
 // Random craft material
 bool _magic_1117(Character& target)
 {
-    if (target.index >= 16)
+    if (!target.is_player_or_ally())
     {
         txt(i18n::s.get("core.common.nothing_happens"));
         obvious = 0;
@@ -866,7 +866,7 @@ bool _magic_632_454_1144(
 {
     if (!is_cursed_potion_of_cure_mutation)
     {
-        if (target.index != 0)
+        if (!target.is_player())
         {
             return _magic_628(subject, target);
         }
@@ -878,7 +878,7 @@ bool _magic_632_454_1144(
                 return true;
             }
         }
-        if (target.index != 0)
+        if (!target.is_player())
         {
             txt(i18n::s.get("core.common.nothing_happens"));
             return true;
@@ -975,7 +975,7 @@ bool _magic_632_454_1144(
 // Item: potion of cure mutation
 bool _magic_1121(Character& subject, Character& target)
 {
-    if (target.index != 0)
+    if (!target.is_player())
     {
         txt(i18n::s.get("core.common.nothing_happens"));
         return true;
@@ -1044,7 +1044,7 @@ bool _magic_1121(Character& subject, Character& target)
 // Identify
 bool _magic_411(Character& subject)
 {
-    if (subject.index != 0)
+    if (!subject.is_player())
     {
         txt(i18n::s.get("core.common.nothing_happens"));
         obvious = 0;
@@ -1110,7 +1110,7 @@ bool _magic_461(Character& subject)
     MiracleAnimation(MiracleAnimation::Mode::target_one, cdata[stat]).play();
     snd("core.pray2");
     cdata[stat].emotion_icon = 317;
-    if (subject.index == 0)
+    if (subject.is_player())
     {
         chara_modify_impression(cdata[stat], 15);
         if (stat >= 16)
@@ -1231,7 +1231,7 @@ bool _magic_412(Character& subject, Character& target)
 // Oracle
 bool _magic_413(Character& target)
 {
-    if (target.index >= 16)
+    if (!target.is_player_or_ally())
     {
         txt(i18n::s.get("core.common.nothing_happens"));
         return true;
@@ -1260,7 +1260,7 @@ bool _magic_413(Character& target)
 // Gain spell stock
 bool _magic_1104(Character& target)
 {
-    if (target.index != 0)
+    if (!target.is_player())
     {
         txt(i18n::s.get("core.common.nothing_happens"));
         obvious = 0;
@@ -1443,7 +1443,7 @@ bool _magic_1105(Character& target)
 // Item: scroll of faith
 bool _magic_1107(Character& target)
 {
-    if (target.index != 0)
+    if (!target.is_player())
     {
         txt(i18n::s.get("core.common.nothing_happens"));
         obvious = 0;
@@ -1613,7 +1613,7 @@ bool _magic_1113(Character& target)
             snd("core.curse3");
         }
     }
-    if (target.index == 0)
+    if (target.is_player())
     {
         save_set_autosave();
     }
@@ -1625,7 +1625,7 @@ bool _magic_1113(Character& target)
 // Vanish
 bool _magic_653(Character& target)
 {
-    if (target.index < 57)
+    if (target.is_global())
     {
         return true;
     }
@@ -1644,7 +1644,7 @@ bool _magic_653(Character& target)
 // Sense Object / Magic Map
 bool _magic_430_429(Character& target)
 {
-    if (target.index >= 16)
+    if (!target.is_player_or_ally())
     {
         txt(i18n::s.get("core.common.nothing_happens"));
         obvious = 0;
@@ -1732,7 +1732,7 @@ bool _magic_658(Character& subject, Character& target)
         snd("core.atksword");
         txt(i18n::s.get("core.magic.vorpal.sound"),
             Message::color{ColorIndex::red});
-        if (target.index >= 16)
+        if (!target.is_player_or_ally())
         {
             game_data.proc_damage_events_flag = 2;
             txt3rd = 1;
@@ -1853,7 +1853,7 @@ bool _magic_441(Character& subject)
 // Item: scroll of escape
 bool _magic_1141(Character& target)
 {
-    if (target.index != 0)
+    if (!target.is_player())
     {
         txt(i18n::s.get("core.common.nothing_happens"));
         obvious = 0;
@@ -1908,7 +1908,7 @@ bool _magic_1141(Character& target)
 // Return
 bool _magic_428(Character& target)
 {
-    if (target.index != 0)
+    if (!target.is_player())
     {
         txt(i18n::s.get("core.common.nothing_happens"));
         obvious = 0;
@@ -2058,7 +2058,7 @@ bool _magic_645_1114(Character& subject, Character& target)
     {
         return true;
     }
-    if (target.index < 16)
+    if (target.is_player_or_ally())
     {
         if (rnd(3))
         {
@@ -2174,7 +2174,7 @@ bool _magic_1118(Character& target)
 // of young lady
 bool _magic_1138_1123_1122_1137(Character& subject)
 {
-    if (subject.index != 0 && subject.index < 16)
+    if (subject.is_ally())
     {
         txt(i18n::s.get("core.common.nothing_happens"));
         return true;
@@ -2211,7 +2211,7 @@ bool _magic_1138_1123_1122_1137(Character& subject)
 // Dominate
 bool _magic_435(Character& subject, Character& target)
 {
-    if (subject.index != 0 || target.index == 0 || target.relationship == 10)
+    if (!subject.is_player() || target.is_player() || target.relationship == 10)
     {
         txt(i18n::s.get("core.common.nothing_happens"));
         obvious = 0;
@@ -2350,7 +2350,7 @@ bool _magic_436_437_455_634_456(Character& subject)
 // Item: scroll of name
 bool _magic_1145(Character& subject)
 {
-    if (subject.index != 0)
+    if (!subject.is_player())
     {
         txt(i18n::s.get("core.common.nothing_happens"));
         obvious = 0;
@@ -2392,7 +2392,7 @@ bool _magic_1145(Character& subject)
 // Item: Garok's hammer
 bool _magic_49(Character& subject, const ItemRef& hammer)
 {
-    if (subject.index != 0)
+    if (!subject.is_player())
     {
         txt(i18n::s.get("core.common.nothing_happens"));
         obvious = 0;
@@ -2456,7 +2456,7 @@ bool _magic_49(Character& subject, const ItemRef& hammer)
 // Item: scroll of change material
 bool _magic_21_1127(Character& subject)
 {
-    if (subject.index != 0)
+    if (!subject.is_player())
     {
         txt(i18n::s.get("core.common.nothing_happens"));
         obvious = 0;
@@ -2555,7 +2555,7 @@ bool _magic_21_1127(Character& subject)
 // Item: deed of inheritance
 bool _magic_1128(Character& subject)
 {
-    if (subject.index != 0)
+    if (!subject.is_player())
     {
         txt(i18n::s.get("core.common.nothing_happens"));
         obvious = 0;
@@ -2577,7 +2577,7 @@ bool _magic_1128(Character& subject)
 // Item: scroll of enchant weapon / armor
 bool _magic_1124_1125(Character& subject)
 {
-    if (subject.index != 0)
+    if (!subject.is_player())
     {
         txt(i18n::s.get("core.common.nothing_happens"));
         return true;
@@ -2623,7 +2623,7 @@ bool _magic_1124_1125(Character& subject)
 // Fill Charge / Item: scroll of charge
 bool _magic_630_1129(Character& subject)
 {
-    if (subject.index != 0)
+    if (!subject.is_player())
     {
         txt(i18n::s.get("core.common.nothing_happens"));
         obvious = 0;
@@ -2730,7 +2730,7 @@ bool _magic_630_1129(Character& subject)
 // Draw Charge
 bool _magic_629(Character& subject)
 {
-    if (subject.index != 0)
+    if (!subject.is_player())
     {
         txt(i18n::s.get("core.common.nothing_happens"));
         obvious = 0;
@@ -2791,7 +2791,7 @@ bool _magic_629(Character& subject)
 // Change
 bool _magic_628(Character& subject, Character& target)
 {
-    if (target.index == 0)
+    if (target.is_player())
     {
         txt(i18n::s.get("core.common.nothing_happens"));
         obvious = 0;
@@ -2807,7 +2807,7 @@ bool _magic_628(Character& subject, Character& target)
     {
         f = -1;
     }
-    if (target.index < 57)
+    if (target.is_global())
     {
         f = 0;
     }
@@ -2838,7 +2838,7 @@ bool _magic_628(Character& subject, Character& target)
 // Item: scroll of flying
 bool _magic_1140(Character& subject)
 {
-    if (subject.index != 0)
+    if (!subject.is_player())
     {
         txt(i18n::s.get("core.common.nothing_happens"));
         obvious = 0;
@@ -2909,7 +2909,7 @@ bool _magic_1140(Character& subject)
 // Item: rod of alchemy
 bool _magic_1132(Character& subject, int& fltbk, int& valuebk)
 {
-    if (subject.index != 0)
+    if (!subject.is_player())
     {
         txt(i18n::s.get("core.common.nothing_happens"));
         obvious = 0;
@@ -3235,9 +3235,9 @@ bool _magic_656(Character& subject)
         {
             continue;
         }
-        if (subject.index < 16)
+        if (subject.is_player_or_ally())
         {
-            if (cnt.index >= 16)
+            if (!cnt.is_player_or_ally())
             {
                 continue;
             }
@@ -3284,7 +3284,7 @@ bool _magic_656(Character& subject)
 // Item: potion of cure corruption
 bool _magic_1131(Character& target)
 {
-    if (target.index != 0)
+    if (!target.is_player())
     {
         txt(i18n::s.get("core.common.nothing_happens"));
         return true;
@@ -3310,7 +3310,7 @@ bool _magic_1131(Character& target)
 // Eye of Ether
 bool _magic_633(Character& subject, Character& target)
 {
-    if (target.index != 0)
+    if (!target.is_player())
     {
         return true;
     }
@@ -3533,7 +3533,7 @@ bool _magic_463()
 int _calc_ball_spell_range(Character& subject)
 {
     int ret = the_ability_db[efid]->range % 1000 + 1;
-    if (debug::voldemort && subject.index == 0)
+    if (debug::voldemort && subject.is_player())
     {
         ret *= 2;
     }
@@ -3591,7 +3591,7 @@ optional_ref<Character> _ball_spell_internal(
             if (efid == 404)
             {
                 f = 0;
-                if (subject.index == 0 || subject.relationship >= 0)
+                if (subject.is_player() || subject.relationship >= 0)
                 {
                     if (cdata[target_index].relationship >= 0)
                     {
@@ -3620,7 +3620,7 @@ optional_ref<Character> _ball_spell_internal(
             if (efid == 637)
             {
                 f = 0;
-                if (subject.index == 0 || subject.relationship >= 0)
+                if (subject.is_player() || subject.relationship >= 0)
                 {
                     if (cdata[target_index].relationship >= 0)
                     {
@@ -3831,7 +3831,7 @@ optional<bool> _proc_general_magic(Character& subject, Character& target)
         }
         if (efid == 625 || efid == 446)
         {
-            if ((target.index == 0 && subject.index == 0) ||
+            if ((target.is_player() && subject.is_player()) ||
                 subject.index == game_data.mount)
             {
                 if (game_data.mount != 0)
@@ -3878,7 +3878,7 @@ optional<bool> _proc_general_magic(Character& subject, Character& target)
         }
         if (efid == 458)
         {
-            if (target.index == 0)
+            if (target.is_player())
             {
                 incognitobegin();
             }
@@ -3893,7 +3893,7 @@ optional<bool> _proc_general_magic(Character& subject, Character& target)
         ele = damage->element;
         elep = damage->element_power;
     }
-    if (subject.index == 0)
+    if (subject.is_player())
     {
         if (trait(165))
         {
@@ -4016,7 +4016,7 @@ optional<bool> _proc_general_magic(Character& subject, Character& target)
         dmg = roll(dice1, dice2, bonus);
         if (is_in_fov(target))
         {
-            if (target.index >= 16)
+            if (!target.is_player_or_ally())
             {
                 game_data.proc_damage_events_flag = 2;
                 txt3rd = 1;
@@ -4075,7 +4075,7 @@ optional<bool> _proc_general_magic(Character& subject, Character& target)
         {
             if (is_in_fov(subject))
             {
-                if (subject.index == 0)
+                if (subject.is_player())
                 {
                     txt(i18n::s.get(
                         "core.magic.special_attack.self",
@@ -4100,7 +4100,7 @@ optional<bool> _proc_general_magic(Character& subject, Character& target)
         {
             if (is_in_fov(subject))
             {
-                if (target.index >= 16)
+                if (!target.is_player_or_ally())
                 {
                     game_data.proc_damage_events_flag = 2;
                     txt(i18n::s.get(
@@ -4122,7 +4122,7 @@ optional<bool> _proc_general_magic(Character& subject, Character& target)
         }
         else if (is_in_fov(subject))
         {
-            if (target.index >= 16)
+            if (!target.is_player_or_ally())
             {
                 game_data.proc_damage_events_flag = 2;
                 txt(i18n::s.get(
@@ -4194,7 +4194,7 @@ optional<bool> _proc_general_magic(Character& subject, Character& target)
         }
         return true;
     case 7:
-        if (subject.index == 0)
+        if (subject.is_player())
         {
             if (game_data.crowd_density + 100 >= ELONA_MAX_OTHER_CHARACTERS)
             {

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -491,7 +491,7 @@ bool _magic_301(Character& subject, Character& target)
     }
     if (game_data.mount != 0)
     {
-        if (target.index == subject.index)
+        if (target == subject)
         {
             int stat = cell_findspace(
                 cdata.player().position.x, cdata.player().position.y, 1);
@@ -520,7 +520,7 @@ bool _magic_301(Character& subject, Character& target)
         txt(i18n::s.get("core.magic.mount.not_client"));
         return true;
     }
-    if (target.index == subject.index)
+    if (target == subject)
     {
         if (game_data.mount == 0)
         {
@@ -3073,7 +3073,7 @@ bool _magic_631(Character& subject)
         {
             continue;
         }
-        if (subject.index == cnt.index)
+        if (subject == cnt)
         {
             continue;
         }
@@ -3131,7 +3131,7 @@ bool _magic_466(Character& subject)
         {
             continue;
         }
-        if (subject.index == cnt.index)
+        if (subject == cnt)
         {
             continue;
         }
@@ -3171,7 +3171,7 @@ bool _magic_657(Character& subject)
         {
             continue;
         }
-        if (subject.index == cnt.index)
+        if (subject == cnt)
         {
             continue;
         }
@@ -3231,7 +3231,7 @@ bool _magic_656(Character& subject)
         {
             continue;
         }
-        if (subject.index == cnt.index)
+        if (subject == cnt)
         {
             continue;
         }

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -192,7 +192,7 @@ bool _magic_1135(Character& target)
         txt(i18n::s.get("core.magic.love_potion.spill", target));
         chara_modify_impression(target, clamp(efp / 15, 0, 15));
         status_ailment_damage(target, StatusAilment::dimmed, 100);
-        lovemiracle(target.index);
+        lovemiracle(target);
         return true;
     }
     if (target.is_player())
@@ -202,7 +202,7 @@ bool _magic_1135(Character& target)
     else
     {
         txt(i18n::s.get("core.magic.love_potion.other", target));
-        lovemiracle(target.index);
+        lovemiracle(target);
         chara_modify_impression(target, clamp(efp / 4, 0, 25));
     }
     status_ailment_damage(target, StatusAilment::dimmed, 500);

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -500,7 +500,7 @@ bool _magic_301(Character& subject, Character& target)
                 txt(i18n::s.get("core.magic.mount.no_place_to_get_off"));
                 return true;
             }
-            cell_setchara(game_data.mount, rtval, rtval(1));
+            cell_setchara(cdata[game_data.mount], rtval, rtval(1));
             txt(i18n::s.get(
                 "core.magic.mount.dismount", cdata[game_data.mount]));
             txt(name(game_data.mount) +

--- a/src/elona/map.cpp
+++ b/src/elona/map.cpp
@@ -1687,7 +1687,7 @@ TurnResult exit_map()
         }
         cell_data.at(chara.position.x, chara.position.y).chara_index_plus_one =
             0;
-        if (chara.index != 0)
+        if (!chara.is_player())
         {
             if (chara.current_map != 0)
             {
@@ -2186,7 +2186,7 @@ void map_global_proc_travel_events(Character& chara)
 
 void sense_map_feats_on_move(Character& chara)
 {
-    if (chara.index != 0)
+    if (!chara.is_player())
         return;
 
     game_data.player_x_on_map_leave = -1;

--- a/src/elona/map_cell.cpp
+++ b/src/elona/map_cell.cpp
@@ -193,9 +193,9 @@ void cell_setchara(Character& chara, int x, int y)
 
 
 
-void cell_removechara(int x, int y)
+void cell_removechara(const Position& pos)
 {
-    cell_data.at(x, y).chara_index_plus_one = 0;
+    cell_data.at(pos.x, pos.y).chara_index_plus_one = 0;
 }
 
 

--- a/src/elona/map_cell.cpp
+++ b/src/elona/map_cell.cpp
@@ -9,10 +9,6 @@
 namespace elona
 {
 
-int tc_at_m81 = 0;
-
-
-
 void cell_featset(int x, int y, int info1, int info2, int info3, int info4)
 {
     elona_vector1<int> feat_at_m80;
@@ -172,7 +168,7 @@ void cell_movechara(Character& chara, int x, int y)
         {
             return;
         }
-        cell_swap(chara, cdata[tc_at_m81]);
+        cell_swap(chara, cdata[chara_b_index_plus_one - 1]);
     }
     else
     {

--- a/src/elona/map_cell.cpp
+++ b/src/elona/map_cell.cpp
@@ -163,23 +163,23 @@ bool cell_swap(Character& chara_a, Character& chara_b)
 
 
 
-void cell_movechara(int chara_index, int x, int y)
+void cell_movechara(Character& chara, int x, int y)
 {
-    if (cell_data.at(x, y).chara_index_plus_one != 0)
+    if (const auto chara_b_index_plus_one =
+            cell_data.at(x, y).chara_index_plus_one)
     {
-        if (cell_data.at(x, y).chara_index_plus_one - 1 == chara_index)
+        if (chara_b_index_plus_one - 1 == chara.index)
         {
             return;
         }
-        cell_swap(cdata[chara_index], cdata[tc_at_m81]);
+        cell_swap(chara, cdata[tc_at_m81]);
     }
     else
     {
-        cell_data
-            .at(cdata[chara_index].position.x, cdata[chara_index].position.y)
-            .chara_index_plus_one = 0;
-        cdata[chara_index].position = {x, y};
-        cell_data.at(x, y).chara_index_plus_one = chara_index + 1;
+        cell_data.at(chara.position.x, chara.position.y).chara_index_plus_one =
+            0;
+        chara.position = {x, y};
+        cell_data.at(x, y).chara_index_plus_one = chara.index + 1;
     }
 }
 

--- a/src/elona/map_cell.cpp
+++ b/src/elona/map_cell.cpp
@@ -185,10 +185,10 @@ void cell_movechara(Character& chara, int x, int y)
 
 
 
-void cell_setchara(int chara_index, int x, int y)
+void cell_setchara(Character& chara, int x, int y)
 {
-    cell_data.at(x, y).chara_index_plus_one = chara_index + 1;
-    cdata[chara_index].position = Position{x, y};
+    cell_data.at(x, y).chara_index_plus_one = chara.index + 1;
+    chara.position = {x, y};
 }
 
 

--- a/src/elona/map_cell.cpp
+++ b/src/elona/map_cell.cpp
@@ -102,49 +102,56 @@ void cell_check(int x, int y)
 
 
 
-bool cell_swap(int chara_index_a, int chara_index_b, int x, int y)
+bool cell_swap(Character& chara, const Position& pos)
 {
-    int x2_at_m81 = 0;
-    int y2_at_m81 = 0;
+    if (const auto chara_b_index_plus_one =
+            cell_data.at(pos.x, pos.y).chara_index_plus_one)
+    {
+        return cell_swap(chara, cdata[chara_b_index_plus_one - 1]);
+    }
+
     if (game_data.mount != 0)
     {
-        if (game_data.mount == chara_index_a ||
-            game_data.mount == chara_index_b)
+        if (game_data.mount == chara.index)
         {
             return false;
         }
     }
-    tc_at_m81 = chara_index_b;
-    if (tc_at_m81 == -1)
+
+    cell_data.at(chara.position.x, chara.position.y).chara_index_plus_one = 0;
+    chara.position = pos;
+    cell_data.at(pos.x, pos.y).chara_index_plus_one = chara.index + 1;
+
+    if (chara.is_player())
     {
-        if (cell_data.at(x, y).chara_index_plus_one != 0)
+        if (game_data.mount)
         {
-            tc_at_m81 = cell_data.at(x, y).chara_index_plus_one - 1;
+            cdata[game_data.mount].position = cdata.player().position;
         }
     }
-    if (tc_at_m81 != -1)
+    return true;
+}
+
+
+
+bool cell_swap(Character& chara_a, Character& chara_b)
+{
+    if (game_data.mount != 0)
     {
-        cell_data
-            .at(cdata[chara_index_a].position.x,
-                cdata[chara_index_a].position.y)
-            .chara_index_plus_one = tc_at_m81 + 1;
-        x2_at_m81 = cdata[tc_at_m81].position.x;
-        y2_at_m81 = cdata[tc_at_m81].position.y;
-        cdata[tc_at_m81].position = cdata[chara_index_a].position;
+        if (game_data.mount == chara_a.index ||
+            game_data.mount == chara_b.index)
+        {
+            return false;
+        }
     }
-    else
-    {
-        cell_data
-            .at(cdata[chara_index_a].position.x,
-                cdata[chara_index_a].position.y)
-            .chara_index_plus_one = 0;
-        x2_at_m81 = x;
-        y2_at_m81 = y;
-    }
-    cell_data.at(x2_at_m81, y2_at_m81).chara_index_plus_one = chara_index_a + 1;
-    cdata[chara_index_a].position.x = x2_at_m81;
-    cdata[chara_index_a].position.y = y2_at_m81;
-    if (chara_index_a == 0 || tc_at_m81 == 0)
+
+    std::swap(chara_a.position, chara_b.position);
+    cell_data.at(chara_a.position.x, chara_a.position.y).chara_index_plus_one =
+        chara_a.index + 1;
+    cell_data.at(chara_b.position.x, chara_b.position.y).chara_index_plus_one =
+        chara_b.index + 1;
+
+    if (chara_a.is_player() || chara_b.is_player())
     {
         if (game_data.mount)
         {
@@ -164,7 +171,7 @@ void cell_movechara(int chara_index, int x, int y)
         {
             return;
         }
-        cell_swap(chara_index, tc_at_m81);
+        cell_swap(cdata[chara_index], cdata[tc_at_m81]);
     }
     else
     {

--- a/src/elona/map_cell.hpp
+++ b/src/elona/map_cell.hpp
@@ -31,7 +31,7 @@ int cell_findspace(int = 0, int = 0, int = 0);
 void cell_check(int = 0, int = 0);
 void cell_featclear(int = 0, int = 0);
 void cell_featset(int = 0, int = 0, int = 0, int = 0, int = 0, int = 0);
-void cell_movechara(int = 0, int = 0, int = 0);
+void cell_movechara(Character& chara, int x, int y);
 void cell_refresh(int = 0, int = 0);
 void cell_removechara(int = 0, int = 0);
 void cell_setchara(int = 0, int = 0, int = 0);

--- a/src/elona/map_cell.hpp
+++ b/src/elona/map_cell.hpp
@@ -33,7 +33,7 @@ void cell_featclear(int = 0, int = 0);
 void cell_featset(int = 0, int = 0, int = 0, int = 0, int = 0, int = 0);
 void cell_movechara(Character& chara, int x, int y);
 void cell_refresh(int = 0, int = 0);
-void cell_removechara(int = 0, int = 0);
+void cell_removechara(const Position& pos);
 void cell_setchara(Character& chara, int x, int y);
 bool cell_swap(Character& chara, const Position& pos);
 bool cell_swap(Character& chara_a, Character& chara_b);

--- a/src/elona/map_cell.hpp
+++ b/src/elona/map_cell.hpp
@@ -12,6 +12,7 @@ namespace elona
 
 struct Item;
 struct Position;
+struct Character;
 
 
 
@@ -34,7 +35,8 @@ void cell_movechara(int = 0, int = 0, int = 0);
 void cell_refresh(int = 0, int = 0);
 void cell_removechara(int = 0, int = 0);
 void cell_setchara(int = 0, int = 0, int = 0);
-bool cell_swap(int = 0, int = 0, int = 0, int = 0);
+bool cell_swap(Character& chara, const Position& pos);
+bool cell_swap(Character& chara_a, Character& chara_b);
 
 
 /**

--- a/src/elona/map_cell.hpp
+++ b/src/elona/map_cell.hpp
@@ -34,7 +34,7 @@ void cell_featset(int = 0, int = 0, int = 0, int = 0, int = 0, int = 0);
 void cell_movechara(Character& chara, int x, int y);
 void cell_refresh(int = 0, int = 0);
 void cell_removechara(int = 0, int = 0);
-void cell_setchara(int = 0, int = 0, int = 0);
+void cell_setchara(Character& chara, int x, int y);
 bool cell_swap(Character& chara, const Position& pos);
 bool cell_swap(Character& chara_a, Character& chara_b);
 

--- a/src/elona/mapgen.cpp
+++ b/src/elona/mapgen.cpp
@@ -439,7 +439,7 @@ void map_placeplayer()
         {
             continue;
         }
-        if (chara.index != 0)
+        if (!chara.is_player())
         {
             if (game_data.mount == chara.index)
             {
@@ -461,7 +461,7 @@ void map_placeplayer()
         }
         if (chara.current_map == game_data.current_map)
         {
-            if (chara.index != 0)
+            if (!chara.is_player())
             {
                 cxinit = chara.initial_position.x;
                 cyinit = chara.initial_position.y;

--- a/src/elona/mef.cpp
+++ b/src/elona/mef.cpp
@@ -235,7 +235,11 @@ void mef_proc(Character& chara)
                     mef(5, ef));
                 if (stat == 0)
                 {
-                    check_kill(mef(6, ef), chara.index);
+                    check_kill(
+                        mef(6, ef) >= 0
+                            ? optional_ref<Character>{cdata[mef(6, ef)]}
+                            : optional_ref<Character>{},
+                        chara);
                 }
             }
         }
@@ -258,7 +262,10 @@ void mef_proc(Character& chara)
             chara, rnd_capped(mef(5, ef) / 15 + 5) + 1, -9, 50, mef(5, ef));
         if (stat == 0)
         {
-            check_kill(mef(6, ef), chara.index);
+            check_kill(
+                mef(6, ef) >= 0 ? optional_ref<Character>{cdata[mef(6, ef)]}
+                                : optional_ref<Character>{},
+                chara);
         }
     }
     if (mef(0, ef) == 6)
@@ -283,7 +290,10 @@ void mef_proc(Character& chara)
             item_db_on_drink(chara, nullptr, mef(7, ef));
             if (chara.state() == Character::State::empty)
             {
-                check_kill(mef(6, ef), chara.index);
+                check_kill(
+                    mef(6, ef) >= 0 ? optional_ref<Character>{cdata[mef(6, ef)]}
+                                    : optional_ref<Character>{},
+                    chara);
             }
             mef_delete(ef);
         }

--- a/src/elona/mef.cpp
+++ b/src/elona/mef.cpp
@@ -270,7 +270,7 @@ void mef_proc(Character& chara)
                 snd("core.water2");
                 txt(i18n::s.get("core.mef.steps_in_pool", chara));
             }
-            wet(chara.index, 25);
+            chara_get_wet(chara, 25);
             if (mef(6, ef) == 0)
             {
                 if (!chara.is_player())

--- a/src/elona/mef.cpp
+++ b/src/elona/mef.cpp
@@ -224,7 +224,7 @@ void mef_proc(Character& chara)
                 {
                     if (!chara.is_player())
                     {
-                        hostileaction(0, chara.index);
+                        chara_act_hostile_action(cdata.player(), chara);
                     }
                 }
                 int stat = damage_hp(
@@ -251,7 +251,7 @@ void mef_proc(Character& chara)
         {
             if (!chara.is_player())
             {
-                hostileaction(0, chara.index);
+                chara_act_hostile_action(cdata.player(), chara);
             }
         }
         int stat = damage_hp(
@@ -275,7 +275,7 @@ void mef_proc(Character& chara)
             {
                 if (!chara.is_player())
                 {
-                    hostileaction(0, chara.index);
+                    chara_act_hostile_action(cdata.player(), chara);
                 }
             }
             potionspill = 1;

--- a/src/elona/mef.cpp
+++ b/src/elona/mef.cpp
@@ -222,7 +222,7 @@ void mef_proc(Character& chara)
                 }
                 if (mef(6, ef) == 0)
                 {
-                    if (chara.index != 0)
+                    if (!chara.is_player())
                     {
                         hostileaction(0, chara.index);
                     }
@@ -249,7 +249,7 @@ void mef_proc(Character& chara)
         }
         if (mef(6, ef) == 0)
         {
-            if (chara.index != 0)
+            if (!chara.is_player())
             {
                 hostileaction(0, chara.index);
             }
@@ -273,7 +273,7 @@ void mef_proc(Character& chara)
             wet(chara.index, 25);
             if (mef(6, ef) == 0)
             {
-                if (chara.index != 0)
+                if (!chara.is_player())
                 {
                     hostileaction(0, chara.index);
                 }

--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -131,7 +131,7 @@ std::string _set_pcc_info(Character& chara, int val0)
         }
         if (val0 == 9)
         {
-            if (chara.index != 0)
+            if (!chara.is_player())
             {
                 rtval(0) = 101;
                 rtval(1) = 0;
@@ -714,7 +714,7 @@ ChangeAppearanceResult menu_change_appearance(Character& chara)
                 s(6) = i18n::s.get("core.ui.appearance.basic.cloth");
                 s(7) = i18n::s.get("core.ui.appearance.basic.pants");
                 s(8) = i18n::s.get("core.ui.appearance.basic.set_detail");
-                if (chara.index != 0)
+                if (!chara.is_player())
                 {
                     s(9) = i18n::s.get("core.ui.appearance.basic.custom");
                 }
@@ -722,8 +722,8 @@ ChangeAppearanceResult menu_change_appearance(Character& chara)
                 {
                     s(9) = i18n::s.get("core.ui.appearance.basic.riding");
                 }
-                p = 9 + (chara.index != 0) +
-                    (chara.index == 0) * (game_data.mount != 0);
+                p = 9 + (!chara.is_player()) +
+                    (chara.is_player()) * (game_data.mount != 0);
             }
             else
             {

--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -1363,7 +1363,7 @@ void screen_analyze_self()
     snd("core.pop2");
     buff = "";
     notesel(buff);
-    chara_delete(56);
+    chara_delete(cdata.tmp());
     cdata.tmp().piety_point = cdata.player().piety_point;
     cdata.tmp().god_id = cdata.player().god_id;
     for (int cnt = 0; cnt < 600; ++cnt)

--- a/src/elona/save.cpp
+++ b/src/elona/save.cpp
@@ -118,7 +118,7 @@ void load_save_data()
     set_item_info();
     for (auto&& chara : cdata.player_and_allies())
     {
-        if (chara.has_own_sprite() || chara.index == 0)
+        if (chara.has_own_sprite() || chara.is_player())
         {
             create_pcpic(chara);
         }

--- a/src/elona/save.cpp
+++ b/src/elona/save.cpp
@@ -114,7 +114,7 @@ void load_save_data()
     update_save_data(save_dir);
     ctrl_file(FileOperation2::global_read, save_dir);
 
-    chara_delete(56);
+    chara_delete(cdata.tmp());
     set_item_info();
     for (auto&& chara : cdata.player_and_allies())
     {
@@ -220,7 +220,7 @@ void load_gene_files()
     }
     for (auto&& cnt : cdata.all())
     {
-        chara_delete(cnt.index);
+        chara_delete(cnt);
     }
     game_data.play_time = genetemp(805);
 }

--- a/src/elona/status_ailment.cpp
+++ b/src/elona/status_ailment.cpp
@@ -22,12 +22,12 @@ namespace
 {
 
 int calc_power_decreased_by_resistance(
-    int chara_index,
+    Character& chara,
     int power,
     Element element)
 {
     const auto resistance_level =
-        cdata[chara_index].get_skill(static_cast<int>(element)).level / 50;
+        chara.get_skill(static_cast<int>(element)).level / 50;
     power = (rnd_capped(power / 2 + 1) + power / 2) * 100 /
         (50 + resistance_level * 50);
 
@@ -62,8 +62,8 @@ void status_ailment_damage(
             return;
         if (chara.quality > Quality::great && rnd_capped(chara.level / 2 + 1))
             return;
-        power = calc_power_decreased_by_resistance(
-            chara.index, power, Element::darkness);
+        power =
+            calc_power_decreased_by_resistance(chara, power, Element::darkness);
         turn = power / 6;
         if (turn <= 0)
             return;
@@ -90,8 +90,7 @@ void status_ailment_damage(
             return;
         if (chara.quality > Quality::great && rnd_capped(chara.level / 2 + 1))
             return;
-        power = calc_power_decreased_by_resistance(
-            chara.index, power, Element::mind);
+        power = calc_power_decreased_by_resistance(chara, power, Element::mind);
         turn = power / 7;
         if (turn <= 0)
             return;
@@ -116,8 +115,8 @@ void status_ailment_damage(
             return;
         if (chara.quality > Quality::great && rnd_capped(chara.level + 1))
             return;
-        power = calc_power_decreased_by_resistance(
-            chara.index, power, Element::nerve);
+        power =
+            calc_power_decreased_by_resistance(chara, power, Element::nerve);
         turn = power / 10;
         if (turn <= 0)
             return;
@@ -142,8 +141,8 @@ void status_ailment_damage(
             return;
         if (chara.quality > Quality::great && rnd_capped(chara.level / 3 + 1))
             return;
-        power = calc_power_decreased_by_resistance(
-            chara.index, power, Element::poison);
+        power =
+            calc_power_decreased_by_resistance(chara, power, Element::poison);
         turn = power / 5;
         if (turn <= 0)
             return;
@@ -168,8 +167,8 @@ void status_ailment_damage(
             return;
         if (chara.quality > Quality::great && rnd_capped(chara.level / 5 + 1))
             return;
-        power = calc_power_decreased_by_resistance(
-            chara.index, power, Element::nerve);
+        power =
+            calc_power_decreased_by_resistance(chara, power, Element::nerve);
         turn = power / 4;
         if (turn <= 0)
             return;
@@ -198,8 +197,7 @@ void status_ailment_damage(
             return;
         if (chara.quality > Quality::great && rnd_capped(chara.level / 5 + 1))
             return;
-        power = calc_power_decreased_by_resistance(
-            chara.index, power, Element::mind);
+        power = calc_power_decreased_by_resistance(chara, power, Element::mind);
         turn = power / 7;
         if (turn <= 0)
             return;
@@ -217,8 +215,8 @@ void status_ailment_damage(
             return;
         if (chara.race == "core.golem")
             return;
-        power = calc_power_decreased_by_resistance(
-            chara.index, power, Element::sound);
+        power =
+            calc_power_decreased_by_resistance(chara, power, Element::sound);
         turn = power / 8;
         if (turn <= 0)
             return;

--- a/src/elona/talk.cpp
+++ b/src/elona/talk.cpp
@@ -105,7 +105,7 @@ void talk_to_npc(Character& chara)
     }
     chatval_unique_chara_id = none;
     chatval_show_impress = true;
-    if (chara.quality == Quality::special && chara.index >= 16)
+    if (chara.quality == Quality::special && !chara.is_player_or_ally())
     {
         chatval_unique_chara_id = charaid2int(chara.id);
         chatval_show_impress = false;
@@ -130,7 +130,7 @@ void talk_to_npc(Character& chara)
         talk_wrapper(chara, TalkResult::talk_busy);
         return;
     }
-    if (chara.index == 0)
+    if (chara.is_player())
     {
         talk_wrapper(chara, TalkResult::talk_end);
         return;
@@ -143,7 +143,7 @@ void talk_to_npc(Character& chara)
 
     if (chatval_unique_chara_id &&
         game_data.current_map != mdata_t::MapId::show_house &&
-        chara.index >= 16)
+        !chara.is_player_or_ally())
     {
         talk_wrapper(chara, TalkResult::talk_unique);
         return;

--- a/src/elona/talk_house_visitor.cpp
+++ b/src/elona/talk_house_visitor.cpp
@@ -226,7 +226,8 @@ int _adventurer_get_trained_skill(Character& speaker)
 
 void _adventurer_learn_skill(int skill_id)
 {
-    cdata.player().platinum_coin -= calclearncost(skill_id, 0, true);
+    cdata.player().platinum_coin -=
+        calc_skill_learning_cost(skill_id, cdata.player(), true);
     chara_gain_skill(cdata.player(), skill_id);
     ++game_data.number_of_learned_skills_by_trainer;
 }
@@ -262,11 +263,11 @@ TalkResult _talk_hv_adventurer_train(Character& speaker)
             "core.talk.visitor.adventurer.train.learn.dialog",
             the_ability_db.get_text(skill_id, "name"),
             std::to_string(
-                calclearncost(skill_id, cdata.player().index, true)) +
+                calc_skill_learning_cost(skill_id, cdata.player(), true)) +
                 i18n::s.get("core.ui.platinum"),
             speaker);
         if (cdata.player().platinum_coin >=
-            calclearncost(skill_id, cdata.player().index, true))
+            calc_skill_learning_cost(skill_id, cdata.player(), true))
         {
             list(0, listmax) = 1;
             listn(0, listmax) =
@@ -280,7 +281,7 @@ TalkResult _talk_hv_adventurer_train(Character& speaker)
             "core.talk.visitor.adventurer.train.train.dialog",
             the_ability_db.get_text(skill_id, "name"),
             std::to_string(
-                calclearncost(skill_id, cdata.player().index, true)) +
+                calc_skill_learning_cost(skill_id, cdata.player(), true)) +
                 i18n::s.get("core.ui.platinum"),
             speaker);
         if (cdata.player().platinum_coin >=

--- a/src/elona/talk_house_visitor.cpp
+++ b/src/elona/talk_house_visitor.cpp
@@ -235,7 +235,8 @@ void _adventurer_learn_skill(int skill_id)
 
 void _adventurer_train_skill(int skill_id)
 {
-    cdata.player().platinum_coin -= calctraincost(skill_id, 0, true);
+    cdata.player().platinum_coin -=
+        calc_skill_training_cost(skill_id, cdata.player(), true);
     modify_potential(
         cdata.player(),
         skill_id,
@@ -283,7 +284,7 @@ TalkResult _talk_hv_adventurer_train(Character& speaker)
                 i18n::s.get("core.ui.platinum"),
             speaker);
         if (cdata.player().platinum_coin >=
-            calctraincost(skill_id, cdata.player().index, true))
+            calc_skill_training_cost(skill_id, cdata.player(), true))
         {
             list(0, listmax) = 2;
             listn(0, listmax) =

--- a/src/elona/talk_house_visitor.cpp
+++ b/src/elona/talk_house_visitor.cpp
@@ -209,17 +209,15 @@ void _talk_hv_adventurer_best_friend(Character& speaker)
 
 int _adventurer_get_trained_skill(Character& speaker)
 {
-    int stat = advfavoriteskill(speaker.index);
-    int val = rtval(rnd(stat));
+    int skill_id = adventurer_favorite_skill(speaker);
     if (speaker.impression >= 300)
     {
         if (rnd(3) == 0)
         {
-            stat = advfavoritestat(speaker.index);
-            val = stat;
+            skill_id = adventurer_favorite_stat(speaker);
         }
     }
-    return val;
+    return skill_id;
 }
 
 
@@ -490,8 +488,7 @@ TalkResult _talk_hv_adventurer_materials(Character& speaker)
 
 TalkResult _talk_hv_adventurer_favorite_skill(Character& speaker)
 {
-    int stat = advfavoriteskill(speaker.index);
-    int skill_id = rtval(rnd(stat));
+    int skill_id = adventurer_favorite_skill(speaker);
     listmax = 0;
     buff = i18n::s.get(
         "core.talk.visitor.adventurer.favorite_skill.dialog",
@@ -516,7 +513,7 @@ TalkResult _talk_hv_adventurer_favorite_skill(Character& speaker)
 
 TalkResult _talk_hv_adventurer_favorite_stat(Character& speaker)
 {
-    int skill_id = advfavoritestat(speaker.index);
+    int skill_id = adventurer_favorite_stat(speaker);
     listmax = 0;
     buff = i18n::s.get(
         "core.talk.visitor.adventurer.favorite_stat.dialog",

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -1478,10 +1478,10 @@ TalkResult talk_trainer(Character& speaker, bool is_training)
         buff = i18n::s.get(
             "core.talk.npc.trainer.cost.learning",
             the_ability_db.get_text(selected_skill, "name"),
-            calclearncost(selected_skill, cdata.player().index),
+            calc_skill_learning_cost(selected_skill, cdata.player()),
             speaker);
         if (cdata.player().platinum_coin >=
-            calclearncost(selected_skill, cdata.player().index))
+            calc_skill_learning_cost(selected_skill, cdata.player()))
         {
             list(0, listmax) = 1;
             listn(0, listmax) =
@@ -1515,7 +1515,7 @@ TalkResult talk_trainer(Character& speaker, bool is_training)
         else
         {
             cdata.player().platinum_coin -=
-                calclearncost(selected_skill, cdata.player().index);
+                calc_skill_learning_cost(selected_skill, cdata.player());
             chara_gain_skill(cdata.player(), selected_skill);
             ++game_data.number_of_learned_skills_by_trainer;
             buff =

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -650,7 +650,7 @@ TalkResult talk_ally_abandon(Character& speaker)
         txt(i18n::s.get("core.talk.npc.ally.abandon.you_abandoned", speaker));
         cell_data.at(speaker.position.x, speaker.position.y)
             .chara_index_plus_one = 0;
-        chara_delete(speaker.index);
+        chara_delete(speaker);
         return TalkResult::talk_end;
     }
     buff = "";
@@ -748,7 +748,7 @@ TalkResult talk_slave_sell(Character& speaker)
             {
                 event_add(15, charaid2int(cdata[stat].id));
             }
-            chara_delete(stat);
+            chara_delete(cdata[stat]);
             buff = i18n::s.get("core.talk.npc.common.thanks", speaker);
         }
         else

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -1829,7 +1829,7 @@ TalkResult talk_npc(Character& speaker)
         {
             if (speaker.relationship != 10)
             {
-                if (speaker.index >= 16)
+                if (!speaker.is_player_or_ally())
                 {
                     if (rnd(3) == 0)
                     {
@@ -1909,7 +1909,7 @@ TalkResult talk_npc(Character& speaker)
                 57, i18n::s.get("core.talk.npc.horse_keeper.choices.buy"));
         }
     }
-    if (speaker.index < 16)
+    if (speaker.is_player_or_ally())
     {
         if (speaker.is_escorted() == 0)
         {
@@ -2099,7 +2099,7 @@ TalkResult talk_npc(Character& speaker)
     {
         if (game_data.current_map != mdata_t::MapId::show_house)
         {
-            if (speaker.index >= 16)
+            if (!speaker.is_player_or_ally())
             {
                 if (!event_has_pending_events())
                 {
@@ -2239,7 +2239,7 @@ TalkResult talk_npc(Character& speaker)
     }
     if (game_data.current_map == mdata_t::MapId::your_home)
     {
-        if (speaker.index >= 57)
+        if (speaker.is_map_local())
         {
             if (speaker.role != Role::none)
             {

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -239,7 +239,7 @@ TalkResult talk_arena_master(Character& speaker, int chatval_)
             txt(i18n::s.get("core.magic.mount.no_place_to_get_off"));
             return TalkResult::talk_end;
         }
-        cell_setchara(game_data.mount, rtval, rtval(1));
+        cell_setchara(cdata[game_data.mount], rtval, rtval(1));
         txt(i18n::s.get("core.magic.mount.dismount", cdata[game_data.mount]));
         ride_end();
     }

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -1332,7 +1332,7 @@ TalkResult talk_guard_where_is(Character& speaker, int chatval_)
     }
     p = dist(cdata.player().position, chara_you_ask.position);
 
-    if (chara_you_ask.index == speaker.index)
+    if (chara_you_ask == speaker)
     {
         s = i18n::s.get("core.talk.npc.common.you_kidding", speaker);
     }

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -1095,7 +1095,7 @@ TalkResult talk_moyer_sell_paels_mom(Character& speaker)
         lily->relationship = 0;
         lily->initial_position.x = 48;
         lily->initial_position.y = 18;
-        cell_movechara(lily->index, 48, 18);
+        cell_movechara(*lily, 48, 18);
         buff = i18n::s.get("core.talk.npc.common.thanks", speaker);
     }
     else

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -1129,14 +1129,16 @@ TalkResult talk_wizard_return(Character& speaker)
 
 TalkResult talk_shop_reload_ammo(Character& speaker)
 {
-    if (calccostreload(0) == 0)
+    if (calc_ammo_reloading_cost(cdata.player()) == 0)
     {
         buff = i18n::s.get("core.talk.npc.shop.ammo.no_ammo", speaker);
         return TalkResult::talk_npc;
     }
-    buff =
-        i18n::s.get("core.talk.npc.shop.ammo.cost", calccostreload(0), speaker);
-    if (cdata.player().gold >= calccostreload(0))
+    buff = i18n::s.get(
+        "core.talk.npc.shop.ammo.cost",
+        calc_ammo_reloading_cost(cdata.player()),
+        speaker);
+    if (cdata.player().gold >= calc_ammo_reloading_cost(cdata.player()))
     {
         ELONA_APPEND_RESPONSE(
             1, i18n::s.get("core.talk.npc.shop.ammo.choices.pay"));
@@ -1148,8 +1150,8 @@ TalkResult talk_shop_reload_ammo(Character& speaker)
     if (chatval_ == 1)
     {
         snd("core.paygold1");
-        cdata.player().gold -= calccostreload(0);
-        p = calccostreload(0, true);
+        cdata.player().gold -= calc_ammo_reloading_cost(cdata.player());
+        p = calc_ammo_reloading_cost(cdata.player(), true);
         buff = i18n::s.get("core.talk.npc.common.thanks", speaker);
     }
     else

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -1822,8 +1822,8 @@ TalkResult talk_npc(Character& speaker)
     if (buff == ""s)
     {
         get_npc_talk(speaker);
-        int stat = chara_custom_talk(speaker.index, 106);
-        if (stat)
+        bool did_speak = chara_custom_talk(speaker, 106);
+        if (did_speak)
         {
             text_replace_tags_in_quest_board(speaker);
         }

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -1462,10 +1462,10 @@ TalkResult talk_trainer(Character& speaker, bool is_training)
         buff = i18n::s.get(
             "core.talk.npc.trainer.cost.training",
             the_ability_db.get_text(selected_skill, "name"),
-            calctraincost(selected_skill, cdata.player().index),
+            calc_skill_training_cost(selected_skill, cdata.player()),
             speaker);
         if (cdata.player().platinum_coin >=
-            calctraincost(selected_skill, cdata.player().index))
+            calc_skill_training_cost(selected_skill, cdata.player()))
         {
             list(0, listmax) = 1;
             listn(0, listmax) =
@@ -1500,7 +1500,7 @@ TalkResult talk_trainer(Character& speaker, bool is_training)
         if (is_training)
         {
             cdata.player().platinum_coin -=
-                calctraincost(selected_skill, cdata.player().index);
+                calc_skill_training_cost(selected_skill, cdata.player());
             modify_potential(
                 cdata.player(),
                 selected_skill,

--- a/src/elona/text.cpp
+++ b/src/elona/text.cpp
@@ -963,7 +963,7 @@ void get_npc_talk(Character& chara)
             p = instr(buff, 0, u8"%BORED,"s + i18n::s.get("core.meta.tag"));
             break;
         }
-        if (chara.index < 16)
+        if (chara.is_player_or_ally())
         {
             p = instr(
                 buff, 0, u8"%ALLY_DEFAULT,"s + i18n::s.get("core.meta.tag"));

--- a/src/elona/trait.cpp
+++ b/src/elona/trait.cpp
@@ -870,7 +870,7 @@ void trait_load_desc(Character& chara)
     int featrq = 0;
 
     listmax = 0;
-    if (chara.index == 0 && game_data.acquirable_feat_count > 0)
+    if (chara.is_player() && game_data.acquirable_feat_count > 0)
     {
         list(0, listmax) = -1;
         list(1, listmax) = 0;
@@ -879,7 +879,7 @@ void trait_load_desc(Character& chara)
     f = 0;
     for (int cnt = 0; cnt < 217; ++cnt)
     {
-        if (chara.index != 0)
+        if (!chara.is_player())
         {
             break;
         }
@@ -1017,7 +1017,7 @@ void trait_load_desc(Character& chara)
                 "core.trait.body_is_complicated", chara.speed_correction_value);
         ++listmax;
     }
-    if (chara.index == 0 && game_data.ether_disease_speed != 0)
+    if (chara.is_player() && game_data.ether_disease_speed != 0)
     {
         if (game_data.ether_disease_speed > 0)
         {

--- a/src/elona/turn_sequence.cpp
+++ b/src/elona/turn_sequence.cpp
@@ -389,11 +389,11 @@ optional<TurnResult> npc_turn_misc(Character& chara, int& enemy_index)
                 {
                     if (chara.hate <= 0)
                     {
-                        chara_custom_talk(chara.index, 100);
+                        chara_custom_talk(chara, 100);
                     }
                     if (chara.hate > 0)
                     {
-                        chara_custom_talk(chara.index, 101);
+                        chara_custom_talk(chara, 101);
                     }
                 }
             }

--- a/src/elona/turn_sequence.cpp
+++ b/src/elona/turn_sequence.cpp
@@ -157,7 +157,7 @@ optional<TurnResult> npc_turn_misc(Character& chara, int& enemy_index)
                 if (rnd(2))
                 {
                     txt(i18n::s.get("core.action.npc.leash.dialog"));
-                    hostileaction(0, chara.index);
+                    chara_act_hostile_action(cdata.player(), chara);
                 }
                 if (rnd(4) == 0)
                 {

--- a/src/elona/turn_sequence.cpp
+++ b/src/elona/turn_sequence.cpp
@@ -147,7 +147,7 @@ optional<TurnResult> npc_turn_misc(Character& chara, int& enemy_index)
     {
         if (rnd(4) == 0)
         {
-            if (chara.index < 16)
+            if (chara.is_player_or_ally())
             {
                 chara.hate = 0;
                 chara.enemy_id = 0;
@@ -324,7 +324,7 @@ optional<TurnResult> npc_turn_misc(Character& chara, int& enemy_index)
     {
         if (chara.index != game_data.fire_giant)
         {
-            if (chara.index >= 16)
+            if (!chara.is_player_or_ally())
             {
                 if (game_data.released_fire_giant != 0)
                 {
@@ -1042,7 +1042,7 @@ TurnResult pass_one_turn(bool time_passing)
                 }
                 if (rnd(4) == 0)
                 {
-                    if (cnt.index != 0)
+                    if (!cnt.is_player())
                     {
                         if (is_in_fov(cdata[ct]) || is_in_fov(cnt))
                         {
@@ -1128,7 +1128,7 @@ void update_emoicon(Character& chara)
     }
     while (chara.experience >= chara.required_experience)
     {
-        if (chara.index == 0)
+        if (chara.is_player())
         {
             snd("core.ding1");
             input_halt_input(HaltInput::alert);
@@ -1571,7 +1571,7 @@ void proc_turn_end(Character& chara)
         {
             regen = 0;
         }
-        if (chara.index >= 16)
+        if (!chara.is_player_or_ally())
         {
             if (chara.quality >= Quality::miracle)
             {
@@ -1684,7 +1684,7 @@ void proc_turn_end(Character& chara)
             chara.emotion_icon = 124;
         }
     }
-    if (chara.index == 0)
+    if (chara.is_player())
     {
         if (chara.nutrition < 2000)
         {
@@ -1743,7 +1743,7 @@ void proc_turn_end(Character& chara)
     }
     if (game_data.executing_immediate_quest_type == 1009)
     {
-        if (chara.index >= 57)
+        if (chara.is_map_local())
         {
             if (chara.impression >= 53)
             {

--- a/src/elona/ui.cpp
+++ b/src/elona/ui.cpp
@@ -355,7 +355,7 @@ void highlight_characters_in_pet_arena()
     {
         if (chara.state() != Character::State::alive)
             continue;
-        if (chara.index == 0)
+        if (chara.is_player())
             continue;
         snail::Color color{0};
         if (chara.relationship == 10)

--- a/src/elona/ui/ui_menu_character_sheet.cpp
+++ b/src/elona/ui/ui_menu_character_sheet.cpp
@@ -1066,7 +1066,7 @@ optional<UIMenuCharacterSheet::ResultType> UIMenuCharacterSheet::on_key(
         }
         if (action_ == "portrait")
         {
-            if (_chara.index < 16)
+            if (_chara.is_player_or_ally())
             {
                 menu_change_appearance(_chara);
                 if (_operation != CharacterSheetOperation::character_making)

--- a/src/elona/ui/ui_menu_character_sheet.cpp
+++ b/src/elona/ui/ui_menu_character_sheet.cpp
@@ -896,7 +896,7 @@ void UIMenuCharacterSheet::_draw_skill_train_cost(
 
     if (is_training)
     {
-        train_cost = ""s + calctraincost(skill_id, _chara.index) + u8"p "s;
+        train_cost = ""s + calc_skill_training_cost(skill_id, _chara) + u8"p "s;
     }
     else
     {

--- a/src/elona/ui/ui_menu_character_sheet.cpp
+++ b/src/elona/ui/ui_menu_character_sheet.cpp
@@ -900,7 +900,7 @@ void UIMenuCharacterSheet::_draw_skill_train_cost(
     }
     else
     {
-        train_cost = ""s + calclearncost(skill_id, _chara.index) + u8"p "s;
+        train_cost = ""s + calc_skill_learning_cost(skill_id, _chara) + u8"p "s;
     }
     mes(wx + 322 - strlen_u(train_cost) * 7,
         wy + 66 + cnt * 19 + 2,

--- a/src/elona/ui/ui_menu_charamake_attributes.cpp
+++ b/src/elona/ui/ui_menu_charamake_attributes.cpp
@@ -22,7 +22,7 @@ bool UIMenuCharamakeAttributes::init()
 
 void UIMenuCharamakeAttributes::_reroll_attributes()
 {
-    chara_delete(0);
+    chara_delete(cdata.player());
     race_init_chara(cdata.player(), _race_id);
     class_init_chara(cdata.player(), _class_id);
     cdata.player().level = 1;

--- a/src/elona/ui/ui_menu_charamake_class.cpp
+++ b/src/elona/ui/ui_menu_charamake_class.cpp
@@ -146,7 +146,7 @@ void UIMenuCharamakeClass::_draw_choices()
 
 static void _reload_selected_class(data::InstanceId class_id)
 {
-    chara_delete(0);
+    chara_delete(cdata.player());
     class_init_chara(cdata.player(), class_id);
 }
 

--- a/src/elona/ui/ui_menu_charamake_race.cpp
+++ b/src/elona/ui/ui_menu_charamake_race.cpp
@@ -154,7 +154,7 @@ void UIMenuCharamakeRace::_draw_choices()
 
 static void _reload_selected_race(data::InstanceId race_id)
 {
-    chara_delete(0);
+    chara_delete(cdata.player());
     race_init_chara(cdata.player(), race_id);
 }
 

--- a/src/elona/ui/ui_menu_hire.cpp
+++ b/src/elona/ui/ui_menu_hire.cpp
@@ -33,7 +33,7 @@ bool UIMenuHire::_should_display_chara(const Character& chara)
         {
             return false;
         }
-        if (chara.index < 16)
+        if (chara.is_player_or_ally())
         {
             if (chara.current_map != game_data.current_map)
             {
@@ -41,7 +41,7 @@ bool UIMenuHire::_should_display_chara(const Character& chara)
             }
         }
     }
-    if (chara.index == 0)
+    if (chara.is_player())
     {
         return false;
     }

--- a/src/tests/lua_handles.cpp
+++ b/src/tests/lua_handles.cpp
@@ -368,7 +368,7 @@ TEST_CASE(
         REQUIRE_NOTHROW(elona::lua::lua->get_state()->safe_script(
             R"(assert(chara ~= chara2))"));
 
-        chara_delete(chara.index);
+        chara_delete(chara);
 
         REQUIRE_NOTHROW(elona::lua::lua->get_state()->safe_script(
             R"(assert(chara ~= nil))"));
@@ -529,7 +529,7 @@ TEST_CASE(
     Character& chara = *chara_opt;
     auto handle = handle_mgr.get_handle(chara);
 
-    chara_delete(chara.index);
+    chara_delete(chara);
 
     // Invalidation is deferred until the handle is recreated in the same slot.
     REQUIRE(handle_mgr.handle_is_valid(handle) == true);

--- a/src/tests/util.cpp
+++ b/src/tests/util.cpp
@@ -111,7 +111,7 @@ void invalidate_chara(Character& chara)
     int old_y = chara.position.y;
 
     // Delete the character and create new ones until the index is taken again.
-    chara_delete(chara.index);
+    chara_delete(chara);
     while (true)
     {
         const auto new_chara = chara_create(-1, old_id, old_x, old_y);


### PR DESCRIPTION

# Summary

## Refactoring

Reduce uses of `Character::index`.

- Define methods to check character party
- Refactor `addnews()`
- Refactor `calctraincost()`
- Refactor `calclearncost()`
- Refactor `calccostreload()`
- Refactor `chara_custom_talk()`
- Refactor `advfavoriteskill/stat()`
- Remove `chara_remove()`
- Refactor `chara_delete()`
- Refactor `hostileaction()`
- Refactor `wet()`
- Refactor `txteledmg()`
- Refactor `make_sound()`
- Refactor `turn_aggro()`
- Refactor `check_kill()`
- Refactor `cell_swap()`
- Refactor `cell_movechara()`
- Refactor `cell_setchara()`
- Refactor `cell_removechara()`
- Refactor `lovemiracle()`
- Define `Character::operator==/!=` to compare character's identity
- Refactor `sleep_start()`
- Refactor `activity_sex()`
- Refactor `calc_power_decreased_by_resistance()`


## Bug fixes

- Fix `cell_movechara()`
  - Related known bug in vanilla: When you join to some guild, a guild guard moves by one tile from the downstairs to the guild. If the cell he will move to is occupied by someone, the guard's position is swapped with one of a random character (`tc_at_m81`).


# TODO

- [x] Merge #1694 
