### PR TITLE
Fix GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,32 @@ jobs:
       with:
         submodules: true
 
+    - name: Install Dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y \
+          libsdl2-dev \
+          libsdl2-image-dev \
+          libsdl2-mixer-dev \
+          libsdl2-ttf-dev \
+          libsmpeg-dev \
+          timidity
+
+    - name: Cache Vanilla Elona
+      uses: actions/cache@v1
+      with:
+        path: deps/elona
+        key: elona122
+
+    - name: Download Vanilla Elona
+      run: |
+        if [ ! -d deps/elona ]
+        then
+          mkdir deps
+          wget --no-verbose "http://ylvania.style.coocan.jp/file/elona122.zip"
+          unzip -qq elona122.zip -d deps
+        fi
+
     - name: Test
       run: |
         cargo test --verbose
@@ -25,6 +51,30 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+
+    - name: Install Dependencies
+      run: |
+        brew update
+        brew install -f \
+          sdl2 \
+          sdl2_image \
+          sdl2_mixer \
+          sdl2_ttf
+
+    - name: Cache Vanilla Elona
+      uses: actions/cache@v1
+      with:
+        path: deps/elona
+        key: elona122
+
+    - name: Download Vanilla Elona
+      run: |
+        if [ ! -d deps/elona ]
+        then
+          mkdir deps
+          wget --no-verbose "http://ylvania.style.coocan.jp/file/elona122.zip"
+          unzip -qq elona122.zip -d deps
+        fi
 
     - name: Test
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
+name = "cc"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+
+[[package]]
 name = "cexpr"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +256,7 @@ name = "elonafoobar-lua-sys"
 version = "0.8.0"
 dependencies = [
  "bindgen",
+ "cc",
 ]
 
 [[package]]

--- a/elonafoobar-lua-sys/Cargo.toml
+++ b/elonafoobar-lua-sys/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2018"
 publish = false
 
 [build-dependencies]
+cc = "1.0.66"
 bindgen = "0.55.1"

--- a/elonafoobar-lua-sys/build.rs
+++ b/elonafoobar-lua-sys/build.rs
@@ -16,4 +16,44 @@ fn main() {
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("`bindgen` failed to write generated bindings.");
+
+    cc::Build::new()
+        .files(&[
+            // Core
+            "lua/lapi.c",
+            "lua/lcode.c",
+            "lua/lctype.c",
+            "lua/ldebug.c",
+            "lua/ldo.c",
+            "lua/ldump.c",
+            "lua/lfunc.c",
+            "lua/lgc.c",
+            "lua/llex.c",
+            "lua/lmem.c",
+            "lua/lobject.c",
+            "lua/lopcodes.c",
+            "lua/lparser.c",
+            "lua/lstate.c",
+            "lua/lstring.c",
+            "lua/ltable.c",
+            "lua/ltm.c",
+            "lua/lundump.c",
+            "lua/lvm.c",
+            "lua/lzio.c",
+            "lua/ltests.c",
+            "lua/lauxlib.c",
+            // Libraries
+            "lua/lbaselib.c",
+            "lua/ldblib.c",
+            "lua/liolib.c",
+            "lua/lmathlib.c",
+            "lua/loslib.c",
+            "lua/ltablib.c",
+            "lua/lstrlib.c",
+            "lua/lutf8lib.c",
+            "lua/loadlib.c",
+            "lua/lcorolib.c",
+            "lua/linit.c",
+        ])
+        .compile("lua");
 }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,6 @@
+[toolchain]
+channel = "nightly"
+components = [
+  "rustfmt",
+  "clippy",
+]


### PR DESCRIPTION
# Description

Fix broken GitHub Actions.

* Install required dependencies on Ubuntu and macOS.
* Download the vanilla zip.
* Build liblua in CI.
* Add `rust-toolchain` file to fix Rust toolchain's version.