### PR TITLE
Refactor struct Inventory

### DIFF
--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -1055,7 +1055,7 @@ void activity_others_end_steal(const ItemRef& steal_target)
         chara_refresh(item_owner);
     }
 
-    const auto stolen_item = item_separate(steal_target, slot, in);
+    const auto stolen_item = item_separate(steal_target, g_inv.pc(), slot, in);
     stolen_item->is_stolen = true;
     stolen_item->own_state = OwnState::none;
     txt(i18n::s.get("core.activity.steal.succeed", stolen_item));

--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -1872,7 +1872,7 @@ void spot_digging(Character& chara)
     txt(i18n::s.get("core.activity.dig_spot.finish"));
     if (map_data.type == mdata_t::MapType::world_map)
     {
-        for (const auto& item : g_inv.pc())
+        for (const auto& item : *g_inv.pc())
         {
             if (item->id == "core.treasure_map" && item->param1 != 0 &&
                 item->param1 == cdata.player().position.x &&

--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -1038,7 +1038,7 @@ void activity_others_end_steal(const ItemRef& steal_target)
         in = steal_target->number();
     }
 
-    const auto slot_opt = inv_get_free_slot(g_inv.pc());
+    const auto slot_opt = inv_get_free_slot(inv_player());
     if (!slot_opt)
     {
         txt(i18n::s.get("core.action.pick_up.your_inventory_is_full"));
@@ -1055,7 +1055,8 @@ void activity_others_end_steal(const ItemRef& steal_target)
         chara_refresh(item_owner);
     }
 
-    const auto stolen_item = item_separate(steal_target, g_inv.pc(), slot, in);
+    const auto stolen_item =
+        item_separate(steal_target, inv_player(), slot, in);
     stolen_item->is_stolen = true;
     stolen_item->own_state = OwnState::none;
     txt(i18n::s.get("core.activity.steal.succeed", stolen_item));
@@ -1068,7 +1069,7 @@ void activity_others_end_steal(const ItemRef& steal_target)
     }
     else
     {
-        inv_stack(g_inv.pc(), stolen_item, true);
+        inv_stack(inv_player(), stolen_item, true);
         sound_pick_up();
     }
     refresh_burden_state();
@@ -1124,7 +1125,7 @@ void activity_others_end_harvest(const ItemRef& crop)
     txt(i18n::s.get(
         "core.activity.harvest.finish", crop, cnvweight(crop->weight)));
     in = crop->number();
-    pick_up_item(g_inv.pc(), crop, none);
+    pick_up_item(inv_player(), crop, none);
 }
 
 
