### PR TITLE
Fix throwing animation not colored (#1722)

### DIFF
--- a/src/elona/attack.cpp
+++ b/src/elona/attack.cpp
@@ -226,8 +226,8 @@ bool do_physical_attack_internal(
             target.position,
             static_cast<RangedAttackAnimation::Type>(attackskill),
             the_item_db[weapon->id]->subcategory,
-            weapon->image % 1000,
-            weapon->image / 1000)
+            weapon->image,
+            weapon->tint)
             .play();
     }
 


### PR DESCRIPTION
# Related Issues

Close #1722.


# Summary

Pass correct arguments to `ThrowingAnimation`'s constructor.