### PR TITLE
Organize knpc/kitem/krecipe

### DIFF
--- a/src/elona/blending.cpp
+++ b/src/elona/blending.cpp
@@ -1169,13 +1169,13 @@ std::string blending_get_recipe_name(int recipe_id)
 
 
 
-void blending_clear_recipememory()
+void blending_clear_recipe_memory()
 {
-    for (const auto& [_, recipe_data] : the_blending_recipe_db)
+    for (const auto& [id, recipe_data] : the_blending_recipe_db)
     {
         if (recipe_data.known)
         {
-            recipememory(recipe_data.integer_id) = 1;
+            game()->blending_recipe_memories().set_read_count(id, 1);
         }
     }
 }
@@ -1264,9 +1264,9 @@ TurnResult blending_menu()
             rppage(0) = 0;
             rppage(1) = 0;
             listmax = 0;
-            for (const auto& [_, recipe_data] : the_blending_recipe_db)
+            for (const auto& [id, recipe_data] : the_blending_recipe_db)
             {
-                if (recipememory(recipe_data.integer_id) > 0)
+                if (game()->blending_recipe_memories().read_count(id) > 0)
                 {
                     list(0, listmax) = recipe_data.integer_id;
                     list(1, listmax) = recipe_data.integer_id;

--- a/src/elona/blending.hpp
+++ b/src/elona/blending.hpp
@@ -15,7 +15,7 @@ void blending_init_recipe_data();
 
 std::string blending_get_recipe_name(int recipe_id);
 
-void blending_clear_recipememory();
+void blending_clear_recipe_memory();
 
 TurnResult blending_menu();
 void window_recipe2(int = 0);

--- a/src/elona/blending_recipe_memory.hpp
+++ b/src/elona/blending_recipe_memory.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <unordered_map>
+
+#include "../util/mathutil.hpp"
+#include "data/id.hpp"
+#include "typedefs.hpp"
+
+
+
+namespace elona
+{
+
+template <typename T>
+struct elona_vector1;
+
+
+
+/**
+ * Records one blending recipe's memory.
+ */
+struct BlendingRecipeMemory
+{
+    /// Read count
+    lua_int read_count{};
+
+#if 0
+    /// Extension data
+    lua_table ext{};
+#endif
+};
+
+
+
+/**
+ * A table of @ref BlendingRecipeMemory indexed by blending recipe ID. It
+ * delays creation of entries until the first assignment.
+ */
+struct BlendingRecipeMemoryTable
+{
+    /**
+     * Gets the read count of @a id.
+     *
+     * @param id The blending recipe ID
+     * @return The number of blending recipes you have read ever
+     */
+    lua_int read_count(data::InstanceId id) const noexcept
+    {
+        if (const auto itr = _memories.find(id); itr != _memories.end())
+        {
+            return itr->second.read_count;
+        }
+        else
+        {
+            return 0;
+        }
+    }
+
+
+
+    /**
+     * Sets the read count of @a id with the given @a new_read_count. If @a
+     * new_read_count is negative, the read count is set to zero.
+     */
+    void set_read_count(data::InstanceId id, lua_int new_read_count)
+    {
+        if (new_read_count == 0 && _memories.find(id) == _memories.end())
+            return;
+
+        _memories[id].read_count = std::max(new_read_count, lua_int{0});
+    }
+
+
+
+    /**
+     * Increments the read count of @a id.
+     */
+    void increment_read_count(data::InstanceId id)
+    {
+        mathutil::saturating_inc(_memories[id].read_count);
+    }
+
+
+
+    // for integration with legacy codebase.
+    void pack_to(elona_vector1<int>& legacy_recipememory) const;
+    void unpack_from(elona_vector1<int>& legacy_recipememory);
+
+
+
+private:
+    std::unordered_map<data::InstanceId, BlendingRecipeMemory> _memories;
+};
+
+} // namespace elona

--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -76,13 +76,14 @@ int _get_random_npc_id()
 {
     WeightedRandomSampler<int> sampler;
 
-    for (const auto& data : the_character_db.values())
+    for (const auto& [id, data] : the_character_db)
     {
         if (data.level > objlv)
             continue;
         if (fltselect != data.fltselect)
             continue;
-        if (fltselect == 2 && npcmemory(1, data.integer_id) != 0)
+        if (fltselect == 2 &&
+            game()->character_memories().generate_count(id) != 0)
             continue;
         if (flttypemajor != 0 && flttypemajor != data.category)
             continue;
@@ -163,7 +164,8 @@ optional<int> chara_create_internal(int slot, int chara_id)
 
     cm = slot + 1;
     cmshade = 0;
-    ++npcmemory(1, chara_id);
+    game()->character_memories().increment_generate_count(
+        *the_character_db.get_id_from_integer(chara_id));
     if (chara_id == 323)
     {
         if (rnd(5))
@@ -700,7 +702,8 @@ optional_ref<Character> chara_create(int slot, int chara_id, int x, int y)
         if (*result == 56)
         {
             cdata[*result].set_state(Character::State::empty);
-            --npcmemory(1, charaid2int(cdata[*result].id));
+            game()->character_memories().decrement_generate_count(
+                cdata[*result].new_id());
             return cdata.tmp();
         }
         if (*result != 0)
@@ -1508,7 +1511,7 @@ int chara_copy(const Character& source)
     // Increase crowd density.
     modify_crowd_density(slot, 1);
     // Increase the generation counter.
-    ++npcmemory(1, charaid2int(destination.id));
+    game()->character_memories().increment_generate_count(destination.new_id());
 
     return slot;
 }

--- a/src/elona/character_memory.hpp
+++ b/src/elona/character_memory.hpp
@@ -1,0 +1,134 @@
+#pragma once
+
+#include <unordered_map>
+
+#include "../util/mathutil.hpp"
+#include "data/id.hpp"
+#include "typedefs.hpp"
+
+
+
+namespace elona
+{
+
+template <typename T>
+struct elona_vector2;
+
+
+
+/**
+ * Records one character's memory.
+ */
+struct CharacterMemory
+{
+    /// Generate count
+    lua_int generate_count{};
+
+    /// Kill count
+    lua_int kill_count{};
+
+#if 0
+    /// Extension data
+    lua_table ext{};
+#endif
+};
+
+
+
+/**
+ * A table of @ref CharacterMemory indexed by character ID. It delays
+ * creation of entries until the first assignment.
+ */
+struct CharacterMemoryTable
+{
+    /**
+     * Gets the generation count of @a id.
+     *
+     * @param id The character ID
+     * @return The number of characters generated ever
+     */
+    lua_int generate_count(data::InstanceId id) const noexcept
+    {
+        if (const auto itr = _memories.find(id); itr != _memories.end())
+        {
+            return itr->second.generate_count;
+        }
+        else
+        {
+            return 0;
+        }
+    }
+
+
+
+    /**
+     * Increments the generation count of @a id.
+     */
+    void increment_generate_count(data::InstanceId id)
+    {
+        mathutil::saturating_inc(_memories[id].generate_count);
+    }
+
+
+
+    /**
+     * Decrements the generation count of @a id.
+     */
+    void decrement_generate_count(data::InstanceId id)
+    {
+        mathutil::saturating_dec(_memories[id].generate_count, lua_int{0});
+    }
+
+
+
+    /**
+     * Gets the kill count of @a id.
+     *
+     * @param id The character ID
+     * @return The number of characters killed ever
+     */
+    lua_int kill_count(data::InstanceId id) const noexcept
+    {
+        if (const auto itr = _memories.find(id); itr != _memories.end())
+        {
+            return itr->second.kill_count;
+        }
+        else
+        {
+            return 0;
+        }
+    }
+
+
+
+    /**
+     * Increments the kill count of @a id.
+     */
+    void increment_kill_count(data::InstanceId id)
+    {
+        mathutil::saturating_inc(_memories[id].kill_count);
+    }
+
+
+
+    /**
+     * Decrements the kill count of @a id.
+     */
+    void decrement_kill_count(data::InstanceId id)
+    {
+        mathutil::saturating_dec(_memories[id].kill_count, lua_int{0});
+    }
+
+
+
+    // for integration with legacy codebase.
+    void pack_to(elona_vector2<int>& legacy_npcmemory) const;
+    void unpack_from(elona_vector2<int>& legacy_npcmemory);
+
+
+
+private:
+    std::unordered_map<data::InstanceId, CharacterMemory> _memories;
+};
+
+} // namespace elona

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -4301,9 +4301,9 @@ int decode_book(Character& reader, const ItemRef& book)
                         1000) +
                 1);
         chara_gain_exp_memorization(cdata.player(), efid);
-        if (itemmemory(2, the_item_db[book->id]->integer_id) == 0)
+        if (!game()->item_memories().is_decoded(book->id))
         {
-            itemmemory(2, the_item_db[book->id]->integer_id) = 1;
+            game()->item_memories().set_decoded(book->id, true);
         }
     }
     item_identify(book, IdentifyState::partly);

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -19,6 +19,7 @@
 #include "crafting_material.hpp"
 #include "ctrl_file.hpp"
 #include "data/types/type_ability.hpp"
+#include "data/types/type_blending_recipe.hpp"
 #include "data/types/type_crafting_material.hpp"
 #include "data/types/type_item.hpp"
 #include "data/types/type_item_material.hpp"
@@ -4262,7 +4263,8 @@ int decode_book(Character& reader, const ItemRef& book)
             return 1;
         }
         txt(i18n::s.get("core.action.read.recipe.learned", book));
