### PR TITLE
Fix use-after-free by using std::move()

### DIFF
--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -1352,7 +1352,7 @@ void activity_perform(Character& performer, ItemRef instrument)
 {
     if (!performer.activity)
     {
-        activity_perform_start(performer, std::move(instrument));
+        activity_perform_start(performer, instrument);
     }
     else if (performer.activity.turn > 0)
     {
@@ -2276,7 +2276,7 @@ void sleep_start(const OptionalItemRef& bed)
 void start_stealing(Character& thief, ItemRef steal_target)
 {
     game_data.activity_about_to_start = 105;
-    activity_others(thief, std::move(steal_target));
+    activity_others(thief, steal_target);
 }
 
 } // namespace elona

--- a/src/elona/attack.cpp
+++ b/src/elona/attack.cpp
@@ -183,7 +183,7 @@ CanDoRangedAttackResult can_do_ranged_attack(const Character& chara)
         }
     }
     attackskill = weapon->skill;
-    return {1, std::move(weapon), std::move(ammo)};
+    return {1, weapon, ammo};
 }
 
 

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -1919,7 +1919,7 @@ TurnResult do_use_command(ItemRef use_item)
             return TurnResult::pc_turn_user_error;
         }
         game_data.activity_about_to_start = 100;
-        activity_others(cdata.player(), std::move(use_item));
+        activity_others(cdata.player(), use_item);
         return TurnResult::turn_end;
     }
     if (use_item->id == ItemId::red_treasure_machine ||
@@ -2167,15 +2167,15 @@ TurnResult do_use_command(ItemRef use_item)
     }
     case 15:
         efid = 184;
-        magic(cdata.player(), cdata.player(), std::move(use_item));
+        magic(cdata.player(), cdata.player(), use_item);
         break;
     case 16:
         efid = 185;
-        magic(cdata.player(), cdata.player(), std::move(use_item));
+        magic(cdata.player(), cdata.player(), use_item);
         break;
     case 17:
         efid = 183;
-        magic(cdata.player(), cdata.player(), std::move(use_item));
+        magic(cdata.player(), cdata.player(), use_item);
         break;
     case 14:
         if (cdata.player().index == 0)
@@ -2212,7 +2212,7 @@ TurnResult do_use_command(ItemRef use_item)
         chara_refresh(cdata.player());
         break;
     case 9: {
-        if (read_textbook(cdata.player(), std::move(use_item)))
+        if (read_textbook(cdata.player(), use_item))
         {
             return TurnResult::turn_end;
         }
@@ -2441,7 +2441,7 @@ TurnResult do_use_command(ItemRef use_item)
                 return TurnResult::pc_turn_user_error;
             }
             game_data.activity_about_to_start = 101;
-            activity_others(cdata.player(), std::move(use_item));
+            activity_others(cdata.player(), use_item);
             return TurnResult::turn_end;
         }
         if (area_data[game_data.current_map].id ==
@@ -2462,7 +2462,7 @@ TurnResult do_use_command(ItemRef use_item)
             }
         }
         game_data.activity_about_to_start = 102;
-        activity_others(cdata.player(), std::move(use_item));
+        activity_others(cdata.player(), use_item);
         break;
     case 11:
         if (moneybox(use_item->param2) > cdata.player().gold)
@@ -2506,7 +2506,7 @@ TurnResult do_use_command(ItemRef use_item)
         snd("core.build1");
         efid = 49;
         efp = 100;
-        magic(cdata.player(), cdata.player(), std::move(use_item));
+        magic(cdata.player(), cdata.player(), use_item);
         break;
     case 21:
         txt(i18n::s.get("core.action.use.hammer.use", use_item));
@@ -3383,7 +3383,7 @@ TurnResult do_eat_command(Character& eater, const ItemRef& food)
 TurnResult do_drink_command(Character& chara, ItemRef potion)
 {
     const auto item_id = itemid2int(potion->id);
-    item_db_on_drink(chara, std::move(potion), item_id);
+    item_db_on_drink(chara, potion, item_id);
     return TurnResult::turn_end;
 }
 
@@ -4074,7 +4074,7 @@ bool read_textbook(Character& doer, ItemRef textbook)
         }
     }
     game_data.activity_about_to_start = 104;
