### PR TITLE
Fix 2 crashes related to item drawing

### DIFF
--- a/src/elona/cell_draw.cpp
+++ b/src/elona/cell_draw.cpp
@@ -1348,6 +1348,11 @@ void draw_items(int x, int y, int dx, int dy, int scrturn_)
                 ? g_inv.ground().at(0) /* TODO phantom ref */
                 : g_inv.ground().at(item_index - 1);
 
+            if (!item)
+            {
+                continue; /* TODO phantom ref */
+            }
+
             const auto item_chip_id = item->image;
             const auto color_id = item->color;
             const auto chara_chip_id = item->param1;

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -582,7 +582,8 @@ void Item::set_number(int new_number)
 
     auto inv_owner = inv_get_owner(*inventory());
     const auto inv_owner_chara = inv_owner.as_character();
-    const auto needs_cell_refresh = inv_owner.is_map();
+    const auto needs_cell_refresh =
+        inv_owner.is_map() && (number_ == 0 || new_number == 0);
     const auto needs_refresh_burden_state =
         inv_owner_chara && inv_owner_chara->index;
 


### PR DESCRIPTION
# Fix a crash bug when you drop/pick up items

## How to reproduce

1. Put one stack of items on the ground.
2. Pick up all of them.
3. Move to the next tile.
4. Put one of them on the ground.
5. Then, the item appears both on the tile you standing and the tile you stood at step 2.

## Cause

`cell_refresh()` function, which refreshes item display information, was also called for the old tile ("the tile you stood at step 2"). We need to limit calling it by this condition: `(number_ == 0 || new_number == 0)`.


# Fix a crash related to item drawing

## How to reproduce

1. Put an arbitrary item in a town.
2. Leave there and wait for 5 days.
3. Visit the town.

## Description

When a town is refreshed, all items you put on the ground are swept. However, item display information (`CellData::item_info_memory`) is not removed. It is an expected behavior, but as a result, causes a crash of Elona foobar. To draw a removed item, it has to be stored in a save data somehow. I am working on the issue, but have not completed yet.
As a band-aid, ghost items are not rendered in this version.