@@ -1872,7 +1873,7 @@ void spot_digging(Character& chara)
     txt(i18n::s.get("core.activity.dig_spot.finish"));
     if (map_data.type == mdata_t::MapType::world_map)
     {
-        for (const auto& item : *g_inv.pc())
+        for (const auto& item : *inv_player())
         {
             if (item->id == "core.treasure_map" && item->param1 != 0 &&
                 item->param1 == cdata.player().position.x &&

--- a/src/elona/adventurer.cpp
+++ b/src/elona/adventurer.cpp
@@ -326,7 +326,7 @@ void adventurer_discover_equipment(Character& adv)
     f = 0;
     for (int _i = 0; _i < 10; ++_i)
     {
-        const auto inv = g_inv.for_chara(adv);
+        const auto inv = adv.inventory();
         const auto item = inv->at(inv_get_random_slot(inv));
         if (!item)
         {

--- a/src/elona/adventurer.cpp
+++ b/src/elona/adventurer.cpp
@@ -326,8 +326,8 @@ void adventurer_discover_equipment(Character& adv)
     f = 0;
     for (int _i = 0; _i < 10; ++_i)
     {
-        const auto item =
-            Inventory::at(inv_get_random_slot(g_inv.for_chara(adv)));
+        const auto inv = g_inv.for_chara(adv);
+        const auto item = inv->at(inv_get_random_slot(inv));
         if (!item)
         {
             f = 1;

--- a/src/elona/ai.cpp
+++ b/src/elona/ai.cpp
@@ -11,6 +11,7 @@
 #include "data/types/type_item.hpp"
 #include "fov.hpp"
 #include "i18n.hpp"
+#include "inventory.hpp"
 #include "item.hpp"
 #include "itemgen.hpp"
 #include "magic.hpp"
@@ -289,7 +290,7 @@ void _ally_sells_item(Character& chara)
     int sold_item_count = 0;
     int earned_money = 0;
 
-    for (const auto& item : *g_inv.for_chara(chara))
+    for (const auto& item : *chara.inventory())
     {
         if (the_item_db[item->id]->category == ItemCategory::ore)
         {
@@ -421,7 +422,7 @@ optional<TurnResult> _proc_make_snowman(Character& chara)
     // Throws a snowball to a snowman.
     if (rnd(12) == 0)
     {
-        for (const auto& item : *g_inv.ground())
+        for (const auto& item : *inv_map())
         {
             if (item->id == "core.snow_man" && item->position().x >= scx &&
                 item->position().x < scx + inf_screenw &&

--- a/src/elona/ai.cpp
+++ b/src/elona/ai.cpp
@@ -289,7 +289,7 @@ void _ally_sells_item(Character& chara)
     int sold_item_count = 0;
     int earned_money = 0;
 
-    for (const auto& item : g_inv.for_chara(chara))
+    for (const auto& item : *g_inv.for_chara(chara))
     {
         if (the_item_db[item->id]->category == ItemCategory::ore)
         {
@@ -421,7 +421,7 @@ optional<TurnResult> _proc_make_snowman(Character& chara)
     // Throws a snowball to a snowman.
     if (rnd(12) == 0)
     {
-        for (const auto& item : g_inv.ground())
+        for (const auto& item : *g_inv.ground())
         {
             if (item->id == "core.snow_man" && item->position().x >= scx &&
                 item->position().x < scx + inf_screenw &&

--- a/src/elona/blending.cpp
+++ b/src/elona/blending.cpp
@@ -205,7 +205,7 @@ bool find_blending_materials(int inventory, int recipe_id, int step)
     assert(inventory == -1 || inventory == 0);
 
     const auto check_pos = inventory == -1;
-    for (const auto& item : *(inventory == -1 ? g_inv.ground() : g_inv.pc()))
+    for (const auto& item : *(inventory == -1 ? inv_map() : inv_player()))
     {
         if (check_one_blending_material(item, recipe_id, step, check_pos))
         {
@@ -225,7 +225,7 @@ int count_blending_materials(int inventory, int recipe_id, int step)
 
     const auto check_pos = inventory == -1;
     int ret = 0;
-    for (const auto& item : *(inventory == -1 ? g_inv.ground() : g_inv.pc()))
+    for (const auto& item : *(inventory == -1 ? inv_map() : inv_player()))
     {
         if (check_one_blending_material(item, recipe_id, step, check_pos))
         {
@@ -247,7 +247,7 @@ void collect_blending_materials(
     assert(inventory == -1 || inventory == 0);
 
     const auto check_pos = inventory == -1;
-    for (const auto& item : *(inventory == -1 ? g_inv.ground() : g_inv.pc()))
+    for (const auto& item : *(inventory == -1 ? inv_map() : inv_player()))
     {
         if (result.size() >= 500)
         {
@@ -1005,7 +1005,7 @@ void blending_proc_on_success_events()
     auto on_success_args = lua::create_table("materials", materials);
     the_blending_recipe_db.ensure(rpid).on_success.call(on_success_args);
 
-    inv_stack(g_inv.pc(), item1);
+    inv_stack(inv_player(), item1);
     if (item1->body_part != 0)
     {
         create_pcpic(cdata.player());

--- a/src/elona/blending.cpp
+++ b/src/elona/blending.cpp
@@ -205,7 +205,7 @@ bool find_blending_materials(int inventory, int recipe_id, int step)
     assert(inventory == -1 || inventory == 0);
 
     const auto check_pos = inventory == -1;
-    for (const auto& item : inventory == -1 ? g_inv.ground() : g_inv.pc())
+    for (const auto& item : *(inventory == -1 ? g_inv.ground() : g_inv.pc()))
     {
         if (check_one_blending_material(item, recipe_id, step, check_pos))
         {
@@ -225,7 +225,7 @@ int count_blending_materials(int inventory, int recipe_id, int step)
 
     const auto check_pos = inventory == -1;
     int ret = 0;
-    for (const auto& item : inventory == -1 ? g_inv.ground() : g_inv.pc())
+    for (const auto& item : *(inventory == -1 ? g_inv.ground() : g_inv.pc()))
     {
         if (check_one_blending_material(item, recipe_id, step, check_pos))
         {
@@ -247,7 +247,7 @@ void collect_blending_materials(
     assert(inventory == -1 || inventory == 0);
 
     const auto check_pos = inventory == -1;
-    for (const auto& item : inventory == -1 ? g_inv.ground() : g_inv.pc())
+    for (const auto& item : *(inventory == -1 ? g_inv.ground() : g_inv.pc()))
     {
         if (result.size() >= 500)
         {

--- a/src/elona/building.cpp
+++ b/src/elona/building.cpp
@@ -158,7 +158,7 @@ std::vector<ItemForSale> list_items_for_sale()
 {
     std::vector<ItemForSale> ret;
 
-    for (const auto& item : *g_inv.ground())
+    for (const auto& item : *inv_map())
     {
         if (item->id == "core.shop_strongbox")
         {
@@ -466,7 +466,7 @@ TurnResult show_house_board()
     p(0) = 0;
     p(1) = 0;
     p(2) = 400;
-    for (const auto& item : *g_inv.ground())
+    for (const auto& item : *inv_map())
     {
         if (the_item_db[item->id]->category != ItemCategory::furniture)
         {
@@ -1173,7 +1173,7 @@ void update_shop()
             cell_data.at(x, y).light = 0;
         }
     }
-    for (const auto& item : *g_inv.ground())
+    for (const auto& item : *inv_map())
     {
         x = item->position().x;
         y = item->position().y;
@@ -1226,7 +1226,7 @@ void update_museum()
     rankorg = game_data.ranks.at(3);
     rankcur = 0;
     DIM3(dblist, 2, 800);
-    for (const auto& item : *g_inv.ground())
+    for (const auto& item : *inv_map())
     {
         if (item->id != "core.figurine" && item->id != "core.card")
         {
@@ -1288,7 +1288,7 @@ std::vector<HomeRankHeirloom> building_update_home_rank()
     game_data.total_heirloom_value = 0;
 
     std::vector<HomeRankHeirloom> heirlooms;
-    for (const auto& item : *g_inv.ground())
+    for (const auto& item : *inv_map())
     {
         if (cell_data.at(item->position().x, item->position().y)
                 .item_info_actual.stack_count() != 1)
@@ -1843,7 +1843,7 @@ void create_harvested_item()
     if (const auto item = itemcreate_player_inv(item_id, 0))
     {
         txt(i18n::s.get("core.action.plant.harvest", item.unwrap()));
-        inv_stack(g_inv.pc(), item.unwrap(), true);
+        inv_stack(inv_player(), item.unwrap(), true);
     }
 }
 

--- a/src/elona/building.cpp
+++ b/src/elona/building.cpp
@@ -158,7 +158,7 @@ std::vector<ItemForSale> list_items_for_sale()
 {
     std::vector<ItemForSale> ret;
 
-    for (const auto& item : g_inv.ground())
+    for (const auto& item : *g_inv.ground())
     {
         if (item->id == "core.shop_strongbox")
         {
@@ -466,7 +466,7 @@ TurnResult show_house_board()
     p(0) = 0;
     p(1) = 0;
     p(2) = 400;
-    for (const auto& item : g_inv.ground())
+    for (const auto& item : *g_inv.ground())
     {
         if (the_item_db[item->id]->category != ItemCategory::furniture)
         {
@@ -1173,7 +1173,7 @@ void update_shop()
             cell_data.at(x, y).light = 0;
         }
     }
-    for (const auto& item : g_inv.ground())
+    for (const auto& item : *g_inv.ground())
     {
         x = item->position().x;
         y = item->position().y;
@@ -1226,7 +1226,7 @@ void update_museum()
     rankorg = game_data.ranks.at(3);
     rankcur = 0;
     DIM3(dblist, 2, 800);
-    for (const auto& item : g_inv.ground())
+    for (const auto& item : *g_inv.ground())
     {
         if (item->id != "core.figurine" && item->id != "core.card")
         {
@@ -1288,7 +1288,7 @@ std::vector<HomeRankHeirloom> building_update_home_rank()
     game_data.total_heirloom_value = 0;
 
     std::vector<HomeRankHeirloom> heirlooms;
-    for (const auto& item : g_inv.ground())
+    for (const auto& item : *g_inv.ground())
     {
         if (cell_data.at(item->position().x, item->position().y)
                 .item_info_actual.stack_count() != 1)
@@ -1629,7 +1629,7 @@ void supply_income()
         if (cdata.player().level > 5)
         {
             save_trigger_autosaving();
-            if (!g_inv.tmp().has_free_slot())
+            if (!g_inv.tmp()->has_free_slot())
             {
                 inv_compress(g_inv.tmp());
             }

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -1205,7 +1205,7 @@ int calc_ammo_reloading_cost(Character& owner, bool do_reload)
 {
     int cost{};
 
-    for (const auto& item : g_inv.for_chara(owner))
+    for (const auto& item : *g_inv.for_chara(owner))
     {
         if (the_item_db[item->id]->category != ItemCategory::ammo)
             continue;
@@ -1262,7 +1262,7 @@ int calcidentifyvalue(int type)
     if (type == 1)
     {
         int need_to_identify{};
-        for (const auto& item : g_inv.pc())
+        for (const auto& item : *g_inv.pc())
         {
             if (item->identify_state != IdentifyState::completely)
             {

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -904,7 +904,8 @@ int calcitemvalue(const ItemRef& item, int calc_mode)
         else
         {
             ret = cdata.player().level / 5 *
-                    ((game_data.random_seed + item->index() * 31) %
+                    ((game_data.random_seed +
+                      static_cast<int>(item->slot()) * 31) %
                          cdata.player().level +
                      4) +
                 10;

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -10,6 +10,7 @@
 #include "elona.hpp"
 #include "fov.hpp"
 #include "i18n.hpp"
+#include "inventory.hpp"
 #include "item.hpp"
 #include "map.hpp"
 #include "message.hpp"
@@ -1206,7 +1207,7 @@ int calc_ammo_reloading_cost(Character& owner, bool do_reload)
 {
     int cost{};
 
-    for (const auto& item : *g_inv.for_chara(owner))
+    for (const auto& item : *owner.inventory())
     {
         if (the_item_db[item->id]->category != ItemCategory::ammo)
             continue;
@@ -1263,7 +1264,7 @@ int calcidentifyvalue(int type)
     if (type == 1)
     {
         int need_to_identify{};
-        for (const auto& item : *g_inv.pc())
+        for (const auto& item : *inv_player())
         {
             if (item->identify_state != IdentifyState::completely)
             {

--- a/src/elona/cell_draw.cpp
+++ b/src/elona/cell_draw.cpp
@@ -6,6 +6,7 @@
 #include "draw.hpp"
 #include "elona.hpp"
 #include "fov.hpp"
+#include "inventory.hpp"
 #include "item.hpp"
 #include "map.hpp"
 #include "map_cell.hpp"
@@ -1352,10 +1353,9 @@ void draw_items(int x, int y, int dx, int dy, int scrturn_)
                 break;
 
             const auto item = item_index < 0
-                ? g_inv.ground()->at(
+                ? inv_map()->at(
                       static_cast<InventorySlot>(0)) /* TODO phantom ref */
-                : g_inv.ground()->at(
-                      static_cast<InventorySlot>(item_index - 1));
+                : inv_map()->at(static_cast<InventorySlot>(item_index - 1));
 
             if (!item)
             {

--- a/src/elona/cell_draw.cpp
+++ b/src/elona/cell_draw.cpp
@@ -1352,8 +1352,8 @@ void draw_items(int x, int y, int dx, int dy, int scrturn_)
                 break;
 
             const auto item = item_index < 0
-                ? g_inv.ground().at(0) /* TODO phantom ref */
-                : g_inv.ground().at(item_index - 1);
+                ? g_inv.ground()->at(0) /* TODO phantom ref */
+                : g_inv.ground()->at(item_index - 1);
 
             if (!item)
             {

--- a/src/elona/cell_draw.cpp
+++ b/src/elona/cell_draw.cpp
@@ -1352,8 +1352,10 @@ void draw_items(int x, int y, int dx, int dy, int scrturn_)
                 break;
 
             const auto item = item_index < 0
-                ? g_inv.ground()->at(0) /* TODO phantom ref */
-                : g_inv.ground()->at(item_index - 1);
+                ? g_inv.ground()->at(
+                      static_cast<InventorySlot>(0)) /* TODO phantom ref */
+                : g_inv.ground()->at(
+                      static_cast<InventorySlot>(item_index - 1));
 
             if (!item)
             {

--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -1511,7 +1511,7 @@ void chara_delete(Character& chara)
 {
     chara.set_state(Character::State::empty);
 
-    for (const auto& item : g_inv.for_chara(chara))
+    for (const auto& item : *g_inv.for_chara(chara))
     {
         item->remove();
     }
@@ -1554,7 +1554,8 @@ void chara_relocate(
     }
 
     // Move all items in `source`'s inventory to `destination`'s.
-    Inventory::move_all(g_inv.for_chara(source), g_inv.for_chara(destination));
+    Inventory::move_all(
+        *g_inv.for_chara(source), *g_inv.for_chara(destination));
 
     // Clear some fields which should not be copied.
     source.ai_item = nullptr;
@@ -1777,7 +1778,7 @@ void initialize_pc_character()
     gain_race_feat();
     cdata.player().skill_bonus = 5 + trait(154);
     cdata.player().total_skill_bonus = 5 + trait(154);
-    for (const auto& item : g_inv.pc())
+    for (const auto& item : *g_inv.pc())
     {
         item->identify_state = IdentifyState::completely;
     }

--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -573,6 +573,13 @@ bool Character::is_map_local() const
 
 
 
+InventoryRef Character::inventory()
+{
+    return g_inv.for_chara(*this);
+}
+
+
+
 CData::CData()
     : storage(ELONA_MAX_CHARACTERS)
 {
@@ -1511,7 +1518,7 @@ void chara_delete(Character& chara)
 {
     chara.set_state(Character::State::empty);
 
-    for (const auto& item : *g_inv.for_chara(chara))
+    for (const auto& item : *chara.inventory())
     {
         item->remove();
     }
@@ -1554,8 +1561,7 @@ void chara_relocate(
     }
 
     // Move all items in `source`'s inventory to `destination`'s.
-    Inventory::move_all(
-        *g_inv.for_chara(source), *g_inv.for_chara(destination));
+    Inventory::move_all(*source.inventory(), *destination.inventory());
 
     // Clear some fields which should not be copied.
     source.ai_item = nullptr;
@@ -1778,7 +1784,7 @@ void initialize_pc_character()
     gain_race_feat();
     cdata.player().skill_bonus = 5 + trait(154);
     cdata.player().total_skill_bonus = 5 + trait(154);
-    for (const auto& item : *g_inv.pc())
+    for (const auto& item : *inv_player())
     {
         item->identify_state = IdentifyState::completely;
     }
@@ -2062,13 +2068,13 @@ void chara_get_wet(Character& chara, int turns)
 void refresh_burden_state()
 {
     cdata.player().inventory_weight =
-        clamp(inv_weight(g_inv.pc()), 0, 20000000) *
+        clamp(inv_weight(inv_player()), 0, 20000000) *
         (100 - trait(201) * 10 + trait(205) * 20) / 100;
     cdata.player().max_inventory_weight =
         cdata.player().get_skill(10).level * 500 +
         cdata.player().get_skill(11).level * 250 +
         cdata.player().get_skill(153).level * 2000 + 45000;
-    game_data.cargo_weight = inv_cargo_weight(g_inv.pc());
+    game_data.cargo_weight = inv_cargo_weight(inv_player());
     for (int cnt = 0; cnt < 1; ++cnt)
     {
         if (cdata.player().inventory_weight >

--- a/src/elona/character.hpp
+++ b/src/elona/character.hpp
@@ -26,6 +26,8 @@ namespace elona
 {
 
 struct Item;
+struct Inventory;
+using InventoryRef = Inventory*;
 
 
 
@@ -393,6 +395,8 @@ public:
     data::InstanceId race;
     data::InstanceId class_;
     std::string talk;
+
+    InventoryRef inventory();
 
 
 

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -96,7 +96,7 @@ bool any_of_characters_around_you(F predicate, bool ignore_pc = true)
 void _search_for_crystal()
 {
     optional<int> d;
-    for (const auto& item : g_inv.ground())
+    for (const auto& item : *g_inv.ground())
     {
         if (item->own_state != OwnState::town_special)
         {
@@ -1678,7 +1678,7 @@ TurnResult do_dip_command(const ItemRef& mix_item, const ItemRef& mix_target)
                         "core.action.dip.result.natural_potion_drop"));
                     return TurnResult::turn_end;
                 }
-                if (!g_inv.pc().has_free_slot())
+                if (!g_inv.pc()->has_free_slot())
                 {
                     txt(i18n::s.get("core.ui.inv.common.inventory_is_full"));
                     return TurnResult::turn_end;
@@ -3477,7 +3477,7 @@ TurnResult do_get_command()
                     .feats = 0;
                 return TurnResult::turn_end;
             }
-            if (!g_inv.pc().has_free_slot())
+            if (!g_inv.pc()->has_free_slot())
             {
                 txt(i18n::s.get("core.ui.inv.common.inventory_is_full"));
                 update_screen();
@@ -5263,7 +5263,7 @@ bool prompt_magic_location(Character& caster, int& enemy_index)
 
 
 PickUpItemResult pick_up_item(
-    Inventory& inv,
+    const InventoryRef& inv,
     const ItemRef& item,
     optional_ref<Character> shopkeeper,
     bool play_sound)
@@ -5326,7 +5326,7 @@ PickUpItemResult pick_up_item(
             {
                 if (!cdata.player().activity)
                 {
-                    if (!g_inv.pc().has_free_slot())
+                    if (!g_inv.pc()->has_free_slot())
                     {
                         txt(i18n::s.get(
                             "core.ui.inv.common.inventory_is_full"));
@@ -5362,7 +5362,7 @@ PickUpItemResult pick_up_item(
                 return {0, nullptr};
             }
         }
-        if (!inv.has_free_slot())
+        if (!inv->has_free_slot())
         {
             txt(i18n::s.get("core.action.pick_up.your_inventory_is_full"));
             return {0, nullptr};
@@ -5573,7 +5573,7 @@ PickUpItemResult pick_up_item(
             if (map_data.play_campfire_sound == 1)
             {
                 f = 0;
-                for (const auto& item_ : g_inv.ground())
+                for (const auto& item_ : *g_inv.ground())
                 {
                     if (item_->id == "core.campfire")
                     {
@@ -5826,7 +5826,7 @@ void proc_autopick()
         return;
 
 
-    for (const auto& item : g_inv.ground())
+    for (const auto& item : *g_inv.ground())
     {
         if (item->position() != cdata.player().position)
             continue;

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -1164,7 +1164,7 @@ TurnResult do_throw_command(Character& thrower, const ItemRef& throw_item)
     if (throw_item->id == "core.monster_ball")
     {
         const auto slot = inv_make_free_slot_force(g_inv.ground());
-        const auto ball = item_separate(throw_item, slot, 1);
+        const auto ball = item_separate(throw_item, g_inv.ground(), slot, 1);
         ball->set_position({tlocx, tlocy});
         return do_throw_command_internal(thrower, ball);
     }
@@ -5442,7 +5442,7 @@ PickUpItemResult pick_up_item(
             return {0, nullptr};
         }
         const auto slot = *slot_opt;
-        picked_up_item = item_separate(item, slot, in);
+        picked_up_item = item_separate(item, inv, slot, in);
     }
     assert(picked_up_item);
 

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -96,7 +96,7 @@ bool any_of_characters_around_you(F predicate, bool ignore_pc = true)
 void _search_for_crystal()
 {
     optional<int> d;
-    for (const auto& item : *g_inv.ground())
+    for (const auto& item : *inv_map())
     {
         if (item->own_state != OwnState::town_special)
         {
@@ -1163,8 +1163,8 @@ TurnResult do_throw_command(Character& thrower, const ItemRef& throw_item)
 
     if (throw_item->id == "core.monster_ball")
     {
-        const auto slot = inv_make_free_slot_force(g_inv.ground());
-        const auto ball = item_separate(throw_item, g_inv.ground(), slot, 1);
+        const auto slot = inv_make_free_slot_force(inv_map());
+        const auto ball = item_separate(throw_item, inv_map(), slot, 1);
         ball->set_position({tlocx, tlocy});
         return do_throw_command_internal(thrower, ball);
     }
@@ -1678,7 +1678,7 @@ TurnResult do_dip_command(const ItemRef& mix_item, const ItemRef& mix_target)
                         "core.action.dip.result.natural_potion_drop"));
                     return TurnResult::turn_end;
                 }
-                if (!g_inv.pc()->has_free_slot())
+                if (!inv_player()->has_free_slot())
                 {
                     txt(i18n::s.get("core.ui.inv.common.inventory_is_full"));
                     return TurnResult::turn_end;
@@ -1705,7 +1705,7 @@ TurnResult do_dip_command(const ItemRef& mix_item, const ItemRef& mix_target)
                     txt(i18n::s.get("core.action.dip.result.natural_potion"));
                     txt(i18n::s.get(
                         "core.action.dip.you_get", natural_potion.unwrap()));
-                    inv_stack(g_inv.pc(), natural_potion.unwrap(), true);
+                    inv_stack(inv_player(), natural_potion.unwrap(), true);
                 }
                 return TurnResult::turn_end;
             }
@@ -2763,7 +2763,7 @@ TurnResult do_use_command(ItemRef use_item)
         txt(i18n::s.get("core.action.use.deck.put_away"));
         break;
     case 38:
-        if (!itemfind(g_inv.pc(), "core.deck"))
+        if (!itemfind(inv_player(), "core.deck"))
         {
             txt(i18n::s.get("core.action.use.deck.no_deck"));
             update_screen();
@@ -2948,7 +2948,7 @@ TurnResult do_open_command(const ItemRef& box, bool play_sound)
         {
             open_box(box);
         }
-        inv_stack(g_inv.pc(), box);
+        inv_stack(inv_player(), box);
     }
     screenupdate = -1;
     update_screen();
@@ -3477,7 +3477,7 @@ TurnResult do_get_command()
                     .feats = 0;
                 return TurnResult::turn_end;
             }
-            if (!g_inv.pc()->has_free_slot())
+            if (!inv_player()->has_free_slot())
             {
                 txt(i18n::s.get("core.ui.inv.common.inventory_is_full"));
                 update_screen();
@@ -3541,7 +3541,7 @@ TurnResult do_get_command()
                 {
                     item->curse_state = CurseState::none;
                     item->identify_state = IdentifyState::completely;
-                    inv_stack(g_inv.pc(), item.unwrap(), true);
+                    inv_stack(inv_player(), item.unwrap(), true);
                 }
             }
             return TurnResult::turn_end;
@@ -3582,7 +3582,7 @@ TurnResult do_get_command()
     }
 
     in = item_opt->number();
-    int stat = pick_up_item(g_inv.pc(), item_opt.unwrap(), none).type;
+    int stat = pick_up_item(inv_player(), item_opt.unwrap(), none).type;
     if (stat == 1 || stat == -1)
     {
         return TurnResult::turn_end;
@@ -4274,7 +4274,7 @@ int decode_book(Character& reader, const ItemRef& book)
         book->param2 = 1;
         book->charges = 1;
         book->has_charges = false;
-        inv_stack(g_inv.pc(), book, true);
+        inv_stack(inv_player(), book, true);
     }
     else
     {
@@ -5326,7 +5326,7 @@ PickUpItemResult pick_up_item(
             {
                 if (!cdata.player().activity)
                 {
-                    if (!g_inv.pc()->has_free_slot())
+                    if (!inv_player()->has_free_slot())
                     {
                         txt(i18n::s.get(
                             "core.ui.inv.common.inventory_is_full"));
@@ -5573,7 +5573,7 @@ PickUpItemResult pick_up_item(
             if (map_data.play_campfire_sound == 1)
             {
                 f = 0;
-                for (const auto& item_ : *g_inv.ground())
+                for (const auto& item_ : *inv_map())
                 {
                     if (item_->id == "core.campfire")
                     {
@@ -5647,7 +5647,7 @@ TurnResult do_bash(Character& chara)
             {
                 txt(i18n::s.get(
                     "core.action.bash.tree.falls_down", fruit.unwrap()));
-                inv_stack(g_inv.ground(), fruit.unwrap());
+                inv_stack(inv_map(), fruit.unwrap());
             }
             return TurnResult::turn_end;
         }
@@ -5826,7 +5826,7 @@ void proc_autopick()
         return;
 
 
-    for (const auto& item : *g_inv.ground())
+    for (const auto& item : *inv_map())
     {
         if (item->position() != cdata.player().position)
             continue;
@@ -5863,7 +5863,7 @@ void proc_autopick()
             {
                 in = item->number();
                 const auto pick_up_item_result =
-                    pick_up_item(g_inv.pc(), item, none, !op.sound);
+                    pick_up_item(inv_player(), item, none, !op.sound);
                 if (pick_up_item_result.type != 1)
                 {
                     break;

--- a/src/elona/command.hpp
+++ b/src/elona/command.hpp
@@ -10,6 +10,7 @@ namespace elona
 
 enum class TurnResult;
 struct Inventory;
+using InventoryRef = Inventory*;
 struct Item;
 struct Character;
 
@@ -64,7 +65,7 @@ struct PickUpItemResult
     OptionalItemRef picked_up_item;
 };
 PickUpItemResult pick_up_item(
-    Inventory& inv,
+    const InventoryRef& inv,
     const ItemRef& item,
     optional_ref<Character> shopkeeper,
     bool play_sound = true);

--- a/src/elona/crafting.cpp
+++ b/src/elona/crafting.cpp
@@ -402,7 +402,7 @@ static void _craft_item(int matid, const CraftingRecipe& recipe)
     if (const auto item = itemcreate_player_inv(matid, 0))
     {
         txt(i18n::s.get("core.crafting.you_crafted", item.unwrap()));
-        inv_stack(g_inv.pc(), item.unwrap());
+        inv_stack(inv_player(), item.unwrap());
     }
 }
 

--- a/src/elona/ctrl_file.cpp
+++ b/src/elona/ctrl_file.cpp
@@ -381,11 +381,12 @@ void inventory_deserialize(serialization::binary::IArchive& ar, Inventory& inv)
     const auto n = inv.size();
     for (size_t i = 0; i < n; ++i)
     {
+        const auto slot = static_cast<InventorySlot>(i);
         bool exists;
         ar(exists);
         if (exists)
         {
-            const auto item_ref = Inventory::create(InventorySlot{&inv, i});
+            const auto item_ref = inv.create(slot);
             auto& item = *item_ref.get_raw_ptr();
             ar(item);
             ItemIdTable::instance().add(item_ref);
@@ -400,11 +401,12 @@ void inventory_serialize(serialization::binary::OArchive& ar, Inventory& inv)
     const auto n = inv.size();
     for (size_t i = 0; i < n; ++i)
     {
-        bool exists = !!inv.at(i);
+        const auto slot = static_cast<InventorySlot>(i);
+        bool exists = !!inv.at(slot);
         ar(exists);
         if (exists)
         {
-            const auto item_ref = inv.at(i).unwrap();
+            const auto item_ref = inv.at(slot).unwrap();
             auto& item = *item_ref.get_raw_ptr();
             ar(item);
         }

--- a/src/elona/ctrl_file.cpp
+++ b/src/elona/ctrl_file.cpp
@@ -1089,7 +1089,7 @@ void ctrl_file_tmp_inv_read(const fs::path& filename)
     (void)save_fs_exists(filename);
 
     load_internal(
-        path, [&](auto& ar) { inventory_deserialize(ar, g_inv.tmp()); });
+        path, [&](auto& ar) { inventory_deserialize(ar, *g_inv.tmp()); });
 
     ELONA_LOG("save.ctrl_file")
         << "tmp_inv_read(" << filename.to_u8string() << ") END";
@@ -1107,7 +1107,7 @@ void ctrl_file_tmp_inv_write(const fs::path& filename)
     (void)save_fs_exists(filename);
 
     save_internal(
-        path, [&](auto& ar) { inventory_serialize(ar, g_inv.tmp()); });
+        path, [&](auto& ar) { inventory_serialize(ar, *g_inv.tmp()); });
 
     ELONA_LOG("save.ctrl_file")
         << "tmp_inv_write(" << filename.to_u8string() << ") END";

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -187,7 +187,7 @@ void remove_card_and_figure_from_heir_trunk()
 {
     if (invctrl == 22 && invctrl(1) == 1)
     {
-        for (const auto& item : g_inv.tmp())
+        for (const auto& item : *g_inv.tmp())
         {
             if (item->id == "core.card" || item->id == "core.figurine")
             {
@@ -264,20 +264,20 @@ void make_item_list(
             }
             if (refers_to_tmp_inventory(invctrl(0)))
             {
-                inv = &g_inv.tmp();
+                inv = g_inv.tmp();
             }
             else
             {
-                inv = &g_inv.ground();
+                inv = g_inv.ground();
             }
         }
         if (cnt == 1)
         {
-            inv = &g_inv.pc();
+            inv = g_inv.pc();
             if (invctrl == 20 || invctrl == 25)
             {
                 assert(inventory_owner);
-                inv = &g_inv.for_chara(*inventory_owner);
+                inv = g_inv.for_chara(*inventory_owner);
             }
             if (invctrl == 27)
             {
@@ -287,7 +287,7 @@ void make_item_list(
                 {
                     continue;
                 }
-                inv = &g_inv.for_chara(cdata[target_chara_index]);
+                inv = g_inv.for_chara(cdata[target_chara_index]);
             }
             if (exclude_character_items(invctrl(0)))
             {
@@ -1327,7 +1327,7 @@ OnEnterResult on_enter_drop(
         txt(i18n::s.get("core.ui.inv.common.set_as_no_drop"));
         return OnEnterResult{2};
     }
-    if (!g_inv.ground().has_free_slot())
+    if (!g_inv.ground()->has_free_slot())
     {
         txt(i18n::s.get("core.ui.inv.drop.cannot_anymore"));
         snd("core.fail1");
@@ -1560,7 +1560,7 @@ OnEnterResult on_enter_external_inventory(
             }
         }
     }
-    auto& destination_inventory =
+    const auto destination_inventory =
         (invctrl == 12 || (invctrl == 24 && invctrl(1) != 0)) ? g_inv.tmp()
                                                               : g_inv.pc();
     int stat =

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -1887,7 +1887,8 @@ OnEnterResult on_enter_give(
             selected_item->modify_number(-1);
             return OnEnterResult{1};
         }
-        const auto handed_over_item = item_separate(selected_item, slot, 1);
+        const auto handed_over_item = item_separate(
+            selected_item, g_inv.for_chara(inventory_owner), slot, 1);
         const auto stacked_item =
             inv_stack(g_inv.for_chara(inventory_owner), handed_over_item, true)
                 .stacked_item;
@@ -2231,7 +2232,8 @@ OnEnterResult on_enter_receive(
     }
     else
     {
-        const auto received_item = item_separate(selected_item, slot, in);
+        const auto received_item =
+            item_separate(selected_item, g_inv.pc(), slot, in);
         const auto stacked_item =
             inv_stack(g_inv.pc(), received_item, true).stacked_item;
         item_convert_artifact(stacked_item);
@@ -2315,7 +2317,7 @@ OnEnterResult on_enter_small_medal(const ItemRef& selected_item)
     assert(small_medals);
     small_medals->modify_number(-calcmedalvalue(selected_item));
     snd("core.paygold1");
-    const auto received_item = item_copy(selected_item, slot);
+    const auto received_item = item_copy(selected_item, g_inv.pc(), slot);
     txt(i18n::s.get("core.ui.inv.trade_medals.you_receive", received_item));
     const auto stacked_item =
         inv_stack(g_inv.pc(), received_item, true).stacked_item;

--- a/src/elona/deferred_event.cpp
+++ b/src/elona/deferred_event.cpp
@@ -979,7 +979,7 @@ void eh_guest_visit(const DeferredEvent&)
         }
         OptionalItemRef chair;
         auto distance_to_guest_chair = 6;
-        for (const auto& item : g_inv.ground())
+        for (const auto& item : *g_inv.ground())
         {
             if (item->function != 44)
                 continue;

--- a/src/elona/deferred_event.cpp
+++ b/src/elona/deferred_event.cpp
@@ -12,6 +12,7 @@
 #include "draw.hpp"
 #include "enums.hpp"
 #include "i18n.hpp"
+#include "inventory.hpp"
 #include "item.hpp"
 #include "itemgen.hpp"
 #include "map.hpp"
@@ -979,7 +980,7 @@ void eh_guest_visit(const DeferredEvent&)
         }
         OptionalItemRef chair;
         auto distance_to_guest_chair = 6;
-        for (const auto& item : *g_inv.ground())
+        for (const auto& item : *inv_map())
         {
             if (item->function != 44)
                 continue;

--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -1547,7 +1547,7 @@ void character_drops_item(Character& victim)
             {
                 const auto slot = inv_make_free_slot_force(g_inv.ground());
                 const auto dropped_item =
-                    item_separate(item, slot, item->number());
+                    item_separate(item, g_inv.ground(), slot, item->number());
                 dropped_item->own_state = OwnState::lost;
             }
         }
@@ -1668,7 +1668,7 @@ void character_drops_item(Character& victim)
         if (!inv_stack(g_inv.ground(), item).stacked)
         {
             const auto slot = inv_make_free_slot_force(g_inv.ground());
-            item_separate(item, slot, item->number());
+            item_separate(item, g_inv.ground(), slot, item->number());
         }
     }
     if (victim.quality >= Quality::miracle || rnd(20) == 0 ||

--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -76,7 +76,7 @@ void dmgheal_death_by_backpack(Character& chara)
     OptionalItemRef heaviest_item;
     int heaviest_weight = 0;
 
-    for (const auto& item : g_inv.for_chara(chara))
+    for (const auto& item : *g_inv.for_chara(chara))
     {
         if (item->weight > heaviest_weight)
         {
@@ -1425,7 +1425,7 @@ void character_drops_item(Character& victim)
         {
             return;
         }
-        for (const auto& item : g_inv.for_chara(victim))
+        for (const auto& item : *g_inv.for_chara(victim))
         {
             if (map_data.refresh_type == 0)
             {
@@ -1591,7 +1591,7 @@ void character_drops_item(Character& victim)
             return;
         }
     }
-    for (const auto& item : g_inv.for_chara(victim))
+    for (const auto& item : *g_inv.for_chara(victim))
     {
         f = 0;
         if (victim.role == Role::user)

--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -76,7 +76,7 @@ void dmgheal_death_by_backpack(Character& chara)
     OptionalItemRef heaviest_item;
     int heaviest_weight = 0;
 
-    for (const auto& item : *g_inv.for_chara(chara))
+    for (const auto& item : *chara.inventory())
     {
         if (item->weight > heaviest_weight)
         {
@@ -689,11 +689,11 @@ int damage_hp(
         }
         if ((element == 50 || damage_source == -9) && victim.wet == 0)
         {
-            item_fire(g_inv.for_chara(victim));
+            item_fire(victim.inventory());
         }
         if (element == 51)
         {
-            item_cold(g_inv.for_chara(victim));
+            item_cold(victim.inventory());
         }
         if (victim.sleep != 0)
         {
@@ -1425,7 +1425,7 @@ void character_drops_item(Character& victim)
         {
             return;
         }
-        for (const auto& item : *g_inv.for_chara(victim))
+        for (const auto& item : *victim.inventory())
         {
             if (map_data.refresh_type == 0)
             {
@@ -1543,11 +1543,11 @@ void character_drops_item(Character& victim)
             }
             item->set_position(victim.position);
             item->set_position(victim.position);
-            if (!inv_stack(g_inv.ground(), item).stacked)
+            if (!inv_stack(inv_map(), item).stacked)
             {
-                const auto slot = inv_make_free_slot_force(g_inv.ground());
+                const auto slot = inv_make_free_slot_force(inv_map());
                 const auto dropped_item =
-                    item_separate(item, g_inv.ground(), slot, item->number());
+                    item_separate(item, inv_map(), slot, item->number());
                 dropped_item->own_state = OwnState::lost;
             }
         }
@@ -1591,7 +1591,7 @@ void character_drops_item(Character& victim)
             return;
         }
     }
-    for (const auto& item : *g_inv.for_chara(victim))
+    for (const auto& item : *victim.inventory())
     {
         f = 0;
         if (victim.role == Role::user)
@@ -1665,10 +1665,10 @@ void character_drops_item(Character& victim)
         }
         item->set_position(victim.position);
         itemturn(item);
-        if (!inv_stack(g_inv.ground(), item).stacked)
+        if (!inv_stack(inv_map(), item).stacked)
         {
-            const auto slot = inv_make_free_slot_force(g_inv.ground());
-            item_separate(item, g_inv.ground(), slot, item->number());
+            const auto slot = inv_make_free_slot_force(inv_map());
+            item_separate(item, inv_map(), slot, item->number());
         }
     }
     if (victim.quality >= Quality::miracle || rnd(20) == 0 ||

--- a/src/elona/equipment.cpp
+++ b/src/elona/equipment.cpp
@@ -242,7 +242,7 @@ void eqrandweaponmage()
 
 void wear_most_valuable_equipment_for_all_body_parts(Character& chara)
 {
-    for (const auto& item : *g_inv.for_chara(chara))
+    for (const auto& item : *chara.inventory())
     {
         if (item->body_part != 0)
         {
@@ -321,7 +321,7 @@ void supply_new_equipment(Character& chara)
         f = 0;
         for (int _j = 0; _j < 4; ++_j)
         {
-            const auto inv = g_inv.for_chara(chara);
+            const auto inv = chara.inventory();
             const auto item = inv->at(inv_get_random_slot(inv));
             if (!item)
             {
@@ -1375,7 +1375,7 @@ void unequip_item(Character& chara, size_t equipment_slot_index)
         return;
     }
     equipment_slot.equipment->body_part = 0;
-    inv_stack(g_inv.for_chara(chara), equipment_slot.equipment.unwrap());
+    inv_stack(chara.inventory(), equipment_slot.equipment.unwrap());
     equipment_slot.unequip();
 }
 

--- a/src/elona/equipment.cpp
+++ b/src/elona/equipment.cpp
@@ -242,7 +242,7 @@ void eqrandweaponmage()
 
 void wear_most_valuable_equipment_for_all_body_parts(Character& chara)
 {
-    for (const auto& item : g_inv.for_chara(chara))
+    for (const auto& item : *g_inv.for_chara(chara))
     {
         if (item->body_part != 0)
         {

--- a/src/elona/equipment.cpp
+++ b/src/elona/equipment.cpp
@@ -321,8 +321,8 @@ void supply_new_equipment(Character& chara)
         f = 0;
         for (int _j = 0; _j < 4; ++_j)
         {
-            const auto item =
-                Inventory::at(inv_get_random_slot(g_inv.for_chara(chara)));
+            const auto inv = g_inv.for_chara(chara);
+            const auto item = inv->at(inv_get_random_slot(inv));
             if (!item)
             {
                 f = 1;

--- a/src/elona/fish.cpp
+++ b/src/elona/fish.cpp
@@ -23,7 +23,7 @@ void fish_get(int integer_fish_id)
         item->value = the_fish_db[integer_fish_id]->value;
         item->weight = the_fish_db[integer_fish_id]->weight;
         txt(i18n::s.get("core.activity.fishing.get", item.unwrap()));
-        inv_stack(g_inv.pc(), item.unwrap(), true);
+        inv_stack(inv_player(), item.unwrap(), true);
     }
 }
 

--- a/src/elona/food.cpp
+++ b/src/elona/food.cpp
@@ -261,7 +261,7 @@ void chara_vomit(Character& chara)
     if (map_data.type != mdata_t::MapType::world_map)
     {
         auto p = 2;
-        for (const auto& item : g_inv.ground())
+        for (const auto& item : *g_inv.ground())
         {
             if (item->id == "core.vomit")
             {
@@ -1480,12 +1480,12 @@ void foods_get_rotten()
             continue;
         }
 
-        for (const auto& item : g_inv.for_chara(chara))
+        for (const auto& item : *g_inv.for_chara(chara))
         {
             _food_gets_rotten(chara.index, item);
         }
     }
-    for (const auto& item : g_inv.ground())
+    for (const auto& item : *g_inv.ground())
     {
         _food_gets_rotten(-1, item);
     }

--- a/src/elona/food.cpp
+++ b/src/elona/food.cpp
@@ -261,7 +261,7 @@ void chara_vomit(Character& chara)
     if (map_data.type != mdata_t::MapType::world_map)
     {
         auto p = 2;
-        for (const auto& item : *g_inv.ground())
+        for (const auto& item : *inv_map())
         {
             if (item->id == "core.vomit")
             {
@@ -444,7 +444,7 @@ void food_cook(Character& cook, const ItemRef& cook_tool, const ItemRef& food)
 
     make_dish(food, dish_rank);
     txt(i18n::s.get("core.food.cook", item_name_prev, cook_tool, food));
-    inv_stack(g_inv.pc(), food, true);
+    inv_stack(inv_player(), food, true);
     const auto rank = food->param2;
     if (rank > 2)
     {
@@ -1480,12 +1480,12 @@ void foods_get_rotten()
             continue;
         }
 
-        for (const auto& item : *g_inv.for_chara(chara))
+        for (const auto& item : *chara.inventory())
         {
             _food_gets_rotten(chara.index, item);
         }
     }
-    for (const auto& item : *g_inv.ground())
+    for (const auto& item : *inv_map())
     {
         _food_gets_rotten(-1, item);
     }

--- a/src/elona/initialize_map.cpp
+++ b/src/elona/initialize_map.cpp
@@ -1395,7 +1395,7 @@ void migrate_old_save_v17()
             cell_data.at(x, y).item_info_memory.clear();
         }
     }
-    for (const auto& item : g_inv.ground())
+    for (const auto& item : *g_inv.ground())
     {
         cell_refresh(item->position().x, item->position().y);
     }

--- a/src/elona/initialize_map.cpp
+++ b/src/elona/initialize_map.cpp
@@ -16,6 +16,7 @@
 #include "food.hpp"
 #include "i18n.hpp"
 #include "initialize_map_types.hpp"
+#include "inventory.hpp"
 #include "item.hpp"
 #include "itemgen.hpp"
 #include "lua_env/event_manager.hpp"
@@ -1395,7 +1396,7 @@ void migrate_old_save_v17()
             cell_data.at(x, y).item_info_memory.clear();
         }
     }
-    for (const auto& item : *g_inv.ground())
+    for (const auto& item : *inv_map())
     {
         cell_refresh(item->position().x, item->position().y);
     }

--- a/src/elona/initialize_map_types.cpp
+++ b/src/elona/initialize_map_types.cpp
@@ -1007,7 +1007,7 @@ static void _init_map_your_home()
                 cnt.initial_position.y = map_data.height / 2;
             }
             ctrl_file_map_items_read(fs::u8path(u8"inv_"s + mid + u8".s2"));
-            for (const auto& item : g_inv.ground())
+            for (const auto& item : *g_inv.ground())
             {
                 item->set_position({map_data.width / 2, map_data.height / 2});
                 cell_refresh(item->position().x, item->position().y);

--- a/src/elona/initialize_map_types.cpp
+++ b/src/elona/initialize_map_types.cpp
@@ -7,6 +7,7 @@
 #include "deferred_event.hpp"
 #include "gdata.hpp"
 #include "i18n.hpp"
+#include "inventory.hpp"
 #include "item.hpp"
 #include "itemgen.hpp"
 #include "map.hpp"
@@ -1007,7 +1008,7 @@ static void _init_map_your_home()
                 cnt.initial_position.y = map_data.height / 2;
             }
             ctrl_file_map_items_read(fs::u8path(u8"inv_"s + mid + u8".s2"));
-            for (const auto& item : *g_inv.ground())
+            for (const auto& item : *inv_map())
             {
                 item->set_position({map_data.width / 2, map_data.height / 2});
                 cell_refresh(item->position().x, item->position().y);

--- a/src/elona/inventory.cpp
+++ b/src/elona/inventory.cpp
@@ -106,7 +106,7 @@ InventorySlot inv_make_free_slot_force(const InventoryRef& inv)
     while (true)
     {
         const auto slot = inv_get_random_slot(inv);
-        const auto item = Inventory::at(slot).unwrap();
+        const auto item = inv->at(slot).unwrap();
         const auto owner_chara = owner.as_character();
         assert(owner_chara);
         if (item->body_part == 0)
@@ -184,7 +184,7 @@ InventorySlot inv_compress(const InventoryRef& inv)
 
     // Destroy 1 existing item forcely.
     const auto slot = inv_get_random_slot(inv);
-    Inventory::at(slot)->remove();
+    inv->at(slot)->remove();
 
     return slot;
 }
@@ -193,8 +193,7 @@ InventorySlot inv_compress(const InventoryRef& inv)
 
 InventorySlot inv_get_random_slot(const InventoryRef& inv)
 {
-    const auto index = rnd(inv->size());
-    return {inv, index};
+    return static_cast<InventorySlot>(rnd(inv->size()));
 }
 
 

--- a/src/elona/inventory.cpp
+++ b/src/elona/inventory.cpp
@@ -38,6 +38,20 @@ bool is_stackable_with(const ItemRef& item, const ItemRef& base_item)
 
 
 
+InventoryRef inv_player()
+{
+    return cdata.player().inventory();
+}
+
+
+
+InventoryRef inv_map()
+{
+    return g_inv.ground();
+}
+
+
+
 lua_int inv_weight(const InventoryRef& inv)
 {
     lua_int weight{};

--- a/src/elona/inventory.cpp
+++ b/src/elona/inventory.cpp
@@ -38,10 +38,10 @@ bool is_stackable_with(const ItemRef& item, const ItemRef& base_item)
 
 
 
-lua_int inv_weight(Inventory& inv)
+lua_int inv_weight(const InventoryRef& inv)
 {
     lua_int weight{};
-    for (const auto& item : inv)
+    for (const auto& item : *inv)
     {
         if (item->weight >= 0)
         {
@@ -53,10 +53,10 @@ lua_int inv_weight(Inventory& inv)
 
 
 
-lua_int inv_cargo_weight(Inventory& inv)
+lua_int inv_cargo_weight(const InventoryRef& inv)
 {
     lua_int weight{};
-    for (const auto& item : inv)
+    for (const auto& item : *inv)
     {
         if (item->weight < 0)
         {
@@ -68,14 +68,14 @@ lua_int inv_cargo_weight(Inventory& inv)
 
 
 
-optional<InventorySlot> inv_get_free_slot(Inventory& inv)
+optional<InventorySlot> inv_get_free_slot(const InventoryRef& inv)
 {
-    return inv.get_free_slot();
+    return inv->get_free_slot();
 }
 
 
 
-optional<InventorySlot> inv_make_free_slot(Inventory& inv)
+optional<InventorySlot> inv_make_free_slot(const InventoryRef& inv)
 {
     if (inv_get_owner(inv).is_map())
     {
@@ -89,7 +89,7 @@ optional<InventorySlot> inv_make_free_slot(Inventory& inv)
 
 
 
-InventorySlot inv_make_free_slot_force(Inventory& inv)
+InventorySlot inv_make_free_slot_force(const InventoryRef& inv)
 {
     if (const auto slot = inv_get_free_slot(inv))
     {
@@ -123,12 +123,11 @@ InventorySlot inv_make_free_slot_force(Inventory& inv)
 
 
 
-int inv_count(Inventory& inv)
+lua_int inv_count(const InventoryRef& inv)
 {
-    int n{};
-    for (const auto& _item : inv)
+    lua_int n{};
+    for ([[maybe_unused]] const auto& _i : *inv)
     {
-        (void)_item;
         ++n;
     }
     return n;
@@ -136,31 +135,31 @@ int inv_count(Inventory& inv)
 
 
 
-ItemOwner inv_get_owner(Inventory& inv)
+ItemOwner inv_get_owner(const InventoryRef& inv)
 {
-    if (inv.inventory_id() == -1)
+    if (inv->inventory_id() == -1)
     {
         return ItemOwner::map();
     }
-    else if (inv.inventory_id() == 255)
+    else if (inv->inventory_id() == 255)
     {
         return ItemOwner::temporary();
     }
     else
     {
-        return ItemOwner::character(cdata[inv.inventory_id()]);
+        return ItemOwner::character(cdata[inv->inventory_id()]);
     }
 }
 
 
 
-InventorySlot inv_compress(Inventory& inv)
+InventorySlot inv_compress(const InventoryRef& inv)
 {
     int number_of_deleted_items{};
     for (int i = 0; i < 100; ++i)
     {
         int threshold = 200 * (i * i + 1);
-        for (const auto& item : inv)
+        for (const auto& item : *inv)
         {
             if (!item->is_precious && item->value < threshold)
             {
@@ -178,7 +177,7 @@ InventorySlot inv_compress(Inventory& inv)
         }
     }
 
-    if (const auto free_slot = inv.get_free_slot())
+    if (const auto free_slot = inv->get_free_slot())
     {
         return *free_slot;
     }
@@ -192,16 +191,16 @@ InventorySlot inv_compress(Inventory& inv)
 
 
 
-InventorySlot inv_get_random_slot(Inventory& inv)
+InventorySlot inv_get_random_slot(const InventoryRef& inv)
 {
-    const auto index = rnd(inv.size());
-    return {&inv, index};
+    const auto index = rnd(inv->size());
+    return {inv, index};
 }
 
 
 
 InvStackResult inv_stack(
-    Inventory& inv,
+    const InventoryRef& inv,
     const ItemRef& base_item,
     bool show_message,
     optional<lua_int> number)
@@ -211,7 +210,7 @@ InvStackResult inv_stack(
         return {false, base_item};
     }
 
-    for (const auto& item : inv)
+    for (const auto& item : *inv)
     {
         if (item == base_item || item->id != base_item->id)
             continue;
@@ -243,7 +242,7 @@ void inv_open_tmp_inv(const fs::path& file_name)
     }
     else
     {
-        g_inv.tmp().clear();
+        g_inv.tmp()->clear();
     }
 }
 
@@ -252,21 +251,21 @@ void inv_open_tmp_inv(const fs::path& file_name)
 void inv_close_tmp_inv(const fs::path& file_name)
 {
     ctrl_file_tmp_inv_write(file_name);
-    g_inv.tmp().clear();
+    g_inv.tmp()->clear();
 }
 
 
 
 void inv_open_tmp_inv_no_physical_file()
 {
-    g_inv.tmp().clear();
+    g_inv.tmp()->clear();
 }
 
 
 
 void inv_close_tmp_inv_no_physical_file()
 {
-    g_inv.tmp().clear();
+    g_inv.tmp()->clear();
 }
 
 } // namespace elona

--- a/src/elona/inventory.cpp
+++ b/src/elona/inventory.cpp
@@ -140,8 +140,9 @@ InventorySlot inv_make_free_slot_force(const InventoryRef& inv)
 lua_int inv_count(const InventoryRef& inv)
 {
     lua_int n{};
-    for ([[maybe_unused]] const auto& _i : *inv)
+    for (const auto& _i : *inv)
     {
+        (void)_i;
         ++n;
     }
     return n;

--- a/src/elona/inventory.hpp
+++ b/src/elona/inventory.hpp
@@ -9,6 +9,23 @@ namespace elona
 {
 
 /**
+ * Helper function to access the player character's inventory. It is equivalent
+ * to `cdata.player().inventory()`.
+ *
+ * @return The player character's inventory.
+ */
+InventoryRef inv_player();
+
+
+/**
+ * Helper function to access the current map's inventory.
+ *
+ * @return The current map's inventory.
+ */
+InventoryRef inv_map();
+
+
+/**
  * Calculate the sum of item weight excluding cargo goods.
  *
  * @param inv The inventory to calculate weight.

--- a/src/elona/inventory.hpp
+++ b/src/elona/inventory.hpp
@@ -14,7 +14,7 @@ namespace elona
  * @param inv The inventory to calculate weight.
  * @return The sum of item weight.
  */
-lua_int inv_weight(Inventory& inv);
+lua_int inv_weight(const InventoryRef& inv);
 
 
 /**
@@ -23,7 +23,7 @@ lua_int inv_weight(Inventory& inv);
  * @param inv The inventory to calculate weight.
  * @return The sum of cargo item's weight.
  */
-lua_int inv_cargo_weight(Inventory& inv);
+lua_int inv_cargo_weight(const InventoryRef& inv);
 
 
 /**
@@ -32,7 +32,7 @@ lua_int inv_cargo_weight(Inventory& inv);
  * @param inv The inventory to query.
  * @return The free slot.
  */
-optional<InventorySlot> inv_get_free_slot(Inventory& inv);
+optional<InventorySlot> inv_get_free_slot(const InventoryRef& inv);
 
 
 /**
@@ -43,7 +43,7 @@ optional<InventorySlot> inv_get_free_slot(Inventory& inv);
  * @param inv The inventory.
  * @return The free slot.
  */
-optional<InventorySlot> inv_make_free_slot(Inventory& inv);
+optional<InventorySlot> inv_make_free_slot(const InventoryRef& inv);
 
 
 /**
@@ -53,7 +53,7 @@ optional<InventorySlot> inv_make_free_slot(Inventory& inv);
  * @param inv The inventory.
  * @return The free slot.
  */
-InventorySlot inv_make_free_slot_force(Inventory& inv);
+InventorySlot inv_make_free_slot_force(const InventoryRef& inv);
 
 
 /**
@@ -62,7 +62,7 @@ InventorySlot inv_make_free_slot_force(Inventory& inv);
  * @param inv The inventory to count.
  * @return The number of items @a inv has.
  */
-int inv_count(Inventory& inv);
+lua_int inv_count(const InventoryRef& inv);
 
 
 /**
@@ -71,7 +71,7 @@ int inv_count(Inventory& inv);
  * @param inv The inventory to query.
  * @return @a inv's owner.
  */
-ItemOwner inv_get_owner(Inventory& inv);
+ItemOwner inv_get_owner(const InventoryRef& inv);
 
 
 /**
@@ -80,7 +80,7 @@ ItemOwner inv_get_owner(Inventory& inv);
  * @param inv The inventory to compress.
  * @return The free slot created by the compression.
  */
-InventorySlot inv_compress(Inventory& inv);
+InventorySlot inv_compress(const InventoryRef& inv);
 
 
 /**
@@ -89,7 +89,7 @@ InventorySlot inv_compress(Inventory& inv);
  * @param inv The inventory.
  * @return An item slot in @a inv.
  */
-InventorySlot inv_get_random_slot(Inventory& inv);
+InventorySlot inv_get_random_slot(const InventoryRef& inv);
 
 
 /**
@@ -104,9 +104,9 @@ template <
     typename F,
     std::enable_if_t<std::is_invocable_v<F, const ItemRef&>, std::nullptr_t> =
         nullptr>
-OptionalItemRef inv_find(Inventory& inv, F predicate)
+OptionalItemRef inv_find(const InventoryRef& inv, F predicate)
 {
-    for (const auto& item : inv)
+    for (const auto& item : *inv)
     {
         if (predicate(item))
         {
@@ -128,11 +128,11 @@ OptionalItemRef inv_find(Inventory& inv, F predicate)
 template <
     typename F,
     std::enable_if_t<
-        std::is_invocable_v<F, const ItemRef&, Inventory&>,
+        std::is_invocable_v<F, const ItemRef&, const InventoryRef&>,
         std::nullptr_t> = nullptr>
-OptionalItemRef inv_find(Inventory& inv, F predicate)
+OptionalItemRef inv_find(const InventoryRef& inv, F predicate)
 {
-    for (const auto& item : inv)
+    for (const auto& item : *inv)
     {
         if (predicate(item, inv))
         {
@@ -155,10 +155,10 @@ template <
     typename F,
     std::enable_if_t<std::is_invocable_v<F, const ItemRef&>, std::nullptr_t> =
         nullptr>
-OptionalItemRef inv_find_last_match(Inventory& inv, F predicate)
+OptionalItemRef inv_find_last_match(const InventoryRef& inv, F predicate)
 {
     OptionalItemRef result;
-    for (const auto& item : inv)
+    for (const auto& item : *inv)
     {
         if (predicate(item))
         {
@@ -180,12 +180,12 @@ OptionalItemRef inv_find_last_match(Inventory& inv, F predicate)
 template <
     typename F,
     std::enable_if_t<
-        std::is_invocable_v<F, const ItemRef&, Inventory&>,
+        std::is_invocable_v<F, const ItemRef&, const InventoryRef&>,
         std::nullptr_t> = nullptr>
-OptionalItemRef inv_find_last_match(Inventory& inv, F predicate)
+OptionalItemRef inv_find_last_match(const InventoryRef& inv, F predicate)
 {
     OptionalItemRef result;
-    for (const auto& item : inv)
+    for (const auto& item : *inv)
     {
         if (predicate(item, inv))
         {
@@ -211,7 +211,7 @@ struct InvStackResult
  * Try to stack @a inv with @a base_item.
  */
 InvStackResult inv_stack(
-    Inventory& inv,
+    const InventoryRef& inv,
     const ItemRef& base_item,
     bool show_message = false,
     optional<lua_int> number = none);

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -447,7 +447,6 @@ public:
     ItemRef operator[](int index);
 
 
-    InventoryRef pc();
     InventoryRef ground();
     InventoryRef tmp();
     InventoryRef for_chara(const Character& chara);

--- a/src/elona/item.hpp
+++ b/src/elona/item.hpp
@@ -435,6 +435,10 @@ private:
 
 
 
+using InventoryRef = Inventory*;
+
+
+
 struct AllInventory
 {
 private:
@@ -451,11 +455,11 @@ public:
     ItemRef operator[](int index);
 
 
-    Inventory& pc();
-    Inventory& ground();
-    Inventory& tmp();
-    Inventory& for_chara(const Character& chara);
-    Inventory& by_index(int index);
+    InventoryRef pc();
+    InventoryRef ground();
+    InventoryRef tmp();
+    InventoryRef for_chara(const Character& chara);
+    InventoryRef by_index(int index);
 
     iterator_pair_type all();
     iterator_pair_type global();
@@ -493,8 +497,8 @@ void item_acid(const Character& owner, OptionalItemRef item = nullptr);
 
 void itemturn(const ItemRef& item);
 
-OptionalItemRef itemfind(Inventory& inv, data::InstanceId id);
-OptionalItemRef itemfind(Inventory& inv, int subcategory);
+OptionalItemRef itemfind(const InventoryRef& inv, data::InstanceId id);
+OptionalItemRef itemfind(const InventoryRef& inv, int subcategory);
 
 int itemusingfind(const ItemRef& item, bool disallow_pc = false);
 
@@ -524,9 +528,13 @@ ItemRef item_separate(const ItemRef& stacked_item);
 
 void item_dump_desc(const ItemRef&);
 
-bool item_fire(Inventory& inv, const OptionalItemRef& burned_item = nullptr);
+bool item_fire(
+    const InventoryRef& inv,
+    const OptionalItemRef& burned_item = nullptr);
 void mapitem_fire(optional_ref<Character> arsonist, int x, int y);
-bool item_cold(Inventory& inv, const OptionalItemRef& destroyed_item = nullptr);
+bool item_cold(
+    const InventoryRef& inv,
+    const OptionalItemRef& destroyed_item = nullptr);
 void mapitem_cold(int x, int y);
 
 

--- a/src/elona/itemgen.cpp
+++ b/src/elona/itemgen.cpp
@@ -50,11 +50,12 @@ int calculate_original_value(const ItemRef& item)
 namespace elona
 {
 
-OptionalItemRef do_create_item(int, Inventory&, int, int);
+OptionalItemRef do_create_item(int, const InventoryRef&, int, int);
 
 
 
-OptionalItemRef itemcreate(Inventory& inv, int id, int x, int y, int number)
+OptionalItemRef
+itemcreate(const InventoryRef& inv, int id, int x, int y, int number)
 {
     if (flttypeminor != 0)
     {
@@ -67,7 +68,7 @@ OptionalItemRef itemcreate(Inventory& inv, int id, int x, int y, int number)
 
 
 OptionalItemRef
-itemcreate(Inventory& inv, int id, const Position& pos, int number)
+itemcreate(const InventoryRef& inv, int id, const Position& pos, int number)
 {
     return itemcreate(inv, id, pos.x, pos.y, number);
 }
@@ -151,7 +152,7 @@ int get_random_item_id()
 
 
 
-bool upgrade_item_quality(Inventory& inv)
+bool upgrade_item_quality(const InventoryRef& inv)
 {
     const auto owner_chara = inv_get_owner(inv).as_character();
     if (owner_chara && !owner_chara->is_player())
@@ -162,7 +163,8 @@ bool upgrade_item_quality(Inventory& inv)
 
 
 
-OptionalItemRef do_create_item(int item_id, Inventory& inv, int x, int y)
+OptionalItemRef
+do_create_item(int item_id, const InventoryRef& inv, int x, int y)
 {
     if (fixlv < Quality::godly && upgrade_item_quality(inv))
     {

--- a/src/elona/itemgen.cpp
+++ b/src/elona/itemgen.cpp
@@ -84,14 +84,14 @@ OptionalItemRef itemcreate_player_inv(int id, int number)
 
 OptionalItemRef itemcreate_chara_inv(Character& chara, int id, int number)
 {
-    return itemcreate(g_inv.for_chara(chara), id, -1, -1, number);
+    return itemcreate(chara.inventory(), id, -1, -1, number);
 }
 
 
 
 OptionalItemRef itemcreate_map_inv(int id, int x, int y, int number)
 {
-    return itemcreate(g_inv.ground(), id, x, y, number);
+    return itemcreate(inv_map(), id, x, y, number);
 }
 
 

--- a/src/elona/itemgen.cpp
+++ b/src/elona/itemgen.cpp
@@ -268,7 +268,7 @@ do_create_item(int item_id, const InventoryRef& inv, int x, int y)
         }
     }
 
-    const auto item = Inventory::create(empty_slot);
+    const auto item = inv->create(empty_slot);
     if (item_pos)
     {
         item->set_position(*item_pos);

--- a/src/elona/itemgen.hpp
+++ b/src/elona/itemgen.hpp
@@ -11,6 +11,7 @@ namespace elona
 {
 
 struct Inventory;
+using InventoryRef = Inventory*;
 struct Item;
 struct Character;
 struct Position;
@@ -18,10 +19,13 @@ struct Position;
 
 
 OptionalItemRef
-itemcreate(Inventory& inv, int id, int x, int y, int number = 0);
+itemcreate(const InventoryRef& inv, int id, int x, int y, int number = 0);
 
-OptionalItemRef
-itemcreate(Inventory& inv, int id, const Position& pos, int number = 0);
+OptionalItemRef itemcreate(
+    const InventoryRef& inv,
+    int id,
+    const Position& pos,
+    int number = 0);
 
 OptionalItemRef itemcreate_player_inv(int id, int number = 0);
 

--- a/src/elona/lua_env/api/classes/class_LuaInventory.cpp
+++ b/src/elona/lua_env/api/classes/class_LuaInventory.cpp
@@ -62,7 +62,7 @@ sol::optional<ItemRef> LuaInventory_stack(
     sol::optional<bool> show_message)
 {
     const auto stack_result =
-        inv_stack(*self, item, show_message.value_or(false));
+        inv_stack(self, item, show_message.value_or(false));
     if (stack_result.stacked)
     {
         return stack_result.stacked_item;

--- a/src/elona/lua_env/api/modules/module_Inventory.cpp
+++ b/src/elona/lua_env/api/modules/module_Inventory.cpp
@@ -20,7 +20,7 @@ namespace elona::lua::api::modules::module_Inventory
  */
 Inventory* Inventory_player()
 {
-    return &g_inv.pc();
+    return g_inv.pc();
 }
 
 
@@ -35,7 +35,7 @@ Inventory* Inventory_player()
  */
 Inventory* Inventory_map()
 {
-    return &g_inv.ground();
+    return g_inv.ground();
 }
 
 
@@ -43,7 +43,7 @@ Inventory* Inventory_map()
 // Undocumented because it is unstable API.
 Inventory* Inventory_tmp()
 {
-    return &g_inv.tmp();
+    return g_inv.tmp();
 }
 
 

--- a/src/elona/lua_env/api/modules/module_Inventory.cpp
+++ b/src/elona/lua_env/api/modules/module_Inventory.cpp
@@ -20,7 +20,7 @@ namespace elona::lua::api::modules::module_Inventory
  */
 Inventory* Inventory_player()
 {
-    return g_inv.pc();
+    return inv_player();
 }
 
 
@@ -35,7 +35,7 @@ Inventory* Inventory_player()
  */
 Inventory* Inventory_map()
 {
-    return g_inv.ground();
+    return inv_map();
 }
 
 

--- a/src/elona/lua_env/api/modules/module_Item.cpp
+++ b/src/elona/lua_env/api/modules/module_Item.cpp
@@ -29,7 +29,7 @@ namespace elona::lua::api::modules::module_Item
  */
 int Item_count()
 {
-    return inv_count(g_inv.ground());
+    return inv_count(inv_map());
 }
 
 
@@ -99,7 +99,7 @@ sol::optional<ItemRef> Item_create_xy(int x, int y, sol::table args)
     }
     if (!inv)
     {
-        inv = g_inv.ground();
+        inv = inv_map();
     }
 
     // Random objlv

--- a/src/elona/lua_env/api/modules/module_Item.cpp
+++ b/src/elona/lua_env/api/modules/module_Item.cpp
@@ -73,7 +73,7 @@ sol::optional<ItemRef> Item_create_xy(int x, int y, sol::table args)
     // body for some reason.
 #ifndef ELONA_DOCGEN
     int id = 0;
-    Inventory* inv = nullptr;
+    InventoryRef inv{};
     int number = 0;
     objlv = 0;
     fixlv = Quality::none;
@@ -93,13 +93,13 @@ sol::optional<ItemRef> Item_create_xy(int x, int y, sol::table args)
         number = *it;
     }
 
-    if (auto it = args.get<sol::optional<Inventory*>>("inventory"))
+    if (auto it = args.get<sol::optional<InventoryRef>>("inventory"))
     {
         inv = *it;
     }
     if (!inv)
     {
-        inv = &g_inv.ground();
+        inv = g_inv.ground();
     }
 
     // Random objlv
@@ -155,7 +155,7 @@ sol::optional<ItemRef> Item_create_xy(int x, int y, sol::table args)
         id = data.integer_id;
     }
 
-    if (const auto item = itemcreate(*inv, id, x, y, number))
+    if (const auto item = itemcreate(inv, id, x, y, number))
     {
         return item.unwrap();
     }

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -560,7 +560,7 @@ bool _magic_183(Character& subject, OptionalItemRef instrument)
 
     if (!subject.is_player())
     {
-        for (const auto& item : g_inv.for_chara(subject))
+        for (const auto& item : *g_inv.for_chara(subject))
         {
             if (item->skill == 183)
             {
@@ -651,7 +651,7 @@ bool _magic_185(Character& subject, const ItemRef& rod)
         txt(i18n::s.get("core.magic.fish.do_not_know"));
         return false;
     }
-    if (!g_inv.pc().has_free_slot())
+    if (!g_inv.pc()->has_free_slot())
     {
         txt(i18n::s.get("core.ui.inv.common.inventory_is_full"));
         return false;
@@ -1153,7 +1153,7 @@ bool _magic_412(Character& subject, Character& target)
     }
     p(1) = 0;
     p(2) = 0;
-    for (const auto& item : g_inv.for_chara(target))
+    for (const auto& item : *g_inv.for_chara(target))
     {
         if (!is_cursed(item->curse_state))
         {
@@ -3400,7 +3400,7 @@ bool _magic_651(Character& subject, Character& target)
         txt(i18n::s.get("core.magic.scavenge.apply", subject, target));
     }
     OptionalItemRef eat_item_opt;
-    for (const auto& item : g_inv.for_chara(target))
+    for (const auto& item : *g_inv.for_chara(target))
     {
         if (item->id == "core.fish_a")
         {
@@ -3410,7 +3410,7 @@ bool _magic_651(Character& subject, Character& target)
     }
     if (!eat_item_opt)
     {
-        for (const auto& item : g_inv.for_chara(target))
+        for (const auto& item : *g_inv.for_chara(target))
         {
             if (item->is_precious)
             {

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -560,7 +560,7 @@ bool _magic_183(Character& subject, OptionalItemRef instrument)
 
     if (!subject.is_player())
     {
-        for (const auto& item : *g_inv.for_chara(subject))
+        for (const auto& item : *subject.inventory())
         {
             if (item->skill == 183)
             {
@@ -651,7 +651,7 @@ bool _magic_185(Character& subject, const ItemRef& rod)
         txt(i18n::s.get("core.magic.fish.do_not_know"));
         return false;
     }
-    if (!g_inv.pc()->has_free_slot())
+    if (!inv_player()->has_free_slot())
     {
         txt(i18n::s.get("core.ui.inv.common.inventory_is_full"));
         return false;
@@ -1153,7 +1153,7 @@ bool _magic_412(Character& subject, Character& target)
     }
     p(1) = 0;
     p(2) = 0;
-    for (const auto& item : *g_inv.for_chara(target))
+    for (const auto& item : *target.inventory())
     {
         if (!is_cursed(item->curse_state))
         {
@@ -1182,7 +1182,7 @@ bool _magic_412(Character& subject, Character& target)
             {
                 ++p(1);
                 item->curse_state = CurseState::none;
-                inv_stack(g_inv.for_chara(target), item, true);
+                inv_stack(target.inventory(), item, true);
             }
             else
             {
@@ -2090,7 +2090,7 @@ bool _magic_645_1114(Character& subject, Character& target)
     {
         for (int _i = 0; _i < 200; ++_i)
         {
-            const auto inv = g_inv.for_chara(target);
+            const auto inv = target.inventory();
             const auto item = inv->at(inv_get_random_slot(inv));
             if (!item)
             {
@@ -2127,7 +2127,7 @@ bool _magic_645_1114(Character& subject, Character& target)
         chara_refresh(target);
         snd("core.curse3");
         animeload(14, target);
-        inv_stack(g_inv.for_chara(target), cursed_item, true);
+        inv_stack(target.inventory(), cursed_item, true);
     }
     else
     {
@@ -2226,7 +2226,7 @@ bool _magic_435(Character& subject, Character& target)
     }
     f = 1;
     {
-        if (itemfind(g_inv.for_chara(subject), "core.monster_heart"))
+        if (itemfind(subject.inventory(), "core.monster_heart"))
         {
             efp = efp * 3 / 2;
         }
@@ -3400,7 +3400,7 @@ bool _magic_651(Character& subject, Character& target)
         txt(i18n::s.get("core.magic.scavenge.apply", subject, target));
     }
     OptionalItemRef eat_item_opt;
-    for (const auto& item : *g_inv.for_chara(target))
+    for (const auto& item : *target.inventory())
     {
         if (item->id == "core.fish_a")
         {
@@ -3410,7 +3410,7 @@ bool _magic_651(Character& subject, Character& target)
     }
     if (!eat_item_opt)
     {
-        for (const auto& item : *g_inv.for_chara(target))
+        for (const auto& item : *target.inventory())
         {
             if (item->is_precious)
             {

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -2090,8 +2090,8 @@ bool _magic_645_1114(Character& subject, Character& target)
     {
         for (int _i = 0; _i < 200; ++_i)
         {
-            const auto item =
-                Inventory::at(inv_get_random_slot(g_inv.for_chara(target)));
+            const auto inv = g_inv.for_chara(target);
+            const auto item = inv->at(inv_get_random_slot(inv));
             if (!item)
             {
                 continue;

--- a/src/elona/map.cpp
+++ b/src/elona/map.cpp
@@ -289,7 +289,7 @@ void map_reload(const std::string& map_filename)
 
     mef_clear_all();
 
-    for (const auto& item : g_inv.ground())
+    for (const auto& item : *g_inv.ground())
     {
         if (item->own_state == OwnState::town)
         {
@@ -635,7 +635,7 @@ static void _clear_material_spots()
 
 static void _modify_items_on_regenerate()
 {
-    for (const auto& item : g_inv.ground())
+    for (const auto& item : *g_inv.ground())
     {
         // Update tree of fruits.
         if (item->id == "core.tree_of_fruits")
@@ -879,7 +879,7 @@ void map_proc_regen_and_update()
 
 void map_reload_noyel()
 {
-    for (const auto& item : g_inv.ground())
+    for (const auto& item : *g_inv.ground())
     {
         if (item->id == "core.shelter" || item->id == "core.giants_shackle")
         {
@@ -2091,7 +2091,7 @@ void map_global_proc_travel_events(Character& chara)
     }
     if (cdata.player().nutrition <= 5000)
     {
-        for (const auto& item : g_inv.for_chara(chara))
+        for (const auto& item : *g_inv.for_chara(chara))
         {
             if (the_item_db[item->id]->category == ItemCategory::travelers_food)
             {

--- a/src/elona/map.cpp
+++ b/src/elona/map.cpp
@@ -289,7 +289,7 @@ void map_reload(const std::string& map_filename)
 
     mef_clear_all();
 
-    for (const auto& item : *g_inv.ground())
+    for (const auto& item : *inv_map())
     {
         if (item->own_state == OwnState::town)
         {
@@ -635,7 +635,7 @@ static void _clear_material_spots()
 
 static void _modify_items_on_regenerate()
 {
-    for (const auto& item : *g_inv.ground())
+    for (const auto& item : *inv_map())
     {
         // Update tree of fruits.
         if (item->id == "core.tree_of_fruits")
@@ -751,7 +751,7 @@ static void _grow_plants()
 
 static void _proc_generate_bard_items(Character& chara)
 {
-    if (!itemfind(g_inv.for_chara(chara), 60005))
+    if (!itemfind(chara.inventory(), 60005))
     {
         if (rnd(150) == 0)
         {
@@ -800,7 +800,7 @@ static void _restock_character_inventories()
         {
             supply_new_equipment(cnt);
         }
-        if (rnd(2) == 0 && inv_count(g_inv.for_chara(cnt)) < 8)
+        if (rnd(2) == 0 && inv_count(cnt.inventory()) < 8)
         {
             _generate_bad_quality_item(cnt);
         }
@@ -879,7 +879,7 @@ void map_proc_regen_and_update()
 
 void map_reload_noyel()
 {
-    for (const auto& item : *g_inv.ground())
+    for (const auto& item : *inv_map())
     {
         if (item->id == "core.shelter" || item->id == "core.giants_shackle")
         {
@@ -1446,7 +1446,7 @@ TurnResult exit_map()
                         mdata_t::MapId::the_void)
                     {
                         if (!itemfind(
-                                g_inv.pc(),
+                                inv_player(),
                                 "core.license_of_the_void_explorer"))
                         {
                             txt(i18n::s.get(
@@ -2091,7 +2091,7 @@ void map_global_proc_travel_events(Character& chara)
     }
     if (cdata.player().nutrition <= 5000)
     {
-        for (const auto& item : *g_inv.for_chara(chara))
+        for (const auto& item : *chara.inventory())
         {
             if (the_item_db[item->id]->category == ItemCategory::travelers_food)
             {

--- a/src/elona/map_cell.cpp
+++ b/src/elona/map_cell.cpp
@@ -2,9 +2,12 @@
 
 #include "character.hpp"
 #include "elona.hpp"
+#include "inventory.hpp"
 #include "item.hpp"
 #include "map.hpp"
 #include "variables.hpp"
+
+
 
 namespace elona
 {
@@ -245,7 +248,7 @@ int cell_findspace(int base_x, int base_y, int range)
 int cell_count_exact_item_stacks(const Position& pos)
 {
     int ret{};
-    for (const auto& item : *g_inv.ground())
+    for (const auto& item : *inv_map())
     {
         if (item->number() > 0 && item->position() == pos)
         {
@@ -267,7 +270,7 @@ OptionalItemRef cell_get_item_if_only_one(const Position& pos)
     else
     {
         const auto index = item_info_actual.item_indice()[0];
-        return g_inv.ground()->at(static_cast<InventorySlot>(index - 1));
+        return inv_map()->at(static_cast<InventorySlot>(index - 1));
     }
 }
 

--- a/src/elona/map_cell.cpp
+++ b/src/elona/map_cell.cpp
@@ -245,7 +245,7 @@ int cell_findspace(int base_x, int base_y, int range)
 int cell_count_exact_item_stacks(const Position& pos)
 {
     int ret{};
-    for (const auto& item : g_inv.ground())
+    for (const auto& item : *g_inv.ground())
     {
         if (item->number() > 0 && item->position() == pos)
         {
@@ -267,7 +267,7 @@ OptionalItemRef cell_get_item_if_only_one(const Position& pos)
     else
     {
         const auto index = item_info_actual.item_indice()[0];
-        return g_inv.ground().at(index - 1);
+        return g_inv.ground()->at(index - 1);
     }
 }
 

--- a/src/elona/map_cell.cpp
+++ b/src/elona/map_cell.cpp
@@ -267,7 +267,7 @@ OptionalItemRef cell_get_item_if_only_one(const Position& pos)
     else
     {
         const auto index = item_info_actual.item_indice()[0];
-        return g_inv.ground()->at(index - 1);
+        return g_inv.ground()->at(static_cast<InventorySlot>(index - 1));
     }
 }
 

--- a/src/elona/mapgen.cpp
+++ b/src/elona/mapgen.cpp
@@ -7,6 +7,7 @@
 #include "elona.hpp"
 #include "enums.hpp"
 #include "i18n.hpp"
+#include "inventory.hpp"
 #include "item.hpp"
 #include "itemgen.hpp"
 #include "map.hpp"
@@ -2926,7 +2927,7 @@ int initialize_quest_map_party()
             chara->original_relationship = -1;
         }
     }
-    for (const auto& item : *g_inv.ground())
+    for (const auto& item : *inv_map())
     {
         item->own_state = OwnState::town;
     }
@@ -2975,7 +2976,7 @@ void initialize_quest_map_town()
             }
         }
     }
-    for (const auto& item : *g_inv.ground())
+    for (const auto& item : *inv_map())
     {
         f = 0;
         if (item->id == "core.well" || item->id == "core.fountain")

--- a/src/elona/mapgen.cpp
+++ b/src/elona/mapgen.cpp
@@ -2926,7 +2926,7 @@ int initialize_quest_map_party()
             chara->original_relationship = -1;
         }
     }
-    for (const auto& item : g_inv.ground())
+    for (const auto& item : *g_inv.ground())
     {
         item->own_state = OwnState::town;
     }
@@ -2975,7 +2975,7 @@ void initialize_quest_map_town()
             }
         }
     }
-    for (const auto& item : g_inv.ground())
+    for (const auto& item : *g_inv.ground())
     {
         f = 0;
         if (item->id == "core.well" || item->id == "core.fountain")

--- a/src/elona/quest.cpp
+++ b/src/elona/quest.cpp
@@ -12,6 +12,7 @@
 #include "dmgheal.hpp"
 #include "food.hpp"
 #include "i18n.hpp"
+#include "inventory.hpp"
 #include "item.hpp"
 #include "itemgen.hpp"
 #include "map.hpp"
@@ -1109,7 +1110,7 @@ void quest_exit_map()
 {
     if (game_data.executing_immediate_quest_type == 1006)
     {
-        for (const auto& item : *g_inv.pc())
+        for (const auto& item : *inv_player())
         {
             if (item->own_state == OwnState::crop)
             {

--- a/src/elona/quest.cpp
+++ b/src/elona/quest.cpp
@@ -1109,7 +1109,7 @@ void quest_exit_map()
 {
     if (game_data.executing_immediate_quest_type == 1006)
     {
-        for (const auto& item : g_inv.pc())
+        for (const auto& item : *g_inv.pc())
         {
             if (item->own_state == OwnState::crop)
             {

--- a/src/elona/random_event.cpp
+++ b/src/elona/random_event.cpp
@@ -99,14 +99,14 @@ optional<RandomEvent> generate_random_event_in_sleep()
     }
     if (rnd(250) == 0)
     {
-        if (g_inv.pc()->has_free_slot())
+        if (inv_player()->has_free_slot())
         {
             id = 19;
         }
     }
     if (rnd(10000) == 0)
     {
-        if (g_inv.pc()->has_free_slot())
+        if (inv_player()->has_free_slot())
         {
             id = 21;
         }

--- a/src/elona/random_event.cpp
+++ b/src/elona/random_event.cpp
@@ -99,14 +99,14 @@ optional<RandomEvent> generate_random_event_in_sleep()
     }
     if (rnd(250) == 0)
     {
-        if (g_inv.pc().has_free_slot())
+        if (g_inv.pc()->has_free_slot())
         {
             id = 19;
         }
     }
     if (rnd(10000) == 0)
     {
-        if (g_inv.pc().has_free_slot())
+        if (g_inv.pc()->has_free_slot())
         {
             id = 21;
         }

--- a/src/elona/talk_house_visitor.cpp
+++ b/src/elona/talk_house_visitor.cpp
@@ -406,7 +406,7 @@ TalkResult _talk_hv_adventurer_friendship(Character& speaker)
 
 void _adventurer_receive_souvenir()
 {
-    if (!g_inv.pc().has_free_slot())
+    if (!g_inv.pc()->has_free_slot())
     {
         txt(i18n::s.get(
             "core.talk.visitor.adventurer.souvenir.inventory_is_full"));

--- a/src/elona/talk_house_visitor.cpp
+++ b/src/elona/talk_house_visitor.cpp
@@ -359,7 +359,7 @@ TalkResult _talk_hv_adventurer_train(Character& speaker)
 
 void _adventurer_receive_coin(Character& speaker)
 {
-    inv_make_free_slot_force(g_inv.ground());
+    inv_make_free_slot_force(inv_map());
 
     if (rnd(4))
     {
@@ -406,7 +406,7 @@ TalkResult _talk_hv_adventurer_friendship(Character& speaker)
 
 void _adventurer_receive_souvenir()
 {
-    if (!g_inv.pc()->has_free_slot())
+    if (!inv_player()->has_free_slot())
     {
         txt(i18n::s.get(
             "core.talk.visitor.adventurer.souvenir.inventory_is_full"));
@@ -619,7 +619,7 @@ TalkResult _talk_hv_adventurer(Character& speaker)
     }
     if (speaker.impression >= 100 && !speaker.is_best_friend())
     {
-        inv_make_free_slot_force(g_inv.ground());
+        inv_make_free_slot_force(inv_map());
         _talk_hv_adventurer_best_friend(speaker);
         // NOTE: this dialog falls through.
     }

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -98,7 +98,7 @@ TalkResult talk_wizard_identify(Character& speaker, int chatval_)
         return TalkResult::talk_npc;
     }
     p = 0;
-    for (const auto& item : g_inv.pc())
+    for (const auto& item : *g_inv.pc())
     {
         if (item->identify_state != IdentifyState::completely)
         {
@@ -117,7 +117,7 @@ TalkResult talk_wizard_identify(Character& speaker, int chatval_)
         p(1) = 0;
         p(0) = 0;
         p(1) = 0;
-        for (const auto& item : g_inv.pc())
+        for (const auto& item : *g_inv.pc())
         {
             if (item->identify_state != IdentifyState::completely)
             {
@@ -210,7 +210,7 @@ TalkResult talk_healer_restore_attributes(Character& speaker)
 TalkResult talk_trade(Character& speaker)
 {
     invsubroutine = 1;
-    for (const auto& item : g_inv.for_chara(speaker))
+    for (const auto& item : *g_inv.for_chara(speaker))
     {
         item->identify_state = IdentifyState::completely;
     }
@@ -1673,7 +1673,7 @@ TalkResult talk_quest_giver(Character& speaker)
         }
         if (quest_data[rq].id == 1002)
         {
-            if (!g_inv.pc().has_free_slot())
+            if (!g_inv.pc()->has_free_slot())
             {
                 buff = i18n::s.get(
                     "core.talk.npc.quest_giver.about.backpack_full", speaker);
@@ -2170,7 +2170,7 @@ TalkResult talk_npc(Character& speaker)
                 {
                     p = quest_data[cnt].target_item_id;
                     deliver = cnt;
-                    for (const auto& item : g_inv.pc())
+                    for (const auto& item : *g_inv.pc())
                     {
                         if (the_item_db[item->id]->integer_id == p)
                         {
@@ -2190,7 +2190,7 @@ TalkResult talk_npc(Character& speaker)
             quest_data[rq].client_chara_type == 3 &&
             quest_data[rq].progress == 1)
         {
-            for (const auto& item : g_inv.pc())
+            for (const auto& item : *g_inv.pc())
             {
                 if (item->is_no_drop)
                 {

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -98,7 +98,7 @@ TalkResult talk_wizard_identify(Character& speaker, int chatval_)
         return TalkResult::talk_npc;
     }
     p = 0;
-    for (const auto& item : *g_inv.pc())
+    for (const auto& item : *inv_player())
     {
         if (item->identify_state != IdentifyState::completely)
         {
@@ -117,12 +117,12 @@ TalkResult talk_wizard_identify(Character& speaker, int chatval_)
         p(1) = 0;
         p(0) = 0;
         p(1) = 0;
-        for (const auto& item : *g_inv.pc())
+        for (const auto& item : *inv_player())
         {
             if (item->identify_state != IdentifyState::completely)
             {
                 const auto result = item_identify(item, 250);
-                inv_stack(g_inv.pc(), item, true);
+                inv_stack(inv_player(), item, true);
                 ++p(1);
                 if (result >= IdentifyState::completely)
                 {
@@ -210,7 +210,7 @@ TalkResult talk_healer_restore_attributes(Character& speaker)
 TalkResult talk_trade(Character& speaker)
 {
     invsubroutine = 1;
-    for (const auto& item : *g_inv.for_chara(speaker))
+    for (const auto& item : *speaker.inventory())
     {
         item->identify_state = IdentifyState::completely;
     }
@@ -453,7 +453,7 @@ TalkResult talk_quest_delivery(
     const ItemRef& item_to_deliver)
 {
     txt(i18n::s.get("core.talk.npc.common.hand_over", item_to_deliver));
-    const auto inv = g_inv.for_chara(speaker);
+    const auto inv = speaker.inventory();
     const auto slot = inv_make_free_slot_force(inv);
     const auto handed_over_item = item_separate(item_to_deliver, inv, slot, 1);
     chara_set_ai_item(speaker, handed_over_item);
@@ -469,7 +469,7 @@ TalkResult talk_quest_delivery(
 TalkResult talk_quest_supply(Character& speaker, const ItemRef& item_to_supply)
 {
     txt(i18n::s.get("core.talk.npc.common.hand_over", item_to_supply));
-    const auto inv = g_inv.for_chara(speaker);
+    const auto inv = speaker.inventory();
     const auto slot = inv_make_free_slot_force(inv);
     const auto handed_over_item = item_separate(item_to_supply, inv, slot, 1);
     speaker.was_passed_item_by_you_just_now() = true;
@@ -506,10 +506,10 @@ TalkResult talk_shop_attack(Character& speaker)
 TalkResult talk_guard_return_item(Character& speaker)
 {
     listmax = 0;
-    auto wallet_opt = itemfind(g_inv.pc(), "core.wallet");
+    auto wallet_opt = itemfind(inv_player(), "core.wallet");
     if (!wallet_opt)
     {
-        wallet_opt = itemfind(g_inv.pc(), "core.suitcase");
+        wallet_opt = itemfind(inv_player(), "core.suitcase");
     }
     const auto wallet = wallet_opt.unwrap();
     wallet->modify_number(-1);
@@ -1675,7 +1675,7 @@ TalkResult talk_quest_giver(Character& speaker)
         }
         if (quest_data[rq].id == 1002)
         {
-            if (!g_inv.pc()->has_free_slot())
+            if (!inv_player()->has_free_slot())
             {
                 buff = i18n::s.get(
                     "core.talk.npc.quest_giver.about.backpack_full", speaker);
@@ -2082,12 +2082,12 @@ TalkResult talk_npc(Character& speaker)
                         cdata[rtval(cnt)]));
             }
         }
-        if (itemfind(g_inv.pc(), "core.wallet"))
+        if (itemfind(inv_player(), "core.wallet"))
         {
             ELONA_APPEND_RESPONSE(
                 32, i18n::s.get("core.talk.npc.guard.choices.lost_wallet"));
         }
-        else if (itemfind(g_inv.pc(), "core.suitcase"))
+        else if (itemfind(inv_player(), "core.suitcase"))
         {
             ELONA_APPEND_RESPONSE(
                 32, i18n::s.get("core.talk.npc.guard.choices.lost_suitcase"));
@@ -2172,7 +2172,7 @@ TalkResult talk_npc(Character& speaker)
                 {
                     p = quest_data[cnt].target_item_id;
                     deliver = cnt;
-                    for (const auto& item : *g_inv.pc())
+                    for (const auto& item : *inv_player())
                     {
                         if (the_item_db[item->id]->integer_id == p)
                         {
@@ -2192,7 +2192,7 @@ TalkResult talk_npc(Character& speaker)
             quest_data[rq].client_chara_type == 3 &&
             quest_data[rq].progress == 1)
         {
-            for (const auto& item : *g_inv.pc())
+            for (const auto& item : *inv_player())
             {
                 if (item->is_no_drop)
                 {

--- a/src/elona/talk_npc.cpp
+++ b/src/elona/talk_npc.cpp
@@ -453,8 +453,9 @@ TalkResult talk_quest_delivery(
     const ItemRef& item_to_deliver)
 {
     txt(i18n::s.get("core.talk.npc.common.hand_over", item_to_deliver));
-    const auto slot = inv_make_free_slot_force(g_inv.for_chara(speaker));
-    const auto handed_over_item = item_separate(item_to_deliver, slot, 1);
+    const auto inv = g_inv.for_chara(speaker);
+    const auto slot = inv_make_free_slot_force(inv);
+    const auto handed_over_item = item_separate(item_to_deliver, inv, slot, 1);
     chara_set_ai_item(speaker, handed_over_item);
     rq = deliver;
     quest_set_data(speaker, 3);
@@ -468,8 +469,9 @@ TalkResult talk_quest_delivery(
 TalkResult talk_quest_supply(Character& speaker, const ItemRef& item_to_supply)
 {
     txt(i18n::s.get("core.talk.npc.common.hand_over", item_to_supply));
-    const auto slot = inv_make_free_slot_force(g_inv.for_chara(speaker));
-    const auto handed_over_item = item_separate(item_to_supply, slot, 1);
+    const auto inv = g_inv.for_chara(speaker);
+    const auto slot = inv_make_free_slot_force(inv);
+    const auto handed_over_item = item_separate(item_to_supply, inv, slot, 1);
     speaker.was_passed_item_by_you_just_now() = true;
     chara_set_ai_item(speaker, handed_over_item);
     quest_set_data(speaker, 3);

--- a/src/elona/text.cpp
+++ b/src/elona/text.cpp
@@ -11,6 +11,7 @@
 #include "enchantment.hpp"
 #include "fov.hpp"
 #include "i18n.hpp"
+#include "inventory.hpp"
 #include "item.hpp"
 #include "lua_env/interface.hpp"
 #include "map.hpp"
@@ -2576,9 +2577,9 @@ std::string txtitemoncell(int x, int y)
             break;
 
         const auto item = item_index < 0
-            ? g_inv.ground()->at(
+            ? inv_map()->at(
                   static_cast<InventorySlot>(0)) /* TODO phantom ref */
-            : g_inv.ground()->at(static_cast<InventorySlot>(item_index - 1));
+            : inv_map()->at(static_cast<InventorySlot>(item_index - 1));
         if (first)
         {
             first = false;

--- a/src/elona/text.cpp
+++ b/src/elona/text.cpp
@@ -2576,8 +2576,8 @@ std::string txtitemoncell(int x, int y)
             break;
 
         const auto item = item_index < 0
-            ? g_inv.ground().at(0) /* TODO phantom ref */
-            : g_inv.ground().at(item_index - 1);
+            ? g_inv.ground()->at(0) /* TODO phantom ref */
+            : g_inv.ground()->at(item_index - 1);
         if (first)
         {
             first = false;

--- a/src/elona/text.cpp
+++ b/src/elona/text.cpp
@@ -2576,8 +2576,9 @@ std::string txtitemoncell(int x, int y)
             break;
 
         const auto item = item_index < 0
-            ? g_inv.ground()->at(0) /* TODO phantom ref */
-            : g_inv.ground()->at(item_index - 1);
+            ? g_inv.ground()->at(
+                  static_cast<InventorySlot>(0)) /* TODO phantom ref */
+            : g_inv.ground()->at(static_cast<InventorySlot>(item_index - 1));
         if (first)
         {
             first = false;

--- a/src/elona/turn_sequence.cpp
+++ b/src/elona/turn_sequence.cpp
@@ -1386,7 +1386,7 @@ optional<TurnResult> pc_turn_advance_time()
     }
     if (trait(210) != 0 && rnd(5) == 0)
     {
-        const auto item = Inventory::at(inv_get_random_slot(g_inv.pc()));
+        const auto item = g_inv.pc()->at(inv_get_random_slot(g_inv.pc()));
         if (item && the_item_db[item->id]->category == ItemCategory::potion)
         {
             item_db_on_drink(

--- a/src/elona/turn_sequence.cpp
+++ b/src/elona/turn_sequence.cpp
@@ -533,11 +533,10 @@ TurnResult npc_turn_ai_main(Character& chara, int& enemy_index)
                         in = item_opt->number();
                         if (game_data.mount != chara.index)
                         {
-                            int stat = pick_up_item(
-                                           g_inv.for_chara(chara),
-                                           item_opt.unwrap(),
-                                           none)
-                                           .type;
+                            int stat =
+                                pick_up_item(
+                                    chara.inventory(), item_opt.unwrap(), none)
+                                    .type;
                             if (stat == 1)
                             {
                                 return TurnResult::turn_end;
@@ -1386,7 +1385,7 @@ optional<TurnResult> pc_turn_advance_time()
     }
     if (trait(210) != 0 && rnd(5) == 0)
     {
-        const auto item = g_inv.pc()->at(inv_get_random_slot(g_inv.pc()));
+        const auto item = inv_player()->at(inv_get_random_slot(inv_player()));
         if (item && the_item_db[item->id]->category == ItemCategory::potion)
         {
             item_db_on_drink(

--- a/src/elona/turn_sequence_pc_actions.cpp
+++ b/src/elona/turn_sequence_pc_actions.cpp
@@ -230,7 +230,7 @@ optional<TurnResult> handle_pc_action(std::string& action)
             action = "search";
         }
         p = 0;
-        for (const auto& item : g_inv.ground())
+        for (const auto& item : *g_inv.ground())
         {
             if (item->position() != cdata.player().position)
                 continue;

--- a/src/elona/turn_sequence_pc_actions.cpp
+++ b/src/elona/turn_sequence_pc_actions.cpp
@@ -18,6 +18,7 @@
 #include "gdata.hpp"
 #include "i18n.hpp"
 #include "input.hpp"
+#include "inventory.hpp"
 #include "item.hpp"
 #include "lua_env/console.hpp"
 #include "magic.hpp"
@@ -230,7 +231,7 @@ optional<TurnResult> handle_pc_action(std::string& action)
             action = "search";
         }
         p = 0;
-        for (const auto& item : *g_inv.ground())
+        for (const auto& item : *inv_map())
         {
             if (item->position() != cdata.player().position)
                 continue;

--- a/src/elona/ui/ui_menu_crafting.cpp
+++ b/src/elona/ui/ui_menu_crafting.cpp
@@ -328,7 +328,7 @@ optional<UIMenuCrafting::ResultType> UIMenuCrafting::on_key(
             set_reupdate();
             return none;
         }
-        if (!g_inv.pc()->has_free_slot())
+        if (!inv_player()->has_free_slot())
         {
             snd("core.fail1");
             txt(i18n::s.get("core.ui.inv.common.inventory_is_full"));

--- a/src/elona/ui/ui_menu_crafting.cpp
+++ b/src/elona/ui/ui_menu_crafting.cpp
@@ -328,7 +328,7 @@ optional<UIMenuCrafting::ResultType> UIMenuCrafting::on_key(
             set_reupdate();
             return none;
         }
-        if (!g_inv.pc().has_free_slot())
+        if (!g_inv.pc()->has_free_slot())
         {
             snd("core.fail1");
             txt(i18n::s.get("core.ui.inv.common.inventory_is_full"));


### PR DESCRIPTION

# Summary


* Change `Inventory&` -> `InventoryRef` (aka, `Inventory*`)
* Change the representation of `InventorySlot`
  * Now, the struct is just an `enum class` as a strongly-typed index. It has no information about an owner inventory, and points to some index.
* Reduce use of `g_inv`
  * `g_inv.for_chara(chara)` -> `chara.inventory()`
  * `g_inv.ground()` -> `inv_map()`
  * `g_inv.pc()` -> `inv_player()`