### PR TITLE
cargo-upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "const_format"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0998bb2339a89730a82650d94458509281454c72d2fb2521ece92626c005ee3"
+checksum = "22a4a8f54f8711dac1985899102324870f6f69488d6480fff8e75ee17bd2bd72"
 dependencies = [
  "const_format_proc_macros",
 ]

--- a/elonafoobar-rand/Cargo.toml
+++ b/elonafoobar-rand/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 rand_xoshiro = "0.6.0"
 
 [dependencies.rand]
-version = "0.8.0"
+version = "0.8.1"
 default-features = false

--- a/elonafoobar/Cargo.toml
+++ b/elonafoobar/Cargo.toml
@@ -15,7 +15,7 @@ elonafoobar-rand = { path = "../elonafoobar-rand" }
 elonafoobar-utils = { path = "../elonafoobar-utils" }
 anyhow = "1.0.37"
 clap = "2.33.3"
-const_format = "0.2.11"
+const_format = "0.2.12"
 json5 = "0.3.0"
 lazy_static = "1.4.0"
 petgraph = "0.5.1"


### PR DESCRIPTION
# Related Issues

#1809

# Description

Upgrade some dependencies. This PR is, in fact, for invalidating build cache (see #1809 for cache-related issue) by modifying `Cargo.lock` file (as of 2020/01/09, there is no way to clear GitHub Actions cache manually).