### PR TITLE
Deny unformatted codes or lint warnings in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,7 +92,7 @@ jobs:
 
     - name: Run cargo fmt
       run: |
-        cargo fmt
+        cargo fmt -- --check
 
 
   lint:
@@ -106,4 +106,4 @@ jobs:
 
     - name: Run cargo clippy
       run: |
-        cargo clippy
+        cargo clippy -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,12 +195,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "either"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
-
-[[package]]
 name = "elonafoobar"
 version = "0.8.0"
 dependencies = [
@@ -212,7 +206,6 @@ dependencies = [
  "elonafoobar-net",
  "elonafoobar-utils",
  "fs_extra",
- "itertools",
  "json5",
  "lazy_static",
  "petgraph",
@@ -351,15 +344,6 @@ checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
 dependencies = [
  "autocfg",
  "hashbrown",
-]
-
-[[package]]
-name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,13 +52,12 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bindgen"
-version = "0.55.1"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b13ce559e6433d360c26305643803cb52cfbabbc2b9c47ce04a58493dfb443"
+checksum = "2da379dbebc0b76ef63ca68d8fc6e71c0f13e59432e0987e508c1820e6ab5239"
 dependencies = [
  "bitflags",
  "cexpr",
- "cfg-if 0.1.10",
  "clang-sys",
  "clap",
  "env_logger",
@@ -268,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
 dependencies = [
  "atty",
  "humantime",
@@ -329,12 +328,9 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
+checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "indexmap"
@@ -357,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "json5"
-version = "0.2.8"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb2522ff59fbfefb955e9bd44d04d5e5c2d0e8865bfc2c3d1ab3916183ef5ee"
+checksum = "3d993b17585f39e5e3bd98ff52bbd9e2a6d6b3f5b09d8abcec9d1873fb04cf3f"
 dependencies = [
  "pest",
  "pest_derive",
@@ -517,12 +513,6 @@ checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"

--- a/elonafoobar-gui/Cargo.toml
+++ b/elonafoobar-gui/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-anyhow = "1.0.33"
+anyhow = "1.0.37"
 
 [dependencies.sdl2]
 version = "0.34.3"

--- a/elonafoobar-log/Cargo.toml
+++ b/elonafoobar-log/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 ansi_term = "0.12.1"
 atty = "0.2.14"
 log = { version = "0.4.11", features = ["std"] }
-thiserror = "1.0.21"
+thiserror = "1.0.23"

--- a/elonafoobar-lua-sys/Cargo.toml
+++ b/elonafoobar-lua-sys/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 
 [build-dependencies]
 cc = "1.0.66"
-bindgen = "0.55.1"
+bindgen = "0.56.0"

--- a/elonafoobar-lua-sys/src/lib.rs
+++ b/elonafoobar-lua-sys/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+#![allow(clippy::all)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/elonafoobar-lua/Cargo.toml
+++ b/elonafoobar-lua/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 [dependencies]
 elonafoobar-lua-sys = { path = "../elonafoobar-lua-sys" }
 elonafoobar-utils = { path = "../elonafoobar-utils" }
-anyhow = "1.0.33"
+anyhow = "1.0.37"
 bitflags = "1.2.1"

--- a/elonafoobar-lua/src/conv.rs
+++ b/elonafoobar-lua/src/conv.rs
@@ -2,4 +2,4 @@ pub mod from_lua;
 pub mod to_lua;
 
 pub use from_lua::{FromLuaInt, FromLuaValue, FromLuaValues};
-pub use to_lua::{ToLuaInt, ToLuaValue, ToLuaValues};
+pub use to_lua::{IntoLuaInt, ToLuaValue, ToLuaValues};

--- a/elonafoobar-lua/src/conv/to_lua.rs
+++ b/elonafoobar-lua/src/conv/to_lua.rs
@@ -45,10 +45,10 @@ impl ToLuaValue for PathBuf {
 
 impl<T> ToLuaValue for AsLuaInt<T>
 where
-    T: ToLuaInt,
+    T: IntoLuaInt,
 {
     fn push(self, state: ffi::State) -> Result<()> {
-        let value = self.0.to_lua_int()?;
+        let value = self.0.into_lua_int()?;
         value.push(state)
     }
 }
@@ -96,8 +96,8 @@ where
     }
 }
 
-pub trait ToLuaInt: Sized {
-    fn to_lua_int(self) -> Result<LuaInt>;
+pub trait IntoLuaInt: Sized {
+    fn into_lua_int(self) -> Result<LuaInt>;
 }
 
 pub trait ToLuaValues: Sized {

--- a/elonafoobar-lua/src/lib.rs
+++ b/elonafoobar-lua/src/lib.rs
@@ -9,4 +9,4 @@ pub mod utils;
 pub use crate::state::Lua;
 pub use crate::types::{AsLuaInt, LuaUserdata};
 
-pub use crate::conv::{FromLuaInt, ToLuaInt};
+pub use crate::conv::{FromLuaInt, IntoLuaInt};

--- a/elonafoobar-lua/src/state.rs
+++ b/elonafoobar-lua/src/state.rs
@@ -216,7 +216,7 @@ impl Lua {
         ffi::lua_pushstring(self.inner, "__gc")?;
         ffi::lua_pushcfunction(self.inner, free::<T>);
         ffi::lua_rawset(self.inner, -3);
-        self.pop_one()?;
+        self.pop_one();
 
         Ok(())
     }
@@ -261,9 +261,8 @@ impl Lua {
         Ok(())
     }
 
-    fn pop_one(&mut self) -> Result<()> {
+    fn pop_one(&mut self) {
         ffi::lua_pop_one(self.inner);
-        Ok(())
     }
 
     fn set_global(&mut self, name: &str) -> Result<()> {

--- a/elonafoobar-utils/Cargo.toml
+++ b/elonafoobar-utils/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-num-traits = "0.2.12"
+num-traits = "0.2.14"

--- a/elonafoobar/Cargo.toml
+++ b/elonafoobar/Cargo.toml
@@ -12,17 +12,17 @@ elonafoobar-log = { path = "../elonafoobar-log" }
 elonafoobar-lua = { path = "../elonafoobar-lua" }
 elonafoobar-net = { path = "../elonafoobar-net" }
 elonafoobar-utils = { path = "../elonafoobar-utils" }
-anyhow = "1.0.33"
+anyhow = "1.0.37"
 clap = "2.33.3"
-json5 = "0.2.8"
+json5 = "0.3.0"
 lazy_static = "1.4.0"
 petgraph = "0.5.1"
 semver = { version = "0.11.0", features = ["serde"] }
-serde = { version = "1.0.116", features = ["derive"] }
-thiserror = "1.0.21"
+serde = { version = "1.0.118", features = ["derive"] }
+thiserror = "1.0.23"
 
 [build-dependencies]
-anyhow = "1.0.33"
+anyhow = "1.0.37"
 fs_extra = "1.2.0"
-regex = "1.4.1"
+regex = "1.4.2"
 vergen = "3.1.0"

--- a/elonafoobar/Cargo.toml
+++ b/elonafoobar/Cargo.toml
@@ -14,7 +14,6 @@ elonafoobar-net = { path = "../elonafoobar-net" }
 elonafoobar-utils = { path = "../elonafoobar-utils" }
 anyhow = "1.0.33"
 clap = "2.33.3"
-itertools = "0.9.0"
 json5 = "0.2.8"
 lazy_static = "1.4.0"
 petgraph = "0.5.1"

--- a/elonafoobar/src/api.rs
+++ b/elonafoobar/src/api.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unnecessary_wraps)]
+
 use anyhow::Result;
 use elonafoobar_lua::Lua;
 

--- a/elonafoobar/src/api/module_log.rs
+++ b/elonafoobar/src/api/module_log.rs
@@ -2,7 +2,7 @@ use anyhow::format_err;
 use anyhow::Result;
 use elonafoobar_log::{log, trace, Level as LogLevel};
 use elonafoobar_lua::types::LuaInt;
-use elonafoobar_lua::{AsLuaInt, FromLuaInt, Lua, ToLuaInt};
+use elonafoobar_lua::{AsLuaInt, FromLuaInt, IntoLuaInt, Lua};
 
 struct Level(LogLevel);
 
@@ -19,8 +19,8 @@ impl FromLuaInt for Level {
     }
 }
 
-impl ToLuaInt for Level {
-    fn to_lua_int(self) -> Result<LuaInt> {
+impl IntoLuaInt for Level {
+    fn into_lua_int(self) -> Result<LuaInt> {
         match self.0 {
             LogLevel::Error => Ok(5),
             LogLevel::Warn => Ok(4),


### PR DESCRIPTION
# Description

## Deny unformatted codes or lint warnings in GitHub Actions.

Now, `cargo fmt` and `cargo clippy` fail when they encounter unformatted codes/warnings.

## Upgrade dependencies to the latest

Also remove `itertools` crate from dependency as it is unused.

## Apply rust-clippy's suggestions

Also suppress clippy warnings on auto-generated codes by bindgen.