-    activity_others(doer, std::move(textbook));
+    activity_others(doer, textbook);
     return true;
 }
 
@@ -4341,7 +4341,7 @@ int read_normal_book(Character& reader, ItemRef book)
     }
     if (book->id == ItemId::textbook)
     {
-        return read_textbook(reader, std::move(book));
+        return read_textbook(reader, book);
     }
     if (book->id == ItemId::book_of_rachel)
     {
@@ -5620,7 +5620,7 @@ PickUpItemResult pick_up_item(
         refresh_burden_state();
     }
 
-    return {1, std::move(picked_up_item)};
+    return {1, picked_up_item};
 }
 
 

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -2699,9 +2699,7 @@ CtrlInventoryResult ctrl_inventory(optional_ref<Character> inventory_owner)
             {
                 switch (result->type)
                 {
-                case 0:
-                    return {
-                        result->menu_result, std::move(result->selected_item)};
+                case 0: return {result->menu_result, result->selected_item};
                 case 1:
                     init = true;
                     update_page = true;
@@ -2728,8 +2726,7 @@ CtrlInventoryResult ctrl_inventory(optional_ref<Character> inventory_owner)
                 on_enter(inventory_owner, p(0), citrade, cidip, dropcontinue);
             switch (result.type)
             {
-            case 0:
-                return {result.menu_result, std::move(result.selected_item)};
+            case 0: return {result.menu_result, result.selected_item};
             case 1:
                 init = true;
                 update_page = true;

--- a/src/elona/equipment.cpp
+++ b/src/elona/equipment.cpp
@@ -278,7 +278,7 @@ void wear_most_valuable_equipment(Character& chara, ItemRef equipment)
         auto& equipment_slot = chara.equipment_slots[equipment_slot_index];
         if (!equipment_slot.equipment)
         {
-            equip_item(chara, equipment_slot_index, std::move(equipment));
+            equip_item(chara, equipment_slot_index, equipment);
             break;
         }
         bool equip = false;
@@ -303,7 +303,7 @@ void wear_most_valuable_equipment(Character& chara, ItemRef equipment)
         if (equip)
         {
             unequip_item(chara, equipment_slot_index);
-            equip_item(chara, equipment_slot_index, std::move(equipment));
+            equip_item(chara, equipment_slot_index, equipment);
             break;
         }
     }
@@ -1360,7 +1360,7 @@ void equip_item(
         item_identify(equipment, IdentifyState::almost);
     }
     equipment->body_part = equipment_slot_index + 100;
-    equipment_slot.equip(std::move(equipment));
+    equipment_slot.equip(equipment);
 }
 
 

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -1734,7 +1734,7 @@ bool item_fire(Inventory& inv, const OptionalItemRef& burned_item)
 
     for (int _i = 0; _i < 3; ++_i)
     {
-        const auto item = choice(std::move(list));
+        const auto item = choice(list);
         if (item->number() <= 0)
         {
             continue;
@@ -1961,7 +1961,7 @@ bool item_cold(Inventory& inv, const OptionalItemRef& destroyed_item)
     bool broken{};
     for (int _i = 0; _i < 2; ++_i)
     {
-        const auto item = choice(std::move(list));
+        const auto item = choice(list);
         if (item->number() <= 0)
         {
             continue;

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -596,7 +596,7 @@ bool _magic_183(Character& subject, OptionalItemRef instrument)
             rnd(the_ability_db[efid]->cost / 2 + 1) +
                 the_ability_db[efid]->cost / 2 + 1);
     }
-    activity_perform(subject, std::move(instrument).unwrap());
+    activity_perform(subject, instrument.unwrap());
     return true;
 }
 
@@ -2108,7 +2108,7 @@ bool _magic_645_1114(Character& subject, Character& target)
     }
     if (!candidates.empty())
     {
-        const auto cursed_item = choice(std::move(candidates));
+        const auto cursed_item = choice(candidates);
         const auto original_item_name = itemname(cursed_item, 1, false);
         if (cursed_item->curse_state == CurseState::cursed)
         {


### PR DESCRIPTION
# Summary

Fix use-after-free by using `std::move()`. Also remove error-prune uses of `std::move()` even if it actually does not cause use-after-free.
