### PR TITLE
Change Lua enums' naming convention: lower_snake to UPPER_SNAKE

### DIFF
--- a/runtime/data/script/core/enums.lua
+++ b/runtime/data/script/core/enums.lua
@@ -18,43 +18,37 @@ Enums.new_enum = new_enum
 ---
 --- The curse state of an item.
 --- @usage local item = Item.create(10, 10, "core.putitoro", 3)
---- item.curse_state = "Blessed"
+--- item.curse_state = Enums.CurseState.BLESSED
 Enums.CurseState = new_enum {
-   doomed = -2,
-   cursed = -1,
-   none = 0,
-   blessed = 1,
+   DOOMED = -2,
+   CURSED = -1,
+   NONE = 0,
+   BLESSED = 1,
 }
-
-
 
 --- @enum IdentifyState
 ---
 --- The identify state of an item.
 --- @usage local item = Item.create(10, 10, "core.putitoro", 3)
---- item.identify_state = "Completely"
+--- item.identify_state = Enums.IdentifyState.COMPLETELY
 Enums.IdentifyState = new_enum {
-   unidentified = 0,
-   partly = 1,
-   almost = 2,
-   completely = 3,
+   UNIDENTIFIED = 0,
+   PARTLY = 1,
+   ALMOST = 2,
+   COMPLETELY = 3,
 }
-
-
 
 --- @enum Quality
 ---
 --- The quality of randomly generated equipment.
 Enums.Quality = new_enum {
-   none = 0,
-   bad = 1,
-   good = 2,
-   great = 3,
-   miracle = 4,
-   godly = 5,
-   special = 6,
+   NONE = 0,
+   BAD = 1,
+   GOOD = 2,
+   GREAT = 3,
+   MIRACLE = 4,
+   GODLY = 5,
+   SPECIAL = 6,
 }
-
-
 
 return Enums

--- a/runtime/data/script/core/enums.lua
+++ b/runtime/data/script/core/enums.lua
@@ -1,25 +1,38 @@
 local Enums = {}
 
+local class, xtype = _ENV.prelude.class, _ENV.prelude.xtype
 
-local function new_enum(definitions)
-   local enum = {}
+local Enum = class("core.Enums.Enum")
+
+function Enum:__init(definitions)
+   assert(type(definitions) == "table", "Enum.new: definitions must be a table.")
+
    for k, v in pairs(definitions) do
-      enum[k] = v
-      enum[v] = k
+      assert(type(k) == "string", "Enum.new: name must be a string.")
+      assert(xtype(v) == "integer", "Enum.new: value must be an integer.")
+      self[k] = v
+      self[v] = k
    end
-   return enum
 end
 
-Enums.new_enum = new_enum
+function Enum:is_valid_value(value)
+   return type(self[value]) == "string"
+end
 
+function Enum:is_valid_name(name)
+   return xtype(self[name]) == "integer"
+end
 
+Enums.Enum = Enum
+
+Enums.new_enum = Enum.new
 
 --- @enum CurseState
 ---
 --- The curse state of an item.
 --- @usage local item = Item.create(10, 10, "core.putitoro", 3)
 --- item.curse_state = Enums.CurseState.BLESSED