-        ++recipememory(book->subname);
+        game()->blending_recipe_memories().increment_read_count(
+            *the_blending_recipe_db.get_id_from_integer(book->subname));
         item_identify(book, IdentifyState::partly);
         book->modify_number(-1);
         if (is_in_fov(reader))

--- a/src/elona/ctrl_file.cpp
+++ b/src/elona/ctrl_file.cpp
@@ -466,7 +466,10 @@ void ctrl_file_global_read(const fs::path& dir)
 
     {
         const auto filepath = dir / u8"knpc.s1";
+        elona_vector2<int> npcmemory;
+        DIM3(npcmemory, 2, 800);
         load_v2(filepath, npcmemory, 0, 2, 0, 800);
+        game()->character_memories().unpack_from(npcmemory);
     }
 
     {
@@ -624,6 +627,9 @@ void ctrl_file_global_write(const fs::path& dir)
 
     {
         const auto filepath = dir / u8"knpc.s1";
+        elona_vector2<int> npcmemory;
+        DIM3(npcmemory, 2, 800);
+        game()->character_memories().pack_to(npcmemory);
         save_v2(filepath, npcmemory, 0, 2, 0, 800);
     }
 
@@ -1269,6 +1275,46 @@ void BlendingRecipeMemoryTable::unpack_from(
                 the_blending_recipe_db.get_id_from_integer(integer_recipe_id))
         {
             _memories[*id].read_count = legacy_recipememory(i);
+        }
+    }
+}
+
+
+
+void CharacterMemoryTable::pack_to(elona_vector2<int>& legacy_npcmemory) const
+{
+    for (int i = 0; i < 800; ++i)
+    {
+        const auto integer_chara_id = i;
+        if (const auto id =
+                the_character_db.get_id_from_integer(integer_chara_id))
+        {
+            if (const auto itr = _memories.find(*id); itr != _memories.end())
+            {
+                legacy_npcmemory(0, i) = itr->second.kill_count;
+                legacy_npcmemory(1, i) = itr->second.generate_count;
+            }
+        }
+    }
+}
+
+
+
+void CharacterMemoryTable::unpack_from(elona_vector2<int>& legacy_npcmemory)
+{
+    _memories.clear();
+
+    for (int i = 0; i < 800; ++i)
+    {
+        if (legacy_npcmemory(0, i) == 0 && legacy_npcmemory(1, i) == 0)
+            continue;
+
+        const auto integer_chara_id = i;
+        if (const auto id =
+                the_character_db.get_id_from_integer(integer_chara_id))
+        {
+            _memories[*id].kill_count = legacy_npcmemory(0, i);
+            _memories[*id].generate_count = legacy_npcmemory(1, i);
         }
     }
 }

