### PR TITLE
Add 'core.' prefix to all asset IDs

### DIFF
--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -2204,7 +2204,7 @@ void sleep_start(const OptionalItemRef& bed)
                 i18n::s.get("core.activity.sleep.new_gene.title"),
                 i18n::s.get("core.activity.sleep.new_gene.text", *gene_chara),
                 {i18n::s.get_enum("core.activity.sleep.new_gene.choices", 0)},
-                u8"bg_re14");
+                u8"core.bg_re14");
             save_save_gene();
         }
     }

--- a/src/elona/animation.cpp
+++ b/src/elona/animation.cpp
@@ -201,7 +201,7 @@ void FailureToCastAnimation::do_play()
 
     do_animation(
         rendering_base_position_center(caster_pos),
-        "failure_to_cast_effect",
+        "core.failure_to_cast_effect",
         12,
         [](const auto& key, const auto& center, auto t) {
             draw_rotated(
@@ -725,7 +725,7 @@ void SwarmAnimation::do_play()
 
     do_animation(
         rendering_base_position_center(target_pos),
-        "swarm_effect",
+        "core.swarm_effect",
         4,
         [](const auto& key, const auto& center, auto t) {
             draw_rotated(
@@ -830,11 +830,11 @@ void MeleeAttackAnimation::do_play()
         }
         if (ap == 1)
         {
-            draw_indexed("anim_slash", anidx, anidy, cnt);
+            draw_indexed("core.anim_slash", anidx, anidy, cnt);
         }
         if (ap == 2)
         {
-            draw_indexed("anim_bash", anidx, anidy, cnt);
+            draw_indexed("core.anim_bash", anidx, anidy, cnt);
         }
         redraw();
         gmode(0);
@@ -1196,7 +1196,7 @@ void BreakingAnimation::do_play()
 
     do_particle_animation(
         rendering_base_position_center(position),
-        "breaking_effect",
+        "core.breaking_effect",
         5,
         4,
         [](auto) {

--- a/src/elona/blending.cpp
+++ b/src/elona/blending.cpp
@@ -442,7 +442,7 @@ void window_recipe(
         dy_ += 17;
         ++i_;
     }
-    draw("deco_blend_b", wx + ww + 243, wy - 4);
+    draw("core.deco_blend_b", wx + ww + 243, wy - 4);
     if (step == i_ - 2)
     {
         boxf(dx_ - 10, dy_ - 2, width - 60, 17, {60, 20, 10, 32});
@@ -642,13 +642,16 @@ optional<TurnResult> blending_menu_select_recipe()
 
             if (blendchecklist(cnt))
             {
-                draw("blend_ingredient", wx + 330, wy + 53 + cnt * 19);
+                draw("core.blend_ingredient", wx + 330, wy + 53 + cnt * 19);
             }
             rpid = list(0, p);
 
             int difficulty = (4 - calc_success_rate(rpid, -1, -1) / 25);
             draw_indexed(
-                "recipe_difficulty", wx + 317, wy + 60 + cnt * 19, difficulty);
+                "core.recipe_difficulty",
+                wx + 317,
+                wy + 60 + cnt * 19,
+                difficulty);
         }
         font(14 - en * 2);
         cs_listbk();
@@ -678,7 +681,7 @@ optional<TurnResult> blending_menu_select_recipe()
             cs_bk = cs;
         }
         windowshadow(1) = 0;
-        draw("deco_blend_c", wx + 10, wy + wh - 100);
+        draw("core.deco_blend_c", wx + 10, wy + wh - 100);
         redraw();
 
         const auto action = get_selected_item(p(0));
@@ -795,7 +798,7 @@ void blendig_menu_select_materials()
 
             if (g_inv[p]->body_part != 0)
             {
-                draw("equipped", wx + 46, wy + 72 + cnt * 18 - 3);
+                draw("core.equipped", wx + 46, wy + 72 + cnt * 18 - 3);
             }
             cs_list(
                 cs == cnt,
@@ -825,7 +828,7 @@ void blendig_menu_select_materials()
             cs_bk = cs;
         }
         windowshadow(1) = 0;
-        draw("deco_blend_c", wx + 10, wy + wh - 100);
+        draw("core.deco_blend_c", wx + 10, wy + wh - 100);
         redraw();
 
         const auto action = get_selected_item(p(0));
@@ -1209,7 +1212,7 @@ TurnResult blending_menu()
 {
     step = -1;
     rpid = 0;
-    asset_load("deco_blend");
+    asset_load("core.deco_blend");
     gsel(0);
     clear_rprefmat();
 
@@ -1310,7 +1313,7 @@ void window_recipe2(int number_of_products)
     const auto dy = 10;
 
     gmode(2);
-    draw("deco_blend_a", dx, 0);
+    draw("core.deco_blend_a", dx, 0);
 
     font(15 - en * 2, snail::Font::Style::bold);
     bmes(

--- a/src/elona/casino.cpp
+++ b/src/elona/casino.cpp
@@ -42,7 +42,7 @@ void casino_dealer()
     atxpic = 0;
     snd("core.pop3");
     mode = 9;
-    atxbg = u8"bg13"s;
+    atxbg = u8"core.bg13"s;
     atxbgbk = "";
     SDIM3(atxinfon, 80, 5);
     txt(i18n::s.get("core.casino.talk_to_dealer"));
@@ -392,7 +392,7 @@ void casino_wrapper()
 bool casino_start()
 {
     bool finished = false;
-    atxbg = u8"bg14"s;
+    atxbg = u8"core.bg14"s;
     mattile = -1;
     atxinfon(0) = i18n::s.get("core.casino.window.title");
     atxinit();
@@ -794,7 +794,7 @@ void atxinit()
         gmode(0);
         asset_load(data::InstanceId{atxbg});
         draw(
-            "atx_background",
+            "core.atx_background",
             0,
             inf_msgh,
             windoww,
@@ -811,7 +811,7 @@ void atxinit()
             {
                 sx = 192;
             }
-            draw_region("message_window", cnt * 192, 0, sx, inf_msgh);
+            draw_region("core.message_window", cnt * 192, 0, sx, inf_msgh);
         }
         window2(windoww - 208, 0, 208, 98, 0, 0);
         gcopy(

--- a/src/elona/casino_card.cpp
+++ b/src/elona/casino_card.cpp
@@ -78,11 +78,11 @@ void showcard2(int card_index, bool show_rank = true)
     gmode(2);
     if (is_closed)
     {
-        draw("card_back", x, y);
+        draw("core.card_back", x, y);
     }
     else
     {
-        draw("card_front", x, y);
+        draw("core.card_front", x, y);
 
         if (show_rank)
         {
@@ -99,8 +99,9 @@ void showcard2(int card_index, bool show_rank = true)
                 x + 32 - rect.width / 2,
                 y + 88 - rect.height);
 
-            draw_indexed("card_suit", x + 8, y + 16, static_cast<int>(suit));
-            draw_indexed("card_rank", x + 32, y + 16, rank - 1);
+            draw_indexed(
+                "core.card_suit", x + 8, y + 16, static_cast<int>(suit));
+            draw_indexed("core.card_rank", x + 32, y + 16, rank - 1);
         }
         else
         {
@@ -175,7 +176,7 @@ void initcard(int x, int y, int)
 void showcardpile()
 {
     int pilestack_at_cardcontrol = 0;
-    draw("card_pile", pilex_at_cardcontrol - 8, piley_at_cardcontrol - 8);
+    draw("core.card_pile", pilex_at_cardcontrol - 8, piley_at_cardcontrol - 8);
     pilestack_at_cardcontrol = 0;
     for (int cnt = 0, cnt_end = (cardmax_at_cardcontrol); cnt < cnt_end; ++cnt)
     {
@@ -256,7 +257,7 @@ int servecard(int player_id)
         if (cnt != 0)
         {
             draw(
-                "card_scratch",
+                "core.card_scratch",
                 card_at_cardcontrol(3, cardid_at_cardcontrol),
                 card_at_cardcontrol(4, cardid_at_cardcontrol));
         }
@@ -280,7 +281,7 @@ int servecard(int player_id)
             0,
             card_at_cardcontrol(3, cardid_at_cardcontrol),
             card_at_cardcontrol(4, cardid_at_cardcontrol),
-            "card_scratch");
+            "core.card_scratch");
 
         gsel(0);
         gmode(2);
@@ -307,7 +308,8 @@ void showcardholder()
             dx_at_cardcontrol =
                 cardplayer_at_cardcontrol(1, p_at_cardcontrol) + cnt * 88;
             dy_at_cardcontrol = cardplayer_at_cardcontrol(2, p_at_cardcontrol);
-            draw("card_pile", dx_at_cardcontrol - 8, dy_at_cardcontrol - 8);
+            draw(
+                "core.card_pile", dx_at_cardcontrol - 8, dy_at_cardcontrol - 8);
         }
     }
 }
@@ -329,7 +331,7 @@ int opencard2(int card_index, int player_id)
         if (player_id == 0)
         {
             draw(
-                "card_pile",
+                "core.card_pile",
                 card_at_cardcontrol(3, card_index) - 8,
                 card_at_cardcontrol(4, card_index) - 8);
         }
@@ -346,7 +348,7 @@ int opencard2(int card_index, int player_id)
         }
         gmode(2);
         draw_centered(
-            "card_back",
+            "core.card_back",
             card_at_cardcontrol(3, card_index) + 32,
             card_at_cardcontrol(4, card_index) + 48,
             64 - cnt * 14,
@@ -368,7 +370,7 @@ int trashcard(int card_index)
     for (int cnt = 0; cnt < 21; ++cnt)
     {
         draw(
-            "card_pile",
+            "core.card_pile",
             card_at_cardcontrol(3, card_index) - 8,
             card_at_cardcontrol(4, card_index) - 8);
         if (cnt == 20)
@@ -377,7 +379,7 @@ int trashcard(int card_index)
             break;
         }
         draw_rotated(
-            "card_back",
+            "core.card_back",
             card_at_cardcontrol(3, card_index) + 32,
             card_at_cardcontrol(4, card_index) + 48,
             64 - cnt * 3,

--- a/src/elona/cell_draw.cpp
+++ b/src/elona/cell_draw.cpp
@@ -421,7 +421,7 @@ void render_shadow_low(int light)
         if (slight(x + 2, y + 2) >= 1000)
         {
             draw_indexed(
-                "shadow_edges",
+                "core.shadow_edges",
                 x * inf_tiles + inf_screenx,
                 y * inf_tiles + inf_screeny,
                 0);
@@ -469,84 +469,91 @@ void render_shadow(int l, int dx, int dy)
                 switch (deco2)
                 {
                 case 1:
-                    draw_indexed_region("shadow", dx, dy, 7, 1, 1, 1);
+                    draw_indexed_region("core.shadow", dx, dy, 7, 1, 1, 1);
                     break;
                 case 2:
-                    draw_indexed_region("shadow", dx + 24, dy + 24, 6, 0, 1, 1);
+                    draw_indexed_region(
+                        "core.shadow", dx + 24, dy + 24, 6, 0, 1, 1);
                     break;
                 case 3:
-                    draw_indexed_region("shadow", dx, dy + 24, 7, 0, 1, 1);
+                    draw_indexed_region("core.shadow", dx, dy + 24, 7, 0, 1, 1);
                     break;
                 case 4:
-                    draw_indexed_region("shadow", dx + 24, dy, 6, 1, 1, 1);
+                    draw_indexed_region("core.shadow", dx + 24, dy, 6, 1, 1, 1);
                     break;
                 case 5:
-                    draw_indexed_region("shadow", dx + 24, dy + 24, 6, 0, 1, 1);
-                    draw_indexed_region("shadow", dx, dy, 7, 1, 1, 1);
+                    draw_indexed_region(
+                        "core.shadow", dx + 24, dy + 24, 6, 0, 1, 1);
+                    draw_indexed_region("core.shadow", dx, dy, 7, 1, 1, 1);
                     break;
                 case 6:
-                    draw_indexed_region("shadow", dx, dy + 24, 7, 0, 1, 1);
-                    draw_indexed_region("shadow", dx + 24, dy, 6, 1, 1, 1);
+                    draw_indexed_region("core.shadow", dx, dy + 24, 7, 0, 1, 1);
+                    draw_indexed_region("core.shadow", dx + 24, dy, 6, 1, 1, 1);
                     break;
                 case 7:
-                    draw_indexed_region("shadow", dx, dy + 24, 7, 0, 1, 1);
-                    draw_indexed_region("shadow", dx + 24, dy + 24, 6, 0, 1, 1);
+                    draw_indexed_region("core.shadow", dx, dy + 24, 7, 0, 1, 1);
+                    draw_indexed_region(
+                        "core.shadow", dx + 24, dy + 24, 6, 0, 1, 1);
                     break;
                 case 8:
-                    draw_indexed_region("shadow", dx, dy, 7, 1, 1, 1);
-                    draw_indexed_region("shadow", dx + 24, dy, 6, 1, 1, 1);
+                    draw_indexed_region("core.shadow", dx, dy, 7, 1, 1, 1);
+                    draw_indexed_region("core.shadow", dx + 24, dy, 6, 1, 1, 1);
                     break;
                 case 9:
-                    draw_indexed_region("shadow", dx, dy, 7, 1, 1, 1);
-                    draw_indexed_region("shadow", dx, dy + 24, 7, 0, 1, 1);
+                    draw_indexed_region("core.shadow", dx, dy, 7, 1, 1, 1);
+                    draw_indexed_region("core.shadow", dx, dy + 24, 7, 0, 1, 1);
                     break;
                 case 10:
-                    draw_indexed_region("shadow", dx + 24, dy, 6, 1, 1, 1);
-                    draw_indexed_region("shadow", dx + 24, dy + 24, 6, 0, 1, 1);
+                    draw_indexed_region("core.shadow", dx + 24, dy, 6, 1, 1, 1);
+                    draw_indexed_region(
+                        "core.shadow", dx + 24, dy + 24, 6, 0, 1, 1);
                     break;
                 case 20:
-                    draw_indexed_region("shadow", dx, dy, 0, 2, 1, 2);
-                    draw_indexed_region("shadow", dx + 24, dy, 5, 2, 1, 2);
+                    draw_indexed_region("core.shadow", dx, dy, 0, 2, 1, 2);
+                    draw_indexed_region("core.shadow", dx + 24, dy, 5, 2, 1, 2);
                     break;
                 case 21:
-                    draw_indexed_region("shadow", dx, dy, 2, 0, 2, 1);
-                    draw_indexed_region("shadow", dx, dy + 24, 2, 5, 2, 1);
+                    draw_indexed_region("core.shadow", dx, dy, 2, 0, 2, 1);
+                    draw_indexed_region("core.shadow", dx, dy + 24, 2, 5, 2, 1);
                     break;
                 case 30:
-                    draw_indexed_region("shadow", dx, dy, 0, 0, 2, 1);
-                    draw_indexed_region("shadow", dx, dy + 24, 0, 5, 2, 1);
+                    draw_indexed_region("core.shadow", dx, dy, 0, 0, 2, 1);
+                    draw_indexed_region("core.shadow", dx, dy + 24, 0, 5, 2, 1);
                     break;
                 case 31:
-                    draw_indexed_region("shadow", dx, dy, 4, 0, 2, 1);
-                    draw_indexed_region("shadow", dx, dy + 24, 4, 5, 2, 1);
+                    draw_indexed_region("core.shadow", dx, dy, 4, 0, 2, 1);
+                    draw_indexed_region("core.shadow", dx, dy + 24, 4, 5, 2, 1);
                     break;
                 case 32:
-                    draw_indexed_region("shadow", dx, dy, 0, 0, 1, 2);
-                    draw_indexed_region("shadow", dx + 24, dy, 5, 0, 1, 2);
+                    draw_indexed_region("core.shadow", dx, dy, 0, 0, 1, 2);
+                    draw_indexed_region("core.shadow", dx + 24, dy, 5, 0, 1, 2);
                     break;
                 case 33:
-                    draw_indexed_region("shadow", dx, dy, 0, 4, 1, 2);
-                    draw_indexed_region("shadow", dx + 24, dy, 5, 4, 1, 2);
+                    draw_indexed_region("core.shadow", dx, dy, 0, 4, 1, 2);
+                    draw_indexed_region("core.shadow", dx + 24, dy, 5, 4, 1, 2);
                     break;
                 case 34:
-                    draw_indexed_region("shadow", dx + 24, dy, 6, 1, 1, 1);
-                    draw_indexed_region("shadow", dx, dy + 24, 7, 0, 1, 1);
-                    draw_indexed_region("shadow", dx + 24, dy + 24, 6, 0, 1, 1);
+                    draw_indexed_region("core.shadow", dx + 24, dy, 6, 1, 1, 1);
+                    draw_indexed_region("core.shadow", dx, dy + 24, 7, 0, 1, 1);
+                    draw_indexed_region(
+                        "core.shadow", dx + 24, dy + 24, 6, 0, 1, 1);
                     break;
                 case 35:
-                    draw_indexed_region("shadow", dx, dy, 7, 1, 1, 1);
-                    draw_indexed_region("shadow", dx + 24, dy, 6, 1, 1, 1);
-                    draw_indexed_region("shadow", dx, dy + 24, 7, 0, 1, 1);
+                    draw_indexed_region("core.shadow", dx, dy, 7, 1, 1, 1);
+                    draw_indexed_region("core.shadow", dx + 24, dy, 6, 1, 1, 1);
+                    draw_indexed_region("core.shadow", dx, dy + 24, 7, 0, 1, 1);
                     break;
                 case 36:
-                    draw_indexed_region("shadow", dx, dy, 7, 1, 1, 1);
-                    draw_indexed_region("shadow", dx + 24, dy, 6, 1, 1, 1);
-                    draw_indexed_region("shadow", dx + 24, dy + 24, 6, 0, 1, 1);
+                    draw_indexed_region("core.shadow", dx, dy, 7, 1, 1, 1);
+                    draw_indexed_region("core.shadow", dx + 24, dy, 6, 1, 1, 1);
+                    draw_indexed_region(
+                        "core.shadow", dx + 24, dy + 24, 6, 0, 1, 1);
                     break;
                 case 37:
-                    draw_indexed_region("shadow", dx, dy, 7, 1, 1, 1);
-                    draw_indexed_region("shadow", dx, dy + 24, 7, 0, 1, 1);
-                    draw_indexed_region("shadow", dx + 24, dy + 24, 6, 0, 1, 1);
+                    draw_indexed_region("core.shadow", dx, dy, 7, 1, 1, 1);
+                    draw_indexed_region("core.shadow", dx, dy + 24, 7, 0, 1, 1);
+                    draw_indexed_region(
+                        "core.shadow", dx + 24, dy + 24, 6, 0, 1, 1);
                     break;
                 default: break;
                 }
@@ -554,7 +561,7 @@ void render_shadow(int l, int dx, int dy)
             else
             {
                 draw_indexed(
-                    "shadow_deco",
+                    "core.shadow_deco",
                     dx,
                     dy,
                     shadow_deco[l]._0,
@@ -621,7 +628,7 @@ void render_shadow(int l, int dx, int dy)
             };
             i = shadow_map[l2];
         }
-        draw_indexed("shadow_edges", dx, dy, i);
+        draw_indexed("core.shadow_edges", dx, dy, i);
     }
 }
 
@@ -692,11 +699,11 @@ void initialize_cloud_data()
         int y0 = rnd(100) + i / 5 * 200 + 100000;
         if (rnd(2) == 0)
         {
-            clouds.emplace_back(x0, y0, "cloud1");
+            clouds.emplace_back(x0, y0, "core.cloud1");
         }
         else
         {
-            clouds.emplace_back(x0, y0, "cloud2");
+            clouds.emplace_back(x0, y0, "core.cloud2");
         }
     }
 }
@@ -744,12 +751,12 @@ void draw_hp_bar(const Character& chara, int x, int y)
     {
         if (map_data.type != mdata_t::MapType::world_map)
         {
-            draw_bar("hp_bar_ally", x + 9, y + 32, ratio, 3, ratio);
+            draw_bar("core.hp_bar_ally", x + 9, y + 32, ratio, 3, ratio);
         }
     }
     else
     {
-        draw_bar("hp_bar_other", x + 9, y + 32, ratio, 3, ratio);
+        draw_bar("core.hp_bar_other", x + 9, y + 32, ratio, 3, ratio);
     }
 }
 
@@ -767,7 +774,7 @@ void draw_character_sprite_in_world_map(
 
     // Shadow
     gmode(2, 85);
-    draw_centered("character_shadow", x + 24, y + 27, 20, 10);
+    draw_centered("core.character_shadow", x + 24, y + 27, 20, 10);
 
     // Character sprite
     gmode(2);
@@ -828,7 +835,7 @@ void draw_character_sprite(
 
     // Shadow
     gmode(2, 110);
-    draw("character_shadow", x + 8, y + 20);
+    draw("core.character_shadow", x + 8, y + 20);
 
     // Character sprite
     gmode(2);
@@ -864,7 +871,7 @@ void draw_chara_chip_sprite_in_world_map(
     int offset_y)
 {
     gmode(2, 85);
-    draw_centered("character_shadow", x + 24, y + 32, 20, 10);
+    draw_centered("core.character_shadow", x + 24, y + 32, 20, 10);
     gmode(2);
     set_color_mod(tint.r, tint.g, tint.b, ext.buffer);
     gcopy_c(
@@ -921,7 +928,7 @@ void draw_chara_chip_sprite(
     int offset_y)
 {
     gmode(2, 110);
-    draw("character_shadow", x + 8, y + 20);
+    draw("core.character_shadow", x + 8, y + 20);
     gmode(2);
     set_color_mod(tint.r, tint.g, tint.b, ext.buffer);
     gcopy(ext.buffer, ext.x, ext.y, ext.width, ext.height, x, y - offset_y);
@@ -953,7 +960,7 @@ void draw_npc_own_sprite(
     gmode(2);
     if (chara.furious != 0)
     {
-        draw("furious_icon", dx + 12, dy - 28);
+        draw("core.furious_icon", dx + 12, dy - 28);
     }
     if (chara.emotion_icon != 0)
     {
@@ -1008,7 +1015,7 @@ void draw_npc_chara_chip(const Character& chara, int dx, int dy, int ground_)
 
         if (chara.furious != 0)
         {
-            draw("furious_icon", dx + 12, dy - offset_y - 12);
+            draw("core.furious_icon", dx + 12, dy - offset_y - 12);
         }
         if (chara.emotion_icon != 0)
         {
@@ -1093,7 +1100,7 @@ void draw_efmap(int x, int y, int dx, int dy, bool update_frame)
         {
             gmode(2, efmap(1, x, y) * 12 + 30);
             draw_indexed_rotated(
-                "mef_subref",
+                "core.mef_subref",
                 dx + 24,
                 dy + 24,
                 mefsubref(0, p_) + efmap(3, x, y),
@@ -1104,7 +1111,7 @@ void draw_efmap(int x, int y, int dx, int dy, bool update_frame)
         {
             gmode(2, 150);
             draw_indexed(
-                "mef_subref",
+                "core.mef_subref",
                 dx + 8,
                 dy + 8,
                 mefsubref(0, p_) + efmap(1, x, y));
@@ -1140,11 +1147,11 @@ void draw_nefia_icons(int x, int y, int dx, int dy)
                 if (area_data[q_].visited_deepest_level ==
                     area_data[q_].deepest_level)
                 {
-                    draw("conquered_nefia_icon", dx + 16, dy - 16);
+                    draw("core.conquered_nefia_icon", dx + 16, dy - 16);
                 }
                 else if (area_data[q_].visited_deepest_level != 0)
                 {
-                    draw("invaded_nefia_icon", dx + 16, dy - 16);
+                    draw("core.invaded_nefia_icon", dx + 16, dy - 16);
                 }
             }
         }
@@ -1505,7 +1512,7 @@ void cell_draw()
                     py_ -= syfix;
                 }
                 gmode(5, 50 + flick_);
-                draw_region("spot_light", px_, py_, 0, 96, 144, 48);
+                draw_region("core.spot_light", px_, py_, 0, 96, 144, 48);
             }
 
             if (reph(2) == y && x_ == repw(2) &&
@@ -1530,7 +1537,8 @@ void cell_draw()
 
                 // Spot light for PC (top 2 thirds)
                 gmode(5, 50 + flick_);
-                draw_region("spot_light", px_ - 48, py_ - 48, 0, 0, 144, 96);
+                draw_region(
+                    "core.spot_light", px_ - 48, py_ - 48, 0, 0, 144, 96);
 
                 if (py_ < windowh - inf_verh - 24)
                 {
@@ -1575,7 +1583,7 @@ void cell_draw()
                 }
                 if (cdata.player().furious != 0)
                 {
-                    draw("furious_icon", px_, py_ - 24);
+                    draw("core.furious_icon", px_, py_ - 24);
                 }
                 if (cdata.player().emotion_icon != 0)
                 {
@@ -1642,7 +1650,7 @@ void cell_draw()
                         light.brightness;
                     gmode(5, light.alpha_base + rnd(light.alpha_random + 1));
                     draw_indexed(
-                        "light",
+                        "core.light",
                         dx_,
                         dy_ - light.dy,
                         light.x + rnd(light.frame + 1));

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -886,7 +886,7 @@ void show_message(const OptionalItemRef& citrade, const OptionalItemRef& cidip)
         }
     }
 
-    asset_load("deco_inv");
+    asset_load("core.deco_inv");
     gsel(0);
     if (returnfromidentify == 0)
     {
@@ -988,7 +988,7 @@ void draw_menu(bool dropcontinue)
     y = 34;
     x = windoww - 650 + 156;
     window2(x, y, 475, 22, 5, 5);
-    draw("radar_deco", x - 28, y - 8);
+    draw("core.radar_deco", x - 28, y - 8);
     if (dropcontinue)
     {
         i = 4;
@@ -1016,12 +1016,13 @@ void draw_menu(bool dropcontinue)
             break;
         }
         p = cycle(cnt, i);
-        draw_indexed("inventory_icon", x + cnt * 44 + 20, y - 24, invicon(p));
+        draw_indexed(
+            "core.inventory_icon", x + cnt * 44 + 20, y - 24, invicon(p));
         if (invctrl == p)
         {
             gmode(5, 70);
             draw_indexed(
-                "inventory_icon", x + cnt * 44 + 20, y - 24, invicon(p));
+                "core.inventory_icon", x + cnt * 44 + 20, y - 24, invicon(p));
             gmode(2);
         }
         std::string inv_command_txt =
@@ -1084,7 +1085,7 @@ void draw_window(optional_ref<Character> inventory_owner, bool dropcontinue)
 
     if (invicon(invctrl) != -1)
     {
-        draw_indexed("inventory_icon", wx + 46, wy - 14, invicon(invctrl));
+        draw_indexed("core.inventory_icon", wx + 46, wy - 14, invicon(invctrl));
     }
     s = i18n::s.get("core.ui.inv.window.weight");
     if (invctrl == 11 || invctrl == 12)
@@ -1100,13 +1101,13 @@ void draw_window(optional_ref<Character> inventory_owner, bool dropcontinue)
 
     draw_additional_item_info_label(wx + 300, wy + 40);
 
-    draw("deco_inv_a", wx + ww - 136, wy - 6);
+    draw("core.deco_inv_a", wx + ww - 136, wy - 6);
     if (g_show_additional_item_info == AdditionalItemInfo::none)
     {
-        draw("deco_inv_b", wx + ww - 186, wy - 6);
+        draw("core.deco_inv_b", wx + ww - 186, wy - 6);
     }
-    draw("deco_inv_c", wx + ww - 246, wy - 6);
-    draw("deco_inv_d", wx - 6, wy - 6);
+    draw("core.deco_inv_c", wx + ww - 246, wy - 6);
+    draw("core.deco_inv_d", wx - 6, wy - 6);
     s = ""s + listmax + u8" items"s;
     s += "  ("s +
         i18n::s.get(
@@ -1238,7 +1239,7 @@ void draw_item_list(const OptionalItemRef& mainweapon)
 
         if (g_inv[p]->body_part != 0)
         {
-            draw("equipped", wx + 46, wy + 72 + cnt * 18 - 3);
+            draw("core.equipped", wx + 46, wy + 72 + cnt * 18 - 3);
             if (g_inv[p] == mainweapon)
             {
                 s += i18n::space_if_needed() + "(" +
@@ -1280,7 +1281,7 @@ void show_money(optional_ref<Character> inventory_owner)
         {
             font(13 - en * 2);
             gmode(2);
-            draw("gold_coin", wx + 340, wy + 32);
+            draw("core.gold_coin", wx + 340, wy + 32);
             mes(wx + 368,
                 wy + 37 - en * 2,
                 ""s + inventory_owner->gold + u8" gp"s);

--- a/src/elona/death.cpp
+++ b/src/elona/death.cpp
@@ -109,7 +109,7 @@ void show_game_score_ranking(
     constexpr size_t range_of_ranking = 8;
 
     gmode(0);
-    draw("void", 0, 0, windoww, windowh);
+    draw("core.void", 0, 0, windoww, windowh);
     gmode(2);
     font(14 - en * 2);
 
@@ -235,7 +235,7 @@ TurnResult pc_died()
 
     save_bone_file(bones, bone_filepath);
 
-    asset_load("void");
+    asset_load("core.void");
     gsel(0);
     show_game_score_ranking(bones, this_death_index);
     ui_draw_caption(i18n::s.get("core.misc.death.you_are_about_to_be_buried"));

--- a/src/elona/deferred_event.cpp
+++ b/src/elona/deferred_event.cpp
@@ -311,7 +311,7 @@ void eh_reunoin_with_pets(const DeferredEvent&)
         i18n::s.get("core.event.popup.reunion_with_pet.title"),
         i18n::s.get("core.event.popup.reunion_with_pet.text"),
         choices,
-        u8"bg_re13");
+        u8"core.bg_re13");
     p = 3;
     if (result == 0)
     {
@@ -348,7 +348,7 @@ void eh_marriage(const DeferredEvent&)
         i18n::s.get("core.event.popup.marriage.title"),
         i18n::s.get("core.event.popup.marriage.text", cdata[marry]),
         {i18n::s.get_enum("core.event.popup.marriage.choices", 0)},
-        u8"bg_re14");
+        u8"core.bg_re14");
     for (int i = 0; i < 5; ++i)
     {
         flt(calcobjlv(cdata[marry].level + 5), calcfixlv(Quality::good));

--- a/src/elona/draw.cpp
+++ b/src/elona/draw.cpp
@@ -409,7 +409,7 @@ void show_hp_bar(HPBarSide side, int inf_clocky)
                 const int width = clamp(ally.hp * 30 / ally.max_hp, 1, 30);
                 const int x_ = 16 + (windoww - 108) * right;
                 const int y_ = y + 17;
-                draw_bar("ally_health_bar", x_, y_, width * 3, 9, width);
+                draw_bar("core.ally_health_bar", x_, y_, width * 3, 9, width);
 
                 // Show leash icon.
                 if (g_config.leash_icon() && ally.is_leashed())
@@ -589,7 +589,7 @@ void show_damage_popups()
 void draw_emo(const Character& chara, int x, int y)
 {
     gmode(2);
-    draw_indexed("emotion_icons", x + 16, y, chara.emotion_icon);
+    draw_indexed("core.emotion_icons", x + 16, y, chara.emotion_icon);
 }
 
 
@@ -885,7 +885,7 @@ void draw_prepare_map_chips()
     gmode(0);
 
     // Contains the sprites for world map clouds.
-    asset_load("map");
+    asset_load("core.map");
 
     gsel(0);
     gmode(2);
@@ -1028,8 +1028,8 @@ void draw_select_key(const std::string& key, int x, int y)
 {
     gmode(0);
     font(13);
-    draw("select_key", x, y);
-    const auto& image_info = get_image_info("select_key");
+    draw("core.select_key", x, y);
+    const auto& image_info = get_image_info("core.select_key");
     const auto glyph_size =
         snail::Application::instance().get_renderer().calculate_text_size(key);
     bmes(
@@ -1276,8 +1276,8 @@ void draw_sleep_background_frame()
 void load_sleep_background()
 {
     gmode(0);
-    asset_load("bg_night");
-    draw("bg_night", 0, 0, windoww, windowh - inf_verh);
+    asset_load("core.bg_night");
+    draw("core.bg_night", 0, 0, windoww, windowh - inf_verh);
     gsel(0);
 }
 

--- a/src/elona/draw.hpp
+++ b/src/elona/draw.hpp
@@ -138,7 +138,6 @@ void draw_item_with_portrait_scale_height(
 struct AssetData;
 
 const AssetData& asset_load(data::InstanceId id);
-const AssetData& asset_load(data::InstanceId id, int window_id);
 void init_assets();
 
 void draw(data::InstanceId id, int x, int y);

--- a/src/elona/draw_asset.cpp
+++ b/src/elona/draw_asset.cpp
@@ -502,15 +502,12 @@ void asset_copy_from(
 
 /**
  * Obtains the window and region data for the asset in @a id. Throws if the
- * asset does not exist. If a mod prefix is not provided in the @a id, it is
- * assumed to be "core".
+ * asset does not exist.
  */
 const AssetData& get_image_info(data::InstanceId id)
 {
     // TODO: Instead of throwing, log once and return a default.
     auto data = the_asset_db[id];
-    if (!data)
-        data = the_asset_db[data::InstanceId{"core." + id.get()}];
     if (!data)
         throw std::runtime_error{u8"Unknown asset ID: "s + id.get()};
     return *data;

--- a/src/elona/input.cpp
+++ b/src/elona/input.cpp
@@ -67,9 +67,9 @@ void input_number_dialog(int x, int y, int max_number, int initial_number)
     while (true)
     {
         window2(x + 20, y, dx - 40, 36, 0, 2);
-        draw("label_input", x + dx / 2 - 56, y - 32);
-        draw("arrow_left", x + 28, y + 4);
-        draw("arrow_right", x + dx - 51, y + 4);
+        draw("core.label_input", x + dx / 2 - 56, y - 32);
+        draw("core.arrow_left", x + 28, y + 4);
+        draw("core.arrow_right", x + dx - 51, y + 4);
         const std::string inputlog2 = inputlog + u8"(" + max_number + u8")";
         mes(x + dx - 70 - strlen_u(inputlog2) * 8 + 8,
             y + vfix + 11,
@@ -190,13 +190,13 @@ bool input_text_dialog(int x, int y, int val2, bool is_cancelable)
         }
         await(g_config.general_wait());
         window2(x, y, dx, 36, 0, 2);
-        draw("label_input", x + dx / 2 - 60, y - 32);
+        draw("core.label_input", x + dx / 2 - 60, y - 32);
 
-        draw("ime_status_english", x + 8, y + 4);
+        draw("core.ime_status_english", x + 8, y + 4);
         apledit(p(2), 2, 0);
         if (p(2) > val2 * (1 + en) - 2)
         {
-            draw("ime_status_none", x + 8, y + 4);
+            draw("core.ime_status_none", x + 8, y + 4);
         }
         if (cnt % 20 < 10)
         {
@@ -256,7 +256,7 @@ bool input_text_dialog(int x, int y, int val2, bool is_cancelable)
         }
 
         gmode(2, p(1) / 2 + 50);
-        draw("input_caret", x + 34 + p(4) * 8, y + 5);
+        draw("core.input_caret", x + 34 + p(4) * 8, y + 5);
         gmode(2);
         mes(x + 36, y + vfix + 9, s, {255, 255, 255});
 
@@ -499,15 +499,15 @@ int ask_direction()
         y = (cdata.player().position.y - scy) * inf_tiles + inf_screeny + 24;
         if (!getkey(snail::Key::alt))
         {
-            draw_rotated("direction_arrow", x, y - 48, 0);
-            draw_rotated("direction_arrow", x, y + 48, 180);
-            draw_rotated("direction_arrow", x + 48, y, 90);
-            draw_rotated("direction_arrow", x - 48, y, 270);
+            draw_rotated("core.direction_arrow", x, y - 48, 0);
+            draw_rotated("core.direction_arrow", x, y + 48, 180);
+            draw_rotated("core.direction_arrow", x + 48, y, 90);
+            draw_rotated("core.direction_arrow", x - 48, y, 270);
         }
-        draw_rotated("direction_arrow", x - 48, y - 48, 315);
-        draw_rotated("direction_arrow", x + 48, y + 48, 135);
-        draw_rotated("direction_arrow", x + 48, y - 48, 45);
-        draw_rotated("direction_arrow", x - 48, y + 48, 225);
+        draw_rotated("core.direction_arrow", x - 48, y - 48, 315);
+        draw_rotated("core.direction_arrow", x + 48, y + 48, 135);
+        draw_rotated("core.direction_arrow", x + 48, y - 48, 45);
+        draw_rotated("core.direction_arrow", x - 48, y + 48, 225);
         redraw();
         gmode(0);
         gcopy(4, 0, 0, 144, 144, x - 48 - 24, y - 48 - 24);

--- a/src/elona/input_prompt.cpp
+++ b/src/elona/input_prompt.cpp
@@ -111,7 +111,7 @@ void Prompt::_draw_keys_and_background(int x, int y, int width)
 void Prompt::_draw_main_frame(int width)
 {
     window2(sx + 8, sy + 8, width - 16, _promptmax * 20 + 42 - 16, 0, 0);
-    draw("radar_deco", sx - 16, sy);
+    draw("core.radar_deco", sx - 16, sy);
     font(14 - en * 2);
 }
 
@@ -175,9 +175,9 @@ void PromptWithNumber::_draw_box()
 void PromptWithNumber::_draw_window()
 {
     window2(dx(1) + sx + 20, dy, dx - 40, 36, 0, 2);
-    draw("label_input", dx(1) + sx + dx / 2 - 56, dy - 32);
-    draw("arrow_left", dx(1) + sx + 28, dy + 4);
-    draw("arrow_right", dx(1) + sx + dx - 51, dy + 4);
+    draw("core.label_input", dx(1) + sx + dx / 2 - 56, dy - 32);
+    draw("core.arrow_left", dx(1) + sx + 28, dy + 4);
+    draw("core.arrow_right", dx(1) + sx + dx - 51, dy + 4);
     const auto inputlog2 =
         ""s + elona::stoi(inputlog(0)) + u8"("s + _max + u8")"s;
     mes(dx(1) + sx + dx - 70 - strlen_u(inputlog2) * 8 + 8,

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -129,7 +129,7 @@ bool _magic_1136(const ItemRef& treasure_map)
     }
     txt(i18n::s.get("core.magic.map.apply"));
     snd("core.book1");
-    const auto& info = asset_load("paper");
+    const auto& info = asset_load("core.paper");
     gsel(0);
     ww = info.width;
     wh = info.height;

--- a/src/elona/main_menu.cpp
+++ b/src/elona/main_menu.cpp
@@ -194,8 +194,8 @@ MainMenuResult main_title_menu()
     load_background_variants(2);
 
     gmode(0);
-    asset_load("title");
-    draw("title", 0, 0, windoww, windowh);
+    asset_load("core.title");
+    draw("core.title", 0, 0, windoww, windowh);
     gmode(2);
 
     font(13 - en * 2);
@@ -268,7 +268,7 @@ MainMenuResult main_title_menu()
 
     keyrange = items.size();
 
-    asset_load("deco_blend");
+    asset_load("core.deco_blend");
     gsel(0);
     gmode(0);
     gcopy(4, 0, 0, windoww, windowh, 0, 0);
@@ -511,10 +511,10 @@ MainMenuResult main_menu_new_game()
     }
     mode = 1;
     cm = 1;
-    asset_load("void");
-    draw("void", 0, 0, windoww, windowh);
+    asset_load("core.void");
+    draw("core.void", 0, 0, windoww, windowh);
     load_background_variants(2);
-    asset_load("deco_cm");
+    asset_load("core.deco_cm");
     gsel(0);
     return MainMenuResult::character_making_select_race;
 }
@@ -692,8 +692,8 @@ MainMenuResult main_menu_incarnate()
 {
     cs = 0;
     cs_bk = -1;
-    asset_load("void");
-    draw("void", 0, 0, windoww, windowh);
+    asset_load("core.void");
+    draw("core.void", 0, 0, windoww, windowh);
     gsel(0);
     gmode(0);
     gcopy(4, 0, 0, windoww, windowh, 0, 0);
@@ -796,8 +796,8 @@ MainMenuResult main_menu_about()
     listmax = 5;
 
     gmode(0);
-    asset_load("void");
-    draw("void", 0, 0, windoww, windowh);
+    asset_load("core.void");
+    draw("core.void", 0, 0, windoww, windowh);
     gmode(2);
 
     ui_draw_caption("Elona foobar " + latest_version.short_string());
@@ -930,8 +930,8 @@ void main_menu_about_one_changelog(const Release& release)
     page = 0;
 
     gmode(0);
-    asset_load("void");
-    draw("void", 0, 0, windoww, windowh);
+    asset_load("core.void");
+    draw("core.void", 0, 0, windoww, windowh);
     gmode(2);
     gsel(0);
 
@@ -1016,8 +1016,8 @@ MainMenuResult main_menu_about_changelogs()
     keyrange = 0;
 
     gmode(0);
-    asset_load("void");
-    draw("void", 0, 0, windoww, windowh);
+    asset_load("core.void");
+    draw("core.void", 0, 0, windoww, windowh);
     gmode(2);
     gsel(0);
 
@@ -1200,8 +1200,8 @@ MainMenuResult main_menu_about_license()
     page = 0;
 
     gmode(0);
-    asset_load("void");
-    draw("void", 0, 0, windoww, windowh);
+    asset_load("core.void");
+    draw("core.void", 0, 0, windoww, windowh);
     gmode(2);
     gsel(0);
 
@@ -1327,8 +1327,8 @@ MainMenuResult main_menu_about_credits()
     page = 0;
 
     gmode(0);
-    asset_load("void");
-    draw("void", 0, 0, windoww, windowh);
+    asset_load("core.void");
+    draw("core.void", 0, 0, windoww, windowh);
     gmode(2);
     gsel(0);
 
@@ -1411,8 +1411,8 @@ MainMenuResult main_menu_mods()
     listmax = 2;
 
     gmode(0);
-    asset_load("void");
-    draw("void", 0, 0, windoww, windowh);
+    asset_load("core.void");
+    draw("core.void", 0, 0, windoww, windowh);
     gmode(2);
 
     windowshadow = 1;

--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -347,7 +347,7 @@ bool maybe_show_ex_help(int id, bool should_update_screen)
 
 void show_ex_help(int id)
 {
-    asset_load("deco_help");
+    asset_load("core.deco_help");
     gsel(0);
     page = 0;
     notesel(buff);
@@ -389,9 +389,9 @@ void show_ex_help(int id)
         wy = winposy(dy);
         window2(
             (windoww - 325) / 2 + inf_screenx, winposy(dy) + 6, 325, 32, 0, 1);
-        draw("deco_help_a", wx + 5, wy + 4);
-        draw("deco_help_a", wx + dx - 55, wy + 4);
-        draw("deco_help_b", wx + 10, wy + 42);
+        draw("core.deco_help_a", wx + 5, wy + 4);
+        draw("core.deco_help_a", wx + dx - 55, wy + 4);
+        draw("core.deco_help_b", wx + 10, wy + 42);
         font(16 - en * 2, snail::Font::Style::bold);
         bmes(
             i18n::s.get("core.ui.exhelp.title"),
@@ -693,7 +693,7 @@ ChangeAppearanceResult menu_change_appearance(Character& chara)
     wy = winposy(wh);
     snd("core.port");
     window_animation(wx, wy, ww, wh, 9, 7);
-    asset_load("deco_mirror");
+    asset_load("core.deco_mirror");
     gsel(0);
     windowshadow = 1;
 
@@ -770,7 +770,7 @@ ChangeAppearanceResult menu_change_appearance(Character& chara)
         pagesize = listmax;
         display_topic(
             i18n::s.get("core.ui.appearance.basic.category"), wx + 34, wy + 36);
-        draw("deco_mirror_a", wx + ww - 40, wy);
+        draw("core.deco_mirror_a", wx + ww - 40, wy);
         window2(wx + 234, wy + 71, 88, 120, 1, 1);
         if (cs == 1 && page == 0)
         {
@@ -845,8 +845,8 @@ ChangeAppearanceResult menu_change_appearance(Character& chara)
             cs_list(cs == cnt, s, wx + 60, wy + 66 + cnt * 21 - 1);
             if (rtval != -2)
             {
-                draw("arrow_left", wx + 30, wy + 66 + cnt * 21 - 5);
-                draw("arrow_right", wx + 175, wy + 66 + cnt * 21 - 5);
+                draw("core.arrow_left", wx + 30, wy + 66 + cnt * 21 - 5);
+                draw("core.arrow_right", wx + 175, wy + 66 + cnt * 21 - 5);
             }
         }
         if (keyrange != 0)
@@ -1077,8 +1077,8 @@ void change_appearance_equipment(Character& chara)
                 {
                     s += u8"Off"s;
                 }
-                draw("arrow_left", wx + 30, wy + 66 + cnt * 21 - 5);
-                draw("arrow_right", wx + 175, wy + 66 + cnt * 21 - 5);
+                draw("core.arrow_left", wx + 30, wy + 66 + cnt * 21 - 5);
+                draw("core.arrow_right", wx + 175, wy + 66 + cnt * 21 - 5);
             }
             cs_list(cs == cnt, s, wx + 60, wy + 66 + cnt * 21 - 1);
         }

--- a/src/elona/menu_quick_menu.cpp
+++ b/src/elona/menu_quick_menu.cpp
@@ -228,11 +228,11 @@ void QuickMenu::_draw()
 
         if (index == 0 || index == 4 || index == 8)
         {
-            draw("quickmenu_submenu", entry.x + _pos_x, entry.y + _pos_y);
+            draw("core.quickmenu_submenu", entry.x + _pos_x, entry.y + _pos_y);
         }
         else
         {
-            draw("quickmenu_action", entry.x + _pos_x, entry.y + _pos_y);
+            draw("core.quickmenu_action", entry.x + _pos_x, entry.y + _pos_y);
         }
 
         uint8_t alpha;
@@ -256,11 +256,11 @@ void QuickMenu::_draw()
 
         if (index == 0 || index == 4 || index == 8)
         {
-            draw("quickmenu_submenu", entry.x + _pos_x, entry.y + _pos_y);
+            draw("core.quickmenu_submenu", entry.x + _pos_x, entry.y + _pos_y);
         }
         else
         {
-            draw("quickmenu_action", entry.x + _pos_x, entry.y + _pos_y);
+            draw("core.quickmenu_action", entry.x + _pos_x, entry.y + _pos_y);
         }
 
         gmode(2);

--- a/src/elona/message.cpp
+++ b/src/elona/message.cpp
@@ -78,13 +78,13 @@ void anime_halt(int x_at_txtfunc, int y_at_txtfunc)
 {
     gmode(0);
     gsel(3);
-    asset_copy_from(0, x_at_txtfunc, y_at_txtfunc, "label_more_scratch");
+    asset_copy_from(0, x_at_txtfunc, y_at_txtfunc, "core.label_more_scratch");
     gsel(0);
     for (int cnt = 0; cnt < 12; ++cnt)
     {
         await(g_config.general_wait() / 3);
         draw(
-            "label_more",
+            "core.label_more",
             x_at_txtfunc,
             y_at_txtfunc + 12 - cnt,
             120,
@@ -96,11 +96,11 @@ void anime_halt(int x_at_txtfunc, int y_at_txtfunc)
     for (int cnt = 0; cnt < 7; ++cnt)
     {
         await(g_config.general_wait() / 3);
-        draw("label_more_scratch", x_at_txtfunc, y_at_txtfunc);
+        draw("core.label_more_scratch", x_at_txtfunc, y_at_txtfunc);
         if (cnt != 6)
         {
             draw(
-                "label_more",
+                "core.label_more",
                 x_at_txtfunc,
                 y_at_txtfunc + cnt * 2,
                 120,
@@ -196,7 +196,7 @@ void Message::_msg_write(std::string& message)
 
         gmode(2);
         draw_indexed(
-            "message_symbol",
+            "core.message_symbol",
             (message_width + widthwise_pos) * 7 + inf_msgx + 7 + en * 3,
             (inf_msgline - 1) * inf_msgspace + inf_msgy + 5,
             symbol_type * 2);
@@ -249,7 +249,7 @@ void Message::_msg_newline()
             x_at_txtfunc = 192;
         }
         draw_region(
-            "message_window_contents",
+            "core.message_window_contents",
             cnt * 192 + inf_msgx,
             inf_msgy + 5 + inf_msgspace * 3 + en * 2,
             0,
@@ -299,7 +299,7 @@ void Message::_txt_conv()
                     x_at_txtfunc = 192;
                 }
                 draw_region(
-                    "message_window_contents",
+                    "core.message_window_contents",
                     i * 192 + inf_msgx,
                     inf_msgy + 5,
                     x_at_txtfunc,

--- a/src/elona/random_event.cpp
+++ b/src/elona/random_event.cpp
@@ -281,49 +281,49 @@ void run_random_event(RandomEvent event)
             }
         }
         listmax = 1;
-        event_bg = u8"bg_re9";
+        event_bg = "core.bg_re9";
         break;
     case 14:
         listmax = 2;
-        event_bg = u8"bg_re10";
+        event_bg = "core.bg_re10";
         break;
     case 13:
         cdata.player().nutrition -= 5000;
         listmax = 1;
-        event_bg = u8"bg_re10";
+        event_bg = "core.bg_re10";
         break;
     case 1:
         listmax = 1;
-        event_bg = u8"bg_re8";
+        event_bg = "core.bg_re8";
         break;
     case 24:
         efid = 1113;
         magic(cdata.player(), cdata.player());
         listmax = 1;
-        event_bg = u8"bg_re4";
+        event_bg = "core.bg_re4";
         break;
     case 18:
         chara_gain_skill_exp(cdata.player(), 181, 1000, 6, 1000);
         listmax = 1;
-        event_bg = u8"bg_re12";
+        event_bg = "core.bg_re12";
         break;
     case 12:
         efid = 1117;
         efp = 100;
         magic(cdata.player(), cdata.player());
         listmax = 1;
-        event_bg = u8"bg_re3";
+        event_bg = "core.bg_re3";
         break;
     case 23:
         efid = 1117;
         efp = 200;
         magic(cdata.player(), cdata.player());
         listmax = 1;
-        event_bg = u8"bg_re3";
+        event_bg = "core.bg_re3";
         break;
     case 10:
         listmax = 2;
-        event_bg = u8"bg_re3";
+        event_bg = "core.bg_re3";
         break;
     case 4:
         snd("core.curse2");
@@ -331,7 +331,7 @@ void run_random_event(RandomEvent event)
         efp = 100;
         magic(cdata.player(), cdata.player());
         listmax = 1;
-        event_bg = u8"bg_re5";
+        event_bg = "core.bg_re5";
         break;
     case 22:
         snd("core.curse2");
@@ -339,7 +339,7 @@ void run_random_event(RandomEvent event)
         efp = 100;
         magic(cdata.player(), cdata.player());
         listmax = 1;
-        event_bg = u8"bg_re2";
+        event_bg = "core.bg_re2";
         break;
     case 19:
         flt();
@@ -349,12 +349,12 @@ void run_random_event(RandomEvent event)
                 "core.common.you_put_in_your_backpack", item.unwrap()));
         }
         listmax = 1;
-        event_bg = u8"bg_re15";
+        event_bg = "core.bg_re15";
         break;
     case 20:
         buff_add(cdata.player(), "core.luck", 777, 1500);
         listmax = 1;
-        event_bg = u8"bg_re12";
+        event_bg = "core.bg_re12";
         break;
     case 21:
         flt();
@@ -364,7 +364,7 @@ void run_random_event(RandomEvent event)
                 "core.common.you_put_in_your_backpack", item.unwrap()));
         }
         listmax = 1;
-        event_bg = u8"bg_re15";
+        event_bg = "core.bg_re15";
         net_send_news("ehekatl");
         break;
     case 5:
@@ -398,7 +398,7 @@ void run_random_event(RandomEvent event)
             }
         }
         listmax = 1;
-        event_bg = u8"bg_re5";
+        event_bg = "core.bg_re5";
         break;
     case 8:
         p = rnd_capped(cdata.player().gold / 8 + 1);
@@ -417,40 +417,40 @@ void run_random_event(RandomEvent event)
             txt(i18n::s.get_enum_property("core.event.popup", "no_effect", 8));
         }
         listmax = 1;
-        event_bg = u8"bg_re9";
+        event_bg = "core.bg_re9";
         break;
     case 11:
         listmax = 2;
-        event_bg = u8"bg_re7";
+        event_bg = "core.bg_re7";
         break;
     case 2:
         efid = 1104;
         efp = 100;
         magic(cdata.player(), cdata.player());
         listmax = 1;
-        event_bg = u8"bg_re6";
+        event_bg = "core.bg_re6";
         break;
     case 3:
         efid = 1119;
         efp = 100;
         magic(cdata.player(), cdata.player());
         listmax = 1;
-        event_bg = u8"bg_re4";
+        event_bg = "core.bg_re4";
         break;
     case 6:
         chara_gain_skill_exp(cdata.player(), 154, 1000);
         listmax = 1;
-        event_bg = u8"bg_re4";
+        event_bg = "core.bg_re4";
         break;
     case 7:
         chara_gain_skill_exp(cdata.player(), 155, 1000);
         listmax = 1;
-        event_bg = u8"bg_re4";
+        event_bg = "core.bg_re4";
         break;
     case 9:
         earn_platinum(cdata.player(), 1);
         listmax = 1;
-        event_bg = u8"bg_re1";
+        event_bg = "core.bg_re1";
         break;
     case 16:
         p = rnd_capped(cdata.player().gold / 10 + 1000) + 1;
@@ -458,14 +458,14 @@ void run_random_event(RandomEvent event)
         txt(i18n::s.get_enum_property(
             "core.event.popup", "you_pick_up", 16, p(0)));
         listmax = 1;
-        event_bg = u8"bg_re1";
+        event_bg = "core.bg_re1";
         break;
     case 17:
         efid = 451;
         efp = 800;
         magic(cdata.player(), cdata.player());
         listmax = 1;
-        event_bg = u8"bg_re11";
+        event_bg = "core.bg_re11";
         break;
     }
 

--- a/src/elona/scene.cpp
+++ b/src/elona/scene.cpp
@@ -40,7 +40,7 @@ void do_play_scene()
     scene_cut = 0;
     scenemode = 1;
     SDIM4(actor, 20, 3, 10);
-    data::InstanceId background_image_id{u8"void"};
+    data::InstanceId background_image_id{u8"core.void"};
     y1 = 60;
     y2 = windowh - 60;
     notesel(buff);
@@ -169,7 +169,7 @@ void do_play_scene()
                     dx = 0;
                 }
                 gmode(2, 95);
-                draw_centered("scene_title", windoww / 2, y + 4, dx, 72);
+                draw_centered("core.scene_title", windoww / 2, y + 4, dx, 72);
             }
             x = 40;
             for (int cnt = 0, cnt_end = (noteinfo()); cnt < cnt_end; ++cnt)
@@ -257,7 +257,7 @@ void do_play_scene()
         scidx = p(4) + 1;
         if (s == u8"{pic}"s)
         {
-            background_image_id = data::InstanceId{s(1)};
+            background_image_id = data::InstanceId{"core." + s(1)};
             continue;
         }
         if (s == u8"{mc}"s)
@@ -375,12 +375,12 @@ void conquer_lesimas()
     mode = 0;
     play_music("core.mcMarch2");
     ui_win_screen_fade();
-    asset_load("void");
-    draw_region("void", 0, 0, 0, 0, 640, 480, windoww, windowh);
+    asset_load("core.void");
+    draw_region("core.void", 0, 0, 0, 0, 640, 480, windoww, windowh);
     gsel(0);
     animation_fade_in();
-    draw_region("void", 0, 0, 0, 0, windoww, windowh);
-    asset_load("g1");
+    draw_region("core.void", 0, 0, 0, 0, windoww, windowh);
+    asset_load("core.g1");
     gsel(0);
     ui_draw_caption(i18n::s.get(
         "core.win.you_acquired_codex",
@@ -398,7 +398,7 @@ void conquer_lesimas()
         ww,
         wh);
     gmode(2, 250);
-    draw_centered("g1", wx + ww - 120, wy + wh / 2, ww / 3 - 20, wh - 140);
+    draw_centered("core.g1", wx + ww - 120, wy + wh / 2, ww / 3 - 20, wh - 140);
     gmode(2);
     display_topic(i18n::s.get("core.win.window.caption"), wx + 28, wy + 40);
     font(14 - en * 2);

--- a/src/elona/talk.cpp
+++ b/src/elona/talk.cpp
@@ -38,7 +38,7 @@ bool chatval_show_impress;
 
 void talk_start()
 {
-    asset_load("ie_chat");
+    asset_load("core.ie_chat");
     gsel(0);
 }
 
@@ -666,7 +666,7 @@ void talk_window_init(std::string& text)
     ww = 600;
     wh = 380;
     gmode(2, 80);
-    draw("ie_chat", wx + 4, wy - 16);
+    draw("core.ie_chat", wx + 4, wy - 16);
 }
 
 
@@ -679,7 +679,7 @@ void talk_window_show(
     optional<std::pair<int, int>> impress_interest)
 {
     gmode(2);
-    draw("ie_chat", wx, wy - 20);
+    draw("core.ie_chat", wx, wy - 20);
     if (portrait_id)
     {
         if (const auto rect = draw_get_rect_portrait(*portrait_id))
@@ -742,7 +742,7 @@ void talk_window_show(
             for (int cnt = 0, cnt_end = (interest / 5 + 1); cnt < cnt_end;
                  ++cnt)
             {
-                draw("interest_icon", wx + 26 + cnt * 4, wy + 245);
+                draw("core.interest_icon", wx + 26 + cnt * 4, wy + 245);
             }
         }
     }

--- a/src/elona/tcg.cpp
+++ b/src/elona/tcg.cpp
@@ -1561,7 +1561,7 @@ int putcard(int card_index, int player_index)
 
 void tcgdrawbg()
 {
-    const auto& info = get_image_info("deco_card_a");
+    const auto& info = get_image_info("core.deco_card_a");
 
     gmode(0);
     for (int cnt = 0, cnt_end = (windowh / info.height + 1); cnt < cnt_end;
@@ -1649,11 +1649,11 @@ void tcginit()
     deckiy_at_tcg(0) = basey_at_tcg + 420;
     deckiy_at_tcg(1) = basey_at_tcg + 20;
     selectmode_at_tcg = -1;
-    asset_load("deco_card");
-    asset_load("interface2");
+    asset_load("core.deco_card");
+    asset_load("core.interface2");
     gsel(2);
     picload(filesystem::dirs::graphic() / u8"card0.bmp", 0, 0, false);
-    asset_load("bg_card");
+    asset_load("core.bg_card");
     tcg_prepare_cnt2();
     tcgdrawbg();
 }
@@ -2097,7 +2097,7 @@ void tcg_update_mana()
 {
     elona_vector1<int> mana_at_tcg;
     int m_at_tcg = 0;
-    asset_load("bg_card");
+    asset_load("core.bg_card");
     gmode(2);
     font(14 - en * 2);
     for (int cnt = 0; cnt < 2; ++cnt)
@@ -2281,7 +2281,7 @@ void tcg_draw_selection()
 void tcg_draw_deck_editor()
 {
     gmode(0);
-    draw("bg_card", basex_at_tcg, basey_at_tcg);
+    draw("core.bg_card", basex_at_tcg, basey_at_tcg);
     font(13 - en * 2);
     gmode(2);
     if (cardmode_at_tcg != 0 || ct_at_tcg == player_at_tcg)
@@ -2448,7 +2448,7 @@ void tcg_update_page()
 
 void tcg_draw_menu()
 {
-    asset_load("bg_card");
+    asset_load("core.bg_card");
     gsel(0);
     DIM3(dlist_at_tcg, 2, 400);
     DIM2(cflist_at_tcg, 10);
@@ -2736,7 +2736,7 @@ void tcg_draw_menu()
 
 int tcg_draw_background()
 {
-    asset_load("bg_card");
+    asset_load("core.bg_card");
     tcg_prepare_cnt2();
     return rtval_at_tcg;
 }

--- a/src/elona/turn_sequence_pc_actions.cpp
+++ b/src/elona/turn_sequence_pc_actions.cpp
@@ -191,7 +191,7 @@ optional<TurnResult> handle_pc_action(std::string& action)
             {
                 sx = 192;
             }
-            draw_region("message_window", i * 192, inf_msgy, sx);
+            draw_region("core.message_window", i * 192, inf_msgy, sx);
         }
         redraw();
         wait_key_pressed();

--- a/src/elona/ui.cpp
+++ b/src/elona/ui.cpp
@@ -68,11 +68,12 @@ void update_screen_hud()
         {
             sx = 192;
         }
-        draw_bar_vert("hud_bar", cnt * 192, inf_bary, sx, inf_barh, inf_barh);
-        draw_region("message_window", cnt * 192, inf_msgy, sx, inf_msgh);
+        draw_bar_vert(
+            "core.hud_bar", cnt * 192, inf_bary, sx, inf_barh, inf_barh);
+        draw_region("core.message_window", cnt * 192, inf_msgy, sx, inf_msgh);
     }
-    draw_region("hud_minimap", 0, inf_msgy, inf_msgx, inf_verh);
-    draw("map_name_icon", inf_radarw + 6, inf_bary);
+    draw_region("core.hud_minimap", 0, inf_msgy, inf_msgx, inf_verh);
+    draw("core.map_name_icon", inf_radarw + 6, inf_bary);
     for (int cnt = 0; cnt < 10; ++cnt)
     {
         sx = 0;
@@ -85,7 +86,7 @@ void update_screen_hud()
             sx = 14;
         }
         draw_indexed(
-            "attribute_icon",
+            "core.attribute_icon",
             inf_radarw + cnt * 47 + 148 + sx,
             inf_bary + 1,
             cnt);
@@ -229,7 +230,7 @@ void render_weather_effect_snow()
         {
             // Draw.
             draw_indexed_region(
-                "weather_particle",
+                "core.weather_particle",
                 particle.x,
                 particle.y,
                 particle.x % 2,
@@ -281,7 +282,7 @@ void render_weather_effect_etherwind()
         {
             // Draw.
             draw_indexed_region(
-                "weather_particle",
+                "core.weather_particle",
                 particle.x,
                 particle.y,
                 2 + particle.x % 2,
@@ -338,7 +339,7 @@ void draw_minimap_pixel(int x, int y)
     const auto x2 = 120 * x / map_data.width;
     const auto y2 = 84 * y / map_data.height;
     draw_region(
-        "minimap_scratch",
+        "core.minimap_scratch",
         inf_radarx + x2,
         inf_radary + y2,
         x2,
@@ -384,7 +385,7 @@ void highlight_characters_in_pet_arena()
             if (chara.index == camera)
             {
                 gmode(2, 120);
-                draw("camera", x + 36, y + 32);
+                draw("core.camera", x + 36, y + 32);
                 gmode(2);
             }
         }
@@ -402,7 +403,7 @@ void render_pc_position_in_minimap()
 
     raderx = x;
     radery = y;
-    draw("minimap_position", inf_radarx + x, inf_radary + y);
+    draw("core.minimap_position", inf_radarx + x, inf_radary + y);
 }
 
 
@@ -418,7 +419,7 @@ void render_stair_positions_in_minimap()
             {
                 const auto sx = clamp(120 * x / map_data.width, 2, 112);
                 const auto sy = clamp(84 * y / map_data.height, 2, 76);
-                draw("minimap_position", inf_radarx + sx, inf_radary + sy);
+                draw("core.minimap_position", inf_radarx + sx, inf_radary + sy);
             }
         }
     }
@@ -434,7 +435,7 @@ void _render_hp_or_mp_bar(
     data::InstanceId bar_id,
     bool show_digit = false)
 {
-    draw("hp_bar_frame", x, y);
+    draw("core.hp_bar_frame", x, y);
 
     if (value > 0)
     {
@@ -457,7 +458,7 @@ void render_hp_bar(
     bool show_digit = false)
 {
     _render_hp_or_mp_bar(
-        chara.hp, chara.max_hp, x, y, "hud_hp_bar", show_digit);
+        chara.hp, chara.max_hp, x, y, "core.hud_hp_bar", show_digit);
 }
 
 
@@ -469,7 +470,7 @@ void render_mp_bar(
     bool show_digit = false)
 {
     _render_hp_or_mp_bar(
-        chara.mp, chara.max_mp, x, y, "hud_mp_bar", show_digit);
+        chara.mp, chara.max_mp, x, y, "core.hud_mp_bar", show_digit);
 }
 
 
@@ -483,7 +484,7 @@ void render_basic_attributes_and_pv_dv()
         if (i < 8)
         {
             // Basic attributes except for Speed
-            draw_region("attributes_bar", x, y, 28);
+            draw_region("core.attributes_bar", x, y, 28);
             const auto text_color = cdata.player().attr_adjs[i] < 0
                 ? snail::Color{200, 0, 0}
                 : snail::Color{0, 0, 0};
@@ -495,7 +496,7 @@ void render_basic_attributes_and_pv_dv()
         else if (i == 8)
         {
             // Speed
-            draw_region("attributes_bar", x + 8, y, 34);
+            draw_region("core.attributes_bar", x + 8, y, 34);
             snail::Color text_color{0, 0, 0};
             if (gspdorg > gspd)
             {
@@ -514,7 +515,7 @@ void render_basic_attributes_and_pv_dv()
         else
         {
             // PV/DV
-            draw_region("attributes_bar", x + 14, y, 64);
+            draw_region("core.attributes_bar", x + 14, y, 64);
             mes(x + 14,
                 y,
                 ""s + cdata.player().dv + u8"/"s + cdata.player().pv);
@@ -540,7 +541,11 @@ void _render_gold_or_platinum(
 void render_gold()
 {
     _render_gold_or_platinum(
-        cdata.player().gold, windoww - 240, inf_ver - 16, "gold_coin", "gp");
+        cdata.player().gold,
+        windoww - 240,
+        inf_ver - 16,
+        "core.gold_coin",
+        "gp");
 }
 
 
@@ -551,7 +556,7 @@ void render_platinum()
         cdata.player().platinum_coin,
         windoww - 120,
         inf_ver - 16,
-        "platinum_coin",
+        "core.platinum_coin",
         "pp");
 }
 
@@ -563,7 +568,7 @@ void render_character_level()
     const auto exp =
         cdata.player().required_experience - cdata.player().experience;
 
-    draw("character_level_icon", 4, inf_ver - 16);
+    draw("core.character_level_icon", 4, inf_ver - 16);
     bmes(u8"Lv"s + lvl + u8"/"s + exp, 32, inf_ver - 14);
 }
 
@@ -571,8 +576,8 @@ void render_character_level()
 
 void render_date_label()
 {
-    draw("clock", 0, inf_clocky);
-    draw("date_label_frame", 78, inf_clocky + 8);
+    draw("core.clock", 0, inf_clocky);
+    draw("core.date_label_frame", 78, inf_clocky + 8);
 }
 
 
@@ -588,7 +593,7 @@ void render_buffs()
             break;
 
         // Icon
-        draw_indexed("buff_icon", x, y, buff.id);
+        draw_indexed("core.buff_icon", x, y, buff.id);
         // Turns
         mes(x + 3, y + 19, std::to_string(buff.turns));
         // Turns
@@ -602,17 +607,17 @@ void render_buffs()
 
 void render_analogue_clock()
 {
-    const auto& info = get_image_info("clock_hand");
+    const auto& info = get_image_info("core.clock_hand");
 
     // Short hand
     draw_rotated(
-        "clock_hand",
+        "core.clock_hand",
         inf_clockarrowx,
         inf_clockarrowy,
         game_data.date.hour * 30 + game_data.date.minute / 2);
     // Long hand
     draw_rotated(
-        "clock_hand",
+        "core.clock_hand",
         inf_clockarrowx,
         inf_clockarrowy,
         info.width / 2,
@@ -746,7 +751,7 @@ int render_one_status_ailment(
     if (!do_render(value))
         return y;
 
-    draw_region("status_ailment_bar", x, y, 50 + en * 30);
+    draw_region("core.status_ailment_bar", x, y, 50 + en * 30);
     const auto text_color = get_color(value);
     mes(x + 6, y + vfix + 1, get_text(value), text_color);
 
@@ -1097,7 +1102,8 @@ void render_autoturn_animation()
     font(13 - en * 2, snail::Font::Style::bold);
     bmes(u8"AUTO TURN"s, sx + 43, sy + vfix + 6, {235, 235, 235});
     gmode(2);
-    draw_rotated("hourglass", sx + 18, sy + 12, game_data.date.minute / 4 * 24);
+    draw_rotated(
+        "core.hourglass", sx + 18, sy + 12, game_data.date.minute / 4 * 24);
 
     if (cdata.player().activity.type == Activity::Type::dig_ground ||
         cdata.player().activity.type == Activity::Type::dig_wall ||
@@ -1431,9 +1437,9 @@ void screen_txtadv()
         {
             sx = 265;
             sy = 8;
-            draw("casino_title_decoration_left", sx - 30, 5);
+            draw("core.casino_title_decoration_left", sx - 30, 5);
             draw(
-                "casino_title_decoration_right",
+                "core.casino_title_decoration_right",
                 sx + strlen_u(atxinfon(0)) * 13 / 2 + 14,
                 5);
         }
@@ -1605,9 +1611,9 @@ void ui_draw_caption(const std::string& text)
             ap = 128;
         }
 
-        draw_region("caption", cnt * 128 + msgx, msgy, 0, 0, ap, 3);
-        draw_region("caption", cnt * 128 + msgx, msgy + 2, 0, 3, ap, 22);
-        draw_region("caption", cnt * 128 + msgx, msgy + 22, 0, 0, ap, 2);
+        draw_region("core.caption", cnt * 128 + msgx, msgy, 0, 0, ap, 3);
+        draw_region("core.caption", cnt * 128 + msgx, msgy + 2, 0, 3, ap, 22);
+        draw_region("core.caption", cnt * 128 + msgx, msgy + 22, 0, 0, ap, 2);
     }
     mes(msgx + 18, msgy + vfix + 4, text, {245, 245, 245});
     gmode(2);
@@ -1809,7 +1815,7 @@ void ui_render_non_hud()
     if (raderx != -1)
     {
         draw_region(
-            "minimap_scratch",
+            "core.minimap_scratch",
             inf_radarx + raderx,
             inf_radary + radery,
             raderx,
@@ -2136,7 +2142,7 @@ void ui_display_window(
             1);
     }
     gmode(2);
-    draw("tip_icon", x + 30 + x_offset, y + height - 47 - height % 8);
+    draw("core.tip_icon", x + 30 + x_offset, y + height - 47 - height % 8);
     line(
         x + 50 + x_offset,
         y + height - 48 - height % 8,
@@ -2233,7 +2239,7 @@ void display_note(const std::string& text, int x_offset)
 void display_topic(const std::string& topic, int x, int y)
 {
     font(12 + sizefix - en * 2, snail::Font::Style::bold);
-    draw("topic_icon", x, y + 7);
+    draw("core.topic_icon", x, y + 7);
     mes(x + 26, y + vfix + 8, topic);
     line(x + 22, y + 21, x + strlen_u(topic) * 7 + 36, y + 21);
 }
@@ -2310,11 +2316,11 @@ void load_background_variants(int buffer)
 
 void clear_background_in_character_making()
 {
-    asset_load("void");
-    draw("void", 0, 0, windoww, windowh);
+    asset_load("core.void");
+    draw("core.void", 0, 0, windoww, windowh);
     gsel(0);
     gmode(0);
-    draw_region("void", 0, 0, 0, 0, windoww, 64);
+    draw_region("core.void", 0, 0, 0, 0, windoww, 64);
     gmode(2);
 }
 
@@ -2322,11 +2328,11 @@ void clear_background_in_character_making()
 
 void clear_background_in_continue()
 {
-    asset_load("void");
-    draw("void", 0, 0, windoww, windowh);
+    asset_load("core.void");
+    draw("core.void", 0, 0, windoww, windowh);
     gsel(0);
     gmode(0);
-    draw("void", 0, 0, windoww, windowh);
+    draw("core.void", 0, 0, windoww, windowh);
     gmode(2);
 }
 
@@ -2343,21 +2349,33 @@ void draw_scroll(int x, int y, int width, int height)
         {
             if (i == 0)
             {
-                draw_region("ie_scroll", x, y, 0, 0, 64, 48);
-                draw_region("ie_scroll", x, y3, 0, 144, 64, 48);
+                draw_region("core.ie_scroll", x, y, 0, 0, 64, 48);
+                draw_region("core.ie_scroll", x, y3, 0, 144, 64, 48);
             }
             continue;
         }
         if (i < width / 8 - 8)
         {
             draw_region(
-                "ie_scroll", i * 8 + x, y, (i - 8) % 18 * 8 + 64, 0, 8, 48);
+                "core.ie_scroll",
+                i * 8 + x,
+                y,
+                (i - 8) % 18 * 8 + 64,
+                0,
+                8,
+                48);
             draw_region(
-                "ie_scroll", i * 8 + x, y3, (i - 8) % 18 * 8 + 64, 144, 8, 48);
+                "core.ie_scroll",
+                i * 8 + x,
+                y3,
+                (i - 8) % 18 * 8 + 64,
+                144,
+                8,
+                48);
             continue;
         }
-        draw_region("ie_scroll", x3, y, 208, 0, 64, 48);
-        draw_region("ie_scroll", x3, y3, 208, 144, 64, 48);
+        draw_region("core.ie_scroll", x3, y, 208, 0, 64, 48);
+        draw_region("core.ie_scroll", x3, y3, 208, 144, 64, 48);
         break;
     }
 
@@ -2368,13 +2386,19 @@ void draw_scroll(int x, int y, int width, int height)
             if (j == 0)
             {
                 draw_region(
-                    "ie_scroll", x, i * 8 + y + 48, 0, i % 12 * 8 + 48, 64, 8);
+                    "core.ie_scroll",
+                    x,
+                    i * 8 + y + 48,
+                    0,
+                    i % 12 * 8 + 48,
+                    64,
+                    8);
                 continue;
             }
             if (j < width / 8 - 15)
             {
                 draw_region(
-                    "ie_scroll",
+                    "core.ie_scroll",
                     j * 8 + x + 56,
                     i * 8 + y + 48,
                     j % 18 * 8 + 64,
@@ -2384,7 +2408,13 @@ void draw_scroll(int x, int y, int width, int height)
                 continue;
             }
             draw_region(
-                "ie_scroll", x3, i * 8 + y + 48, 208, i % 12 * 8 + 48, 64, 8);
+                "core.ie_scroll",
+                x3,
+                i * 8 + y + 48,
+                208,
+                i % 12 * 8 + 48,
+                64,
+                8);
             break;
         }
     }
@@ -2396,7 +2426,8 @@ void cs_listbk()
 {
     if (cs_bk == -1)
         return;
-    draw_region("list_scratch", cs_posbk_x, cs_posbk_y, cs_posbk_w, cs_posbk_h);
+    draw_region(
+        "core.list_scratch", cs_posbk_x, cs_posbk_y, cs_posbk_w, cs_posbk_h);
 }
 
 
@@ -2416,11 +2447,11 @@ void cs_list(
 
         gsel(3);
         gcopy(0, x, y, width, 19, 264, 96);
-        asset_copy_from(0, x, y, width, 19, "list_scratch");
+        asset_copy_from(0, x, y, width, 19, "core.list_scratch");
         gsel(0);
 
         boxf(x, y, width, 19, {127, 191, 255, 63});
-        draw("list_bullet", x + width - 20, y + 4);
+        draw("core.list_bullet", x + width - 20, y + 4);
 
         cs_posbk_x = x;
         cs_posbk_y = y;
@@ -2473,7 +2504,7 @@ void showscroll(const std::string& hint, int x, int y, int width, int height)
     if (hint.empty())
         return;
 
-    draw("tip_icon", x + 40, y + height - 67 - height % 8);
+    draw("core.tip_icon", x + 40, y + height - 67 - height % 8);
     line(
         x + 60,
         y + height - 68 - height % 8,
@@ -2525,14 +2556,14 @@ void window(int x, int y, int width, int height, bool shadow)
     if (!shadow)
     {
         // Top left
-        draw_region("window", x, y, 0, 0, 64, 48);
+        draw_region("core.window", x, y, 0, 0, 64, 48);
     }
     // Top right
-    draw_region("window", x3, y, 208, 0, 56, 48);
+    draw_region("core.window", x3, y, 208, 0, 56, 48);
     // Bottom left
-    draw_region("window", x, y3, 0, 144, 64, 48);
+    draw_region("core.window", x, y3, 0, 144, 64, 48);
     // Bottom right
-    draw_region("window", x3, y3, 208, 144, 56, 48);
+    draw_region("core.window", x3, y3, 208, 144, 56, 48);
 
     for (int dx = 8; dx < width / 8 - 8; ++dx)
     {
@@ -2540,11 +2571,11 @@ void window(int x, int y, int width, int height, bool shadow)
         {
             // Top middle
             draw_region(
-                "window", dx * 8 + x, y, (dx - 8) % 18 * 8 + 36, 0, 8, 48);
+                "core.window", dx * 8 + x, y, (dx - 8) % 18 * 8 + 36, 0, 8, 48);
         }
         // Bottom middle
         draw_region(
-            "window", dx * 8 + x, y3, (dx - 8) % 18 * 8 + 54, 144, 8, 48);
+            "core.window", dx * 8 + x, y3, (dx - 8) % 18 * 8 + 54, 144, 8, 48);
     }
 
     for (int dy = 0; dy < height / 8 - 14; ++dy)
@@ -2553,12 +2584,12 @@ void window(int x, int y, int width, int height, bool shadow)
         {
             // Middle left
             draw_region(
-                "window", x, dy * 8 + y + 48, 0, dy % 12 * 8 + 48, 64, 8);
+                "core.window", x, dy * 8 + y + 48, 0, dy % 12 * 8 + 48, 64, 8);
             // Middle middle
             for (int dx = 1; dx < width / 8 - 15; ++dx)
             {
                 draw_region(
-                    "window",
+                    "core.window",
                     dx * 8 + x + 56,
                     dy * 8 + y + 48,
                     dx % 18 * 8 + 64,
@@ -2569,7 +2600,7 @@ void window(int x, int y, int width, int height, bool shadow)
         }
         // Middle right
         draw_region(
-            "window", x3, dy * 8 + y + 48, 208, dy % 12 * 8 + 48, 56, 8);
+            "core.window", x3, dy * 8 + y + 48, 208, dy % 12 * 8 + 48, 56, 8);
     }
 
     gmode(2);
@@ -2602,33 +2633,73 @@ void window2(
     {
     case 0:
         draw_region(
-            "window", x + 4, y + 4, 24, 24, 228, 144, width - 6, height - 8);
+            "core.window",
+            x + 4,
+            y + 4,
+            24,
+            24,
+            228,
+            144,
+            width - 6,
+            height - 8);
         break;
     case 1:
         draw_region(
-            "window", x + 4, y + 4, 24, 24, 228, 144, width - 6, height - 8);
+            "core.window",
+            x + 4,
+            y + 4,
+            24,
+            24,
+            228,
+            144,
+            width - 6,
+            height - 8);
         boxf(x + 4, y + 4, width - 4, height - 4, {0, 0, 0, 195});
         break;
     case 2:
         draw_region(
-            "window", x + 4, y + 4, 24, 24, 228, 144, width - 6, height - 8);
+            "core.window",
+            x + 4,
+            y + 4,
+            24,
+            24,
+            228,
+            144,
+            width - 6,
+            height - 8);
         boxf(x + 4, y + 4, width - 4, height - 4, {0, 0, 0, 210});
         break;
     case 3:
         draw_region(
-            "window", x + 4, y + 4, 24, 24, 228, 144, width - 6, height - 8);
+            "core.window",
+            x + 4,
+            y + 4,
+            24,
+            24,
+            228,
+            144,
+            width - 6,
+            height - 8);
         boxf(x + 4, y + 4, width - 4, height - 4, {0, 0, 0, 10});
         break;
     case 4:
         draw_region(
-            "window", x + 4, y + 4, 24, 24, 228, 144, width - 6, height - 8);
+            "core.window",
+            x + 4,
+            y + 4,
+            24,
+            24,
+            228,
+            144,
+            width - 6,
+            height - 8);
         boxf(x + 4, y + 4, width - 4, height - 4, {0, 0, 0, 195});
         break;
     case 5: break;
     case 6:
         gmode(2, 180);
         draw_region_centered(
-            "window",
+            "core.window",
             x + width / 2,
             y + height / 2,
             24,
@@ -2645,7 +2716,7 @@ void window2(
     for (int cnt = 0, cnt_end = (width / 16 - 2); cnt < cnt_end; ++cnt)
     {
         draw_region(
-            "window_frame",
+            "core.window_frame",
             cnt * 16 + x + 16,
             y,
             frame_style * 48 + 16,
@@ -2653,7 +2724,7 @@ void window2(
             16,
             16);
         draw_region(
-            "window_frame",
+            "core.window_frame",
             cnt * 16 + x + 16,
             y + height - 16,
             frame_style * 48 + 16,
@@ -2666,9 +2737,9 @@ void window2(
     const auto y2 = y + height / 16 * 16 - 16;
 
     draw_region(
-        "window_frame", x2, y, frame_style * 48 + 16, 0, width % 16, 16);
+        "core.window_frame", x2, y, frame_style * 48 + 16, 0, width % 16, 16);
     draw_region(
-        "window_frame",
+        "core.window_frame",
         x2,
         y + height - 16,
         frame_style * 48 + 16,
@@ -2679,9 +2750,15 @@ void window2(
     for (int i = 0; i < height / 16 - 2; ++i)
     {
         draw_region(
-            "window_frame", x, i * 16 + y + 16, frame_style * 48, 16, 16, 16);
+            "core.window_frame",
+            x,
+            i * 16 + y + 16,
+            frame_style * 48,
+            16,
+            16,
+            16);
         draw_region(
-            "window_frame",
+            "core.window_frame",
             x + width - 16,
             i * 16 + y + 16,
             frame_style * 48 + 32,
@@ -2689,22 +2766,29 @@ void window2(
             16,
             16);
     }
-    draw_region("window_frame", x, y2, frame_style * 48, 16, 16, height % 16);
     draw_region(
-        "window_frame",
+        "core.window_frame", x, y2, frame_style * 48, 16, 16, height % 16);
+    draw_region(
+        "core.window_frame",
         x + width - 16,
         y2,
         frame_style * 48 + 32,
         16,
         16,
         height % 16);
-    draw_region("window_frame", x, y, frame_style * 48, 0, 16, 16);
+    draw_region("core.window_frame", x, y, frame_style * 48, 0, 16, 16);
     draw_region(
-        "window_frame", x, y + height - 16, frame_style * 48, 32, 16, 16);
+        "core.window_frame", x, y + height - 16, frame_style * 48, 32, 16, 16);
     draw_region(
-        "window_frame", x + width - 16, y, frame_style * 48 + 32, 0, 16, 16);
+        "core.window_frame",
+        x + width - 16,
+        y,
+        frame_style * 48 + 32,
+        0,
+        16,
+        16);
     draw_region(
-        "window_frame",
+        "core.window_frame",
         x + width - 16,
         y + height - 16,
         frame_style * 48 + 32,
@@ -2715,7 +2799,15 @@ void window2(
     if (fill_style == 5)
     {
         draw_region(
-            "window", x + 2, y + 2, 24, 24, 228, 144, width - 4, height - 5);
+            "core.window",
+            x + 2,
+            y + 2,
+            24,
+            24,
+            228,
+            144,
+            width - 4,
+            height - 5);
         boxf(x + 2, y + 2, width - 4, height - 4, {0, 0, 0, 195});
     }
 }
@@ -2839,10 +2931,10 @@ void show_title(const std::string& title)
     }
     for (int i = 0; i < (windoww - x - 8) / 192 + 1; ++i)
     {
-        draw("title_label_frame", x + 8 + i * 192, y);
+        draw("core.title_label_frame", x + 8 + i * 192, y);
     }
     gmode(2);
-    draw("tip_icon", x, y + (mode != 1));
+    draw("core.tip_icon", x, y + (mode != 1));
     font(12 + sizefix - en * 2);
     bmes(title, x + 32, y + 1 + vfix + jp, {250, 250, 250});
 }

--- a/src/elona/ui/ui_menu_book.cpp
+++ b/src/elona/ui/ui_menu_book.cpp
@@ -17,7 +17,7 @@ namespace ui
 bool UIMenuBook::init()
 {
     snd("core.book1");
-    asset_load("book");
+    asset_load("core.book");
     gsel(0);
     notesel(buff);
     {
@@ -66,10 +66,10 @@ void UIMenuBook::update()
 
 void UIMenuBook::draw()
 {
-    const auto& info = get_image_info("book");
+    const auto& info = get_image_info("core.book");
     wx = (windoww - info.width + 16) / 2 + inf_screenx;
     wy = winposy(info.height + 20);
-    elona::draw("book", wx, wy);
+    elona::draw("core.book", wx, wy);
 
     for (int cnt = 0, cnt_end = (pagesize); cnt < cnt_end; ++cnt)
     {

--- a/src/elona/ui/ui_menu_character_sheet.cpp
+++ b/src/elona/ui/ui_menu_character_sheet.cpp
@@ -166,7 +166,7 @@ bool UIMenuCharacterSheet::init()
 
     _load_list(_chara, _operation);
 
-    const auto& data = asset_load("ie_sheet");
+    const auto& data = asset_load("core.ie_sheet");
     gsel(0);
     wx = (windoww - data.width) / 2 + inf_screenx;
     wy = winposy(data.height) - 10;
@@ -191,7 +191,7 @@ bool UIMenuCharacterSheet::init()
     if (!_returned_from_portrait)
     {
         gmode(2, 80);
-        elona::draw("ie_sheet", wx + 4, wy + 4);
+        elona::draw("core.ie_sheet", wx + 4, wy + 4);
         gmode(2);
     }
     if (_operation == CharacterSheetOperation::train_skill)
@@ -662,12 +662,12 @@ void UIMenuCharacterSheet::_draw_first_page_buffs(
         if (_chara.buffs[cnt].id == 0)
         {
             gmode(2, 120);
-            elona::draw("buff_icon_none", x, y);
+            elona::draw("core.buff_icon_none", x, y);
             gmode(2);
             continue;
         }
         ++_cs_buffmax;
-        draw_indexed("buff_icon", x, y, _chara.buffs[cnt].id);
+        draw_indexed("core.buff_icon", x, y, _chara.buffs[cnt].id);
         if (_cs_buff == cnt)
         {
             boxf(x, y, 32, 32, {200, 200, 255, 63});

--- a/src/elona/ui/ui_menu_chat_history.cpp
+++ b/src/elona/ui/ui_menu_chat_history.cpp
@@ -17,7 +17,7 @@ bool UIMenuChatHistory::init()
     key_list(0) = keybind_get_bound_key_name("enter");
     keyrange = 0;
     pagesize = 0;
-    asset_load("ie_scroll");
+    asset_load("core.ie_scroll");
     gsel(0);
     windowshadow = 1;
     snd("core.scroll");

--- a/src/elona/ui/ui_menu_composite.hpp
+++ b/src/elona/ui/ui_menu_composite.hpp
@@ -160,7 +160,7 @@ private:
     {
         font(12 + sizefix - en * 2);
         window2(x, y, width, 22, 5, 5);
-        elona::draw("radar_deco", x - 28, y - 8);
+        elona::draw("core.radar_deco", x - 28, y - 8);
     }
 
     void _draw_single_menu_item(
@@ -170,13 +170,19 @@ private:
         int y)
     {
         draw_indexed(
-            "inventory_icon", x + menu_index * 50 + 20, y - 24, menu.image);
+            "core.inventory_icon",
+            x + menu_index * 50 + 20,
+            y - 24,
+            menu.image);
 
         if (_selected == menu_index)
         {
             gmode(5, 70);
             draw_indexed(
-                "inventory_icon", x + menu_index * 50 + 20, y - 24, menu.image);
+                "core.inventory_icon",
+                x + menu_index * 50 + 20,
+                y - 24,
+                menu.image);
             gmode(2);
         }
 

--- a/src/elona/ui/ui_menu_config.cpp
+++ b/src/elona/ui/ui_menu_config.cpp
@@ -30,8 +30,8 @@ void UIMenuConfig::_draw_background()
     if (mode == 10)
     {
         gmode(0);
-        asset_load("title");
-        elona::draw("title", 0, 0, windoww, windowh);
+        asset_load("core.title");
+        elona::draw("core.title", 0, 0, windoww, windowh);
         gsel(0);
         gmode(0);
         gcopy(4, 0, 0, windoww, windowh, 0, 0);
@@ -157,8 +157,8 @@ void UIMenuConfig::_draw_keys(bool is_root_menu)
 
 void UIMenuConfig::_draw_arrows(int item_pos)
 {
-    elona::draw("arrow_left", wx + 220, wy + 66 + item_pos * 19 - 5);
-    elona::draw("arrow_right", wx + 358, wy + 66 + item_pos * 19 - 5);
+    elona::draw("core.arrow_left", wx + 220, wy + 66 + item_pos * 19 - 5);
+    elona::draw("core.arrow_right", wx + 358, wy + 66 + item_pos * 19 - 5);
 }
 
 void UIMenuConfig::_draw_items(ConfigMenu& menu, bool is_root_menu)

--- a/src/elona/ui/ui_menu_equipment.cpp
+++ b/src/elona/ui/ui_menu_equipment.cpp
@@ -93,7 +93,7 @@ bool UIMenuEquipment::init()
     }
 
     window_animation(wx, wy, ww, wh, 9, 4);
-    asset_load("deco_wear");
+    asset_load("core.deco_wear");
     gsel(0);
     windowshadow = 1;
 
@@ -139,9 +139,9 @@ void UIMenuEquipment::_draw_window_deco(bool show_additional_info)
     {
         display_topic(i18n::s.get("core.ui.equip.weight"), wx + 524, wy + 30);
     }
-    draw_indexed("inventory_icon", wx + 46, wy - 16, 10);
-    elona::draw("deco_wear_a", wx + ww - 106, wy);
-    elona::draw("deco_wear_b", wx, wy + wh - 164);
+    draw_indexed("core.inventory_icon", wx + 46, wy - 16, 10);
+    elona::draw("core.deco_wear_a", wx + ww - 106, wy);
+    elona::draw("core.deco_wear_b", wx, wy + wh - 164);
     draw_additional_item_info_label(wx + 350, wy + 40);
 }
 
@@ -183,7 +183,10 @@ void UIMenuEquipment::_draw_key(int cnt, int p_, bool is_main_hand)
     }
 
     draw_indexed(
-        "body_part_icon", wx + 22, wy + 60 + cnt * 19 - 4, list(1, p_) - 1);
+        "core.body_part_icon",
+        wx + 22,
+        wy + 60 + cnt * 19 - 4,
+        list(1, p_) - 1);
     mes(wx + 46, wy + 60 + cnt * 19 + 3, body_part_name);
 }
 

--- a/src/elona/ui/ui_menu_feats.cpp
+++ b/src/elona/ui/ui_menu_feats.cpp
@@ -35,7 +35,7 @@ bool UIMenuFeats::init()
     wx = (windoww - ww) / 2 + inf_screenx;
     wy = winposy(wh);
     window_animation(wx, wy, ww, wh, 9, 4);
-    asset_load("deco_feat");
+    asset_load("core.deco_feat");
     gsel(0);
     windowshadow = 1;
 
@@ -204,11 +204,11 @@ void UIMenuFeats::_draw_window_deco()
     s(2) = i18n::s.get("core.trait.window.detail");
     display_topic(s, wx + 46, wy + 36);
     display_topic(s(2), wx + 255, wy + 36);
-    draw_indexed("inventory_icon", wx + 46, wy - 16, 11);
-    elona::draw("deco_feat_a", wx + ww - 56, wy + wh - 198);
-    elona::draw("deco_feat_b", wx, wy);
-    elona::draw("deco_feat_c", wx + ww - 108, wy);
-    elona::draw("deco_feat_d", wx, wy + wh - 70);
+    draw_indexed("core.inventory_icon", wx + 46, wy - 16, 11);
+    elona::draw("core.deco_feat_a", wx + ww - 56, wy + wh - 198);
+    elona::draw("core.deco_feat_b", wx, wy);
+    elona::draw("core.deco_feat_c", wx + ww - 108, wy);
+    elona::draw("core.deco_feat_d", wx, wy + wh - 70);
 }
 
 
@@ -305,7 +305,10 @@ void UIMenuFeats::_draw_single_list_entry_text(
         x = 70;
     }
     draw_indexed(
-        "trait_icon", wx + (draw_name ? 30 : 45), wy + 61 + cnt * 19, traitref);
+        "core.trait_icon",
+        wx + (draw_name ? 30 : 45),
+        wy + 61 + cnt * 19,
+        traitref);
 
     cs_list(cs == cnt, text, wx + x, wy + 66 + cnt * 19 - 1, 0, text_color);
 

--- a/src/elona/ui/ui_menu_god.cpp
+++ b/src/elona/ui/ui_menu_god.cpp
@@ -51,8 +51,8 @@ bool UIMenuGod::init()
 
     snd("core.pop4");
     gmode(0);
-    asset_load("bg_altar");
-    elona::draw("bg_altar", 0, 0, windoww, windowh - inf_verh);
+    asset_load("core.bg_altar");
+    elona::draw("core.bg_altar", 0, 0, windoww, windowh - inf_verh);
     gsel(0);
 
     return true;
@@ -97,10 +97,11 @@ static std::string _get_god_description(int god_id)
 void UIMenuGod::_draw_window()
 {
     gmode(0);
-    elona::draw_region("bg_altar", 0, 0, 0, 0, windoww, windowh - inf_verh);
+    elona::draw_region(
+        "core.bg_altar", 0, 0, 0, 0, windoww, windowh - inf_verh);
     gmode(2);
     render_hud();
-    const auto& info = get_image_info("bg_altar");
+    const auto& info = get_image_info("core.bg_altar");
     dx = info.width - 80;
     dy = info.height - 130;
     wx = (windoww - dx) / 2 + inf_screenx;

--- a/src/elona/ui/ui_menu_item_desc.cpp
+++ b/src/elona/ui/ui_menu_item_desc.cpp
@@ -97,7 +97,8 @@ _get_pos(int cnt, int list_item, const std::string& list_text)
 void UIMenuItemDesc::_draw_normal_mark(int cnt, int list_item)
 {
     int icon_index = list_item % 10000 - 1;
-    draw_indexed("item_enchant_mark", wx + 40, wy + 61 + cnt * 18, icon_index);
+    draw_indexed(
+        "core.item_enchant_mark", wx + 40, wy + 61 + cnt * 18, icon_index);
 }
 
 void UIMenuItemDesc::_draw_marks(int cnt, int list_item)
@@ -108,7 +109,7 @@ void UIMenuItemDesc::_draw_marks(int cnt, int list_item)
     }
     if (list_item > 10000)
     {
-        elona::draw("inheritance_mark", wx + 15, wy + 63 + cnt * 18);
+        elona::draw("core.inheritance_mark", wx + 15, wy + 63 + cnt * 18);
     }
 }
 

--- a/src/elona/ui/ui_menu_journal.cpp
+++ b/src/elona/ui/ui_menu_journal.cpp
@@ -148,7 +148,7 @@ bool UIMenuJournal::init()
     append_subquest_journal(1);
     listmax = noteinfo();
     show_title(strhint2 + strhint3);
-    const auto& info = get_image_info("book");
+    const auto& info = get_image_info("core.book");
     wx = (windoww - info.width) / 2 + inf_screenx;
     wy = winposy(info.height);
     snd("core.book1");
@@ -169,9 +169,9 @@ void UIMenuJournal::update()
     {
         page = 0;
     }
-    asset_load("book");
+    asset_load("core.book");
     gsel(0);
-    elona::draw("book", wx, wy);
+    elona::draw("core.book", wx, wy);
     for (int cnt = 0, cnt_end = (pagesize); cnt < cnt_end; ++cnt)
     {
         p = pagesize * page + cnt;

--- a/src/elona/ui/ui_menu_keybindings.cpp
+++ b/src/elona/ui/ui_menu_keybindings.cpp
@@ -139,8 +139,8 @@ void UIMenuKeybindings::_draw_background()
     if (mode == 10)
     {
         gmode(0);
-        asset_load("title");
-        elona::draw("title", 0, 0, windoww, windowh);
+        asset_load("core.title");
+        elona::draw("core.title", 0, 0, windoww, windowh);
         gsel(0);
         gmode(0);
         gcopy(4, 0, 0, windoww, windowh, 0, 0);
@@ -157,7 +157,7 @@ bool UIMenuKeybindings::init()
 
     _draw_background();
 
-    const auto& info = asset_load("ie_sheet");
+    const auto& info = asset_load("core.ie_sheet");
     gsel(0);
 
     wx = (windoww - info.width) / 2 + inf_screenx;

--- a/src/elona/ui/ui_menu_materials.cpp
+++ b/src/elona/ui/ui_menu_materials.cpp
@@ -28,7 +28,7 @@ bool UIMenuMaterials::init()
     cs = 0;
     cs_bk = -1;
 
-    const auto& info = asset_load("ie_scroll");
+    const auto& info = asset_load("core.ie_scroll");
     gsel(0);
     snd("core.scroll");
     wx = (windoww - info.width) / 2 + inf_screenx;

--- a/src/elona/ui/ui_menu_message_log.cpp
+++ b/src/elona/ui/ui_menu_message_log.cpp
@@ -26,7 +26,7 @@ void _draw_window()
             const auto x =
                 dx == p ? log_window_width % chunk_width : chunk_width;
             draw_region(
-                "message_window_contents",
+                "core.message_window_contents",
                 dx * chunk_width + inf_msgx,
                 inf_msgy - (dy + 1) * inf_msgspace,
                 0,
@@ -40,7 +40,10 @@ void _draw_window()
     {
         const auto x = dx == p ? log_window_width % chunk_width : chunk_width;
         draw_region(
-            "message_window_border", dx * chunk_width + inf_msgx, inf_msgy, x);
+            "core.message_window_border",
+            dx * chunk_width + inf_msgx,
+            inf_msgy,
+            x);
     }
 }
 

--- a/src/elona/ui/ui_menu_mods.cpp
+++ b/src/elona/ui/ui_menu_mods.cpp
@@ -60,8 +60,8 @@ protected:
 void UIMenuMods::_load_mods()
 {
     // Redraw background as topic size can change, leaving marks
-    asset_load("void");
-    ::draw("void", 0, 0, windoww, windowh);
+    asset_load("core.void");
+    ::draw("core.void", 0, 0, windoww, windowh);
     gsel(0);
     gmode(0);
     gcopy(4, 0, 0, windoww, windowh, 0, 0);

--- a/src/elona/ui/ui_menu_quest_board.cpp
+++ b/src/elona/ui/ui_menu_quest_board.cpp
@@ -56,10 +56,10 @@ static void _populate_quest_list()
 
 void UIMenuQuestBoard::_draw_background()
 {
-    asset_load("deco_board");
+    asset_load("core.deco_board");
     gsel(0);
     gsel(4);
-    draw_bg("deco_board_a");
+    draw_bg("core.deco_board_a");
     ww = 560;
     int h = 140;
     wh = h * 4;
@@ -70,7 +70,7 @@ void UIMenuQuestBoard::_draw_background()
         y = wy + cnt * 120;
         window(wx + 4, y + 4, ww, h, true);
         window(wx, y, ww, h);
-        elona::draw("deco_board_b", wx + 20, y + 8);
+        elona::draw("core.deco_board_b", wx + 20, y + 8);
     }
     render_hud();
     gsel(0);

--- a/src/elona/ui/ui_menu_scene.cpp
+++ b/src/elona/ui/ui_menu_scene.cpp
@@ -49,8 +49,8 @@ static void _load_scenes()
 bool UIMenuScene::init()
 {
     snd("core.book1");
-    asset_load("book");
-    asset_load("g1");
+    asset_load("core.book");
+    asset_load("core.g1");
     gsel(0);
     listmax = 0;
     page = 0;
@@ -76,7 +76,7 @@ void UIMenuScene::update()
     {
         page = 0;
     }
-    const auto& info = get_image_info("book");
+    const auto& info = get_image_info("core.book");
     wx = (windoww - info.width + 16) / 2 + inf_screenx;
     wy = winposy(info.height + 20);
 }
@@ -84,9 +84,9 @@ void UIMenuScene::update()
 void UIMenuScene::_draw_window()
 {
     gmode(2);
-    elona::draw("book", wx, wy);
+    elona::draw("core.book", wx, wy);
     gmode(2, 100);
-    draw_centered("g1", wx + 190, wy + 220, 240, 320);
+    draw_centered("core.g1", wx + 190, wy + 220, 240, 320);
     gmode(2);
 }
 

--- a/src/elona/ui/ui_menu_skills.cpp
+++ b/src/elona/ui/ui_menu_skills.cpp
@@ -55,7 +55,7 @@ bool UIMenuSkills::init()
     }
 
     snd("core.skill");
-    asset_load("deco_skill");
+    asset_load("core.deco_skill");
     gsel(0);
     windowshadow = 1;
 
@@ -93,9 +93,9 @@ void UIMenuSkills::_draw_window()
     display_topic(i18n::s.get("core.ui.skill.cost"), wx + 220, wy + 36);
     display_topic(i18n::s.get("core.ui.skill.detail"), wx + 320, wy + 36);
 
-    draw_indexed("inventory_icon", wx + 46, wy - 16, 14);
-    elona::draw("deco_skill_a", wx + ww - 78, wy + wh - 165);
-    elona::draw("deco_skill_b", wx + ww - 168, wy);
+    draw_indexed("core.inventory_icon", wx + 46, wy - 16, 14);
+    elona::draw("core.deco_skill_a", wx + ww - 78, wy + wh - 165);
+    elona::draw("core.deco_skill_b", wx + ww - 168, wy);
 }
 
 void UIMenuSkills::_draw_key(int cnt)

--- a/src/elona/ui/ui_menu_spells.cpp
+++ b/src/elona/ui/ui_menu_spells.cpp
@@ -46,7 +46,7 @@ bool UIMenuSpells::init()
     }
 
     snd("core.spell");
-    asset_load("deco_spell");
+    asset_load("core.deco_spell");
     gsel(0);
     windowshadow = 1;
 
@@ -87,9 +87,9 @@ void UIMenuSpells::_draw_window()
         wy + 36);
     display_topic(i18n::s.get("core.ui.spell.effect"), wx + 400, wy + 36);
 
-    draw_indexed("inventory_icon", wx + 46, wy - 16, 13);
-    elona::draw("deco_spell_a", wx + ww - 78, wy);
-    elona::draw("deco_spell_b", wx + ww - 180, wy);
+    draw_indexed("core.inventory_icon", wx + 46, wy - 16, 13);
+    elona::draw("core.deco_spell_a", wx + ww - 78, wy);
+    elona::draw("core.deco_spell_b", wx + ww - 180, wy);
 }
 
 void UIMenuSpells::_draw_key(int cnt)

--- a/src/elona/ui/ui_menu_town_chart.cpp
+++ b/src/elona/ui/ui_menu_town_chart.cpp
@@ -23,9 +23,9 @@ void UIMenuTownChart::update()
     cs = 0;
     cs_bk = -1;
     snd("core.chat");
-    asset_load("deco_politics");
+    asset_load("core.deco_politics");
     gsel(0);
-    draw_bg("deco_politics_a");
+    draw_bg("core.deco_politics_a");
     render_hud();
     windowshadow = 1;
 
@@ -86,7 +86,7 @@ void UIMenuTownChart::draw()
                     wx + (ww - 70) / (row.size() + 1) * (column_count + 1);
                 const auto y = wy + 70 + row_count * 55;
 
-                elona::draw("deco_politics_b", x - 26, y - 3);
+                elona::draw("core.deco_politics_b", x - 26, y - 3);
 
                 key_list(post_count) = key_select(post_count);
                 ++keyrange;

--- a/src/elona/ui/ui_menu_town_economy.cpp
+++ b/src/elona/ui/ui_menu_town_economy.cpp
@@ -34,11 +34,11 @@ bool UIMenuTownEconomy::init()
     keyrange = 0;
     pagesize = 1;
     listmax = 2;
-    asset_load("deco_politics");
+    asset_load("core.deco_politics");
     gsel(0);
-    draw_bg("deco_politics_a");
+    draw_bg("core.deco_politics_a");
     render_hud();
-    asset_load("ie_scroll");
+    asset_load("core.ie_scroll");
     gsel(0);
     windowshadow = 1;
     snd("core.scroll");

--- a/src/elona/ui/ui_menu_town_politics.cpp
+++ b/src/elona/ui/ui_menu_town_politics.cpp
@@ -49,11 +49,11 @@ bool UIMenuTownPolitics::init()
     bool is_town = map_data.type == mdata_t::MapType::town;
     _load_politics_list(is_town);
 
-    asset_load("deco_politics");
+    asset_load("core.deco_politics");
     gsel(0);
-    draw_bg("deco_politics_a");
+    draw_bg("core.deco_politics_a");
     render_hud();
-    asset_load("ie_scroll");
+    asset_load("core.ie_scroll");
     gsel(0);
     windowshadow = 1;
     snd("core.scroll");
@@ -97,9 +97,9 @@ void UIMenuTownPolitics::_draw_window()
     }
 
     gmode(2);
-    draw_indexed("politics_law", wx + 155, wy + 46, 1);
+    draw_indexed("core.politics_law", wx + 155, wy + 46, 1);
     gmode(2);
-    draw_indexed("politics_law", wx + 255, wy + 46, 0);
+    draw_indexed("core.politics_law", wx + 255, wy + 46, 0);
 }
 
 void UIMenuTownPolitics::_draw_key(int cnt)
@@ -134,7 +134,8 @@ _draw_single_list_entry(int cnt, int list_item, const std::string& text)
 {
     cs_list(cs == cnt, text, wx + 100, wy + 76 + cnt * 19 - 1);
     gmode(2);
-    draw_indexed("politics_law", wx + 42, wy + 68 + cnt * 19 + 2, list_item);
+    draw_indexed(
+        "core.politics_law", wx + 42, wy + 68 + cnt * 19 + 2, list_item);
 }
 
 void UIMenuTownPolitics::_draw_list_entries()


### PR DESCRIPTION
# Summary

For simplicity and consistency. Previously, if an asset ID is not namespaced, foobar implicitly assumes it belongs to `core` mod. Such implicit "magic" is error-prone, I believe.