### PR TITLE
Remove meaningless map's field (mdata(21) in vanilla)

### DIFF
--- a/src/elona/ctrl_file.cpp
+++ b/src/elona/ctrl_file.cpp
@@ -729,22 +729,8 @@ void ctrl_file_map_read()
 
     {
         const auto filepath = dir / fs::u8path(u8"mef_"s + mid + u8".s2");
-        if (map_data.mefs_loaded_flag == 0)
-        {
-            for (int y = 0; y < map_data.height; ++y)
-            {
-                for (int x = 0; x < map_data.width; ++x)
-                {
-                    cell_data.at(x, y).mef_index_plus_one = 0;
-                }
-            }
-            map_data.mefs_loaded_flag = 1;
-        }
-        else
-        {
-            (void)save_fs_exists(fs::u8path(u8"mef_"s + mid + u8".s2"));
-            load_v2(filepath, mef, 0, 9, 0, MEF_MAX);
-        }
+        (void)save_fs_exists(fs::u8path(u8"mef_"s + mid + u8".s2"));
+        load_v2(filepath, mef, 0, 9, 0, MEF_MAX);
     }
 
     arrayfile(true, u8"mdatan", dir / fs::u8path(u8"mdatan_"s + mid + u8".s2"));

--- a/src/elona/initialize_map.cpp
+++ b/src/elona/initialize_map.cpp
@@ -1287,7 +1287,6 @@ void _generate_new_map()
     randomize();
 
     map_data.regenerate_count = game_data.map_regenerate_count;
-    map_data.mefs_loaded_flag = 1;
 }
 
 

--- a/src/elona/map.cpp
+++ b/src/elona/map.cpp
@@ -217,8 +217,7 @@ ChipData chip_data;
     SERIALIZE(17, should_regenerate); \
     SERIALIZE(18, max_item_count); \
     SERIALIZE(19, regenerate_count); \
-    SERIALIZE(20, play_campfire_sound); \
-    SERIALIZE(21, mefs_loaded_flag);
+    SERIALIZE(20, play_campfire_sound);
 
 
 #define SERIALIZE MDATA_PACK

--- a/src/elona/map.hpp
+++ b/src/elona/map.hpp
@@ -50,7 +50,6 @@ struct MapData
     int max_item_count{};
     int regenerate_count{};
     int play_campfire_sound{};
-    int mefs_loaded_flag{};
 
 
     /**


### PR DESCRIPTION
# Rationale

The field was set to 1 when the map is newly generated, so all uses of it can be replaced with the literal `1`.


# Note for compatibility

As explained above, Elona foobar doesn't need the field, but vanilla and other variants expect the field to be 1 for existing maps. We have to set the value in save conversion process foobar to vanilla and vice versa.