--- a/src/elona/ctrl_file.cpp
+++ b/src/elona/ctrl_file.cpp
@@ -461,7 +461,10 @@ void ctrl_file_global_read(const fs::path& dir)
 
     {
         const auto filepath = dir / u8"kitem.s1";
+        elona_vector2<int> itemmemory;
+        DIM3(itemmemory, 3, 800);
         load_v2(filepath, itemmemory, 0, 3, 0, 800);
+        game()->item_memories().unpack_from(itemmemory);
     }
 
     {
@@ -622,6 +625,9 @@ void ctrl_file_global_write(const fs::path& dir)
 
     {
         const auto filepath = dir / u8"kitem.s1";
+        elona_vector2<int> itemmemory;
+        DIM3(itemmemory, 3, 800);
+        game()->item_memories().pack_to(itemmemory);
         save_v2(filepath, itemmemory, 0, 3, 0, 800);
     }
 
@@ -1315,6 +1321,52 @@ void CharacterMemoryTable::unpack_from(elona_vector2<int>& legacy_npcmemory)
         {
             _memories[*id].kill_count = legacy_npcmemory(0, i);
             _memories[*id].generate_count = legacy_npcmemory(1, i);
+        }
+    }
+}
+
+
+
+void ItemMemoryTable::pack_to(elona_vector2<int>& legacy_itemmemory) const
+{
+    for (int i = 0; i < 800; ++i)
+    {
+        const auto integer_item_id = i;
+        if (const auto id = the_item_db.get_id_from_integer(integer_item_id))
+        {
+            if (const auto itr = _memories.find(*id); itr != _memories.end())
+            {
+                legacy_itemmemory(0, i) =
+                    static_cast<int>(itr->second.identify_state);
+                legacy_itemmemory(1, i) = itr->second.generate_count;
+                legacy_itemmemory(2, i) = itr->second._is_reserved
+                    ? 2
+                    : (itr->second.is_decoded ? 1 : 0);
+            }
+        }
+    }
+}
+
+
+
+void ItemMemoryTable::unpack_from(elona_vector2<int>& legacy_itemmemory)
+{
+    _memories.clear();
+
+    for (int i = 0; i < 800; ++i)
+    {
+        if (legacy_itemmemory(0, i) == 0 && legacy_itemmemory(1, i) == 0 &&
+            legacy_itemmemory(2, i) == 0)
+            continue;
+
+        const auto integer_item_id = i;
+        if (const auto id = the_item_db.get_id_from_integer(integer_item_id))
+        {
+            _memories[*id].identify_state =
+                static_cast<IdentifyState>(legacy_itemmemory(0, i));
+            _memories[*id].generate_count = legacy_itemmemory(1, i);
+            _memories[*id].is_decoded = legacy_itemmemory(2, i) != 0;
+            _memories[*id]._is_reserved = legacy_itemmemory(2, i) == 2;
         }
     }
 }