-Enums.CurseState = new_enum {
+Enums.CurseState = Enums.new_enum {
    DOOMED = -2,
    CURSED = -1,
    NONE = 0,
@@ -31,7 +44,7 @@ Enums.CurseState = new_enum {
 --- The identify state of an item.
 --- @usage local item = Item.create(10, 10, "core.putitoro", 3)
 --- item.identify_state = Enums.IdentifyState.COMPLETELY
-Enums.IdentifyState = new_enum {
+Enums.IdentifyState = Enums.new_enum {
    UNIDENTIFIED = 0,
    PARTLY = 1,
    ALMOST = 2,
@@ -41,7 +54,7 @@ Enums.IdentifyState = new_enum {
 --- @enum Quality
 ---
 --- The quality of randomly generated equipment.
-Enums.Quality = new_enum {
+Enums.Quality = Enums.new_enum {
    NONE = 0,
    BAD = 1,
    GOOD = 2,

--- a/runtime/data/script/core/init.lua
+++ b/runtime/data/script/core/init.lua
@@ -1,8 +1,6 @@
 local core = {}
 
-
 core.Enums = require("core.enums")
 core.I18N = require("core.i18n")
-
 
 return core

--- a/runtime/mod/core/api/impl/shop_inventory.lua
+++ b/runtime/mod/core/api/impl/shop_inventory.lua
@@ -57,7 +57,7 @@ function shop_inventory.apply_rule_properties(rule, ret, index, shopkeeper)
 end
 
 function shop_inventory.apply_rules(index, shopkeeper, inv)
-   local ret = {level = shopkeeper.shop_rank, quality = Enums.Quality.bad}
+   local ret = {level = shopkeeper.shop_rank, quality = Enums.Quality.BAD}
 
    if not inv.rules then
       return ret
@@ -111,7 +111,7 @@ local function is_excluded(item)
 end
 
 local function is_cursed(item)
-   return item.curse_state == Enums.CurseState.cursed or item.curse_state == Enums.CurseState.doomed
+   return item.curse_state == Enums.CurseState.CURSED or item.curse_state == Enums.CurseState.DOOMED
 end
 
 function shop_inventory.should_remove(item, inv)
@@ -278,7 +278,7 @@ function shop_inventory.do_generate(shopkeeper, inv)
       end
 
       -- Blessed items are never generated in multiple (per cycle).
-      if item.curse_state == Enums.CurseState.blessed then
+      if item.curse_state == Enums.CurseState.BLESSED then
          item.number = 1
       end
 

--- a/runtime/mod/core/api/impl/show_dialog.lua
+++ b/runtime/mod/core/api/impl/show_dialog.lua
@@ -61,7 +61,7 @@ local function query(talk, text, choices, default_choice)
       image = talk.speaker.image
    end
    local show_impress = true
-   if talk.speaker.quality == Enums.Quality.special and not Chara.is_ally(talk.speaker) then
+   if talk.speaker.quality == Enums.Quality.SPECIAL and not Chara.is_ally(talk.speaker) then
       show_impress = false
    end
 

--- a/runtime/mod/core/data/blending_recipe.lua
+++ b/runtime/mod/core/data/blending_recipe.lua
@@ -182,13 +182,13 @@ ELONA.data:add(
             local target, water = args.materials[1], args.materials[2]
 
             GUI.txt(I18N.get("core.action.dip.result.blessed_item", target, water), "green")
-            if water.curse_state == Enums.CurseState.blessed then
+            if water.curse_state == Enums.CurseState.BLESSED then
                GUI.txt(I18N.get("core.action.dip.result.becomes_blessed", target), "orange")
-               target.curse_state = Enums.CurseState.blessed
+               target.curse_state = Enums.CurseState.BLESSED
             end
-            if water.curse_state == Enums.CurseState.cursed or water.curse_state == Enums.CurseState.doomed then
+            if water.curse_state == Enums.CurseState.CURSED or water.curse_state == Enums.CurseState.DOOMED then
                GUI.txt(I18N.get("core.action.dip.result.becomes_cursed", target), "purple")
-               target.curse_state = Enums.CurseState.cursed
+               target.curse_state = Enums.CurseState.CURSED
             end
             GUI.play_sound("core.drink1")
          end,
@@ -259,7 +259,7 @@ ELONA.data:add(
                World.data.holy_well_count = World.data.holy_well_count - 1
                natural_potion = Item.create(-1, -1, { id = "core.bottle_of_water", inventory = Inventory.player() })
                if natural_potion then
-                  natural_potion.curse_state = Enums.CurseState.blessed
+                  natural_potion.curse_state = Enums.CurseState.BLESSED
                end
             else
                well.param1 = well.param1 - 3

--- a/runtime/mod/core/data/chara_drop.lua
+++ b/runtime/mod/core/data/chara_drop.lua
@@ -149,7 +149,7 @@ ELONA.data:add(
                                             {
                                                level = args.chara.level,
                                                flttypemajor = 92000,
-                                               quality = Enums.Quality.good,
+                                               quality = Enums.Quality.GOOD,
                                                nostack = true
                                             }
                      )

--- a/runtime/mod/core/data/dialog/unique/doria.lua
+++ b/runtime/mod/core/data/dialog/unique/doria.lua
@@ -46,7 +46,7 @@ end
 
 local function receive_reward()
    World.data.fighters_guild_quota_recurring = false
-   Item.create(Chara.player().position, {objlv = 51 - World.data.ranks[8] // 200, quality = Enums.Quality.good, flttypemajor = 10000})
+   Item.create(Chara.player().position, {objlv = 51 - World.data.ranks[8] // 200, quality = Enums.Quality.GOOD, flttypemajor = 10000})
    Item.create(Chara.player().position, "core.gold_piece", 10000 - World.data.ranks[8] + 1000)
    Item.create(Chara.player().position, "core.platinum_coin", math.clamp(4 - World.data.ranks[8] // 2500, 1, 4))
 

--- a/runtime/mod/core/data/dialog/unique/karam.lua
+++ b/runtime/mod/core/data/dialog/unique/karam.lua
@@ -34,7 +34,7 @@ return {
                   Chara.player().position,
                   {
                      level = Map.data.current_dungeon_level,
-                     quality = Enums.Quality.bad,
+                     quality = Enums.Quality.BAD,
                      flttypemajor = Internal.filter_set_dungeon()
                   }
                )

--- a/runtime/mod/core/data/dialog/unique/lomias.lua
+++ b/runtime/mod/core/data/dialog/unique/lomias.lua
@@ -75,7 +75,7 @@ return {
             function()
                GUI.txt(I18N.get("core.common.something_is_put_on_the_ground"))
                local scroll = Item.create(Chara.player().position, "core.scroll_of_identify", 0)
-               scroll.identify_state = Enums.IdentifyState.completely
+               scroll.identify_state = Enums.IdentifyState.COMPLETELY
             end,
             {"tutorial.after_dig.dialog"},
          },
@@ -191,7 +191,7 @@ return {
          on_finish = function()
             local corpse = Item.create(Chara.player().position, "core.corpse", 0)
             corpse.subname = 9
-            corpse.identify_state = Enums.IdentifyState.completely
+            corpse.identify_state = Enums.IdentifyState.COMPLETELY
             GUI.txt(I18N.get("core.common.something_is_put_on_the_ground"))
             Internal.set_quest_flag("tutorial", 1)
          end
@@ -247,12 +247,12 @@ return {
          },
          on_finish = function()
             local item = Item.create(Chara.player().position, "core.long_bow", 0)
-            item.curse_state = Enums.CurseState.cursed
+            item.curse_state = Enums.CurseState.CURSED
             item = Item.create(Chara.player().position, "core.arrow", 0)
-            item.curse_state = Enums.CurseState.none
+            item.curse_state = Enums.CurseState.NONE
             item = Item.create(Chara.player().position, "core.scroll_of_vanish_curse", 0)
-            item.identify_state = Enums.IdentifyState.completely
-            item.curse_state = Enums.CurseState.blessed
+            item.identify_state = Enums.IdentifyState.COMPLETELY
+            item.curse_state = Enums.CurseState.BLESSED
             GUI.txt(I18N.get("core.common.something_is_put_on_the_ground"))
             Internal.set_quest_flag("tutorial", 5)
          end
@@ -273,7 +273,7 @@ return {
                putit:set_flag("is_not_attacked_by_enemy", true)
             end
             local item = Item.create(Chara.player().position, "core.potion_of_cure_minor_wound", 0)
-            item.identify_state = Enums.IdentifyState.completely
+            item.identify_state = Enums.IdentifyState.COMPLETELY
             Internal.set_quest_flag("tutorial", 6)
          end
       }

--- a/runtime/mod/core/data/dialog/unique/miches.lua
+++ b/runtime/mod/core/data/dialog/unique/miches.lua
@@ -60,8 +60,8 @@ return {
       quest_finish = {
          text = {
             function()
-               Item.create(Chara.player().position, {id = "core.small_shield", level = 10, quality = Enums.Quality.good})
-               Item.create(Chara.player().position, {id = "core.girdle", level = 10, quality = Enums.Quality.good})
+               Item.create(Chara.player().position, {id = "core.small_shield", level = 10, quality = Enums.Quality.GOOD})
+               Item.create(Chara.player().position, {id = "core.girdle", level = 10, quality = Enums.Quality.GOOD})
                Item.create(Chara.player().position, "core.gold_piece", 3000)
                Item.create(Chara.player().position, "core.platinum_coin", 2)
 

--- a/runtime/mod/core/data/map.lua
+++ b/runtime/mod/core/data/map.lua
@@ -9,7 +9,7 @@ local map = require("map/static.lua")
 
 local function chara_filter_town(callbacks)
    return function()
-      local opts = { level = 10, quality = Enums.Quality.bad, fltselect = 5 }
+      local opts = { level = 10, quality = Enums.Quality.BAD, fltselect = 5 }
 
       if callbacks == nil then
          return opts
@@ -490,7 +490,7 @@ ELONA.data:add(
          can_return_to = true,
          shows_floor_count_in_name = true,
          chara_filter = function()
-            local opts = { objlv = Calc.calc_objlv(Map.current_dungeon_level()), quality = Enums.Quality.bad }
+            local opts = { objlv = Calc.calc_objlv(Map.current_dungeon_level()), quality = Enums.Quality.BAD }
 
             if Map.current_dungeon_level() < 4 and opts.objlv > 5 then
                opts.objlv = 5
@@ -518,7 +518,7 @@ ELONA.data:add(
          can_return_to = true,
          prevents_domination = true,
          chara_filter = function()
-            return { level = math.modf(Map.current_dungeon_level(), 50) + 5, quality = Enums.Quality.bad }
+            return { level = math.modf(Map.current_dungeon_level(), 50) + 5, quality = Enums.Quality.BAD }
          end
       },
       tower_of_fire = {
@@ -538,7 +538,7 @@ ELONA.data:add(
          default_ai_calm = 0,
 
          chara_filter = function()
-            return { level = Map.current_dungeon_level(), quality = Enums.Quality.bad, fltn = "fire" }
+            return { level = Map.current_dungeon_level(), quality = Enums.Quality.BAD, fltn = "fire" }
          end
       },
       crypt_of_the_damned = {
@@ -558,7 +558,7 @@ ELONA.data:add(
          default_ai_calm = 0,
 
          chara_filter = function()
-            return { level = Map.current_dungeon_level(), quality = Enums.Quality.bad, fltn = "undead" }
+            return { level = Map.current_dungeon_level(), quality = Enums.Quality.BAD, fltn = "undead" }
          end
       },
       ancient_castle = {
@@ -578,7 +578,7 @@ ELONA.data:add(
          default_ai_calm = 0,
 
          chara_filter = function()
-            local opts = { level = Map.current_dungeon_level(), quality = Enums.Quality.bad }
+            local opts = { level = Map.current_dungeon_level(), quality = Enums.Quality.BAD }
 
             if Rand.one_in(2) then
                opts.fltn = "man"
@@ -604,7 +604,7 @@ ELONA.data:add(
          default_ai_calm = 0,
 
          chara_filter = function()
-            return { level = Map.current_dungeon_level(), quality = Enums.Quality.bad }
+            return { level = Map.current_dungeon_level(), quality = Enums.Quality.BAD }
          end
       },
       mountain_pass = {
@@ -658,7 +658,7 @@ ELONA.data:add(
          default_ai_calm = 0,
 
          chara_filter = function()
-            local opts = { level = Map.current_dungeon_level(), quality = Enums.Quality.bad }
+            local opts = { level = Map.current_dungeon_level(), quality = Enums.Quality.BAD }
 
             if Rand.one_in(2) then
                opts.fltn = "mino"
@@ -684,7 +684,7 @@ ELONA.data:add(
          default_ai_calm = 0,
 
          chara_filter = function()
-            local opts = { level = Map.current_dungeon_level(), quality = Enums.Quality.bad }
+            local opts = { level = Map.current_dungeon_level(), quality = Enums.Quality.BAD }
 
             if Rand.one_in(2) then
                opts.fltn = "yeek"
@@ -711,7 +711,7 @@ ELONA.data:add(
 
          prevents_teleport = true,
          chara_filter = function()
-            return { level = Map.current_dungeon_level(), quality = Enums.Quality.bad, flttypemajor = 13 }
+            return { level = Map.current_dungeon_level(), quality = Enums.Quality.BAD, flttypemajor = 13 }
          end
       },
       lumiest_graveyard = {
@@ -731,7 +731,7 @@ ELONA.data:add(
          default_ai_calm = 1,
 
          chara_filter = function()
-            return { level = 20, quality = Enums.Quality.bad, fltselect = 4 }
+            return { level = 20, quality = Enums.Quality.BAD, fltselect = 4 }
          end
       },
       truce_ground = {
@@ -751,7 +751,7 @@ ELONA.data:add(
          default_ai_calm = 1,
 
          chara_filter = function()
-            return { level = 20, quality = Enums.Quality.bad, fltselect = 4 }
+            return { level = 20, quality = Enums.Quality.BAD, fltselect = 4 }
          end
       },
       jail = {
@@ -791,7 +791,7 @@ ELONA.data:add(
          default_ai_calm = 1,
 
          chara_filter = function()
-            return { level = 10, quality = Enums.Quality.bad, fltn = "sf" }
+            return { level = 10, quality = Enums.Quality.BAD, fltn = "sf" }
          end
       },
       larna = {
@@ -1010,7 +1010,7 @@ local function chara_filter_museum_shop()
       fltselect = 7
    end
 
-   return { level = 100, quality = Enums.Quality.bad, fltselect = fltselect }
+   return { level = 100, quality = Enums.Quality.BAD, fltselect = fltselect }
 end
 
 -- These maps are player-created.
@@ -1068,7 +1068,7 @@ ELONA.data:add(
          is_fixed = false,
 
          chara_filter = function()
-            return { level = Map.data.current_dungeon_level, quality = Enums.Quality.bad }
+            return { level = Map.data.current_dungeon_level, quality = Enums.Quality.BAD }
          end,
 
          -- The following fields are required for loading the data but

--- a/runtime/mod/core/data/shop_inventory.lua
+++ b/runtime/mod/core/data/shop_inventory.lua
@@ -67,8 +67,8 @@ local filter_set_wear = make_filter_list({10000, 10000, 24000, 24000,
 
 local merchant_rules = {
    { choices = filter_set_wear },
-   { fixlv = Enums.Quality.great },
-   { one_in = 2, fixlv = Enums.Quality.miracle },
+   { fixlv = Enums.Quality.GREAT },
+   { one_in = 2, fixlv = Enums.Quality.MIRACLE },
 }
 
 local function merchant_item_number()
@@ -194,8 +194,8 @@ ELONA.data:add(
                   {flttypemajor = 34000},
                }
             },
-            { one_in = 3, fixlv = Enums.Quality.great },
-            { one_in = 10, fixlv = Enums.Quality.miracle },
+            { one_in = 3, fixlv = Enums.Quality.GREAT },
+            { one_in = 10, fixlv = Enums.Quality.MIRACLE },
          },
          item_base_value = function(args)
             return args.item.value * 2
@@ -243,8 +243,8 @@ ELONA.data:add(
          integer_id = 1007,
          rules = {
             { choices = filter_set_wear },
-            { one_in = 3, fixlv = Enums.Quality.great },
-            { one_in = 10, fixlv = Enums.Quality.miracle },
+            { one_in = 3, fixlv = Enums.Quality.GREAT },
+            { one_in = 10, fixlv = Enums.Quality.MIRACLE },
          },
          item_number = function(args)
             return 6 + args.shopkeeper.shop_rank // 10
@@ -437,7 +437,7 @@ ELONA.data:add(
          item_number = function() return #medal_items end,
          on_generate_item = function(args)
             args.item.number = 1
-            args.item.curse_state = Enums.CurseState.none
+            args.item.curse_state = Enums.CurseState.NONE
             if args.item.id == "core.rod_of_domination" then
                args.item.count = 4
             end

--- a/src/tests/lua/enums.lua
+++ b/src/tests/lua/enums.lua
@@ -1,0 +1,22 @@
+require("tests/lua/support/minctest")
+
+local Enums = ELONA.require("core.Enums")
+
+lrun("test Enums.new_enum", function()
+   local Vanilla = Enums.new_enum {
+      stable = 1160,
+      xmas = 1161,
+      develop = 1220,
+   }
+
+   lequal(Vanilla:is_valid_value(1160), true)
+   lequal(Vanilla:is_valid_value(42), false)
+   lequal(Vanilla:is_valid_name("develop"), true)
+   lequal(Vanilla:is_valid_name("nyan"), false)
+end)
+
+lrun("test known enums", function()
+   lequal(Enums.CurseState.BLESSED, 1)
+   lequal(Enums.Quality[5], "GODLY")
+   lequal(Enums.IdentifyState.invalid, nil)
+end)

--- a/src/tests/lua_api.cpp
+++ b/src/tests/lua_api.cpp
@@ -138,3 +138,8 @@ TEST_CASE("Exports: eating_effect", "[Lua: Exports]")
     lua::lua->get_api_manager().init_from_mods();
     lua_testcase("exports/eating_effect.lua");
 }
+
+TEST_CASE("Core API: Enums", "[Lua: API]")
+{
+    lua_testcase("enums.lua");
+}


### PR DESCRIPTION
# Summary

## Change Lua enum's naming convention

Since Lua is not statically-typed language, it is useful to explicit that a variable is mutable or immutable. This PR changes enum's naming convention from `lower_snake_case` to `UPPER_SNAKE_CASE` to explicit they are constants.

## Add `Enums.Enum` class

`Enum.is_valid_value` and `Enum.is_valid_name` is also added for validation.