### PR TITLE
Refactor: simplify Lua binding code related to `Path`

### DIFF
--- a/elonafoobar-lua/src/conv/from_lua.rs
+++ b/elonafoobar-lua/src/conv/from_lua.rs
@@ -1,6 +1,7 @@
 use crate::ffi;
 use crate::types::{AsLuaInt, LuaFloat, LuaInt, LuaUserdata};
 use anyhow::Result;
+use std::path::Path;
 
 pub trait FromLuaValue: Sized {
     fn pop(state: ffi::State) -> Result<Self>;
@@ -38,6 +39,13 @@ impl FromLuaValue for &str {
         let value = ffi::lua_tostring(state, -1)?;
         ffi::lua_pop_one(state);
         Ok(value)
+    }
+}
+
+impl FromLuaValue for &Path {
+    fn pop(state: ffi::State) -> Result<Self> {
+        let raw_str = <&str>::pop(state)?;
+        Ok(Path::new(raw_str))
     }
 }
 

--- a/elonafoobar/src/api/class_app.rs
+++ b/elonafoobar/src/api/class_app.rs
@@ -114,13 +114,11 @@ fn lua_screen_height(args: &App) -> Result<LuaInt> {
     Ok(app.0.screen_height().into())
 }
 
-fn lua_load_image(args: (&mut App, &str, Option<&Color>)) -> Result<Image> {
+fn lua_load_image(args: (&mut App, &Path, Option<&Color>)) -> Result<Image> {
     trace!("native.App.App:load_image()");
 
     let (app, path, key_color) = args;
-    Ok(Image(
-        app.0.load_image(&Path::new(path), key_color.map(|x| x.0))?,
-    ))
+    Ok(Image(app.0.load_image(path, key_color.map(|x| x.0))?))
 }
 
 fn lua_draw_image(
@@ -159,14 +157,12 @@ fn lua_draw_image(
     Ok(())
 }
 
-fn lua_load_font(args: (&mut App, &str, LuaInt, LuaInt)) -> Result<()> {
+fn lua_load_font(args: (&mut App, &Path, LuaInt, LuaInt)) -> Result<()> {
     trace!("native.App.App:load_font()");
 
     let (self_, path, point_size, style) = args;
     let style = FontStyle::from_bits_truncate(style as _);
-    self_
-        .0
-        .load_font(&Path::new(path), clamp(point_size), style)?;
+    self_.0.load_font(path, clamp(point_size), style)?;
 
     Ok(())
 }
@@ -236,11 +232,11 @@ fn lua_draw_text_with_shadow(args: (&mut App, &str, LuaInt, LuaInt, &Color, &Col
     Ok(())
 }
 
-fn lua_load_music(args: (&mut App, &str)) -> Result<()> {
+fn lua_load_music(args: (&mut App, &Path)) -> Result<()> {
     trace!("native.App.App:load_music()");
 
     let (self_, path) = args;
-    self_.0.load_music(&Path::new(path))?;
+    self_.0.load_music(path)?;
 
     Ok(())
 }

--- a/elonafoobar/src/api/module_fs.rs
+++ b/elonafoobar/src/api/module_fs.rs
@@ -21,12 +21,11 @@ pub fn bind(lua: &mut Lua) -> Result<()> {
     })
 }
 
-fn lua_exists(args: &str) -> Result<bool> {
+fn lua_exists(args: &Path) -> Result<bool> {
     trace!("native.Fs.exists()");
 
     let path = args;
-
-    Ok(Path::new(path).exists())
+    Ok(path.exists())
 }
 
 fn lua_get_bundled_font_path(_args: ()) -> Result<PathBuf> {


### PR DESCRIPTION
# Description

Simplify Lua binding code related to `std::path::Path` by implementing `elonafoobar_lua::conv::FromLuaValue` for `&Path`.
It is reasonable to provide implicit conversion from Lua strings to `Path`s because conversion from `&str` to `&Path` is lossless and zero cost.