--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -1192,7 +1192,7 @@ int damage_hp(
         }
         if (!victim.is_player())
         {
-            ++npcmemory(0, charaid2int(victim.id));
+            game()->character_memories().increment_kill_count(victim.new_id());
             chara_custom_talk(victim, 102);
             if (victim.is_player_or_ally())
             {

--- a/src/elona/game.hpp
+++ b/src/elona/game.hpp
@@ -6,6 +6,7 @@
 #include "../version.hpp"
 #include "blending_recipe_memory.hpp"
 #include "character_memory.hpp"
+#include "item_memory.hpp"
 
 
 
@@ -220,6 +221,7 @@ struct Game
 private:
     BlendingRecipeMemoryTable _blending_recipe_memories;
     CharacterMemoryTable _character_memories;
+    ItemMemoryTable _item_memories;
 
 public:
     BlendingRecipeMemoryTable& blending_recipe_memories() noexcept
@@ -231,6 +233,12 @@ public:
     CharacterMemoryTable& character_memories() noexcept
     {
         return _character_memories;
+    }
+
+
+    ItemMemoryTable& item_memories() noexcept
+    {
+        return _item_memories;
     }
 
 

--- a/src/elona/game.hpp
+++ b/src/elona/game.hpp
@@ -5,6 +5,7 @@
 
 #include "../version.hpp"
 #include "blending_recipe_memory.hpp"
+#include "character_memory.hpp"
 
 
 
@@ -218,11 +219,18 @@ struct Game
 
 private:
     BlendingRecipeMemoryTable _blending_recipe_memories;
+    CharacterMemoryTable _character_memories;
 
 public:
     BlendingRecipeMemoryTable& blending_recipe_memories() noexcept
     {
         return _blending_recipe_memories;
+    }
+
+
+    CharacterMemoryTable& character_memories() noexcept
+    {
+        return _character_memories;
     }
 
 

--- a/src/elona/game.hpp
+++ b/src/elona/game.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "../version.hpp"
+#include "blending_recipe_memory.hpp"
 
 
 
@@ -214,6 +215,17 @@ struct Game
 
     QuestFlags quest_flags;
     GuildData guild;
+
+private:
+    BlendingRecipeMemoryTable _blending_recipe_memories;
+
+public:
+    BlendingRecipeMemoryTable& blending_recipe_memories() noexcept
+    {
+        return _blending_recipe_memories;
+    }
+
+
 
     /**
      * Moves this struct's fields into `gdata` so they can be serialized,

--- a/src/elona/god.cpp
+++ b/src/elona/god.cpp
@@ -586,7 +586,8 @@ TurnResult do_pray()
             }
             if (item_id != 0)
             {
-                if (itemmemory(1, item_id))
+                if (game()->item_memories().generate_count(
+                        *the_item_db.get_id_from_integer(item_id)) != 0)
                 {
                     item_id = 559;
                 }
@@ -656,7 +657,8 @@ TurnResult do_pray()
             {
                 item_id = 675;
             }
-            if (itemmemory(1, item_id))
+            if (game()->item_memories().generate_count(
+                    *the_item_db.get_id_from_integer(item_id)) != 0)
             {
                 item_id = 621;
             }

--- a/src/elona/init.cpp
+++ b/src/elona/init.cpp
@@ -221,7 +221,6 @@ void initialize_elona()
     SDIM3(mdatan, 20, 2);
     SDIM2(s1, 1000);
     DIM2(mat, 400);
-    DIM3(itemmemory, 3, 800);
     DIM2(invmark, 35);
     DIM2(feat, 5);
 

--- a/src/elona/init.cpp
+++ b/src/elona/init.cpp
@@ -222,7 +222,6 @@ void initialize_elona()
     SDIM2(s1, 1000);
     DIM2(mat, 400);
     DIM3(itemmemory, 3, 800);
-    DIM3(npcmemory, 2, 800);
     DIM2(invmark, 35);
     DIM2(feat, 5);
 

--- a/src/elona/init.cpp
+++ b/src/elona/init.cpp
@@ -223,7 +223,6 @@ void initialize_elona()
     DIM2(mat, 400);
     DIM3(itemmemory, 3, 800);
     DIM3(npcmemory, 2, 800);
-    DIM2(recipememory, 1200);
     DIM2(invmark, 35);
     DIM2(feat, 5);
 
@@ -591,7 +590,7 @@ void initialize_game()
     {
         game()->next_inventory_serial_id = 1000;
         game()->next_shelter_serial_id = 100;
-        blending_clear_recipememory();
+        blending_clear_recipe_memory();
     }
     if (mode == 3)
     {

--- a/src/elona/initialize_map_types.cpp
+++ b/src/elona/initialize_map_types.cpp
@@ -3022,12 +3022,12 @@ static void _init_map_lesimas()
             cell_featset(x, y, tile_upstairs, 10);
             map_data.stair_up_pos = y * 1000 + x;
             map_place_player_and_allies();
-            if (npcmemory(0, charaid2int(CharaId::zeome)) == 0)
+            if (game()->character_memories().kill_count("core.zeome") == 0)
             {
                 flt();
                 chara_create(-1, 2, 16, 6);
             }
-            else if (npcmemory(0, charaid2int(CharaId::orphe)) == 0)
+            else if (game()->character_memories().kill_count("core.orphe") == 0)
             {
                 flt();
                 chara_create(-1, 23, 16, 6);

--- a/src/elona/item.cpp
+++ b/src/elona/item.cpp
@@ -746,7 +746,8 @@ IdentifyState item_identify(const ItemRef& item, IdentifyState level)
     item->identify_state = level;
     if (item->identify_state >= IdentifyState::partly)
     {
-        itemmemory(0, the_item_db[item->id]->integer_id) = 1;
+        game()->item_memories().set_identify_state(
+            item->id, IdentifyState::partly);
     }
     idtresult = level;
     return idtresult;
@@ -766,7 +767,8 @@ IdentifyState item_identify(const ItemRef& item, int power)
 
 void item_checkknown(const ItemRef& item)
 {
-    if (itemmemory(0, the_item_db[item->id]->integer_id) &&
+    if (game()->item_memories().identify_state(item->id) !=
+            IdentifyState::unidentified &&
         item->identify_state == IdentifyState::unidentified)
     {
         item_identify(item, IdentifyState::partly);
@@ -2257,7 +2259,8 @@ void auto_identify()
         {
             const auto prev_name = itemname(item);
             item_identify(item, IdentifyState::completely);
-            itemmemory(0, the_item_db[item->id]->integer_id) = 1;
+            game()->item_memories().set_identify_state(
+                item->id, IdentifyState::partly);
             if (!g_config.hide_autoidentify())
             {
                 txt(i18n::s.get(

--- a/src/elona/item_memory.hpp
+++ b/src/elona/item_memory.hpp
@@ -1,0 +1,185 @@
+#pragma once
+
+#include <unordered_map>
+
+#include "../util/mathutil.hpp"
+#include "data/id.hpp"
+#include "enums.hpp"
+#include "typedefs.hpp"
+
+
+
+namespace elona
+{
+
+template <typename T>
+struct elona_vector2;
+
+
+
+/**
+ * Records one item's memory.
+ */
+struct ItemMemory
+{
+    /// Generate count
+    lua_int generate_count{};
+
+    /// Identify state
+    IdentifyState identify_state{};
+
+    /// Whether the item has been decoded (for spellbooks only)
+    bool is_decoded{};
+
+    // TODO: move it to spellbook writer's field.
+    bool _is_reserved{};
+
+#if 0
+    /// Extension data
+    lua_table ext{};
+#endif
+};
+
+
+
+/**
+ * A table of @ref ItemMemory indexed by item ID. It delays creation of entries
+ * until the first assignment.
+ */
+struct ItemMemoryTable
+{
+    /**
+     * Gets the generation count of @a id.
+     *
+     * @param id The item ID
+     * @return The number of items generated ever
+     */
+    lua_int generate_count(data::InstanceId id) const noexcept
+    {
+        if (const auto itr = _memories.find(id); itr != _memories.end())
+        {
+            return itr->second.generate_count;
+        }
+        else
+        {
+            return 0;
+        }
+    }
+
+
+
+    /**
+     * Increments the generation count of @a id.
+     */
+    void increment_generate_count(data::InstanceId id)
+    {
+        mathutil::saturating_inc(_memories[id].generate_count);
+    }
+
+
+
+    /**
+     * Decrements the generation count of @a id.
+     */
+    void decrement_generate_count(data::InstanceId id)
+    {
+        mathutil::saturating_dec(_memories[id].generate_count, lua_int{0});
+    }
+
+
+
+    /**
+     * Gets the identify state of @a id.
+     *
+     * @param id The item ID
+     * @return The identify state of the item
+     */
+    IdentifyState identify_state(data::InstanceId id) const noexcept
+    {
+        if (const auto itr = _memories.find(id); itr != _memories.end())
+        {
+            return itr->second.identify_state;
+        }
+        else
+        {
+            return IdentifyState::unidentified;
+        }
+    }
+
+
+
+    /**
+     * Set an identify state for @a id.
+     *
+     * @param id The item ID
+     */
+    void set_identify_state(data::InstanceId id, IdentifyState new_state)
+    {
+        _memories[id].identify_state = new_state;
+    }
+
+
+
+    /**
+     * Returns whether the item has been decoded. (for spellbooks only)
+     *
+     * @param id The item ID
+     * @return True if the spellbook has been decoded.
+     */
+    bool is_decoded(data::InstanceId id) const noexcept
+    {
+        if (const auto itr = _memories.find(id); itr != _memories.end())
+        {
+            return itr->second.is_decoded;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+
+
+    /**
+     * Set is_decoded flag of @a id with the given @a value.
+     *
+     * @param id The item ID
+     * @param value True if the item is decoded.
+     */
+    void set_decoded(data::InstanceId id, bool value)
+    {
+        _memories[id].is_decoded = value;
+    }
+
+
+
+    bool _is_reserved(data::InstanceId id) const noexcept
+    {
+        if (const auto itr = _memories.find(id); itr != _memories.end())
+        {
+            return itr->second._is_reserved;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    void _set_reserved(data::InstanceId id, bool value)
+    {
+        _memories[id]._is_reserved = value;
+    }
+
+
+
+    // for integration with legacy codebase.
+    void pack_to(elona_vector2<int>& legacy_itemmemory) const;
+    void unpack_from(elona_vector2<int>& legacy_itemmemory);
+
+
+
+private:
+    std::unordered_map<data::InstanceId, ItemMemory> _memories;
+};
+
+} // namespace elona

--- a/src/elona/itemgen.cpp
+++ b/src/elona/itemgen.cpp
@@ -300,7 +300,7 @@ do_create_item(int item_id, const InventoryRef& inv, int x, int y)
         item->param1 = 1;
     }
 
-    ++itemmemory(1, item_id);
+    game()->item_memories().increment_generate_count(item->id);
 
     item->quality = static_cast<Quality>(fixlv);
     if (fixlv == Quality::special && mode != 6 && nooracle == 0)
@@ -516,7 +516,8 @@ do_create_item(int item_id, const InventoryRef& inv, int x, int y)
     {
         item->identify_state = IdentifyState::completely;
         item->curse_state = CurseState::none;
-        itemmemory(0, the_item_db[item->id]->integer_id) = 1;
+        game()->item_memories().set_identify_state(
+            item->id, IdentifyState::partly);
     }
     if (category == ItemCategory::bodyparts || category == ItemCategory::junk ||
         category == ItemCategory::ore)

--- a/src/elona/lua_env/api/modules/module_Chara.cpp
+++ b/src/elona/lua_env/api/modules/module_Chara.cpp
@@ -261,12 +261,7 @@ sol::optional<LuaCharacterHandle> Chara_generate_from_map_id_pos(
  */
 int Chara_kill_count(const std::string& id)
 {
-    auto data = the_character_db[data::InstanceId{id}];
-    if (!data)
-    {
-        return 0;
-    }
-    return npcmemory(0, data->integer_id);
+    return game()->character_memories().kill_count(data::InstanceId{id});
 }
 
 

--- a/src/elona/lua_env/api/modules/module_Internal.cpp
+++ b/src/elona/lua_env/api/modules/module_Internal.cpp
@@ -216,9 +216,13 @@ void Internal_strange_scientist_pick_reward()
         }
         randomize(game()->date.day + cnt);
         f = 0;
-        if (itemmemory(0, cnt))
+        if (const auto id = the_item_db.get_id_from_integer(cnt))
         {
-            f = 1;
+            if (game()->item_memories().identify_state(*id) !=
+                IdentifyState::unidentified)
+            {
+                f = 1;
+            }
         }
         if (cnt == 662)
         {

--- a/src/elona/lua_env/api/modules/module_Item.cpp
+++ b/src/elona/lua_env/api/modules/module_Item.cpp
@@ -247,7 +247,18 @@ int Item_memory(int type, const std::string& id)
         return 0;
     }
 
-    return itemmemory(type, data->integer_id);
+    switch (type)
+    {
+    case 0: return game()->item_memories().generate_count(data->id);
+    case 1:
+        return static_cast<int>(
+            game()->item_memories().identify_state(data->id));
+    case 2:
+        return game()->item_memories()._is_reserved(data->id)
+            ? 2
+            : (game()->item_memories().is_decoded(data->id) ? 1 : 0);
+    default: return 0;
+    }
 }
 
 

--- a/src/elona/map.cpp
+++ b/src/elona/map.cpp
@@ -1711,7 +1711,8 @@ TurnResult exit_map()
         {
             if (cnt.state() != Character::State::empty)
             {
-                --npcmemory(1, charaid2int(cnt.id));
+                game()->character_memories().decrement_generate_count(
+                    cnt.new_id());
             }
         }
 

--- a/src/elona/ui/ui_menu_spell_writer.cpp
+++ b/src/elona/ui/ui_menu_spell_writer.cpp
@@ -14,13 +14,16 @@ static void _populate_book_list()
 {
     for (int cnt = 0; cnt < maxitemid; ++cnt)
     {
-        if (itemmemory(2, cnt) == 0)
+        if (const auto id = the_item_db.get_id_from_integer(cnt))
         {
-            continue;
+            if (!game()->item_memories().is_decoded(*id))
+            {
+                continue;
+            }
+            list(0, listmax) = cnt;
+            list(1, listmax) = cnt;
+            ++listmax;
         }
-        list(0, listmax) = cnt;
-        list(1, listmax) = cnt;
-        ++listmax;
     }
     sort_list_by_column1();
 }
@@ -106,7 +109,8 @@ void UIMenuSpellWriter::_draw_list_entry_name(int cnt, int item_index)
 
 void UIMenuSpellWriter::_draw_list_entry_reserve_status(int cnt, int item_index)
 {
-    if (itemmemory(2, item_index) == 1)
+    if (!game()->item_memories()._is_reserved(
+            *the_item_db.get_id_from_integer(item_index)))
     {
         mes(wx + 400,
             wy + 66 + cnt * 19 + 2,
@@ -164,13 +168,16 @@ static bool _book_is_unavailable(int _p)
 
 static void _toggle_book_reserve(int _p)
 {
-    if (itemmemory(2, _p) == 1)
+    if (!game()->item_memories()._is_reserved(
+            *the_item_db.get_id_from_integer(_p)))
     {
-        itemmemory(2, _p) = 2;
+        game()->item_memories()._set_reserved(
+            *the_item_db.get_id_from_integer(_p), true);
     }
     else
     {
-        itemmemory(2, _p) = 1;
+        game()->item_memories()._set_reserved(
+            *the_item_db.get_id_from_integer(_p), false);
     }
 }
 

--- a/src/elona/variables.hpp
+++ b/src/elona/variables.hpp
@@ -165,7 +165,6 @@ ELONA_EXTERN(elona_vector1<int> mat);
 ELONA_EXTERN(elona_vector1<int> mdata);
 ELONA_EXTERN(elona_vector1<int> mdatatmp);
 ELONA_EXTERN(elona_vector1<int> p);
-ELONA_EXTERN(elona_vector1<int> recipememory);
 ELONA_EXTERN(elona_vector1<int> reph);
 ELONA_EXTERN(elona_vector1<int> repw);
 ELONA_EXTERN(elona_vector1<int> rowactre);

--- a/src/elona/variables.hpp
+++ b/src/elona/variables.hpp
@@ -224,7 +224,6 @@ ELONA_EXTERN(elona_vector1<int> eqweapon1);
 ELONA_EXTERN(elona_vector1<int> eqrange);
 ELONA_EXTERN(elona_vector1<int> eqammo);
 ELONA_EXTERN(elona_vector1<int> eqring1);
-ELONA_EXTERN(elona_vector2<int> itemmemory);
 ELONA_EXTERN(elona_vector2<int> list);
 ELONA_EXTERN(elona_vector2<int> mapsync);
 ELONA_EXTERN(elona_vector2<int> pcc);

--- a/src/elona/variables.hpp
+++ b/src/elona/variables.hpp
@@ -227,7 +227,6 @@ ELONA_EXTERN(elona_vector1<int> eqring1);
 ELONA_EXTERN(elona_vector2<int> itemmemory);
 ELONA_EXTERN(elona_vector2<int> list);
 ELONA_EXTERN(elona_vector2<int> mapsync);
-ELONA_EXTERN(elona_vector2<int> npcmemory);
 ELONA_EXTERN(elona_vector2<int> pcc);
 ELONA_EXTERN(elona_vector2<int> picfood);
 ELONA_EXTERN(elona_vector2<int> qdata);

--- a/src/elona/wish.cpp
+++ b/src/elona/wish.cpp
@@ -547,7 +547,7 @@ bool wish_for_item(Character& chara, const std::string& input)
                 // Remove this item and retry.
                 selector.remove(id);
                 item->remove();
-                --itemmemory(1, the_item_db[item->id]->integer_id);
+                game()->item_memories().decrement_generate_count(item->id);
                 continue;
             }
         }

--- a/src/util/mathutil.hpp
+++ b/src/util/mathutil.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <limits>
+
+
+
+namespace mathutil
+{
+
+template <typename T>
+constexpr T& saturating_inc(T& x, T max = std::numeric_limits<T>::max())
+{
+    if (x < max)
+        return ++x;
+    else
+        return x;
+}
+
+
+
+template <typename T>
+constexpr T& saturating_dec(T& x, T min = std::numeric_limits<T>::min())
+{
+    if (min < x)
+        return --x;
+    else
+        return x;
+}
+
+} // namespace mathutil


### PR DESCRIPTION
# Summary

Define `CharacterMemoryTable` for `npcmemory`, `ItemMemoryTable` for `itemmemory`, and `BlendingRecipeMemoryTable` for `recipememory`. They are now member fields of `Game`.

This PR does not change save data at all. Everything is kept compatible.

- [x] merge #1755 