### PR TITLE
Organize mod manifest's fields

### DIFF
--- a/runtime/mod/core/mod.json
+++ b/runtime/mod/core/mod.json
@@ -1,8 +1,11 @@
 {
   id: "core",
   name: "Core Content",
-  author: "KI, Ruin0x11",
+  authors: "KI, Ruin0x11",
   version: "0.2.6",
   license: "MIT",
-  description: "Base game content. Currently, the game cannot be run without this mod.",
+  description: {
+    jp: "ゲームの基本コンテンツ。Elona foobar の動作にはこの MOD が必須です。",
+    en: "Base game content. Elona foobar cannot be run without this mod.",
+  },
 }

--- a/runtime/mod/template_blank/mod.json
+++ b/runtime/mod/template_blank/mod.json
@@ -1,7 +1,7 @@
 {
   id: "template_blank",
   name: "Template blank",
-  author: "Your name here",
+  authors: "Your name here",
   version: "0.1.0",
   license: "Elona foobar License v1",
   description: "Mod description here",

--- a/src/elona/lua_env/mod_manager.cpp
+++ b/src/elona/lua_env/mod_manager.cpp
@@ -372,7 +372,7 @@ void ModManager::create_mod_from_template(
     auto new_mod_manifest = ModManifest::load(to / "mod.json");
     new_mod_manifest.id = new_mod_id;
     new_mod_manifest.version = new_mod_version;
-    new_mod_manifest.name = new_mod_id;
+    new_mod_manifest.name.default_text = new_mod_id;
     new_mod_manifest.save();
 }
 

--- a/src/elona/lua_env/mod_manifest.cpp
+++ b/src/elona/lua_env/mod_manifest.cpp
@@ -12,104 +12,170 @@ namespace lua
 namespace
 {
 
-std::string _read_string(
-    const std::string key,
-    const json5::value::object_type& obj,
-    const fs::path& path)
+struct JSONTable
 {
-    // TODO: Clean up, as with lua::ConfigTable
-    const auto itr = obj.find(key);
-    if (itr != std::end(obj) && itr->second.is_string())
+public:
+    JSONTable(const fs::path& path)
+        : _path(path.to_u8string())
     {
-        return itr->second.get_string();
-    }
-    else
-    {
-        throw std::runtime_error(
-            path.to_u8string() + ": Missing \"" + key + "\" in mod manifest");
-    }
-}
-
-
-
-semver::Version _read_mod_version(
-    const json5::value::object_type& obj,
-    const fs::path& path)
-{
-    // TODO: Clean up, as with lua::ConfigTable
-    const auto itr = obj.find("version");
-    if (itr == std::end(obj))
-    {
-        return semver::Version{};
-    }
-
-    if (itr->second.is_string())
-    {
-        if (const auto result =
-                semver::Version::parse(itr->second.get_string()))
+        std::ifstream in{path.native()};
+        if (!in)
         {
-            return result.right();
+            throw std::runtime_error{"failed to open " + _path + " to read"};
+        }
+        std::string source{
+            std::istreambuf_iterator<char>{in},
+            std::istreambuf_iterator<char>{}};
+        try
+        {
+            const auto value = json5::parse(source);
+            _root_object = value.get_object();
+        }
+        catch (json5::syntax_error& err)
+        {
+            throw std::runtime_error{
+                "failed to parse " + _path + ": " + err.what()};
+        }
+        catch (json5::invalid_type_error& err)
+        {
+            throw std::runtime_error{
+                "the root value of " + _path +
+                " is not an object: " + err.what()};
+        }
+    }
+
+
+
+    template <typename T>
+    T get(const char* key)
+    {
+        if (const auto value = try_get(key))
+        {
+            return convert<T>(*value, key);
         }
         else
         {
-            throw std::runtime_error{result.left()};
+            throw std::runtime_error{
+                "failed to load " + _path + ": property \"" + key +
+                "\" is required"};
         }
+    }
+
+
+    template <typename T>
+    T get_or(const char* key, const T& default_value)
+    {
+        if (const auto value = try_get(key))
+        {
+            return convert<T>(*value, key);
+        }
+        else
+        {
+            return default_value;
+        }
+    }
+
+
+    template <typename T>
+    T get_or_default(const char* key)
+    {
+        return get_or(key, T{});
+    }
+
+
+
+private:
+    std::string _path;
+    json5::value::object_type _root_object;
+
+
+
+    optional_ref<json5::value> try_get(const char* key)
+    {
+        const auto itr = _root_object.find(key);
+        if (itr == std::end(_root_object))
+        {
+            return none;
+        }
+        else
+        {
+            return itr->second;
+        }
+    }
+
+
+    template <typename T>
+    T convert(const json5::value& value, const char* key);
+};
+
+
+
+template <>
+std::string JSONTable::convert<std::string>(
+    const json5::value& value,
+    const char* key)
+{
+    if (!value.is_string())
+    {
+        throw std::runtime_error{
+            "failed to load " + _path + ": property \"" + key +
+            "\" must be a string, but " + to_string(value.type())};
+    }
+    return value.get_string();
+}
+
+
+
+template <>
+semver::Version JSONTable::convert<semver::Version>(
+    const json5::value& value,
+    const char* key)
+{
+    const auto str = convert<std::string>(value, key);
+    if (const auto parse_result = semver::Version::parse(str))
+    {
+        return parse_result.right();
     }
     else
     {
-        throw std::runtime_error(
-            path.to_u8string() + ": Missing \"version\" in mod manifest");
+        throw std::runtime_error{
+            "failed to load " + _path + ": " + parse_result.left()};
     }
 }
 
 
 
-ModManifest::Dependencies _read_dependencies(
-    const json5::value::object_type& obj,
-    const fs::path& path)
+template <>
+ModManifest::Dependencies JSONTable::convert<ModManifest::Dependencies>(
+    const json5::value& value,
+    const char* key)
 {
+    if (!value.is_object())
+    {
+        throw std::runtime_error{
+            "failed to load " + _path + ": property \"" + key +
+            "\" must be an object, but " + to_string(value.type())};
+    }
     ModManifest::Dependencies result;
-
-    const auto itr = obj.find("dependencies");
-    if (itr != std::end(obj))
+    for (const auto& [mod, version] : value.get_object())
     {
-        if (itr->second.is_object())
+        if (!version.is_string())
         {
-            const auto& dependencies = itr->second.get_object();
-
-            for (const auto& kvp : dependencies)
-            {
-                const auto& mod = kvp.first;
-                const auto& version = kvp.second;
-                if (version.is_string())
-                {
-                    if (const auto req = semver::VersionRequirement::parse(
-                            version.get_string()))
-                    {
-                        result.emplace(mod, req.right());
-                    }
-                    else
-                    {
-                        throw std::runtime_error(
-                            path.to_u8string() + ": " + req.left());
-                    }
-                }
-                else
-                {
-                    throw std::runtime_error(
-                        path.to_u8string() +
-                        ": \"dependencies\" field must be an object.");
-                }
-            }
+            throw std::runtime_error{
+                "failed to load " + _path + ": key of \"" + key +
+                "\" must be a string, but " + to_string(version.type())};
+        }
+        if (const auto req =
+                semver::VersionRequirement::parse(version.get_string()))
+        {
+            result.emplace(mod, req.right());
         }
         else
         {
-            throw std::runtime_error(
-                path.to_u8string() +
-                ": \"dependencies\" field must be an object.");
+            throw std::runtime_error{
+                "failed to load " + _path + ": " + req.left()};
         }
     }
-
     return result;
 }
 
@@ -119,30 +185,25 @@ ModManifest::Dependencies _read_dependencies(
 
 ModManifest ModManifest::load(const fs::path& path)
 {
-    // TODO loading error handling.
-    std::ifstream in{path.native()};
-    std::string source{
-        std::istreambuf_iterator<char>{in}, std::istreambuf_iterator<char>{}};
-    const auto value = json5::parse(source);
-    const auto& obj = value.get_object();
+    JSONTable table{path};
 
-    const auto mod_id = _read_string("id", obj, path);
-    const auto mod_name = _read_string("name", obj, path);
-    const auto mod_author = _read_string("author", obj, path);
-    const auto mod_description = _read_string("description", obj, path);
-    const auto mod_license = _read_string("license", obj, path);
-    const auto version = _read_mod_version(obj, path);
-    const auto mod_path = path.parent_path();
-    const auto dependencies = _read_dependencies(obj, path);
+    const auto id = table.get<std::string>("id");
+    const auto name = table.get_or<std::string>("name", id);
+    const auto author = table.get_or_default<std::string>("author");
+    const auto description = table.get_or_default<std::string>("description");
+    const auto license = table.get_or_default<std::string>("license");
+    const auto version = table.get<semver::Version>("version");
+    const auto dependencies =
+        table.get_or_default<ModManifest::Dependencies>("dependencies");
 
     return {
-        mod_id,
-        mod_name,
-        mod_author,
-        mod_description,
-        mod_license,
+        id,
+        name,
+        author,
+        description,
+        license,
         version,
-        mod_path,
+        path.parent_path(),
         dependencies,
     };
 }

--- a/src/elona/lua_env/mod_manifest.hpp
+++ b/src/elona/lua_env/mod_manifest.hpp
@@ -18,6 +18,32 @@ struct ModManifest
     using Dependencies =
         std::unordered_map<std::string, semver::VersionRequirement>;
 
+
+    struct LocalizableString
+    {
+        std::string default_text;
+        std::unordered_map<std::string, std::string> localized_strings;
+
+
+        LocalizableString() = default;
+
+
+        std::string localize(const std::string& locale_id) const
+        {
+            if (const auto itr = localized_strings.find(locale_id);
+                itr != localized_strings.end())
+            {
+                return itr->second;
+            }
+            else
+            {
+                return default_text;
+            }
+        }
+    };
+
+
+
     /**
      * Loads a mod manifest from a mod.json file.
      */
@@ -29,14 +55,41 @@ struct ModManifest
      */
     void save() const;
 
+
+
+    /// The ID. It must be unique. (Required field)
     std::string id;
-    std::string name;
-    std::string author;
-    std::string description;
+
+    /// The display name. It can be localized. (Optional field)
+    LocalizableString name;
+
+    /// The author(s) name. (Optional field)
+    std::string authors;
+
+    /// The description. It can be localized. (Optional field)
+    LocalizableString description;
+
+    /// The license. (Optional field)
     std::string license;
+
+    /// The version. (Required field)
     semver::Version version;
-    optional<fs::path> path;
+
+    /// The dependencies. (Optional field)
     Dependencies dependencies;
+
+    /// The optional dependencies. (Optional field)
+    Dependencies optional_dependencies;
+
+    /// The homepage. (Optional field)
+    std::string homepage;
+
+    /// The tags. (Optional field)
+    std::vector<std::string> tags;
+
+    /// The folder where the mod is located. If it is `none`, the mod is a
+    /// pseudo-mod and does not have phyisical folder.
+    optional<fs::path> path;
 };
 
 } // namespace lua

--- a/src/elona/lua_env/mod_version_resolver.cpp
+++ b/src/elona/lua_env/mod_version_resolver.cpp
@@ -82,7 +82,7 @@ auto calculate_loading_order(
         const auto& version = pair.second;
         sorter.add(mod);
 
-        for (const auto& dep_mod_id : index.get_dependencies(mod, version))
+        for (const auto& [dep_mod_id, _] : index.get_dependencies(mod, version))
         {
             sorter.add_dependency(mod, dep_mod_id);
         }
@@ -218,8 +218,8 @@ ModIndex::QueryResult ModIndex::query_latest(
 
 
 
-std::vector<std::string> ModIndex::get_dependencies(
-    const std::string& id,
+const ModIndex::IndexEntry& ModIndex::get_index_entry(
+    const ModId& id,
     const semver::Version& version) const
 {
     const auto itr = _mods.find(id);
@@ -232,12 +232,7 @@ std::vector<std::string> ModIndex::get_dependencies(
     {
         if (v.version == version)
         {
-            std::vector<std::string> ret;
-            for (const auto& pair : v.dependencies)
-            {
-                ret.push_back(pair.first);
-            }
-            return ret;
+            return v;
         }
     }
     throw std::runtime_error{

--- a/src/elona/lua_env/mod_version_resolver.hpp
+++ b/src/elona/lua_env/mod_version_resolver.hpp
@@ -75,6 +75,7 @@ public:
     {
         semver::Version version;
         Dependencies dependencies;
+        Dependencies optional_dependencies;
     };
 
 
@@ -101,6 +102,14 @@ public:
         const semver::Version& version) const
     {
         return get_index_entry(id, version).dependencies;
+    }
+
+
+    const Dependencies& get_optional_dependencies(
+        const ModId& id,
+        const semver::Version& version) const
+    {
+        return get_index_entry(id, version).optional_dependencies;
     }
 
 

--- a/src/elona/lua_env/mod_version_resolver.hpp
+++ b/src/elona/lua_env/mod_version_resolver.hpp
@@ -67,11 +67,14 @@ struct ModLock
 struct ModIndex
 {
 public:
+    using ModId = std::string;
+    using Dependencies = std::unordered_map<ModId, semver::VersionRequirement>;
+
+
     struct IndexEntry
     {
         semver::Version version;
-        std::unordered_map<std::string, semver::VersionRequirement>
-            dependencies;
+        Dependencies dependencies;
     };
 
 
@@ -82,29 +85,38 @@ public:
     static ModIndex traverse(const fs::path& mod_root_dir);
 
 
-    ModIndex(
-        const std::unordered_map<std::string, std::vector<IndexEntry>>& mods)
+    ModIndex(const std::unordered_map<ModId, std::vector<IndexEntry>>& mods)
         : _mods(mods)
     {
     }
 
 
     QueryResult query_latest(
-        const std::string& id,
+        const ModId& id,
         const semver::VersionRequirement& requirement) const;
 
 
-    std::vector<std::string> get_dependencies(
-        const std::string& id,
-        const semver::Version& version) const;
+    const Dependencies& get_dependencies(
+        const ModId& id,
+        const semver::Version& version) const
+    {
+        return get_index_entry(id, version).dependencies;
+    }
 
 
     // for debugging
     std::string to_string() const;
 
 
+
 private:
-    std::unordered_map<std::string, std::vector<IndexEntry>> _mods;
+    std::unordered_map<ModId, std::vector<IndexEntry>> _mods;
+
+
+
+    const IndexEntry& get_index_entry(
+        const ModId& id,
+        const semver::Version& version) const;
 };
 
 

--- a/src/elona/main_menu.cpp
+++ b/src/elona/main_menu.cpp
@@ -1494,7 +1494,7 @@ MainMenuResult main_menu_mods_develop()
     {
         list(0, template_count) = template_count;
         listn(0, template_count) = tmpl.id + " v" + tmpl.version.to_string();
-        listn(1, template_count) = tmpl.name;
+        listn(1, template_count) = tmpl.name.localize(g_config.language());
         mod_id_and_versions.emplace_back(tmpl.id, tmpl.version);
         key_list(template_count) = key_select(template_count);
         ++template_count;

--- a/src/elona/ui/ui_menu_mod_info.cpp
+++ b/src/elona/ui/ui_menu_mod_info.cpp
@@ -144,7 +144,7 @@ void UIMenuModInfo::_draw_mod_page()
         false);
     gmes(
         "<b>" + i18n::s.get("core.main_menu.mod_list.info.author") + ":<def> " +
-            _desc.manifest.author,
+            _desc.manifest.authors,
         wx + 30,
         y + 16,
         570,
@@ -160,7 +160,8 @@ void UIMenuModInfo::_draw_mod_page()
         false);
     gmes(
         "<b>" + i18n::s.get("core.main_menu.mod_list.info.description") +
-            ":<def> " + _desc.manifest.description,
+            ":<def> " +
+            _desc.manifest.description.localize(g_config.language()),
         wx + 30,
         y + 48,
         570,
@@ -188,7 +189,7 @@ void UIMenuModInfo::_draw_mod_page()
 void UIMenuModInfo::_draw_window()
 {
     ui_display_window(
-        _desc.manifest.name,
+        _desc.manifest.name.localize(g_config.language()),
         strhint2 + strhint3b,
         (windoww - 700) / 2 + inf_screenx,
         winposy(480, 1),

--- a/src/elona/ui/ui_menu_mods.cpp
+++ b/src/elona/ui/ui_menu_mods.cpp
@@ -229,7 +229,7 @@ void UIMenuMods::_draw_mod_list()
 
         cs_list(
             cs == cnt,
-            desc.manifest.name,
+            desc.manifest.name.localize(g_config.language()),
             wx + 84,
             wy + 66 + cnt * 19 - 1,
             0,


### PR DESCRIPTION
# Related Issues

Close #1736.
Close #1737.


# Summary

## Added fields

* `optional_dependencies`
    * It controls the loading order.
* `homepage`
    * The homepage URL.
* `tags`
    * Mod's categories

## Renamed fields

* `author` -> `authors`

## Misc.

Also, `name` and `description` fields now can be localized.