### PR TITLE
Move some enum constants to Lua side (#1723)

### DIFF
--- a/runtime/data/script/core/enums.lua
+++ b/runtime/data/script/core/enums.lua
@@ -1,0 +1,60 @@
+local Enums = {}
+
+
+local function new_enum(definitions)
+   local enum = {}
+   for k, v in pairs(definitions) do
+      enum[k] = v
+      enum[v] = k
+   end
+   return enum
+end
+
+Enums.new_enum = new_enum
+
+
+
+--- @enum CurseState
+---
+--- The curse state of an item.
+--- @usage local item = Item.create(10, 10, "core.putitoro", 3)
+--- item.curse_state = "Blessed"
+Enums.CurseState = new_enum {
+   doomed = -2,
+   cursed = -1,
+   none = 0,
+   blessed = 1,
+}
+
+
+
+--- @enum IdentifyState
+---
+--- The identify state of an item.
+--- @usage local item = Item.create(10, 10, "core.putitoro", 3)
+--- item.identify_state = "Completely"
+Enums.IdentifyState = new_enum {
+   unidentified = 0,
+   partly = 1,
+   almost = 2,
+   completely = 3,
+}
+
+
+
+--- @enum Quality
+---
+--- The quality of randomly generated equipment.
+Enums.Quality = new_enum {
+   none = 0,
+   bad = 1,
+   good = 2,
+   great = 3,
+   miracle = 4,
+   godly = 5,
+   special = 6,
+}
+
+
+
+return Enums

--- a/runtime/data/script/core/init.lua
+++ b/runtime/data/script/core/init.lua
@@ -1,6 +1,7 @@
 local core = {}
 
 
+core.Enums = require("core.enums")
 core.I18N = require("core.i18n")
 
 

--- a/runtime/mod/core/api/impl/shop_inventory.lua
+++ b/runtime/mod/core/api/impl/shop_inventory.lua
@@ -1,4 +1,5 @@
 local Data = ELONA.require("core.Data")
+local Enums = ELONA.require("core.Enums")
 local Inventory = ELONA.require("core.Inventory")
 local Item = ELONA.require("core.Item")
 local math = math
@@ -56,7 +57,7 @@ function shop_inventory.apply_rule_properties(rule, ret, index, shopkeeper)
 end
 
 function shop_inventory.apply_rules(index, shopkeeper, inv)
-   local ret = {level = shopkeeper.shop_rank, quality = "bad"}
+   local ret = {level = shopkeeper.shop_rank, quality = Enums.Quality.bad}
 
    if not inv.rules then
       return ret
@@ -110,7 +111,7 @@ local function is_excluded(item)
 end
 
 local function is_cursed(item)
-   return item.curse_state == "cursed" or item.curse_state == "doomed"
+   return item.curse_state == Enums.CurseState.cursed or item.curse_state == Enums.CurseState.doomed
 end
 
 function shop_inventory.should_remove(item, inv)
@@ -277,7 +278,7 @@ function shop_inventory.do_generate(shopkeeper, inv)
       end
 
       -- Blessed items are never generated in multiple (per cycle).
-      if item.curse_state == "blessed" then
+      if item.curse_state == Enums.CurseState.blessed then
          item.number = 1
       end
 

--- a/runtime/mod/core/api/impl/show_dialog.lua
+++ b/runtime/mod/core/api/impl/show_dialog.lua
@@ -3,6 +3,7 @@ local Data = ELONA.require("core.Data")
 local I18N = ELONA.require("core.I18N")
 local Input = ELONA.require("core.Input")
 local Internal = ELONA.require("core.Internal")
+local Enums = ELONA.require("core.Enums")
 local table = table
 
 local function dialog_error(talk, msg, err)
@@ -60,7 +61,7 @@ local function query(talk, text, choices, default_choice)
       image = talk.speaker.image
    end
    local show_impress = true
-   if talk.speaker.quality == "special" and not Chara.is_ally(talk.speaker) then
+   if talk.speaker.quality == Enums.Quality.special and not Chara.is_ally(talk.speaker) then
       show_impress = false
    end
 

--- a/runtime/mod/core/data/blending_recipe.lua
+++ b/runtime/mod/core/data/blending_recipe.lua
@@ -1,5 +1,6 @@
 local Chara = ELONA.require("core.Chara")
 local Enchantment = ELONA.require("core.Enchantment")
+local Enums = ELONA.require("core.Enums")
 local GUI = ELONA.require("core.GUI")
 local I18N = ELONA.require("core.I18N")
 local Inventory = ELONA.require("core.Inventory")
@@ -181,13 +182,13 @@ ELONA.data:add(
             local target, water = args.materials[1], args.materials[2]
 
             GUI.txt(I18N.get("core.action.dip.result.blessed_item", target, water), "green")
-            if water.curse_state == "blessed" then
+            if water.curse_state == Enums.CurseState.blessed then
                GUI.txt(I18N.get("core.action.dip.result.becomes_blessed", target), "orange")
-               target.curse_state = "blessed"
+               target.curse_state = Enums.CurseState.blessed
             end
-            if water.curse_state == "cursed" or water.curse_state == "doomed" then
+            if water.curse_state == Enums.CurseState.cursed or water.curse_state == Enums.CurseState.doomed then
                GUI.txt(I18N.get("core.action.dip.result.becomes_cursed", target), "purple")
-               target.curse_state = "cursed"
+               target.curse_state = Enums.CurseState.cursed
             end
             GUI.play_sound("core.drink1")
          end,
@@ -258,7 +259,7 @@ ELONA.data:add(
                World.data.holy_well_count = World.data.holy_well_count - 1
                natural_potion = Item.create(-1, -1, { id = "core.bottle_of_water", inventory = Inventory.player() })
                if natural_potion then
-                  natural_potion.curse_state = "blessed"
+                  natural_potion.curse_state = Enums.CurseState.blessed
                end
             else
                well.param1 = well.param1 - 3

--- a/runtime/mod/core/data/chara_drop.lua
+++ b/runtime/mod/core/data/chara_drop.lua
@@ -2,6 +2,7 @@ local Chara = ELONA.require("core.Chara")
 local Item = ELONA.require("core.Item")
 local Map = ELONA.require("core.Map")
 local Rand = ELONA.require("core.Rand")
+local Enums = ELONA.require("core.Enums")
 
 -- Returns 'drops' table from array of item IDs.
 local function make_drops(ids)
@@ -148,7 +149,7 @@ ELONA.data:add(
                                             {
                                                level = args.chara.level,
                                                flttypemajor = 92000,
-                                               quality = "good",
+                                               quality = Enums.Quality.good,
                                                nostack = true
                                             }
                      )

--- a/runtime/mod/core/data/dialog/unique/doria.lua
+++ b/runtime/mod/core/data/dialog/unique/doria.lua
@@ -1,12 +1,13 @@
 local Chara = ELONA.require("core.Chara")
 local Data = ELONA.require("core.Data")
-local Internal = ELONA.require("core.Internal")
-local Rand = ELONA.require("core.Rand")
+local Enums = ELONA.require("core.Enums")
 local GUI = ELONA.require("core.GUI")
-local math = math
 local I18N = ELONA.require("core.I18N")
+local Internal = ELONA.require("core.Internal")
 local Item = ELONA.require("core.Item")
+local Rand = ELONA.require("core.Rand")
 local World = ELONA.require("core.World")
+local math = math
 local table = table
 local string = string
 
@@ -45,7 +46,7 @@ end
 
 local function receive_reward()
    World.data.fighters_guild_quota_recurring = false
-   Item.create(Chara.player().position, {objlv = 51 - World.data.ranks[8] // 200, quality = "good", flttypemajor = 10000})
+   Item.create(Chara.player().position, {objlv = 51 - World.data.ranks[8] // 200, quality = Enums.Quality.good, flttypemajor = 10000})
    Item.create(Chara.player().position, "core.gold_piece", 10000 - World.data.ranks[8] + 1000)
    Item.create(Chara.player().position, "core.platinum_coin", math.clamp(4 - World.data.ranks[8] // 2500, 1, 4))
 

--- a/runtime/mod/core/data/dialog/unique/karam.lua
+++ b/runtime/mod/core/data/dialog/unique/karam.lua
@@ -1,4 +1,5 @@
 local Chara = ELONA.require("core.Chara")
+local Enums = ELONA.require("core.Enums")
 local GUI = ELONA.require("core.GUI")
 local I18N = ELONA.require("core.I18N")
 local Internal = ELONA.require("core.Internal")
@@ -33,7 +34,7 @@ return {
                   Chara.player().position,
                   {
                      level = Map.data.current_dungeon_level,
-                     quality = "bad",
+                     quality = Enums.Quality.bad,
                      flttypemajor = Internal.filter_set_dungeon()
                   }
                )

--- a/runtime/mod/core/data/dialog/unique/lomias.lua
+++ b/runtime/mod/core/data/dialog/unique/lomias.lua
@@ -1,4 +1,5 @@
 local Chara = ELONA.require("core.Chara")
+local Enums = ELONA.require("core.Enums")
 local GUI = ELONA.require("core.GUI")
 local I18N = ELONA.require("core.I18N")
 local Internal = ELONA.require("core.Internal")
@@ -74,7 +75,7 @@ return {
             function()
                GUI.txt(I18N.get("core.common.something_is_put_on_the_ground"))
                local scroll = Item.create(Chara.player().position, "core.scroll_of_identify", 0)
-               scroll.identify_state = "completely"
+               scroll.identify_state = Enums.IdentifyState.completely
             end,
             {"tutorial.after_dig.dialog"},
          },
@@ -190,7 +191,7 @@ return {
          on_finish = function()
             local corpse = Item.create(Chara.player().position, "core.corpse", 0)
             corpse.subname = 9
-            corpse.identify_state = "completely"
+            corpse.identify_state = Enums.IdentifyState.completely
             GUI.txt(I18N.get("core.common.something_is_put_on_the_ground"))
             Internal.set_quest_flag("tutorial", 1)
          end
@@ -246,12 +247,12 @@ return {
          },
          on_finish = function()
             local item = Item.create(Chara.player().position, "core.long_bow", 0)
-            item.curse_state = "cursed"
+            item.curse_state = Enums.CurseState.cursed
             item = Item.create(Chara.player().position, "core.arrow", 0)
-            item.curse_state = "none"
+            item.curse_state = Enums.CurseState.none
             item = Item.create(Chara.player().position, "core.scroll_of_vanish_curse", 0)
-            item.identify_state = "completely"
-            item.curse_state = "blessed"
+            item.identify_state = Enums.IdentifyState.completely
+            item.curse_state = Enums.CurseState.blessed
             GUI.txt(I18N.get("core.common.something_is_put_on_the_ground"))
             Internal.set_quest_flag("tutorial", 5)
          end
@@ -272,7 +273,7 @@ return {
                putit:set_flag("is_not_attacked_by_enemy", true)
             end
             local item = Item.create(Chara.player().position, "core.potion_of_cure_minor_wound", 0)
-            item.identify_state = "completely"
+            item.identify_state = Enums.IdentifyState.completely
             Internal.set_quest_flag("tutorial", 6)
          end
       }

--- a/runtime/mod/core/data/dialog/unique/miches.lua
+++ b/runtime/mod/core/data/dialog/unique/miches.lua
@@ -1,4 +1,5 @@
 local Chara = ELONA.require("core.Chara")
+local Enums = ELONA.require("core.Enums")
 local GUI = ELONA.require("core.GUI")
 local Internal = ELONA.require("core.Internal")
 local Item = ELONA.require("core.Item")
@@ -59,8 +60,8 @@ return {
       quest_finish = {
          text = {
             function()
-               Item.create(Chara.player().position, {id = "core.small_shield", level = 10, quality = "good"})
-               Item.create(Chara.player().position, {id = "core.girdle", level = 10, quality = "good"})
+               Item.create(Chara.player().position, {id = "core.small_shield", level = 10, quality = Enums.Quality.good})
+               Item.create(Chara.player().position, {id = "core.girdle", level = 10, quality = Enums.Quality.good})
                Item.create(Chara.player().position, "core.gold_piece", 3000)
                Item.create(Chara.player().position, "core.platinum_coin", 2)
 

--- a/runtime/mod/core/data/dialog/unique/slan.lua
+++ b/runtime/mod/core/data/dialog/unique/slan.lua
@@ -1,4 +1,5 @@
 local Chara = ELONA.require("core.Chara")
+local Enums = ELONA.require("core.Enums")
 local GUI = ELONA.require("core.GUI")
 local I18N = ELONA.require("core.I18N")
 local Internal = ELONA.require("core.Internal")

--- a/runtime/mod/core/data/map.lua
+++ b/runtime/mod/core/data/map.lua
@@ -1,4 +1,5 @@
 local Calc = ELONA.require("core.Calc")
+local Enums = ELONA.require("core.Enums")
 local Map = ELONA.require("core.Map")
 local math = math
 local Rand = ELONA.require("core.Rand")
@@ -8,7 +9,7 @@ local map = require("map/static.lua")
 
 local function chara_filter_town(callbacks)
    return function()
-      local opts = { level = 10, quality = "bad", fltselect = 5 }
+      local opts = { level = 10, quality = Enums.Quality.bad, fltselect = 5 }
 
       if callbacks == nil then
          return opts
@@ -489,7 +490,7 @@ ELONA.data:add(
          can_return_to = true,
          shows_floor_count_in_name = true,
          chara_filter = function()
-            local opts = { objlv = Calc.calc_objlv(Map.current_dungeon_level()), quality = "bad" }
+            local opts = { objlv = Calc.calc_objlv(Map.current_dungeon_level()), quality = Enums.Quality.bad }
 
             if Map.current_dungeon_level() < 4 and opts.objlv > 5 then
                opts.objlv = 5
@@ -517,7 +518,7 @@ ELONA.data:add(
          can_return_to = true,
          prevents_domination = true,
          chara_filter = function()
-            return { level = math.modf(Map.current_dungeon_level(), 50) + 5, quality = "bad" }
+            return { level = math.modf(Map.current_dungeon_level(), 50) + 5, quality = Enums.Quality.bad }
          end
       },
       tower_of_fire = {
@@ -537,7 +538,7 @@ ELONA.data:add(
          default_ai_calm = 0,
 
          chara_filter = function()
-            return { level = Map.current_dungeon_level(), quality = "bad", fltn = "fire" }
+            return { level = Map.current_dungeon_level(), quality = Enums.Quality.bad, fltn = "fire" }
          end
       },
       crypt_of_the_damned = {
@@ -557,7 +558,7 @@ ELONA.data:add(
          default_ai_calm = 0,
 
          chara_filter = function()
-            return { level = Map.current_dungeon_level(), quality = "bad", fltn = "undead" }
+            return { level = Map.current_dungeon_level(), quality = Enums.Quality.bad, fltn = "undead" }
          end
       },
       ancient_castle = {
@@ -577,7 +578,7 @@ ELONA.data:add(
          default_ai_calm = 0,
 
          chara_filter = function()
-            local opts = { level = Map.current_dungeon_level(), quality = "bad" }
+            local opts = { level = Map.current_dungeon_level(), quality = Enums.Quality.bad }
 
             if Rand.one_in(2) then
                opts.fltn = "man"
@@ -603,7 +604,7 @@ ELONA.data:add(
          default_ai_calm = 0,
 
          chara_filter = function()
-            return { level = Map.current_dungeon_level(), quality = "bad" }
+            return { level = Map.current_dungeon_level(), quality = Enums.Quality.bad }
          end
       },
       mountain_pass = {
@@ -657,7 +658,7 @@ ELONA.data:add(
          default_ai_calm = 0,
 
          chara_filter = function()
-            local opts = { level = Map.current_dungeon_level(), quality = "bad" }
+            local opts = { level = Map.current_dungeon_level(), quality = Enums.Quality.bad }
 
             if Rand.one_in(2) then
                opts.fltn = "mino"
@@ -683,7 +684,7 @@ ELONA.data:add(
          default_ai_calm = 0,
 
          chara_filter = function()
-            local opts = { level = Map.current_dungeon_level(), quality = "bad" }
+            local opts = { level = Map.current_dungeon_level(), quality = Enums.Quality.bad }
 
             if Rand.one_in(2) then
                opts.fltn = "yeek"
@@ -710,7 +711,7 @@ ELONA.data:add(
 
          prevents_teleport = true,
          chara_filter = function()
-            return { level = Map.current_dungeon_level(), quality = "bad", flttypemajor = 13 }
+            return { level = Map.current_dungeon_level(), quality = Enums.Quality.bad, flttypemajor = 13 }
          end
       },
       lumiest_graveyard = {
@@ -730,7 +731,7 @@ ELONA.data:add(
          default_ai_calm = 1,
 
          chara_filter = function()
-            return { level = 20, quality = "bad", fltselect = 4 }
+            return { level = 20, quality = Enums.Quality.bad, fltselect = 4 }
          end
       },
       truce_ground = {
@@ -750,7 +751,7 @@ ELONA.data:add(
          default_ai_calm = 1,
 
          chara_filter = function()
-            return { level = 20, quality = "bad", fltselect = 4 }
+            return { level = 20, quality = Enums.Quality.bad, fltselect = 4 }
          end
       },
       jail = {
@@ -790,7 +791,7 @@ ELONA.data:add(
          default_ai_calm = 1,
 
          chara_filter = function()
-            return { level = 10, quality = "bad", fltn = "sf" }
+            return { level = 10, quality = Enums.Quality.bad, fltn = "sf" }
          end
       },
       larna = {
@@ -1009,7 +1010,7 @@ local function chara_filter_museum_shop()
       fltselect = 7
    end
 
-   return { level = 100, quality = "bad", fltselect = fltselect }
+   return { level = 100, quality = Enums.Quality.bad, fltselect = fltselect }
 end
 
 -- These maps are player-created.
@@ -1067,7 +1068,7 @@ ELONA.data:add(
          is_fixed = false,
 
          chara_filter = function()
-            return { level = Map.data.current_dungeon_level, quality = "bad" }
+            return { level = Map.data.current_dungeon_level, quality = Enums.Quality.bad }
          end,
 
          -- The following fields are required for loading the data but

--- a/runtime/mod/core/data/shop_inventory.lua
+++ b/runtime/mod/core/data/shop_inventory.lua
@@ -1,4 +1,5 @@
 local Data = ELONA.require("core.Data")
+local Enums = ELONA.require("core.Enums")
 local Rand = ELONA.require("core.Rand")
 local Item = ELONA.require("core.Item")
 local math = math
@@ -66,8 +67,8 @@ local filter_set_wear = make_filter_list({10000, 10000, 24000, 24000,
 
 local merchant_rules = {
    { choices = filter_set_wear },
-   { fixlv = "great" },
-   { one_in = 2, fixlv = "miracle" },
+   { fixlv = Enums.Quality.great },
+   { one_in = 2, fixlv = Enums.Quality.miracle },
 }
 
 local function merchant_item_number()
@@ -193,8 +194,8 @@ ELONA.data:add(
                   {flttypemajor = 34000},
                }
             },
-            { one_in = 3, fixlv = "great" },
-            { one_in = 10, fixlv = "miracle" },
+            { one_in = 3, fixlv = Enums.Quality.great },
+            { one_in = 10, fixlv = Enums.Quality.miracle },
          },
          item_base_value = function(args)
             return args.item.value * 2
@@ -242,8 +243,8 @@ ELONA.data:add(
          integer_id = 1007,
          rules = {
             { choices = filter_set_wear },
-            { one_in = 3, fixlv = "great" },
-            { one_in = 10, fixlv = "miracle" },
+            { one_in = 3, fixlv = Enums.Quality.great },
+            { one_in = 10, fixlv = Enums.Quality.miracle },
          },
          item_number = function(args)
             return 6 + args.shopkeeper.shop_rank // 10
@@ -436,7 +437,7 @@ ELONA.data:add(
          item_number = function() return #medal_items end,
          on_generate_item = function(args)
             args.item.number = 1
-            args.item.curse_state = "none"
+            args.item.curse_state = Enums.CurseState.none
             if args.item.id == "core.rod_of_domination" then
                args.item.count = 4
             end

--- a/src/elona/lua_env/api/classes/class_LuaCharacter.cpp
+++ b/src/elona/lua_env/api/classes/class_LuaCharacter.cpp
@@ -884,8 +884,7 @@ void bind(sol::state& lua)
      *
      * [RW] The quality of the character.
      */
-    LuaCharacter.set(
-        "quality", LUA_API_ENUM_PROPERTY(Character, quality, Quality));
+    LuaCharacter.set("quality", &Character::quality);
 
     /**
      * @luadoc prototype field table

--- a/src/elona/lua_env/api/classes/class_LuaItem.cpp
+++ b/src/elona/lua_env/api/classes/class_LuaItem.cpp
@@ -277,13 +277,9 @@ void bind(sol::state& lua)
     LuaItem.set(
         "curse_state",
         sol::property(
-            [](const ItemRef& self) {
-                return LuaEnums::CurseStateTable.convert_to_string(
-                    self->curse_state);
-            },
-            [](const ItemRef& self, const EnumString& s) {
-                self->curse_state =
-                    LuaEnums::CurseStateTable.ensure_from_string(s);
+            [](const ItemRef& self) { return self->curse_state; },
+            [](const ItemRef& self, CurseState new_value) {
+                self->curse_state = new_value;
             }));
 
     /**
@@ -294,13 +290,9 @@ void bind(sol::state& lua)
     LuaItem.set(
         "identify_state",
         sol::property(
-            [](const ItemRef& self) {
-                return LuaEnums::IdentifyStateTable.convert_to_string(
-                    self->identify_state);
-            },
-            [](const ItemRef& self, const EnumString& s) {
-                self->identify_state =
-                    LuaEnums::IdentifyStateTable.ensure_from_string(s);
+            [](const ItemRef& self) { return self->identify_state; },
+            [](const ItemRef& self, IdentifyState new_value) {
+                self->identify_state = new_value;
             }));
 
     /**

--- a/src/elona/lua_env/api/modules/module_Item.cpp
+++ b/src/elona/lua_env/api/modules/module_Item.cpp
@@ -109,9 +109,9 @@ sol::optional<ItemRef> Item_create_xy(int x, int y, sol::table args)
     }
 
     // Random fixlv
-    if (auto it = args.get<sol::optional<std::string>>("quality"))
+    if (auto it = args.get<sol::optional<Quality>>("quality"))
     {
-        fixlv = calcfixlv(LuaEnums::QualityTable.ensure_from_string(*it));
+        fixlv = calcfixlv(*it);
     }
 
     // Clears flttypemajor and flttypeminor.
@@ -124,9 +124,9 @@ sol::optional<ItemRef> Item_create_xy(int x, int y, sol::table args)
     }
 
     // Exact fixlv
-    if (auto it = args.get<sol::optional<std::string>>("fixlv"))
+    if (auto it = args.get<sol::optional<Quality>>("fixlv"))
     {
-        fixlv = LuaEnums::QualityTable.ensure_from_string(*it);
+        fixlv = *it;
     }
 
     if (auto it = args.get<sol::optional<int>>("flttypemajor"))

--- a/src/elona/lua_env/enums/enums.cpp
+++ b/src/elona/lua_env/enums/enums.cpp
@@ -94,41 +94,6 @@ EnumMap<ColorIndex> ColorIndexTable{
 };
 
 
-/**
- * @luadoc
- *
- * The curse state of an item.
- * @usage local item = Item.create(10, 10, "core.putitoro", 3)
- * item.curse_state = "Blessed"
- */
-EnumMap<CurseState> CurseStateTable{
-    "CurseState",
-    {
-        {"doomed", CurseState::doomed},
-        {"cursed", CurseState::cursed},
-        {"none", CurseState::none},
-        {"blessed", CurseState::blessed},
-    },
-};
-
-
-/**
- * @luadoc
- *
- * The identify state of an item.
- * @usage local item = Item.create(10, 10, "core.putitoro", 3)
- * item.identify_state = "Completely"
- */
-EnumMap<IdentifyState> IdentifyStateTable{
-    "IdentifyState",
-    {
-        {"unidentified", IdentifyState::unidentified},
-        {"partly", IdentifyState::partly},
-        {"almost", IdentifyState::almost},
-        {"completely", IdentifyState::completely},
-    },
-};
-
 
 /**
  * @luadoc
@@ -197,23 +162,6 @@ EnumMap<TileKind> TileKindTable{
     },
 };
 
-/**
- * @luadoc
- *
- * The quality of randomly generated equipment.
- */
-EnumMap<Quality> QualityTable{
-    "Quality",
-    {
-        {"none", Quality::none},
-        {"bad", Quality::bad},
-        {"good", Quality::good},
-        {"great", Quality::great},
-        {"miracle", Quality::miracle},
-        {"godly", Quality::godly},
-        {"special", Quality::special},
-    },
-};
 
 /**
  * @luadoc

--- a/src/elona/lua_env/enums/enums.hpp
+++ b/src/elona/lua_env/enums/enums.hpp
@@ -45,12 +45,9 @@ namespace LuaEnums
 
 extern EnumMap<DamageSource> DamageSourceTable;
 extern EnumMap<ColorIndex> ColorIndexTable;
-extern EnumMap<CurseState> CurseStateTable;
-extern EnumMap<IdentifyState> IdentifyStateTable;
 extern EnumMap<StatusAilment> StatusAilmentTable;
 extern EnumMap<Element> ElementTable;
 extern EnumMap<TileKind> TileKindTable;
-extern EnumMap<Quality> QualityTable;
 extern EnumMap<BuffType> BuffTypeTable;
 extern EnumMap<mdata_t::MapType> MapTypeTable;
 extern EnumMap<int> MapEntranceTypeTable;

--- a/src/elona/map_chara_filter.cpp
+++ b/src/elona/map_chara_filter.cpp
@@ -59,15 +59,13 @@ static void _process_chara_filter(const lua::WrappedFunction& chara_filter)
     {
         objlv_ = calcobjlv(*it);
     }
-    if (auto it = opts.optional<std::string>("fixlv"))
+    if (auto it = opts.optional<Quality>("fixlv"))
     {
-        fixlv_ =
-            lua::LuaEnums::QualityTable.get_from_string(*it, Quality::none);
+        fixlv_ = *it;
     }
-    if (auto it = opts.optional<std::string>("quality"))
+    if (auto it = opts.optional<Quality>("quality"))
     {
-        fixlv_ = calcfixlv(
-            lua::LuaEnums::QualityTable.get_from_string(*it, Quality::none));
+        fixlv_ = calcfixlv(*it);
     }
     if (auto it = opts.optional<std::string>("id"))
     {


### PR DESCRIPTION
# Related Issues

#1723


# Summary

Migrate some enum constants (`CurseState`, `Quality`, and `IdentifyState`) from string-based to integer-based. Also define `core.Enums` module to access pre-defined enums. This PR does not convert all enums.