### PR TITLE
Organize spell/spact/trait

### DIFF
--- a/src/elona/ability.cpp
+++ b/src/elona/ability.cpp
@@ -178,17 +178,17 @@ void gain_special_action()
 {
     if (cdata.player().get_skill(174).base_level > 15)
     {
-        if (spact(29) == 0)
+        if (!cdata.player().spacts().has("core.draw_charge"))
         {
-            spact(29) = 1;
+            cdata.player().spacts().gain("core.draw_charge");
             txt(i18n::s.get(
                     "core.skill.gained",
                     the_ability_db.get_text("core.draw_charge", "name")),
                 Message::color{ColorIndex::orange});
         }
-        if (spact(30) == 0)
+        if (!cdata.player().spacts().has("core.fill_charge"))
         {
-            spact(30) = 1;
+            cdata.player().spacts().gain("core.fill_charge");
             txt(i18n::s.get(
                     "core.skill.gained",
                     the_ability_db.get_text("core.fill_charge", "name")),
@@ -197,9 +197,9 @@ void gain_special_action()
     }
     if (cdata.player().get_skill(152).base_level > 15)
     {
-        if (spact(31) == 0)
+        if (!cdata.player().spacts().has("core.swarm"))
         {
-            spact(31) = 1;
+            cdata.player().spacts().gain("core.swarm");
             txt(i18n::s.get(
                     "core.skill.gained",
                     the_ability_db.get_text("core.swarm", "name")),

--- a/src/elona/ability.cpp
+++ b/src/elona/ability.cpp
@@ -145,7 +145,8 @@ void chara_gain_skill(Character& chara, int id, int initial_level, int stock)
     {
         if (chara.is_player())
         {
-            spell(id - 400) += stock;
+            chara.spell_stocks().gain(
+                *the_ability_db.get_id_from_integer(id), stock);
             modify_potential(chara, id, 1);
         }
     }

--- a/src/elona/activity.cpp
+++ b/src/elona/activity.cpp
@@ -184,7 +184,8 @@ void search_material_spot()
                 crafting_material_select_random_id(atxlv, 0, atxspot), 1, i);
         }
     }
-    if (rnd(50 + trait(159) * 20) == 0)
+    if (rnd(50 + cdata.player().traits().level("core.more_materials") * 20) ==
+        0)
     {
         s = i18n::s.get("core.activity.material.searching.no_more");
         if (feat(1) == 26)
@@ -2177,7 +2178,8 @@ void sleep_start(const OptionalItemRef& bed)
     game()->character_and_status_for_gene = 0;
     mode = 0;
     wake_up();
-    cdata.player().nutrition -= 1500 / (trait(158) + 1);
+    cdata.player().nutrition -=
+        1500 / (cdata.player().traits().level("core.slow_digestion") + 1);
     txt(i18n::s.get("core.activity.sleep.slept_for", timeslept),
         Message::color{ColorIndex::green});
 

--- a/src/elona/building.cpp
+++ b/src/elona/building.cpp
@@ -1580,7 +1580,10 @@ void supply_income()
             int item_id = 0;
             flt(calcobjlv((100 - game()->ranks.at(rank_id) / 100) / 2 + 1),
                 calcfixlv(
-                    (rnd(12) < trait(39)) ? Quality::miracle : Quality::great));
+                    (rnd(12) <
+                     cdata.player().traits().level("core.quartermaster"))
+                        ? Quality::miracle
+                        : Quality::great));
             flttypemajor = choice(fsetincome);
             if (rnd(5) == 0)
             {

--- a/src/elona/calc.cpp
+++ b/src/elona/calc.cpp
@@ -717,7 +717,7 @@ int calcattackdmg(
     }
     if (attacker.is_player())
     {
-        if (trait(207))
+        if (cdata.player().traits().level("core.desire_for_violence"))
         {
             dmgfix += 5 + cdata.player().level * 2 / 3;
         }
@@ -806,7 +806,7 @@ int calcattackdmg(
     damage = damagenormal + damagepierce;
     if (attacker.is_player())
     {
-        if (trait(164) != 0)
+        if (cdata.player().traits().level("core.opatos_blessing") != 0)
         {
             --damage;
         }
@@ -1144,7 +1144,8 @@ void calccosthire()
         cost += calc_servant_hire_cost(cnt);
     }
     cost = cost *
-        clamp(100 - clamp(cdata.player().karma / 2, 0, 50) - 7 * trait(38) -
+        clamp(100 - clamp(cdata.player().karma / 2, 0, 50) -
+                  7 * cdata.player().traits().level("core.accountant") -
                   (cdata.player().karma >= 20) * 5,
               25,
               200) /
@@ -1172,7 +1173,8 @@ int calccostbuilding()
     }
 
     return cost *
-        clamp(100 - clamp(cdata.player().karma / 2, 0, 50) - 7 * trait(38) -
+        clamp(100 - clamp(cdata.player().karma / 2, 0, 50) -
+                  7 * cdata.player().traits().level("core.accountant") -
                   (cdata.player().karma >= 20) * 5,
               25,
               200) /
@@ -1188,7 +1190,8 @@ int calccosttax()
     cost += cdata.player().fame;
     cost += cdata.player().level * 200;
     return cost *
-        clamp(100 - clamp(cdata.player().karma / 2, 0, 50) - 7 * trait(38) -
+        clamp(100 - clamp(cdata.player().karma / 2, 0, 50) -
+                  7 * cdata.player().traits().level("core.accountant") -
                   (cdata.player().karma >= 20) * 5,
               25,
               200) /

--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -749,7 +749,8 @@ void chara_refresh(Character& chara)
     if (chara.is_player())
     {
         chara.clear_flags();
-        if (trait(161) != 0)
+        if (cdata.player().traits().level(
+                "core.cannot_wear_heavy_equipments") != 0)
         {
             for (auto&& equipment_slot : chara.equipment_slots)
             {
@@ -1056,9 +1057,12 @@ void chara_refresh(Character& chara)
         god_apply_blessing(chara);
         for (int cnt = 0; cnt < 217; ++cnt)
         {
-            if (trait(cnt) != 0)
+            if (const auto trait_id = the_trait_db.get_id_from_integer(cnt))
             {
-                trait_get_info(1, cnt);
+                if (cdata.player().traits().level(*trait_id) != 0)
+                {
+                    trait_get_info(1, cnt);
+                }
             }
         }
     }
@@ -1099,7 +1103,7 @@ void chara_refresh(Character& chara)
         5;
     chara.max_sp = 100 +
         (chara.get_skill(15).level + chara.get_skill(11).level) / 5 +
-        trait(24) * 8;
+        cdata.player().traits().level("core.stamina_feat") * 8;
     if (chara.max_mp < 1)
     {
         chara.max_mp = 1;
@@ -1779,8 +1783,10 @@ void initialize_pc_character()
         itemcreate_player_inv(378, 0);
     }
     gain_race_feat();
-    cdata.player().skill_bonus = 5 + trait(154);
-    cdata.player().total_skill_bonus = 5 + trait(154);
+    cdata.player().skill_bonus =
+        5 + cdata.player().traits().level("core.more_bonus_points");
+    cdata.player().total_skill_bonus =
+        5 + cdata.player().traits().level("core.more_bonus_points");
     for (const auto& item : *inv_player())
     {
         item->identify_state = IdentifyState::completely;
@@ -2066,7 +2072,9 @@ void refresh_burden_state()
 {
     cdata.player().inventory_weight =
         clamp(inv_weight(inv_player()), 0, 20000000) *
-        (100 - trait(201) * 10 + trait(205) * 20) / 100;
+        (100 - cdata.player().traits().level("core.gravity") * 10 +
+         cdata.player().traits().level("core.feathers") * 20) /
+        100;
     cdata.player().max_inventory_weight =
         cdata.player().get_skill(10).level * 500 +
         cdata.player().get_skill(11).level * 250 +

--- a/src/elona/character.hpp
+++ b/src/elona/character.hpp
@@ -15,6 +15,7 @@
 #include "position.hpp"
 #include "spact.hpp"
 #include "spell.hpp"
+#include "trait.hpp"
 
 
 
@@ -411,6 +412,9 @@ private:
     /// Spacts
     SpactTable _spacts;
 
+    /// All traits (feats, ether diseases and mutations) the character has.
+    TraitLevelTable _traits;
+
 
 public:
     Ability& get_skill(int id)
@@ -446,6 +450,19 @@ public:
     const SpactTable& spacts() const noexcept
     {
         return _spacts;
+    }
+
+
+
+    TraitLevelTable& traits() noexcept
+    {
+        return _traits;
+    }
+
+
+    const TraitLevelTable& traits() const noexcept
+    {
+        return _traits;
     }
 
 

--- a/src/elona/character.hpp
+++ b/src/elona/character.hpp
@@ -13,6 +13,7 @@
 #include "god.hpp"
 #include "lua_env/wrapped_function.hpp"
 #include "position.hpp"
+#include "spell.hpp"
 
 
 
@@ -403,6 +404,9 @@ public:
 private:
     SkillData _skills;
 
+    /// Spell stocks
+    SpellStockTable _spell_stocks;
+
 
 public:
     Ability& get_skill(int id)
@@ -414,6 +418,18 @@ public:
     const Ability& get_skill(int id) const
     {
         return _skills.get(id);
+    }
+
+
+    SpellStockTable& spell_stocks() noexcept
+    {
+        return _spell_stocks;
+    }
+
+
+    const SpellStockTable& spell_stocks() const noexcept
+    {
+        return _spell_stocks;
     }
 
 

--- a/src/elona/character.hpp
+++ b/src/elona/character.hpp
@@ -13,6 +13,7 @@
 #include "god.hpp"
 #include "lua_env/wrapped_function.hpp"
 #include "position.hpp"
+#include "spact.hpp"
 #include "spell.hpp"
 
 
@@ -407,6 +408,9 @@ private:
     /// Spell stocks
     SpellStockTable _spell_stocks;
 
+    /// Spacts
+    SpactTable _spacts;
+
 
 public:
     Ability& get_skill(int id)
@@ -430,6 +434,18 @@ public:
     const SpellStockTable& spell_stocks() const noexcept
     {
         return _spell_stocks;
+    }
+
+
+    SpactTable& spacts() noexcept
+    {
+        return _spacts;
+    }
+
+
+    const SpactTable& spacts() const noexcept
+    {
+        return _spacts;
     }
 
 

--- a/src/elona/character_making.cpp
+++ b/src/elona/character_making.cpp
@@ -172,7 +172,7 @@ MainMenuResult character_making_role_attributes(bool advanced_to_next_menu)
 MainMenuResult character_making_select_feats()
 {
     game()->acquirable_feat_count = 3;
-    DIM2(trait, 500);
+    cdata.player().traits().clear();
     cdata.player().spacts().clear();
     gain_race_feat();
 

--- a/src/elona/character_making.cpp
+++ b/src/elona/character_making.cpp
@@ -173,7 +173,7 @@ MainMenuResult character_making_select_feats()
 {
     game()->acquirable_feat_count = 3;
     DIM2(trait, 500);
-    DIM2(spact, 500);
+    cdata.player().spacts().clear();
     gain_race_feat();
 
     character_making_draw_background("core.chara_making.select_feats.caption");

--- a/src/elona/character_status.cpp
+++ b/src/elona/character_status.cpp
@@ -72,7 +72,7 @@ void modify_ether_disease_stage(int delta)
     int i_at_m134 = 0;
     original_amount = game()->ether_disease_stage / 1000;
     add_amount = delta + (delta > 0) * game()->ether_disease_speed;
-    if (trait(168))
+    if (cdata.player().traits().level("core.slow_ether_disease_progress"))
     {
         if (delta > 0)
         {
@@ -113,11 +113,13 @@ void modify_ether_disease_stage(int delta)
                 {
                     continue;
                 }
-                if (trait(tid) <= traitref(1))
+                if (cdata.player().traits().level(
+                        *the_trait_db.get_id_from_integer(tid)) <= traitref(1))
                 {
                     continue;
                 }
-                --trait(tid);
+                cdata.player().traits().sub(
+                    *the_trait_db.get_id_from_integer(tid), 1);
                 i_at_m134 = original_amount + cnt2_at_m134;
                 game()->ether_disease_history.at(i_at_m134) = tid;
                 txt(i18n::s.get("core.chara.corruption.add"),
@@ -178,11 +180,13 @@ void modify_ether_disease_stage(int delta)
                 {
                     continue;
                 }
-                if (trait(tid) >= 0)
+                if (cdata.player().traits().level(
+                        *the_trait_db.get_id_from_integer(tid)) >= 0)
                 {
                     continue;
                 }
-                ++trait(tid);
+                cdata.player().traits().add(
+                    *the_trait_db.get_id_from_integer(tid), 1);
                 txt(i18n::s.get("core.chara.corruption.remove"),
                     Message::color{ColorIndex::green});
                 txt(traitrefn(0), Message::color{ColorIndex::green});
@@ -207,13 +211,13 @@ void modify_potential(Character& chara, int id, int delta)
 
 void modify_karma(Character& chara, int delta)
 {
-    if (trait(162) && delta < 0)
+    if (cdata.player().traits().level("core.evil_man") && delta < 0)
     {
         delta = delta * 75 / 100;
         if (delta == 0)
             return;
     }
-    if (trait(169) && delta < 0)
+    if (cdata.player().traits().level("core.good_man") && delta < 0)
     {
         delta = delta * 150 / 100;
     }
@@ -249,11 +253,11 @@ void modify_karma(Character& chara, int delta)
     chara.karma += delta;
 
     int max = 20;
-    if (trait(162))
+    if (cdata.player().traits().level("core.evil_man"))
     {
         max -= 20;
     }
-    if (trait(169))
+    if (cdata.player().traits().level("core.good_man"))
     {
         max += 20;
     }
@@ -522,11 +526,13 @@ void gain_level(Character& chara)
             }
         }
         gain_special_action();
-        p += trait(154);
+        p += cdata.player().traits().level("core.more_bonus_points");
     }
     chara.skill_bonus += p;
     chara.total_skill_bonus += p;
-    if (chara.race == "core.mutant" || (chara.is_player() && trait(0) == 1))
+    if (chara.race == "core.mutant" ||
+        (chara.is_player() &&
+         cdata.player().traits().level("core.changing_body") == 1))
     {
         if (chara.level < 37)
         {

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -3640,7 +3640,8 @@ TurnResult do_short_cut_command(int sc_)
         }
         if (efid < 661)
         {
-            if (spact(efid - 600) == 0)
+            if (!cdata.player().spacts().has(
+                    *the_ability_db.get_id_from_integer(efid)))
             {
                 txt(i18n::s.get("core.action.shortcut.cannot_use_anymore"));
                 update_screen();

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -2618,14 +2618,15 @@ TurnResult do_use_command(ItemRef use_item)
         txt(i18n::s.get("core.action.use.statue.creator.in_usermap"));
         break;
     case 29:
-        trait(use_item->param1) = 1;
+        cdata.player().traits().set_level(
+            *the_trait_db.get_id_from_integer(use_item->param1), 1);
         if (use_item->param1 == 169)
         {
-            trait(162) = 0;
+            cdata.player().traits().set_level("core.evil_man", 0);
         }
         if (use_item->param1 == 162)
         {
-            trait(169) = 0;
+            cdata.player().traits().set_level("core.good_man", 0);
         }
         use_item->modify_number(-1);
         txt(i18n::s.get("core.action.use.secret_treasure.use"));
@@ -5380,7 +5381,7 @@ PickUpItemResult pick_up_item(
     item->set_number(in);
     if (inv_owner_chara && inv_owner_chara->is_player())
     {
-        if (trait(215) != 0)
+        if (cdata.player().traits().level("core.mana_battery") != 0)
         {
             if (the_item_db[item->id]->category == ItemCategory::rod)
             {
@@ -5404,7 +5405,7 @@ PickUpItemResult pick_up_item(
                 }
             }
         }
-        if (trait(216) != 0)
+        if (cdata.player().traits().level("core.poisonous_hand") != 0)
         {
             if (the_item_db[item->id]->category == ItemCategory::potion)
             {

--- a/src/elona/ctrl_file.cpp
+++ b/src/elona/ctrl_file.cpp
@@ -476,7 +476,10 @@ void ctrl_file_global_read(const fs::path& dir)
 
     {
         const auto filepath = dir / u8"spact.s1";
+        elona_vector1<int> spact;
+        DIM2(spact, 500);
         load_v1(filepath, spact, 0, 500);
+        cdata.player().spacts().unpack_from(spact);
     }
 
     {
@@ -628,6 +631,9 @@ void ctrl_file_global_write(const fs::path& dir)
 
     {
         const auto filepath = dir / u8"spact.s1";
+        elona_vector1<int> spact;
+        DIM2(spact, 500);
+        cdata.player().spacts().pack_to(spact);
         save_v1(filepath, spact, 0, 500);
     }
 
@@ -1139,6 +1145,44 @@ void SpellStockTable::unpack_from(elona_vector1<int>& legacy_spell)
                 the_ability_db.get_id_from_integer(integer_spell_id))
         {
             _stocks[*id] = legacy_spell(i);
+        }
+    }
+}
+
+
+
+void SpactTable::pack_to(elona_vector1<int>& legacy_spact) const
+{
+    for (int i = 0; i < 500; ++i)
+    {
+        const auto integer_spact_id = i + 600;
+        if (const auto id =
+                the_ability_db.get_id_from_integer(integer_spact_id))
+        {
+            if (_spacts.find(*id) != _spacts.end())
+            {
+                legacy_spact(i) = 1;
+            }
+        }
+    }
+}
+
+
+
+void SpactTable::unpack_from(elona_vector1<int>& legacy_spact)
+{
+    _spacts.clear();
+
+    for (int i = 0; i < 500; ++i)
+    {
+        if (legacy_spact(i) == 0)
+            continue;
+
+        const auto integer_spact_id = i + 600;
+        if (const auto id =
+                the_ability_db.get_id_from_integer(integer_spact_id))
+        {
+            _spacts.emplace(*id);
         }
     }
 }

--- a/src/elona/ctrl_file.cpp
+++ b/src/elona/ctrl_file.cpp
@@ -495,7 +495,10 @@ void ctrl_file_global_read(const fs::path& dir)
 
     {
         const auto filepath = dir / u8"trait.s1";
+        elona_vector1<int> trait;
+        DIM2(trait, 500);
         load_v1(filepath, trait, 0, 500);
+        cdata.player().traits().unpack_from(trait);
     }
 
     {
@@ -650,6 +653,9 @@ void ctrl_file_global_write(const fs::path& dir)
 
     {
         const auto filepath = dir / u8"trait.s1";
+        elona_vector1<int> trait;
+        DIM2(trait, 500);
+        cdata.player().traits().pack_to(trait);
         save_v1(filepath, trait, 0, 500);
     }
 
@@ -1183,6 +1189,42 @@ void SpactTable::unpack_from(elona_vector1<int>& legacy_spact)
                 the_ability_db.get_id_from_integer(integer_spact_id))
         {
             _spacts.emplace(*id);
+        }
+    }
+}
+
+
+
+void TraitLevelTable::pack_to(elona_vector1<int>& legacy_trait) const
+{
+    for (int i = 0; i < 500; ++i)
+    {
+        const auto integer_trait_id = i;
+        if (const auto id = the_trait_db.get_id_from_integer(integer_trait_id))
+        {
+            if (const auto itr = _traits.find(*id); itr != _traits.end())
+            {
+                legacy_trait(i) = itr->second;
+            }
+        }
+    }
+}
+
+
+
+void TraitLevelTable::unpack_from(elona_vector1<int>& legacy_trait)
+{
+    _traits.clear();
+
+    for (int i = 0; i < 500; ++i)
+    {
+        if (legacy_trait(i) == 0)
+            continue;
+
+        const auto integer_trait_id = i;
+        if (const auto id = the_trait_db.get_id_from_integer(integer_trait_id))
+        {
+            _traits[*id] = legacy_trait(i);
         }
     }
 }

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -1629,7 +1629,7 @@ OnEnterResult on_enter_eat(const ItemRef& selected_item, MenuResult& result)
 
 OnEnterResult on_enter_equip(const ItemRef& selected_item, MenuResult& result)
 {
-    if (trait(161) != 0)
+    if (cdata.player().traits().level("core.cannot_wear_heavy_equipments") != 0)
     {
         if (selected_item->weight >= 1000)
         {

--- a/src/elona/deferred_event.cpp
+++ b/src/elona/deferred_event.cpp
@@ -791,7 +791,9 @@ void eh_nuclear_bomb(const DeferredEvent& event)
     }
     if (map_is_town_or_guild())
     {
-        modify_karma(cdata.player(), -80 + trait(162) * 60);
+        modify_karma(
+            cdata.player(),
+            -80 + cdata.player().traits().level("core.evil_man") * 60);
     }
     else
     {

--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -565,7 +565,8 @@ int damage_hp(
                         }
                         if (attacker && attacker->is_player())
                         {
-                            if (trait(44)) // Gentle Face
+                            if (cdata.player().traits().level(
+                                    "core.gentle_face")) // Gentle Face
                             {
                                 runs_away = false;
                             }
@@ -1311,7 +1312,7 @@ void damage_mp(Character& chara, int delta)
         auto damage = -chara.mp * 400 / (100 + chara.get_skill(164).level * 10);
         if (chara.is_player())
         {
-            if (trait(156) == 1)
+            if (cdata.player().traits().level("core.less_mana_reaction") == 1)
             {
                 damage /= 2;
             }
@@ -1391,7 +1392,7 @@ void damage_insanity(Character& chara, int delta)
     delta /= resistance;
     if (chara.is_player_or_ally())
     {
-        if (trait(166))
+        if (cdata.player().traits().level("core.jure_blessing"))
         {
             delta -= rnd(4);
         }

--- a/src/elona/enchantment.cpp
+++ b/src/elona/enchantment.cpp
@@ -825,7 +825,12 @@ int enchantment_gen_level(int base_level)
 
 int enchantment_gen_p(int multiplier)
 {
-    const auto base = rnd(rnd(500 + (trait(163) != 0) * 50) + 1) + 1;
+    const auto base =
+        rnd(rnd(500 +
+                (cdata.player().traits().level("core.ehekatl_blessing") != 0) *
+                    50) +
+            1) +
+        1;
     return base * multiplier / 100;
 }
 

--- a/src/elona/food.cpp
+++ b/src/elona/food.cpp
@@ -372,7 +372,7 @@ void get_sick_if_cursed(CurseState curse_state, Character& drinker)
 
 void get_hungry(Character& chara)
 {
-    if ((trait(158) && rnd(3) == 0))
+    if ((cdata.player().traits().level("core.slow_digestion") && rnd(3) == 0))
         return;
     if (debug_has_wizard_flag("core.wizard.no_hungry"))
         return;
@@ -689,7 +689,7 @@ void apply_general_eating_effect(Character& eater, const ItemRef& food)
         {
             if (eater.is_player())
             {
-                if (trait(41))
+                if (cdata.player().traits().level("core.cannibalism"))
                 {
                     if (food->id == "core.corpse")
                     {
@@ -1133,7 +1133,7 @@ void apply_general_eating_effect(Character& eater, const ItemRef& food)
         {
             if (strutil::contains(s(0), u8"/man/"))
             {
-                if (trait(41))
+                if (cdata.player().traits().level("core.cannibalism"))
                 {
                     txt(i18n::s.get("core.food.effect.human.like"));
                 }
@@ -1142,19 +1142,20 @@ void apply_general_eating_effect(Character& eater, const ItemRef& food)
                     txt(i18n::s.get("core.food.effect.human.dislike"));
                     damage_insanity(eater, 15);
                     status_ailment_damage(eater, StatusAilment::insane, 150);
-                    if (trait(41) == 0)
+                    if (cdata.player().traits().level("core.cannibalism") == 0)
                     {
                         if (rnd(5) == 0)
                         {
                             trait_get_info(0, 41);
                             txt(traitrefn(0),
                                 Message::color{ColorIndex::green});
-                            trait(41) = 1;
+                            cdata.player().traits().set_level(
+                                "core.cannibalism", 1);
                         }
                     }
                 }
             }
-            else if (trait(41))
+            else if (cdata.player().traits().level("core.cannibalism"))
             {
                 txt(i18n::s.get(
                     "core.food.effect.human.would_have_rather_eaten"));

--- a/src/elona/god.cpp
+++ b/src/elona/god.cpp
@@ -410,9 +410,9 @@ void switch_religion()
     cdata.player().piety_point = 0;
     cdata.player().praying_point = 500;
     game()->god_rank = 0;
-    spact(23) = 0;
-    spact(24) = 0;
-    spact(25) = 0;
+    cdata.player().spacts().lose("core.prayer_of_jure");
+    cdata.player().spacts().lose("core.absorb_magic");
+    cdata.player().spacts().lose("core.lulwys_trick");
     if (cdata.player().god_id == core_god::eyth)
     {
         txt(i18n::s.get("core.god.switch.unbeliever"),
@@ -428,15 +428,15 @@ void switch_religion()
             Message::color{ColorIndex::orange});
         if (cdata.player().god_id == core_god::itzpalt)
         {
-            spact(24) = 1;
+            cdata.player().spacts().gain("core.absorb_magic");
         }
         if (cdata.player().god_id == core_god::jure)
         {
-            spact(23) = 1;
+            cdata.player().spacts().gain("core.prayer_of_jure");
         }
         if (cdata.player().god_id == core_god::lulwy)
         {
-            spact(25) = 1;
+            cdata.player().spacts().gain("core.lulwys_trick");
         }
         txtgod(cdata.player().god_id, 5);
     }

--- a/src/elona/init.cpp
+++ b/src/elona/init.cpp
@@ -221,7 +221,6 @@ void initialize_elona()
     SDIM3(mdatan, 20, 2);
     SDIM2(s1, 1000);
     DIM2(mat, 400);
-    DIM2(trait, 500);
     DIM3(itemmemory, 3, 800);
     DIM3(npcmemory, 2, 800);
     DIM2(recipememory, 1200);

--- a/src/elona/init.cpp
+++ b/src/elona/init.cpp
@@ -220,7 +220,6 @@ void initialize_elona()
     map_data.clear();
     SDIM3(mdatan, 20, 2);
     SDIM2(s1, 1000);
-    DIM2(spact, 500);
     DIM2(mat, 400);
     DIM2(trait, 500);
     DIM3(itemmemory, 3, 800);

--- a/src/elona/init.cpp
+++ b/src/elona/init.cpp
@@ -220,7 +220,6 @@ void initialize_elona()
     map_data.clear();
     SDIM3(mdatan, 20, 2);
     SDIM2(s1, 1000);
-    DIM2(spell, 200);
     DIM2(spact, 500);
     DIM2(mat, 400);
     DIM2(trait, 500);

--- a/src/elona/lua_env/api/modules/module_Trait.cpp
+++ b/src/elona/lua_env/api/modules/module_Trait.cpp
@@ -31,7 +31,8 @@ sol::optional<int> Trait_level(int trait_id)
     {
         return sol::nullopt;
     }
-    return elona::trait(trait_id);
+    return elona::cdata.player().traits().level(
+        *the_trait_db.get_id_from_integer(trait_id));
 }
 
 
@@ -90,21 +91,28 @@ void Trait_set(int trait_id, int level)
     {
         return;
     }
-    if (elona::trait(trait_id) < level &&
-        elona::trait(trait_id) < elona::traitref(2) && traitrefn(0) != "")
+    if (elona::cdata.player().traits().level(
+            *the_trait_db.get_id_from_integer(trait_id)) < level &&
+        elona::cdata.player().traits().level(
+            *the_trait_db.get_id_from_integer(trait_id)) < elona::traitref(2) &&
+        traitrefn(0) != "")
     {
         snd("core.ding3");
         elona::txt(traitrefn(0), elona::Message::color{ColorIndex::green});
     }
     else if (
-        elona::trait(trait_id) > level &&
-        elona::trait(trait_id) > elona::traitref(1) && traitrefn(1) != "")
+        elona::cdata.player().traits().level(
+            *the_trait_db.get_id_from_integer(trait_id)) > level &&
+        elona::cdata.player().traits().level(
+            *the_trait_db.get_id_from_integer(trait_id)) > elona::traitref(1) &&
+        traitrefn(1) != "")
     {
         snd("core.ding3");
         elona::txt(traitrefn(1), elona::Message::color{ColorIndex::red});
     }
-    elona::trait(trait_id) =
-        clamp(level, elona::traitref(1), elona::traitref(2));
+    elona::cdata.player().traits().set_level(
+        *the_trait_db.get_id_from_integer(trait_id),
+        clamp(level, elona::traitref(1), elona::traitref(2)));
     chara_refresh(cdata.player());
 }
 
@@ -124,21 +132,31 @@ void Trait_modify(int trait_id, int delta)
     {
         return;
     }
-    if (delta > 0 && elona::trait(trait_id) < elona::traitref(2) &&
+    if (delta > 0 &&
+        elona::cdata.player().traits().level(
+            *the_trait_db.get_id_from_integer(trait_id)) < elona::traitref(2) &&
         traitrefn(0) != "")
     {
         snd("core.ding3");
         elona::txt(traitrefn(0), elona::Message::color{ColorIndex::green});
     }
     else if (
-        delta < 0 && elona::trait(trait_id) > elona::traitref(1) &&
+        delta < 0 &&
+        elona::cdata.player().traits().level(
+            *the_trait_db.get_id_from_integer(trait_id)) > elona::traitref(1) &&
         traitrefn(1) != "")
     {
         snd("core.ding3");
         elona::txt(traitrefn(1), elona::Message::color{ColorIndex::red});
     }
-    elona::trait(trait_id) = clamp(
-        elona::trait(trait_id) + delta, elona::traitref(1), elona::traitref(2));
+    elona::cdata.player().traits().set_level(
+        *the_trait_db.get_id_from_integer(trait_id),
+        clamp(
+            elona::cdata.player().traits().level(
+                *the_trait_db.get_id_from_integer(trait_id)) +
+                delta,
+            elona::traitref(1),
+            elona::traitref(2)));
     chara_refresh(cdata.player());
 }
 

--- a/src/elona/lua_env/console.cpp
+++ b/src/elona/lua_env/console.cpp
@@ -11,6 +11,7 @@
 #include "../character.hpp"
 #include "../character_status.hpp"
 #include "../config.hpp"
+#include "../data/types/type_ability.hpp"
 #include "../debug.hpp"
 #include "../filesystem.hpp"
 #include "../input.hpp"
@@ -323,9 +324,10 @@ void Console::register_builtin_commands()
             _term.println("Activate wizard mode to run the command.");
             return;
         }
-        for (int i = 2; i < 61; ++i)
+        for (int i = 1; i < 61; ++i)
         {
-            spact(i) = 1;
+            cdata.player().spacts().gain(
+                *the_ability_db.get_id_from_integer(i + 600));
         }
     });
 

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -921,11 +921,13 @@ bool _magic_632_454_1144(
             {
                 p = -1;
             }
-            if (trait(tid) >= traitref(2))
+            if (cdata.player().traits().level(
+                    *the_trait_db.get_id_from_integer(tid)) >= traitref(2))
             {
                 p = -1;
             }
-            if (trait(tid) <= traitref(1))
+            if (cdata.player().traits().level(
+                    *the_trait_db.get_id_from_integer(tid)) <= traitref(1))
             {
                 p = 1;
             }
@@ -950,7 +952,8 @@ bool _magic_632_454_1144(
                     continue;
                 }
             }
-            trait(tid) += p;
+            cdata.player().traits().add(
+                *the_trait_db.get_id_from_integer(tid), p);
             txt(i18n::s.get("core.magic.mutation.apply"));
             if (p > 0)
             {
@@ -1008,19 +1011,23 @@ bool _magic_1121(Character& subject, Character& target)
             {
                 continue;
             }
-            if (trait(tid) == 0)
+            if (cdata.player().traits().level(
+                    *the_trait_db.get_id_from_integer(tid)) == 0)
             {
                 continue;
             }
-            if (trait(tid) > 0)
+            if (cdata.player().traits().level(
+                    *the_trait_db.get_id_from_integer(tid)) > 0)
             {
                 p = -1;
             }
-            if (trait(tid) < 0)
+            if (cdata.player().traits().level(
+                    *the_trait_db.get_id_from_integer(tid)) < 0)
             {
                 p = 1;
             }
-            trait(tid) = 0;
+            cdata.player().traits().set_level(
+                *the_trait_db.get_id_from_integer(tid), 0);
             txt(i18n::s.get("core.magic.cure_mutation"));
             if (p > 0)
             {
@@ -2065,7 +2072,7 @@ bool _magic_645_1114(Character& subject, Character& target)
     {
         if (rnd(3))
         {
-            if (trait(42))
+            if (cdata.player().traits().level("core.exorcist"))
             {
                 txt(i18n::s.get("core.magic.curse.no_effect"));
                 return true;
@@ -3896,7 +3903,7 @@ optional<bool> _proc_general_magic(Character& subject, Character& target)
     }
     if (subject.is_player())
     {
-        if (trait(165))
+        if (cdata.player().traits().level("core.itzpalt_blessing"))
         {
             if (ele == 50 || ele == 51 || ele == 52)
             {

--- a/src/elona/magic.cpp
+++ b/src/elona/magic.cpp
@@ -1286,40 +1286,41 @@ bool _magic_1104(Character& target)
                     continue;
                 }
             }
+            if (!the_ability_db[p])
+            {
+                continue;
+            }
             if (!is_cursed(efstatus))
             {
-                if (the_ability_db[p])
+                if (cnt2 == 0)
                 {
-                    if (cnt2 == 0)
-                    {
-                        s = i18n::s.get("core.magic.gain_knowledge.suddenly");
-                    }
-                    else
-                    {
-                        s = i18n::s.get(
-                            "core.magic.gain_knowledge.furthermore");
-                    }
-                    chara_gain_skill(cdata.player(), p, 1, 200);
-                    txt(s +
-                            i18n::s.get(
-                                "core.magic.gain_knowledge.gain",
-                                the_ability_db.get_text(p, "name")),
-                        Message::color{ColorIndex::green});
-                    snd("core.ding2");
-                    f = 1;
-                    break;
+                    s = i18n::s.get("core.magic.gain_knowledge.suddenly");
                 }
+                else
+                {
+                    s = i18n::s.get("core.magic.gain_knowledge.furthermore");
+                }
+                chara_gain_skill(cdata.player(), p, 1, 200);
+                txt(s +
+                        i18n::s.get(
+                            "core.magic.gain_knowledge.gain",
+                            the_ability_db.get_text(p, "name")),
+                    Message::color{ColorIndex::green});
+                snd("core.ding2");
+                f = 1;
+                break;
             }
             else
             {
-                p = p - 400;
-                if (spell(p) > 0)
+                if (target.spell_stocks().amount(
+                        *the_ability_db.get_id_from_integer(p)) > 0)
                 {
-                    spell(p) = 0;
+                    target.spell_stocks().set_amount(
+                        *the_ability_db.get_id_from_integer(p), 0);
                     txt(i18n::s.get("core.magic.common.it_is_cursed"));
                     txt(i18n::s.get(
                             "core.magic.gain_knowledge.lose",
-                            the_ability_db.get_text(p + 400, "name")),
+                            the_ability_db.get_text(p, "name")),
                         Message::color{ColorIndex::red});
                     snd("core.curse3");
                     animeload(14, cdata.player());

--- a/src/elona/menu.cpp
+++ b/src/elona/menu.cpp
@@ -536,7 +536,7 @@ std::string make_spell_description(int skill_id)
         bonus = damage->damage_bonus;
         ele = damage->element;
         elep = damage->element_power;
-        if (trait(165) != 0)
+        if (cdata.player().traits().level("core.itzpalt_blessing") != 0)
         {
             if (ele == 50 || ele == 51 || ele == 52)
             {

--- a/src/elona/race.cpp
+++ b/src/elona/race.cpp
@@ -115,51 +115,53 @@ void gain_race_feat()
 {
     if (cdata.player().race == "core.dwarf")
     {
-        trait(152) = 2;
-        trait(155) = 1;
+        cdata.player().traits().set_level("core.poison_resistance_nature", 2);
+        cdata.player().traits().set_level("core.darkness_resistance_nature", 1);
     }
     if (cdata.player().race == "core.elea")
     {
-        trait(168) = 1;
-        trait(156) = 1;
+        cdata.player().traits().set_level(
+            "core.slow_ether_disease_progress", 1);
+        cdata.player().traits().set_level("core.less_mana_reaction", 1);
     }
     if (cdata.player().race == "core.eulderna")
     {
-        trait(153) = 1;
+        cdata.player().traits().set_level("core.magic_resistance_nature", 1);
     }
     if (cdata.player().race == "core.lich")
     {
-        trait(151) = 1;
-        trait(155) = 2;
-        trait(152) = 1;
+        cdata.player().traits().set_level("core.cold_resistance_nature", 1);
+        cdata.player().traits().set_level("core.darkness_resistance_nature", 2);
+        cdata.player().traits().set_level("core.poison_resistance_nature", 1);
     }
     if (cdata.player().race == "core.golem")
     {
-        trait(157) = 1;
-        trait(152) = 2;
+        cdata.player().traits().set_level("core.will_not_dimmed", 1);
+        cdata.player().traits().set_level("core.poison_resistance_nature", 2);
     }
     if (cdata.player().race == "core.yerles")
     {
-        trait(154) = 1;
+        cdata.player().traits().set_level("core.more_bonus_points", 1);
     }
     if (cdata.player().race == "core.juere")
     {
-        trait(158) = 1;
-        trait(159) = 1;
+        cdata.player().traits().set_level("core.slow_digestion", 1);
+        cdata.player().traits().set_level("core.more_materials", 1);
     }
     if (cdata.player().race == "core.goblin")
     {
-        trait(155) = 1;
-        trait(159) = 1;
+        cdata.player().traits().set_level("core.darkness_resistance_nature", 1);
+        cdata.player().traits().set_level("core.more_materials", 1);
     }
     if (cdata.player().race == "core.mutant")
     {
-        trait(0) = 1;
+        cdata.player().traits().set_level("core.changing_body", 1);
     }
     if (cdata.player().race == "core.fairy")
     {
-        trait(160) = 1;
-        trait(161) = 1;
+        cdata.player().traits().set_level("core.outstanding_resistances", 1);
+        cdata.player().traits().set_level(
+            "core.cannot_wear_heavy_equipments", 1);
     }
 }
 

--- a/src/elona/random_event.cpp
+++ b/src/elona/random_event.cpp
@@ -369,7 +369,7 @@ void run_random_event(RandomEvent event)
         net_send_news("ehekatl");
         break;
     case 5:
-        if (trait(42))
+        if (cdata.player().traits().level("core.exorcist"))
         {
             txt(i18n::s.get_enum_property("core.event.popup", "no_effect", 5));
         }

--- a/src/elona/save_dump.cpp
+++ b/src/elona/save_dump.cpp
@@ -171,9 +171,12 @@ void save_dump_player_info()
             continue;
         }
 
-        if ((trait(206) != 0 && equipment_slot.type == 2) ||
-            (trait(203) != 0 && equipment_slot.type == 9) ||
-            (trait(205) != 0 && equipment_slot.type == 3))
+        if ((cdata.player().traits().level("core.thick_neck") != 0 &&
+             equipment_slot.type == 2) ||
+            (cdata.player().traits().level("core.hooves") != 0 &&
+             equipment_slot.type == 9) ||
+            (cdata.player().traits().level("core.feathers") != 0 &&
+             equipment_slot.type == 3))
         {
             continue;
         }

--- a/src/elona/spact.hpp
+++ b/src/elona/spact.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <unordered_set>
+
+#include "data/id.hpp"
+#include "typedefs.hpp"
+
+
+
+namespace elona
+{
+
+template <typename T>
+struct elona_vector1;
+
+
+
+/**
+ * A set of spacts that one can use.
+ */
+struct SpactTable
+{
+    /**
+     * True if the character has @a id; otherwise, false
+     */
+    bool has(data::InstanceId id) const noexcept
+    {
+        return _spacts.find(id) != _spacts.end();
+    }
+
+
+
+    /**
+     * Gain the given spact of @a id.
+     *
+     * @param id The spact ID
+     */
+    void gain(data::InstanceId id)
+    {
+        _spacts.emplace(id);
+    }
+
+
+
+    /**
+     * Lose the given spact of @a id.
+     *
+     * @param id The spact ID
+     */
+    void lose(data::InstanceId id)
+    {
+        _spacts.erase(id);
+    }
+
+
+
+    /**
+     * Lose all spacts.
+     */
+    void clear()
+    {
+        _spacts.clear();
+    }
+
+
+
+    // for integration with legacy codebase.
+    void pack_to(elona_vector1<int>& legacy_spact) const;
+    void unpack_from(elona_vector1<int>& legacy_spact);
+
+
+
+private:
+    std::unordered_set<data::InstanceId> _spacts;
+};
+
+} // namespace elona

--- a/src/elona/spell.hpp
+++ b/src/elona/spell.hpp
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <unordered_map>
+
+#include "data/id.hpp"
+#include "typedefs.hpp"
+
+
+
+namespace elona
+{
+
+template <typename T>
+struct elona_vector1;
+
+
+
+/**
+ * A table from spell ID to spell stock.
+ */
+struct SpellStockTable
+{
+    /**
+     * Gets the amount of the spell stock of @a id.
+     *
+     * @param id The spell ID
+     * @return The amount of the spell stock
+     */
+    lua_int amount(data::InstanceId id) const noexcept
+    {
+        if (const auto itr = _stocks.find(id); itr != _stocks.end())
+        {
+            return itr->second;
+        }
+        else
+        {
+            return 0;
+        }
+    }
+
+
+
+    /**
+     * Sets the amount of the spell stock of @a id with the given @a
+     * new_amount. If @a new_amount is negative, the amount is set to zero.
+     *
+     * @param id The spell ID
+     * @param new_amount The new amount of the spell stock
+     */
+    void set_amount(data::InstanceId id, lua_int new_amount)
+    {
+        if (new_amount == 0 && _stocks.find(id) == _stocks.end())
+            return;
+
+        _stocks[id] = std::max(new_amount, lua_int{0});
+    }
+
+
+
+    /**
+     * Adds the amount of the spell stock of @a id by the given amount @a
+     * change_amount.
+     *
+     * @param id The spell ID
+     * @param change_amount The change amount to be added
+     */
+    void gain(data::InstanceId id, lua_int change_amount)
+    {
+        if (change_amount == 0)
+            return;
+
+        // TODO: potential overflow
+        _stocks[id] += change_amount;
+    }
+
+
+
+    /**
+     * Subtracts the amount of the spell stock of @a id by the given
+     * amount @a change_amount.
+     *
+     * @param id The spell ID
+     * @param change_amount The change amount to be subtracted
+     */
+    void lose(data::InstanceId id, lua_int change_amount)
+    {
+        // TODO: potential overflow
+        gain(id, -change_amount);
+    }
+
+
+
+    // for integration with legacy codebase.
+    void pack_to(elona_vector1<int>& legacy_spell) const;
+    void unpack_from(elona_vector1<int>& legacy_spell);
+
+
+
+private:
+    std::unordered_map<data::InstanceId, lua_int> _stocks;
+};
+
+} // namespace elona

--- a/src/elona/trait.cpp
+++ b/src/elona/trait.cpp
@@ -22,7 +22,8 @@ void trait_format_other_parameterized(
 {
     optional<std::string> text = none;
     I18NKey full_prefix = i18n_prefix + ".negative.levels";
-    int level = trait(tid);
+    const auto level =
+        cdata.player().traits().level(*the_trait_db.get_id_from_integer(tid));
 
     // Assumptions:
     // 1. Ether Disease traits are not named.
@@ -126,7 +127,8 @@ void trait_format_other_parameterless(
     int max)
 {
     // Change in positive direction
-    if (trait(tid) >= 0)
+    if (cdata.player().traits().level(*the_trait_db.get_id_from_integer(tid)) >=
+        0)
     {
         if (auto text = i18n::s.get_optional(i18n_prefix + ".positive.name"))
         {
@@ -139,7 +141,9 @@ void trait_format_other_parameterless(
         }
     }
     // Change in negative direction
-    else if (trait(tid) < 0)
+    else if (
+        cdata.player().traits().level(*the_trait_db.get_id_from_integer(tid)) <
+        0)
     {
         if (auto text = i18n::s.get_optional(i18n_prefix + ".negative.name"))
         {
@@ -157,7 +161,8 @@ void trait_format_other_parameterless(
 
 bool trait_is_obtainable(const I18NKey& i18n_prefix, int tid)
 {
-    return trait(tid) >= 0 &&
+    return cdata.player().traits().level(
+               *the_trait_db.get_id_from_integer(tid)) >= 0 &&
         i18n::s.get_enum_property_optional(i18n_prefix + ".levels", "name", 0);
 }
 
@@ -232,9 +237,15 @@ bool is_acquirable(int id)
 {
     switch (id)
     {
-    case 4: return trait(id) == 0 || cdata.player().level >= 5;
+    case 4:
+        return cdata.player().traits().level(
+                   *the_trait_db.get_id_from_integer(id)) == 0 ||
+            cdata.player().level >= 5;
     case 6: return cdata.player().get_skill(159).base_level > 0;
-    case 7: return trait(id) == 0 || cdata.player().level >= 5;
+    case 7:
+        return cdata.player().traits().level(
+                   *the_trait_db.get_id_from_integer(id)) == 0 ||
+            cdata.player().level >= 5;
     case 10: return cdata.player().get_skill(173).base_level > 0;
     case 12: return cdata.player().get_skill(172).base_level > 0;
     case 16: return cdata.player().get_skill(156).base_level > 0;
@@ -271,6 +282,8 @@ int trait_get_info(int traitmode, int tid)
 
         return is_acquirable(tid) ? 1 : -1;
     }
+
+    const auto trait_id = data->id;
 
     if (tid == 24)
     {
@@ -309,7 +322,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 21)
     {
         cdata.player().get_skill(17).level = clamp(
-            cdata.player().get_skill(17).level + trait(tid) * 4,
+            cdata.player().get_skill(17).level +
+                cdata.player().traits().level(trait_id) * 4,
             int{cdata.player().get_skill(17).level > 0},
             9999);
         return 1;
@@ -317,7 +331,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 5)
     {
         cdata.player().get_skill(10).level = clamp(
-            cdata.player().get_skill(10).level + trait(tid) * 3,
+            cdata.player().get_skill(10).level +
+                cdata.player().traits().level(trait_id) * 3,
             int{cdata.player().get_skill(10).level > 0},
             9999);
         return 1;
@@ -337,7 +352,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 9)
     {
         cdata.player().get_skill(11).level = clamp(
-            cdata.player().get_skill(11).level + trait(tid) * 3,
+            cdata.player().get_skill(11).level +
+                cdata.player().traits().level(trait_id) * 3,
             int{cdata.player().get_skill(11).level > 0},
             9999);
         return 1;
@@ -345,7 +361,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 20)
     {
         cdata.player().get_skill(106).level = clamp(
-            cdata.player().get_skill(106).level + trait(tid) * 3,
+            cdata.player().get_skill(106).level +
+                cdata.player().traits().level(trait_id) * 3,
             int{cdata.player().get_skill(106).level > 0},
             9999);
         return 1;
@@ -353,7 +370,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 12)
     {
         cdata.player().get_skill(172).level = clamp(
-            cdata.player().get_skill(172).level + trait(tid) * 4,
+            cdata.player().get_skill(172).level +
+                cdata.player().traits().level(trait_id) * 4,
             int{cdata.player().get_skill(172).level > 0},
             9999);
         return 1;
@@ -370,7 +388,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 19)
     {
         cdata.player().get_skill(166).level = clamp(
-            cdata.player().get_skill(166).level + trait(tid) * 4,
+            cdata.player().get_skill(166).level +
+                cdata.player().traits().level(trait_id) * 4,
             int{cdata.player().get_skill(166).level > 0},
             9999);
         return 1;
@@ -378,7 +397,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 15)
     {
         cdata.player().get_skill(53).level = clamp(
-            cdata.player().get_skill(53).level + trait(tid) * 50 / 2,
+            cdata.player().get_skill(53).level +
+                cdata.player().traits().level(trait_id) * 50 / 2,
             int{cdata.player().get_skill(53).level > 0},
             9999);
         return 1;
@@ -386,7 +406,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 18)
     {
         cdata.player().get_skill(55).level = clamp(
-            cdata.player().get_skill(55).level + trait(tid) * 50 / 2,
+            cdata.player().get_skill(55).level +
+                cdata.player().traits().level(trait_id) * 50 / 2,
             int{cdata.player().get_skill(55).level > 0},
             9999);
         return 1;
@@ -394,7 +415,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 16)
     {
         cdata.player().get_skill(156).level = clamp(
-            cdata.player().get_skill(156).level + trait(tid) * 4,
+            cdata.player().get_skill(156).level +
+                cdata.player().traits().level(trait_id) * 4,
             int{cdata.player().get_skill(156).level > 0},
             9999);
         return 1;
@@ -402,7 +424,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 17)
     {
         cdata.player().get_skill(181).level = clamp(
-            cdata.player().get_skill(181).level + trait(tid) * 4,
+            cdata.player().get_skill(181).level +
+                cdata.player().traits().level(trait_id) * 4,
             int{cdata.player().get_skill(181).level > 0},
             9999);
         return 1;
@@ -410,7 +433,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 1)
     {
         cdata.player().get_skill(19).level = clamp(
-            cdata.player().get_skill(19).level + trait(tid) * 5,
+            cdata.player().get_skill(19).level +
+                cdata.player().traits().level(trait_id) * 5,
             int{cdata.player().get_skill(19).level > 0},
             9999);
         return 1;
@@ -418,7 +442,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 2)
     {
         cdata.player().get_skill(2).level = clamp(
-            cdata.player().get_skill(2).level + trait(tid) * 5,
+            cdata.player().get_skill(2).level +
+                cdata.player().traits().level(trait_id) * 5,
             int{cdata.player().get_skill(2).level > 0},
             9999);
         return 1;
@@ -426,7 +451,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 11)
     {
         cdata.player().get_skill(3).level = clamp(
-            cdata.player().get_skill(3).level + trait(tid) * 5,
+            cdata.player().get_skill(3).level +
+                cdata.player().traits().level(trait_id) * 5,
             int{cdata.player().get_skill(3).level > 0},
             9999);
         return 1;
@@ -434,7 +460,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 6)
     {
         cdata.player().get_skill(159).level = clamp(
-            cdata.player().get_skill(159).level + trait(tid) * 3,
+            cdata.player().get_skill(159).level +
+                cdata.player().traits().level(trait_id) * 3,
             int{cdata.player().get_skill(159).level > 0},
             9999);
         return 1;
@@ -442,7 +469,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 4)
     {
         cdata.player().get_skill(18).level = clamp(
-            cdata.player().get_skill(18).level + trait(tid) * 5,
+            cdata.player().get_skill(18).level +
+                cdata.player().traits().level(trait_id) * 5,
             int{cdata.player().get_skill(18).level > 0},
             9999);
         return 1;
@@ -450,7 +478,7 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 7)
     {
         cdata.player().pv = clamp(
-            cdata.player().pv + trait(tid) * 5,
+            cdata.player().pv + cdata.player().traits().level(trait_id) * 5,
             int{cdata.player().pv > 0},
             9999);
         return 1;
@@ -458,7 +486,7 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 8)
     {
         cdata.player().dv = clamp(
-            cdata.player().dv + trait(tid) * 4,
+            cdata.player().dv + cdata.player().traits().level(trait_id) * 4,
             int{cdata.player().dv > 0},
             9999);
         return 1;
@@ -466,7 +494,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 10)
     {
         cdata.player().get_skill(173).level = clamp(
-            cdata.player().get_skill(173).level + trait(tid) * 2,
+            cdata.player().get_skill(173).level +
+                cdata.player().traits().level(trait_id) * 2,
             int{cdata.player().get_skill(173).level > 0},
             9999);
         return 1;
@@ -477,13 +506,14 @@ int trait_get_info(int traitmode, int tid)
     }
     if (tid == 25)
     {
-        cdata.player().pv += trait(tid) * 3;
+        cdata.player().pv += cdata.player().traits().level(trait_id) * 3;
         return 1;
     }
     if (tid == 26)
     {
         cdata.player().get_skill(12).level = clamp(
-            cdata.player().get_skill(12).level + trait(tid) * 3,
+            cdata.player().get_skill(12).level +
+                cdata.player().traits().level(trait_id) * 3,
             int{cdata.player().get_skill(12).level > 0},
             9999);
         return 1;
@@ -491,7 +521,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 27)
     {
         cdata.player().get_skill(154).level = clamp(
-            cdata.player().get_skill(154).level + trait(tid) * 4,
+            cdata.player().get_skill(154).level +
+                cdata.player().traits().level(trait_id) * 4,
             int{cdata.player().get_skill(154).level > 0},
             9999);
         return 1;
@@ -499,7 +530,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 28)
     {
         cdata.player().get_skill(18).level = clamp(
-            cdata.player().get_skill(18).level + trait(tid) * 5,
+            cdata.player().get_skill(18).level +
+                cdata.player().traits().level(trait_id) * 5,
             int{cdata.player().get_skill(18).level > 0},
             9999);
         return 1;
@@ -507,7 +539,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 29)
     {
         cdata.player().get_skill(10).level = clamp(
-            cdata.player().get_skill(10).level + trait(tid) * 3,
+            cdata.player().get_skill(10).level +
+                cdata.player().traits().level(trait_id) * 3,
             int{cdata.player().get_skill(10).level > 0},
             9999);
         return 1;
@@ -515,7 +548,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 30)
     {
         cdata.player().get_skill(17).level = clamp(
-            cdata.player().get_skill(17).level + trait(tid) * 5,
+            cdata.player().get_skill(17).level +
+                cdata.player().traits().level(trait_id) * 5,
             int{cdata.player().get_skill(17).level > 0},
             9999);
         return 1;
@@ -525,7 +559,8 @@ int trait_get_info(int traitmode, int tid)
         if (cdata.player().get_skill(165).base_level != 0)
         {
             cdata.player().get_skill(165).level = clamp(
-                cdata.player().get_skill(165).level + trait(tid) * 4,
+                cdata.player().get_skill(165).level +
+                    cdata.player().traits().level(trait_id) * 4,
                 int{cdata.player().get_skill(165).level > 0},
                 9999);
         }
@@ -534,7 +569,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 32)
     {
         cdata.player().get_skill(60).level = clamp(
-            cdata.player().get_skill(60).level + trait(tid) * 50,
+            cdata.player().get_skill(60).level +
+                cdata.player().traits().level(trait_id) * 50,
             int{cdata.player().get_skill(60).level > 0},
             9999);
         return 1;
@@ -542,7 +578,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 33)
     {
         cdata.player().get_skill(57).level = clamp(
-            cdata.player().get_skill(57).level + trait(tid) * 50,
+            cdata.player().get_skill(57).level +
+                cdata.player().traits().level(trait_id) * 50,
             int{cdata.player().get_skill(57).level > 0},
             9999);
         return 1;
@@ -550,7 +587,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 34)
     {
         cdata.player().get_skill(50).level = clamp(
-            cdata.player().get_skill(50).level + trait(tid) * 50,
+            cdata.player().get_skill(50).level +
+                cdata.player().traits().level(trait_id) * 50,
             int{cdata.player().get_skill(50).level > 0},
             9999);
         return 1;
@@ -558,7 +596,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 35)
     {
         cdata.player().get_skill(51).level = clamp(
-            cdata.player().get_skill(51).level + trait(tid) * 50,
+            cdata.player().get_skill(51).level +
+                cdata.player().traits().level(trait_id) * 50,
             int{cdata.player().get_skill(51).level > 0},
             9999);
         return 1;
@@ -566,7 +605,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 36)
     {
         cdata.player().get_skill(52).level = clamp(
-            cdata.player().get_skill(52).level + trait(tid) * 50,
+            cdata.player().get_skill(52).level +
+                cdata.player().traits().level(trait_id) * 50,
             int{cdata.player().get_skill(52).level > 0},
             9999);
         return 1;
@@ -574,7 +614,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 37)
     {
         cdata.player().get_skill(13).level = clamp(
-            cdata.player().get_skill(13).level + trait(tid) * 5,
+            cdata.player().get_skill(13).level +
+                cdata.player().traits().level(trait_id) * 5,
             int{cdata.player().get_skill(13).level > 0},
             9999);
         return 1;
@@ -582,7 +623,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 150)
     {
         cdata.player().get_skill(50).level = clamp(
-            cdata.player().get_skill(50).level + trait(tid) * 50,
+            cdata.player().get_skill(50).level +
+                cdata.player().traits().level(trait_id) * 50,
             int{cdata.player().get_skill(50).level > 0},
             9999);
         return 1;
@@ -590,7 +632,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 151)
     {
         cdata.player().get_skill(51).level = clamp(
-            cdata.player().get_skill(51).level + trait(tid) * 50,
+            cdata.player().get_skill(51).level +
+                cdata.player().traits().level(trait_id) * 50,
             int{cdata.player().get_skill(51).level > 0},
             9999);
         return 1;
@@ -598,7 +641,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 152)
     {
         cdata.player().get_skill(55).level = clamp(
-            cdata.player().get_skill(55).level + trait(tid) * 50,
+            cdata.player().get_skill(55).level +
+                cdata.player().traits().level(trait_id) * 50,
             int{cdata.player().get_skill(55).level > 0},
             9999);
         return 1;
@@ -606,7 +650,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 155)
     {
         cdata.player().get_skill(53).level = clamp(
-            cdata.player().get_skill(53).level + trait(tid) * 50,
+            cdata.player().get_skill(53).level +
+                cdata.player().traits().level(trait_id) * 50,
             int{cdata.player().get_skill(53).level > 0},
             9999);
         return 1;
@@ -706,7 +751,8 @@ int trait_get_info(int traitmode, int tid)
     if (tid == 153)
     {
         cdata.player().get_skill(60).level = clamp(
-            cdata.player().get_skill(60).level + trait(tid) * 50,
+            cdata.player().get_skill(60).level +
+                cdata.player().traits().level(trait_id) * 50,
             int{cdata.player().get_skill(60).level > 0},
             9999);
         return 1;
@@ -727,7 +773,8 @@ int trait_get_info(int traitmode, int tid)
     {
         cdata.player().get_skill(17).level = clamp(
             cdata.player().get_skill(17).level +
-                trait(tid) * (4 + cdata.player().level / 5),
+                cdata.player().traits().level(trait_id) *
+                    (4 + cdata.player().level / 5),
             int{cdata.player().get_skill(17).level > 0},
             9999);
         return 1;
@@ -901,7 +948,8 @@ void trait_load_desc(Character& chara)
                 }
             }
         }
-        if (trait(cnt) != 0)
+        if (cdata.player().traits().level(
+                *the_trait_db.get_id_from_integer(cnt)) != 0)
         {
             list(0, listmax) = cnt;
             list(1, listmax) = 10000 + cnt + 1;
@@ -938,9 +986,11 @@ void trait_load_desc(Character& chara)
         s = "";
         if (list(1, cnt) < 10000)
         {
-            if (trait(tid) < traitref(2))
+            if (cdata.player().traits().level(
+                    *the_trait_db.get_id_from_integer(tid)) < traitref(2))
             {
-                s = traitrefn2(trait(tid));
+                s = traitrefn2(cdata.player().traits().level(
+                    *the_trait_db.get_id_from_integer(tid)));
             }
             else
             {
@@ -977,7 +1027,10 @@ void trait_load_desc(Character& chara)
                     i18n::s.get("core.trait.window.category.ether_disease") +
                     u8"]"s;
             }
-            s += traitrefn(2 + std::abs(trait(tid)));
+            s += traitrefn(
+                2 +
+                std::abs(cdata.player().traits().level(
+                    *the_trait_db.get_id_from_integer(tid))));
         }
         listn(0, cnt) = s;
     }

--- a/src/elona/trait.cpp
+++ b/src/elona/trait.cpp
@@ -278,32 +278,32 @@ int trait_get_info(int traitmode, int tid)
     }
     if (tid == 3)
     {
-        spact(1) = 1;
+        cdata.player().spacts().gain("core.drain_blood");
         return 1;
     }
     if (tid == 40)
     {
-        spact(56) = 1;
+        cdata.player().spacts().gain("core.cheer");
         return 1;
     }
     if (tid == 13)
     {
-        spact(27) = 1;
+        cdata.player().spacts().gain("core.dimensional_move");
         return 1;
     }
     if (tid == 14)
     {
-        spact(2) = 1;
+        cdata.player().spacts().gain("core.fire_breath");
         return 1;
     }
     if (tid == 22)
     {
-        spact(18) = 1;
+        cdata.player().spacts().gain("core.touch_of_sleep");
         return 1;
     }
     if (tid == 23)
     {
-        spact(15) = 1;
+        cdata.player().spacts().gain("core.touch_of_poison");
         return 1;
     }
     if (tid == 21)

--- a/src/elona/trait.hpp
+++ b/src/elona/trait.hpp
@@ -1,13 +1,114 @@
 #pragma once
 
+#include <unordered_map>
+
+#include "data/id.hpp"
 #include "data/types/type_trait.hpp"
+#include "typedefs.hpp"
 
 
 
 namespace elona
 {
 
+template <typename T>
+struct elona_vector1;
+
 struct Character;
+
+
+
+/**
+ * A table from trait ID to trait level.
+ */
+struct TraitLevelTable
+{
+    /**
+     * Gets the level of @a trait_id.
+     *
+     * @param trait_id The trait ID
+     * @return The level of the trait
+     */
+    lua_int level(data::InstanceId trait_id) const noexcept
+    {
+        if (const auto itr = _traits.find(trait_id); itr != _traits.end())
+        {
+            return itr->second;
+        }
+        else
+        {
+            return 0;
+        }
+    }
+
+
+
+    /**
+     * Sets the level of @a trait_id with the given @a new_level.
+     *
+     * @param trait_id The trait ID
+     * @param new_level The new level of the trait
+     */
+    void set_level(data::InstanceId trait_id, lua_int new_level)
+    {
+        if (new_level == 0 && _traits.find(trait_id) == _traits.end())
+            return;
+
+        _traits[trait_id] = new_level;
+    }
+
+
+
+    /**
+     * Adds the level of @a trait_id by the given amount @a change.
+     *
+     * @param trait_id The trait ID
+     * @param change The change to be added
+     */
+    void add(data::InstanceId trait_id, lua_int change)
+    {
+        if (change == 0)
+            return;
+
+        // FIXME: potential overflow
+        _traits[trait_id] += change;
+    }
+
+
+
+    /**
+     * Subtracts the level of @a trait_id by the given level @a change.
+     *
+     * @param trait_id The trait ID
+     * @param change The change to be subtracted
+     */
+    void sub(data::InstanceId trait_id, lua_int change)
+    {
+        // FIXME: potential overflow
+        add(trait_id, -change);
+    }
+
+
+
+    /**
+     * Clear all traits.
+     */
+    void clear() noexcept
+    {
+        _traits.clear();
+    }
+
+
+
+    // for integration with legacy codebase.
+    void pack_to(elona_vector1<int>& legacy_trait) const;
+    void unpack_from(elona_vector1<int>& legacy_trait);
+
+
+
+private:
+    std::unordered_map<data::InstanceId, lua_int> _traits;
+};
 
 
 

--- a/src/elona/turn_sequence.cpp
+++ b/src/elona/turn_sequence.cpp
@@ -1384,7 +1384,8 @@ optional<TurnResult> pc_turn_advance_time()
             return result;
         }
     }
-    if (trait(210) != 0 && rnd(5) == 0)
+    if (cdata.player().traits().level("core.potion_addiction") != 0 &&
+        rnd(5) == 0)
     {
         const auto item = inv_player()->at(inv_get_random_slot(inv_player()));
         if (item && the_item_db[item->id]->category == ItemCategory::potion)
@@ -1393,8 +1394,8 @@ optional<TurnResult> pc_turn_advance_time()
                 cdata.player(), item, the_item_db[item->id]->integer_id);
         }
     }
-    if (trait(214) != 0 && rnd(250) == 0 &&
-        map_data.type != mdata_t::MapType::world_map)
+    if (cdata.player().traits().level("core.random_teleportation") != 0 &&
+        rnd(250) == 0 && map_data.type != mdata_t::MapType::world_map)
     {
         efid = 408;
         magic(cdata.player(), cdata.player());

--- a/src/elona/ui/ui_menu_equipment.cpp
+++ b/src/elona/ui/ui_menu_equipment.cpp
@@ -21,21 +21,24 @@ static bool _should_show_entry(const EquipmentSlot& equipment_slot)
     {
         return false;
     }
-    if (trait(206) != 0) // Your neck is extremely thick.
+    if (cdata.player().traits().level("core.thick_neck") !=
+        0) // Your neck is extremely thick.
     {
         if (equipment_slot.type == 2)
         {
             return false;
         }
     }
-    if (trait(203) != 0) // Your feet transformed into hooves.
+    if (cdata.player().traits().level("core.hooves") !=
+        0) // Your feet transformed into hooves.
     {
         if (equipment_slot.type == 9)
         {
             return false;
         }
     }
-    if (trait(205) != 0) // You have grown feather.
+    if (cdata.player().traits().level("core.feathers") !=
+        0) // You have grown feather.
     {
         if (equipment_slot.type == 3)
         {

--- a/src/elona/ui/ui_menu_feats.cpp
+++ b/src/elona/ui/ui_menu_feats.cpp
@@ -353,7 +353,8 @@ void UIMenuFeats::_draw_single_list_entry(
     if (list_value != trait_desc_value)
     {
         trait_get_info(0, list_item);
-        text_color = _get_trait_color(trait(list_item));
+        text_color = _get_trait_color(cdata.player().traits().level(
+            *the_trait_db.get_id_from_integer(list_item)));
     }
     else
     {
@@ -406,7 +407,8 @@ bool UIMenuFeats::_gain_trait(int p_, bool show_text)
     int tid = list(0, p_);
     trait_get_info(0, tid);
 
-    if (traitref(2) <= trait(tid))
+    if (traitref(2) <=
+        cdata.player().traits().level(*the_trait_db.get_id_from_integer(tid)))
     {
         if (show_text)
         {
@@ -418,7 +420,7 @@ bool UIMenuFeats::_gain_trait(int p_, bool show_text)
     --game()->acquirable_feat_count;
     cs = -10000 + tid;
     snd("core.ding3");
-    ++trait(tid);
+    cdata.player().traits().add(*the_trait_db.get_id_from_integer(tid), 1);
     chara_refresh(cdata[_chara_index]);
 
     return true;

--- a/src/elona/ui/ui_menu_skills.cpp
+++ b/src/elona/ui/ui_menu_skills.cpp
@@ -29,9 +29,10 @@ static void _populate_skill_list()
             ++listmax;
         }
     }
-    for (int cnt = 0; cnt < 61; ++cnt)
+    for (int cnt = 1; cnt < 61; ++cnt)
     {
-        if (spact(cnt) != 0)
+        if (cdata.player().spacts().has(
+                *the_ability_db.get_id_from_integer(cnt + 600)))
         {
             list(0, listmax) = cnt + 600;
             list(1, listmax) =

--- a/src/elona/ui/ui_menu_spells.cpp
+++ b/src/elona/ui/ui_menu_spells.cpp
@@ -22,12 +22,16 @@ static void _populate_spell_list()
 {
     for (int cnt = 0; cnt < 200; ++cnt)
     {
-        if (spell(cnt) > 0)
+        const auto integer_spell_id = cnt + 400;
+        if (const auto data = the_ability_db[integer_spell_id])
         {
-            list(0, listmax) = cnt + 400;
-            list(1, listmax) = the_ability_db[400 + cnt]
-                                   ->related_basic_attribute; // TODO coupling
-            ++listmax;
+            if (cdata.player().spell_stocks().amount(data->id) > 0)
+            {
+                list(0, listmax) = integer_spell_id;
+                list(1, listmax) =
+                    data->related_basic_attribute; // TODO coupling
+                ++listmax;
+            }
         }
     }
     sort_list_by_column1();
@@ -155,7 +159,9 @@ void UIMenuSpells::_draw_spell_cost(int cnt, int spell_id)
 {
     std::string spell_cost = ""s +
         calc_spell_cost_mp(cdata.player(), spell_id) + u8" ("s +
-        spell((spell_id - 400)) + u8")"s;
+        std::to_string(cdata.player().spell_stocks().amount(
+            *the_ability_db.get_id_from_integer(spell_id))) +
+        u8")"s;
     mes(wx + 328 - strlen_u(spell_cost) * 7,
         wy + 66 + cnt * 19 + 2,
         spell_cost);

--- a/src/elona/variables.hpp
+++ b/src/elona/variables.hpp
@@ -170,7 +170,6 @@ ELONA_EXTERN(elona_vector1<int> reph);
 ELONA_EXTERN(elona_vector1<int> repw);
 ELONA_EXTERN(elona_vector1<int> rowactre);
 ELONA_EXTERN(elona_vector1<int> rtval);
-ELONA_EXTERN(elona_vector1<int> spact);
 ELONA_EXTERN(elona_vector1<int> sx);
 ELONA_EXTERN(elona_vector1<int> sy);
 ELONA_EXTERN(elona_vector1<int> tile);

--- a/src/elona/variables.hpp
+++ b/src/elona/variables.hpp
@@ -178,7 +178,6 @@ ELONA_EXTERN(elona_vector1<int> tile_fog);
 ELONA_EXTERN(elona_vector1<int> tile_room);
 ELONA_EXTERN(elona_vector1<int> tile_tunnel);
 ELONA_EXTERN(elona_vector1<int> tile_wall);
-ELONA_EXTERN(elona_vector1<int> trait);
 ELONA_EXTERN(elona_vector1<int> traitref);
 ELONA_EXTERN(elona_vector1<int> trate);
 ELONA_EXTERN(elona_vector1<int> windowshadow);

--- a/src/elona/variables.hpp
+++ b/src/elona/variables.hpp
@@ -171,7 +171,6 @@ ELONA_EXTERN(elona_vector1<int> repw);
 ELONA_EXTERN(elona_vector1<int> rowactre);
 ELONA_EXTERN(elona_vector1<int> rtval);
 ELONA_EXTERN(elona_vector1<int> spact);
-ELONA_EXTERN(elona_vector1<int> spell);
 ELONA_EXTERN(elona_vector1<int> sx);
 ELONA_EXTERN(elona_vector1<int> sy);
 ELONA_EXTERN(elona_vector1<int> tile);

--- a/src/elona/world.cpp
+++ b/src/elona/world.cpp
@@ -118,7 +118,7 @@ void weather_changes()
             if (p == 0)
             {
                 weatherbk = 0;
-                if (trait(209) != 0)
+                if (cdata.player().traits().level("core.rainy_clouds") != 0)
                 {
                     if (rnd(4) == 0)
                     {


### PR DESCRIPTION
# Summary

Define `SpellStockTable` for `spell`, `SpactTable` for `spact`, and `TraitLevelTable` for `trait`. They are now member fields of `Character`. In the future, they will be used for not only PC but also NPCs.

This PR does not change save data at all. Everything is kept compatible. Thus, only player's `spell_stocks`, `spacts` and `traits` are saved for now. This limitation will be removed by another PR.