### PR TITLE
Fix fatal runtime errors

### DIFF
--- a/src/elona/character.cpp
+++ b/src/elona/character.cpp
@@ -206,6 +206,7 @@ optional<int> chara_create_internal(int slot, int chara_id)
     }
     cdata[slot].quality = static_cast<Quality>(fixlv);
     cdata[slot].index = slot;
+    cdata[slot].set_state(Character::State::alive);
     initialize_character(cdata[slot]);
 
     rtval = slot;
@@ -673,8 +674,6 @@ void initialize_character(Character& chara)
     {
         chara.is_lay_hand_available() = true;
     }
-
-    chara.set_state(Character::State::alive);
 
     cm = 0;
 }

--- a/src/elona/character_making.cpp
+++ b/src/elona/character_making.cpp
@@ -552,6 +552,9 @@ void draw_race_or_class_info(const std::string& description)
     }
     for (int cnt = 150; cnt < 600; ++cnt)
     {
+        if (!the_skill_db.get_id_from_integer(cnt))
+            continue;
+
         if (cdata.player().skills().base_level(
                 *the_skill_db.get_id_from_integer(cnt)) != 0)
         {

--- a/src/elona/command.cpp
+++ b/src/elona/command.cpp
@@ -5300,7 +5300,7 @@ PickUpItemResult pick_up_item(
     const auto inv_owner_chara = inv_owner.as_character();
     if (inv_owner_chara)
     {
-        if (item->id == "core.gold_piece" || item->id == "core.platinum")
+        if (item->id == "core.gold_piece" || item->id == "core.platinum_coin")
         {
             snd_("core.getgold1");
             txt(i18n::s.get(

--- a/src/elona/ctrl_inventory.cpp
+++ b/src/elona/ctrl_inventory.cpp
@@ -436,7 +436,7 @@ void make_item_list(
             if (invctrl == 11)
             {
                 if (item->id == "core.gold_piece" ||
-                    item->id == "core.platinum")
+                    item->id == "core.platinum_coin")
                 {
                     continue;
                 }
@@ -542,7 +542,7 @@ void make_item_list(
             if (invctrl == 20)
             {
                 if (item->id == "core.gold_piece" ||
-                    item->id == "core.platinum")
+                    item->id == "core.platinum_coin")
                 {
                     continue;
                 }

--- a/src/elona/dmgheal.cpp
+++ b/src/elona/dmgheal.cpp
@@ -1618,7 +1618,8 @@ void character_drops_item(Character& victim)
         {
             break;
         }
-        if (item->quality > Quality::miracle || item->id == "core.platinum")
+        if (item->quality > Quality::miracle ||
+            item->id == "core.platinum_coin")
         {
             f = 1;
         }

--- a/src/elona/equipment.cpp
+++ b/src/elona/equipment.cpp
@@ -818,8 +818,11 @@ void supply_initial_equipments(Character& chara)
             eqamulet1 = 722;
         }
     }
-    for (int i = 0; i < 30; ++i)
+    for (size_t i = 0; i < 30; ++i)
     {
+        if (chara.body_parts.size() <= i)
+            continue;
+
         const auto body_part_id = chara.body_parts[i].id;
         if (body_part_id == "core.neck")
         {

--- a/src/elona/story_quest.hpp
+++ b/src/elona/story_quest.hpp
@@ -111,7 +111,7 @@ struct StoryQuestTable
     set_ext(data::InstanceId id, std::string_view field_name, T&& new_value)
     {
         auto& entry = _quests[id];
-        if (entry.ext.empty())
+        if (entry.ext == sol::lua_nil)
         {
             entry.ext = lua::lua->get_state()->create_table();
         }

--- a/src/elona/ui.cpp
+++ b/src/elona/ui.cpp
@@ -569,7 +569,7 @@ void render_platinum()
         cdata.player().platinum,
         windoww - 120,
         inf_ver - 16,
-        "core.platinum",
+        "core.platinum_coin",
         "pp");
 }
 

--- a/src/elona/ui/ui_menu_charamake_attributes.cpp
+++ b/src/elona/ui/ui_menu_charamake_attributes.cpp
@@ -32,7 +32,7 @@ void UIMenuCharamakeAttributes::_reroll_attributes()
         {
             if (_minimum)
             {
-                cdata.player().skills().set_base_level(
+                cdata.player().skills().add_base_level(
                     *the_skill_db.get_id_from_integer(cnt),
                     -cdata.player().skills().base_level(
                         *the_skill_db.get_id_from_integer(cnt)) /
@@ -40,7 +40,7 @@ void UIMenuCharamakeAttributes::_reroll_attributes()
             }
             else
             {
-                cdata.player().skills().set_base_level(
+                cdata.player().skills().add_base_level(
                     *the_skill_db.get_id_from_integer(cnt),
                     -rnd(
                         cdata.player().skills().base_level(

--- a/src/elona/wish.cpp
+++ b/src/elona/wish.cpp
@@ -560,7 +560,7 @@ bool wish_for_item(Character& chara, const std::string& input)
             item->set_number(
                 cdata.player().level * cdata.player().level * 50 + 20000);
         }
-        else if (item->id == "core.platinum")
+        else if (item->id == "core.platinum_coin")
         {
             item->set_number(8 + rnd(5));
         }


### PR DESCRIPTION
# Description

Fix fatal runtime errors.

* Fix crash in character making
* Fix invalid result of attribute role in charamaking
* Fix out-of-index access
* Fix wrong item ID: `core.platinum` -> `core.platinum_coin`
* Avoid calling a method against uninitialized object
* WORKAROUND: fix a Handle-related error
